### PR TITLE
Make regression fit() argument order consistent with CoxPH

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,8 +89,9 @@ Fully migrated from `setup.py` to `pyproject.toml`. `setup.py` deleted.
 
 ## 4. API Consistency Issues
 
-### Regression `fit()` argument order
-`CoxPH.fit(x, Z, ...)` takes time first, while `ProportionalHazardsFitter`, `ParameterSubstitutionFitter`, and `AcceleratedFailureTimeFitter` all take `(Z, x, ...)`. Switching between models silently swaps time and covariates.
+### ~~Regression `fit()` argument order~~ ✓ Done
+~~`CoxPH.fit(x, Z, ...)` takes time first, while `ProportionalHazardsFitter`, `ParameterSubstitutionFitter`, and `AcceleratedFailureTimeFitter` all take `(Z, x, ...)`. Switching between models silently swaps time and covariates.~~
+**Fixed** — all three fitters now use `fit(x, Z, ...)`, matching `CoxPH`, the forest models, and the proportional intensity models. All internal call sites already used keyword arguments, so no callers needed updating.
 
 ### ~~CoxPH docstring inverts censoring convention~~ ✓ Done
 Fixed: `c` parameter now correctly documented as `0=event, 1=right-censored`.

--- a/surpyval/regression/accelerated_failure_time.py
+++ b/surpyval/regression/accelerated_failure_time.py
@@ -104,7 +104,7 @@ class AcceleratedFailureTimeFitter:
             Z_out.append(np.ones(size) * stress)
         return np.concatenate(x), np.concatenate(Z_out)
 
-    def fit(self, Z, x, c=None, n=None, t=None, init=[], fixed={}):
+    def fit(self, x, Z, c=None, n=None, t=None, init=[], fixed={}):
         x, c, n, t = surpyval.xcnt_handler(
             x=x, c=c, n=n, t=t, group_and_sort=False
         )

--- a/surpyval/regression/parameter_substitution.py
+++ b/surpyval/regression/parameter_substitution.py
@@ -200,7 +200,7 @@ class ParameterSubstitutionFitter:
         like = -np.sum(like)
         return like
 
-    def fit(self, Z, x, c=None, n=None, t=None, init=[], fixed={}):
+    def fit(self, x, Z, c=None, n=None, t=None, init=[], fixed={}):
         data = SurpyvalData(x=x, c=c, n=n, t=t, group_and_sort=False)
         data.add_covariates(Z)
         life_parameter_idx = self.param_map[self.life_parameter]

--- a/surpyval/regression/proportional_hazards_fitter.py
+++ b/surpyval/regression/proportional_hazards_fitter.py
@@ -145,17 +145,17 @@ class ProportionalHazardsFitter:
             phi_init=lambda Z: np.zeros(Z.shape[1]),
         )
 
-    def fit(self, Z, x, c=None, n=None, t=None, init=[], fixed={}):
+    def fit(self, x, Z, c=None, n=None, t=None, init=[], fixed={}):
         """
         Fit the proportional hazards model to the data.
 
         Parameters
         ----------
 
-        Z : array_like
-            The covariates to fit the model to.
         x : array_like
             The observed event times.
+        Z : array_like
+            The covariates to fit the model to.
         c : array_like, optional
             The censoring indicators.
         n : array_like, optional


### PR DESCRIPTION
ProportionalHazardsFitter, ParameterSubstitutionFitter, and
AcceleratedFailureTimeFitter previously took fit(Z, x, ...) while CoxPH,
the forest models, and the proportional intensity models all take
fit(x, Z, ...). Switching between models could silently swap time and
covariates when arguments were passed positionally.

All three fitters now use fit(x, Z, ...). Every internal call site
already used keyword arguments, so no callers needed updating. Verified
the fitters produce identical results under the new signature.

https://claude.ai/code/session_016VYLUeajbDtZo4JXBuQkGj