### PR TITLE
Validate distribution name when deserializing parametric models

### DIFF
--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -70,17 +70,28 @@ class Parametric(Distribution):
 
     @classmethod
     def from_json(cls, fp):
-        with open(fp, "r+") as f:
+        with open(fp, "r") as f:
             return cls.from_dict(json.load(f))
 
     @classmethod
     def from_dict(cls, model_dict):
+        # Imported here since parametric_fitter imports this module
+        from surpyval.univariate.parametric.parametric_fitter import (
+            ParametricFitter,
+        )
+
         if model_dict["parameterization"] != "parametric":
             raise ValueError(
                 "Must create parametric model from parametric model dict"
             )
 
-        dist = getattr(surv, model_dict["distribution"])
+        # Restrict the lookup to known distributions so an untrusted
+        # model dict cannot resolve arbitrary surpyval attributes
+        dist = getattr(surv, model_dict["distribution"], None)
+        if not isinstance(dist, ParametricFitter):
+            raise ValueError(
+                "Unknown distribution '{}'".format(model_dict["distribution"])
+            )
         how = model_dict["how"]
         if "data" in model_dict:
             data = model_dict["data"]


### PR DESCRIPTION
Parametric.from_dict resolved the 'distribution' field from a model
dict with an unrestricted getattr on the surpyval namespace, so a
crafted model file could make it look up arbitrary package attributes.
Reject anything that is not a known ParametricFitter with a clear
ValueError instead.

Also open model files read-only in from_json so loading a model no
longer requires write permission on the file.

https://claude.ai/code/session_014tEJudhL9vpKmSWxLEXKMR