### PR TITLE
Migrate to numpy 2.x and pin numpy>=2.1,<3

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -242,7 +242,13 @@ These are safe to bump in a single PR. Run the existing test suite to confirm.
 - `scipy`: 1.10.0 → 1.17.1. Requires numpy ≥1.26 — do this after Phase 3.
 - `formulaic`: 0.5.2 → 1.2.2. The `SimpleFormula`/`StructuredFormula` redesign (v1.0) and the `ModelSpec.required_variables` change (v1.2) will affect the regression formula parsing in `surpyval/regression/`. Audit all `formulaic` call sites before bumping.
 
-#### Phase 3 — numpy 2.x (breaking)
+#### Phase 3 — numpy 2.x (breaking) — ✅ COMPLETED (June 2026)
+
+Completed: the codebase now runs on numpy 2.4.6 with the full test suite
+passing. `numpy>=2.1,<3` is pinned in `pyproject.toml`, `np.in1d` was
+replaced with `np.isin`, and size-1-array-to-scalar conversions (an error
+since numpy 2.x) were fixed in `Logistic.moment`, the Gamma MPP fitter,
+and the test helpers.
 
 numpy 2.0 removed ~100 deprecated aliases (`np.bool`, `np.int`, `np.float`, `np.complex`, `np.object`, `np.str` → use Python built-ins), moved `np.core` to private `np._core`, and changed scalar type promotion rules. This will break code in surpyval and possibly in `autograd` (see §5).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,13 @@ classifiers = [
 ]
 dependencies = [
     "autograd>=1.8",
-    "numpy",
+    "numpy>=2.1,<3",
     "scipy",
     "pandas",
     "matplotlib>=3.10",
     "formulaic",
     "numdifftools>=0.9.42",
+    "joblib",
 ]
 
 [project.optional-dependencies]

--- a/surpyval/regression/forest/forest.py
+++ b/surpyval/regression/forest/forest.py
@@ -20,7 +20,7 @@ class RandomSurvivalForest:
     def __init__(
         self,
         data: SurpyvalData,
-        Z: NDArray,
+        Z: ArrayLike | NDArray,
         n_trees: int = 100,
         max_depth: int | float = float("inf"),
         min_leaf_samples: int = 5,
@@ -30,7 +30,11 @@ class RandomSurvivalForest:
         parametric: bool = True,
     ):
         self.data: SurpyvalData = data
-        self.Z: NDArray = np.array(Z, ndmin=2)
+        Z = np.asarray(Z)
+        if Z.ndim == 1:
+            # A 1-d Z is a single feature, one value per sample
+            Z = Z.reshape(-1, 1)
+        self.Z: NDArray = Z
         self.n_trees = n_trees
         self.bootstrap = bootstrap
         self.parametric = parametric
@@ -80,7 +84,6 @@ class RandomSurvivalForest:
         parametric = parse_leaf_type(leaf_type)
 
         data = SurpyvalData(x, c, n, t, group_and_sort=False)
-        Z = np.array(Z, ndmin=2)
         return cls(
             data,
             Z,
@@ -146,7 +149,7 @@ class RandomSurvivalForest:
     def mortality(
         self, x: int | float | ArrayLike, Z: ArrayLike | NDArray
     ) -> ArrayLike:
-        mortality = self.Hf(x, Z).sum(1)
+        mortality = np.atleast_2d(self.Hf(x, Z)).sum(1)
         return np.clip(mortality, 0, np.finfo(np.float64).max)
 
     def _apply_model_function_to_trees(
@@ -157,6 +160,7 @@ class RandomSurvivalForest:
     ) -> NDArray:
         # Prep input - make sure numpy array
         x = np.array(x, ndmin=1)
+        single_covariant_vector = np.ndim(Z) < 2
         Z = np.array(Z, ndmin=2)
 
         res = np.zeros((Z.shape[0], x.size)).astype(np.float64)
@@ -166,7 +170,10 @@ class RandomSurvivalForest:
                     function_name, x, Z[i_covariant_vector, :]
                 )
                 res[i_covariant_vector, :] += values
-        return res / self.n_trees
+        res = res / self.n_trees
+        if single_covariant_vector:
+            return res[0]
+        return res
 
     def score(
         self,
@@ -186,7 +193,5 @@ def parse_leaf_type(leaf_type: str):
     elif leaf_type.lower() == "parametric":
         return True
     else:
-        raise ValueError(
-            f"leaf_type={leaf_type} is invalid. Must\
-            'parametric' or 'non-parametric'"
-        )
+        raise ValueError(f"leaf_type={leaf_type} is invalid. Must\
+            'parametric' or 'non-parametric'")

--- a/surpyval/regression/forest/log_rank_split.py
+++ b/surpyval/regression/forest/log_rank_split.py
@@ -57,12 +57,16 @@ def log_rank_split(
 
     Parameters
     ----------
-    x : NDArray
-        Survival times
+    data : SurpyvalData
+        Survival data (x, c, n, t)
     Z : NDArray
-        Covariant matrix
-    c : NDArray
-        Censor vector
+        Covariant matrix, of shape (n_samples, n_features)
+    min_leaf_samples : int
+        Minimum number of samples each child must have
+    min_leaf_failures : int
+        Minimum number of failures each child must have
+    feature_indices_in : Iterable[int]
+        Indices of the features to consider for the split
 
     Returns
     -------
@@ -87,9 +91,9 @@ def log_rank_split(
                 continue
             elif Z_u[~mask].size < min_leaf_samples:
                 continue
-            elif (data.c[mask] != 1).sum() <= min_leaf_failures:
+            elif (data.c[mask] != 1).sum() < min_leaf_failures:
                 continue
-            elif (data.c[~mask] != 1).sum() <= min_leaf_failures:
+            elif (data.c[~mask] != 1).sum() < min_leaf_failures:
                 continue
 
             abs_log_rank = log_rank(u, v, data, Z)
@@ -128,8 +132,7 @@ def log_rank(
     expanded_Y_L = np.empty_like(all_x)
     expanded_Y_L.fill(np.nan)
     # expanded_do_L = np.zeros_like(all_x)
-    # x_l_indices = np.in1d(all_x, left_child_x).nonzero()[0]
-    x_l_indices = np.in1d(all_x, data_left_child.x).nonzero()[0]
+    x_l_indices = np.isin(all_x, data_left_child.x).nonzero()[0]
     expanded_d_L[x_l_indices] = d_L
     expanded_Y_L[x_l_indices] = Y_L
     # expanded_do_L[x_l_indices] = do_L
@@ -178,7 +181,7 @@ def log_rank(
         (Y_L / Y) * (1.0 - Y_L / Y) * (Y - d) / (Y - 1) * d
     )
 
-    if denominator_inside_sqrt == 0:
+    if denominator_inside_sqrt <= 0:
         return -float("inf")
 
     try:

--- a/surpyval/regression/forest/node.py
+++ b/surpyval/regression/forest/node.py
@@ -20,8 +20,7 @@ class Node(ABC):
         function_name: str,
         x: int | float | ArrayLike,
         Z: NDArray,
-    ) -> NDArray:
-        ...
+    ) -> NDArray: ...
 
 
 class IntermediateNode(Node):
@@ -128,7 +127,7 @@ def build_tree(
     """
     # If max_depth has been reached, return a TerminalNode
     if curr_depth == max_depth:
-        return TerminalNode(data)
+        return TerminalNode(data, parametric)
 
     # Choose the random n_features_split subset of features, without
     # replacement

--- a/surpyval/regression/forest/tree.py
+++ b/surpyval/regression/forest/tree.py
@@ -22,7 +22,7 @@ class SurvivalTree:
         min_leaf_samples: int = 5,
         min_leaf_failures: int = 2,
         n_features_split: int | float | str = "sqrt",
-        parametric: str = "non-parametric",
+        parametric: bool | str = "non-parametric",
     ):
         self.data = data
         self.Z = Z
@@ -33,7 +33,11 @@ class SurvivalTree:
 
         self.n_features_split = n_features
 
-        is_parametric: bool = parse_leaf_type(parametric)
+        is_parametric: bool = (
+            parametric
+            if isinstance(parametric, bool)
+            else parse_leaf_type(parametric)
+        )
 
         self._root = build_tree(
             data=self.data,
@@ -61,10 +65,18 @@ class SurvivalTree:
         leaf_type: str = "parametric",
     ):
         data = SurpyvalData(x, c, n, t, group_and_sort=False)
-        Z = np.array(Z, ndmin=2)
-        n_features: int = parse_n_features_split(n_features_split, Z.shape[1])
+        Z = np.asarray(Z)
+        if Z.ndim == 1:
+            # A 1-d Z is a single feature, one value per sample
+            Z = Z.reshape(-1, 1)
         return cls(
-            data, Z, max_depth, min_leaf_failures, n_features, leaf_type
+            data,
+            Z,
+            max_depth,
+            min_leaf_samples,
+            min_leaf_failures,
+            n_features_split,
+            parse_leaf_type(leaf_type),
         )
 
     def apply_model_function(
@@ -82,7 +94,7 @@ class SurvivalTree:
     def sf(
         self, x: int | float | ArrayLike, Z: ArrayLike | NDArray
     ) -> NDArray:
-        return self.apply_model_function("ff", x, Z)
+        return self.apply_model_function("sf", x, Z)
 
     def ff(
         self, x: int | float | ArrayLike, Z: ArrayLike | NDArray
@@ -119,10 +131,8 @@ def parse_n_features_split(
     if n_features_split == "all":
         return n_features
     else:
-        raise ValueError(
-            f"n_features_split={n_features_split} is invalid. See\
-                         `Tree` docstring for valid values."
-        )
+        raise ValueError(f"n_features_split={n_features_split} is invalid. See\
+                         `Tree` docstring for valid values.")
 
 
 def parse_leaf_type(leaf_type: str):
@@ -131,7 +141,5 @@ def parse_leaf_type(leaf_type: str):
     elif leaf_type.lower() == "parametric":
         return True
     else:
-        raise ValueError(
-            f"leaf_type={leaf_type} is invalid. Must\
-            'parametric' or 'non-parametric'"
-        )
+        raise ValueError(f"leaf_type={leaf_type} is invalid. Must\
+            'parametric' or 'non-parametric'")

--- a/surpyval/tests/forest/test_forest.py
+++ b/surpyval/tests/forest/test_forest.py
@@ -32,7 +32,7 @@ def test_forest_n_trees(get_x_Z_c_samples: tuple[NDArray, NDArray, NDArray]):
     x, Z, c = get_x_Z_c_samples
 
     # Make forest w/ 5 trees
-    forest = RandomSurvivalForest(x=x, Z=Z, c=c, n_trees=5)
+    forest = RandomSurvivalForest.fit(x=x, Z=Z, c=c, n_trees=5)
 
     # Assert there are only 5 trees
     assert forest.n_trees == 5
@@ -40,42 +40,44 @@ def test_forest_n_trees(get_x_Z_c_samples: tuple[NDArray, NDArray, NDArray]):
 
 
 def test_forest_bootstrap_false(
-    get_x_Z_c_samples: tuple[NDArray, NDArray, NDArray]
+    get_x_Z_c_samples: tuple[NDArray, NDArray, NDArray],
 ):
     # Get samples
     x, Z, c = get_x_Z_c_samples
 
     # Make forest w/ 2 trees
-    forest = RandomSurvivalForest(x=x, Z=Z, c=c, n_trees=2, bootstrap=False)
+    forest = RandomSurvivalForest.fit(
+        x=x, Z=Z, c=c, n_trees=2, bootstrap=False
+    )
 
     assert not forest.bootstrap  # == False
-    assert_array_equal(forest.trees[0].x, x)
-    assert_array_equal(forest.trees[1].x, x)
+    assert_array_equal(forest.trees[0].data.x, x)
+    assert_array_equal(forest.trees[1].data.x, x)
 
 
 def test_forest_bootstrap_true(
-    get_x_Z_c_samples: tuple[NDArray, NDArray, NDArray]
+    get_x_Z_c_samples: tuple[NDArray, NDArray, NDArray],
 ):
     # Get samples
     x, Z, c = get_x_Z_c_samples
 
     # Make forest w/ 1 tree, bootstrapped (boostrap=True by default)
-    forest = RandomSurvivalForest(x=x, Z=Z, c=c, n_trees=1)
+    forest = RandomSurvivalForest.fit(x=x, Z=Z, c=c, n_trees=1)
 
     # Assert all samples are not as given
     assert forest.bootstrap  # == False
     with pytest.raises(AssertionError):
-        assert_array_equal(forest.trees[0].x, x)
+        assert_array_equal(forest.trees[0].data.x, x)
 
 
 def test_forest_sf_scalar_x(
-    get_x_Z_c_samples: tuple[NDArray, NDArray, NDArray]
+    get_x_Z_c_samples: tuple[NDArray, NDArray, NDArray],
 ):
     # Get samples
     x, Z, c = get_x_Z_c_samples
 
     # Make forest w/ 5 trees
-    forest = RandomSurvivalForest(x=x, Z=Z, c=c, n_trees=5)
+    forest = RandomSurvivalForest.fit(x=x, Z=Z, c=c, n_trees=5)
 
     # Make a sf() call for x=1 || 100, and Z = [0.5, 0.5]
     # Should be pretty     low || high
@@ -91,13 +93,13 @@ def test_forest_sf_scalar_x(
 
 
 def test_forest_sf_vector_x(
-    get_x_Z_c_samples: tuple[NDArray, NDArray, NDArray]
+    get_x_Z_c_samples: tuple[NDArray, NDArray, NDArray],
 ):
     # Get samples
     x, Z, c = get_x_Z_c_samples
 
     # Make forest w/ 5 trees
-    forest = RandomSurvivalForest(x=x, Z=Z, c=c, n_trees=5)
+    forest = RandomSurvivalForest.fit(x=x, Z=Z, c=c, n_trees=5)
 
     # Make a sf() call for x=[1, 5, 50, 75, 100], and Z = [0.5, 0.5]
     sf = forest.sf(x=[1, 5, 50, 75, 100], Z=[0.5, 0.5])
@@ -106,13 +108,13 @@ def test_forest_sf_vector_x(
 
 
 def test_forest_all_functions(
-    get_x_Z_c_samples: tuple[NDArray, NDArray, NDArray]
+    get_x_Z_c_samples: tuple[NDArray, NDArray, NDArray],
 ):
     # Get samples
     x, Z, c = get_x_Z_c_samples
 
     # Make forest w/ 5 trees
-    forest = RandomSurvivalForest(x=x, Z=Z, c=c, n_trees=5)
+    forest = RandomSurvivalForest.fit(x=x, Z=Z, c=c, n_trees=5)
 
     # Make a sf(), ff(), df(), hf(), and Hf() call for x=1 and Z = [0.5, 0.5]
     sf = forest.sf(x=1, Z=[0.5, 0.5])

--- a/surpyval/tests/forest/test_log_rank_split.py
+++ b/surpyval/tests/forest/test_log_rank_split.py
@@ -1,6 +1,24 @@
 import numpy as np
 
 from surpyval.regression.forest.log_rank_split import log_rank_split
+from surpyval.utils.surpyval_data import SurpyvalData
+
+
+def log_rank_split_xZc(x, Z, c, min_leaf_failures, feature_indices_in):
+    """Call log_rank_split() from x-Z-c arrays."""
+    data = SurpyvalData(
+        np.asarray(x, dtype=float), np.asarray(c), group_and_sort=False
+    )
+    Z = np.asarray(Z, dtype=float)
+    if Z.ndim == 1:
+        Z = Z.reshape(-1, 1)
+    return log_rank_split(
+        data,
+        Z,
+        min_leaf_samples=1,
+        min_leaf_failures=min_leaf_failures,
+        feature_indices_in=feature_indices_in,
+    )
 
 
 def test_log_rank_split_one_binary_feature():
@@ -12,7 +30,7 @@ def test_log_rank_split_one_binary_feature():
     Z = np.array([0] * 10 + [1] * 10)
     c = np.array([0] * len(x))
 
-    lrs = log_rank_split(
+    lrs = log_rank_split_xZc(
         x,
         Z,
         c,
@@ -32,7 +50,7 @@ def test_log_rank_split_one_feature_four_samples():
     Z = np.array([0, 0.2] + [15.1, 15])
     c = np.array([0] * len(x))
 
-    lrs = log_rank_split(
+    lrs = log_rank_split_xZc(
         x,
         Z,
         c,
@@ -53,7 +71,7 @@ def test_log_rank_split_two_features_two_samples():
     Z = np.array([[0.3, 1], [0.3, 3]])  # Feature 1 should be selected
     c = np.array([0] * len(x))
 
-    lrs = log_rank_split(
+    lrs = log_rank_split_xZc(
         x,
         Z,
         c,
@@ -76,7 +94,7 @@ def test_log_rank_split_min_leaf_failures():
     Z = np.array([0, 0.1, 0, 3, 3.1, 3.2])
     c_A = np.array([0] * len(x))
 
-    lrsA = log_rank_split(
+    lrsA = log_rank_split_xZc(
         x,
         Z,
         c_A,
@@ -88,7 +106,7 @@ def test_log_rank_split_min_leaf_failures():
 
     # Case B: all samples are censored, a split is not possible
     c_B = np.array([1] * len(x))
-    lrsA = log_rank_split(
+    lrsA = log_rank_split_xZc(
         x, Z, c_B, min_leaf_failures=min_leaf_failures, feature_indices_in=[0]
     )
     assert lrsA[0] == -1
@@ -96,7 +114,7 @@ def test_log_rank_split_min_leaf_failures():
 
     # Case C: Not enough uncensored samples to make a split
     c_C = np.array([0, 1, 0, 0, 0, 0])
-    lrsA = log_rank_split(
+    lrsA = log_rank_split_xZc(
         x, Z, c_C, min_leaf_failures=min_leaf_failures, feature_indices_in=[0]
     )
     assert lrsA[0] == -1

--- a/surpyval/tests/forest/test_tree.py
+++ b/surpyval/tests/forest/test_tree.py
@@ -20,7 +20,7 @@ def test_tree_no_split():
 
     exp_weibull = Weibull.fit(x=x, c=c)
 
-    tree = SurvivalTree(x=x, Z=Z, c=c, max_depth=0)
+    tree = SurvivalTree.fit(x=x, Z=Z, c=c, max_depth=0)
 
     actual_weibull = tree._root.model
 
@@ -44,7 +44,7 @@ def test_tree_one_split_one_feature():
     exp_right_weibull = Weibull.fit(x=x[8:], c=c[8:])
 
     # Actual
-    tree = SurvivalTree(x=x, Z=Z, c=c, max_depth=1)
+    tree = SurvivalTree.fit(x=x, Z=Z, c=c, max_depth=1)
 
     # Assert Weibull models
     left_weibull = tree._root.left_child.model
@@ -75,7 +75,7 @@ def test_tree_one_split_two_features():
     c = [0] * len(x)
 
     # Actual
-    tree = SurvivalTree(x=x, Z=Z, c=c, max_depth=1, n_features_split="all")
+    tree = SurvivalTree.fit(x=x, Z=Z, c=c, max_depth=1, n_features_split="all")
 
     # Assert feature 1 was selected
     assert tree._root.split_feature_index == 1
@@ -102,32 +102,32 @@ def test_tree_one_split_two_features_n_features_split():
     c = [0] * len(x)
 
     # Different n_features_split
-    tree_one_feature = SurvivalTree(
+    tree_one_feature = SurvivalTree.fit(
         x=x, Z=Z, c=c, max_depth=1, n_features_split=1
     )
     assert len(tree_one_feature._root.feature_indices_in) == 1
 
-    tree_two_features = SurvivalTree(
+    tree_two_features = SurvivalTree.fit(
         x=x, Z=Z, c=c, max_depth=1, n_features_split=2
     )
     assert len(tree_two_features._root.feature_indices_in) == 2
 
-    tree_one_feature_float = SurvivalTree(
+    tree_one_feature_float = SurvivalTree.fit(
         x=x, Z=Z, c=c, max_depth=1, n_features_split=0.5
     )
     assert len(tree_one_feature_float._root.feature_indices_in) == 1
 
-    tree_one_feature_sqrt = SurvivalTree(
+    tree_one_feature_sqrt = SurvivalTree.fit(
         x=x, Z=Z, c=c, max_depth=1, n_features_split="sqrt"
     )
     assert len(tree_one_feature_sqrt._root.feature_indices_in) == 1
 
-    tree_one_feature_log2 = SurvivalTree(
+    tree_one_feature_log2 = SurvivalTree.fit(
         x=x, Z=Z, c=c, max_depth=1, n_features_split="log2"
     )
     assert len(tree_one_feature_log2._root.feature_indices_in) == 1
 
-    tree_two_features_all = SurvivalTree(
+    tree_two_features_all = SurvivalTree.fit(
         x=x, Z=Z, c=c, max_depth=1, n_features_split="all"
     )
     assert len(tree_two_features_all._root.feature_indices_in) == 2

--- a/surpyval/tests/test_np.py
+++ b/surpyval/tests/test_np.py
@@ -17,9 +17,9 @@ def right_censor(x, tl, frac):
         if c[i] == 0:
             continue
         if np.isfinite(trunc):
-            x_out[i] = np.random.uniform(trunc, value, 1)
+            x_out[i] = np.random.uniform(trunc, value)
         else:
-            x_out[i] = value - np.abs(value * np.random.uniform(0, 1, 1))
+            x_out[i] = value - np.abs(value * np.random.uniform(0, 1))
     return x_out, c
 
 
@@ -56,7 +56,7 @@ def test_kaplan_meier_against_lifelines():
             test_params.append(np.random.uniform(*b))
         test_params = np.array(test_params)
         x = surpyval.Weibull.random(
-            int(np.random.uniform(2, 1000, 1)), *test_params
+            int(np.random.uniform(2, 1000)), *test_params
         )
         n = np.ones_like(x) * int(np.random.uniform(1, 5))
         x_test = np.random.uniform(x.min() / 2, x.max() * 2, 100)
@@ -73,7 +73,7 @@ def test_kaplan_meier_censored_against_lifelines():
             test_params.append(np.random.uniform(*b))
         test_params = np.array(test_params)
         x = surpyval.Weibull.random(
-            int(np.random.uniform(2, 1000, 1)), *test_params
+            int(np.random.uniform(2, 1000)), *test_params
         )
         c = np.random.binomial(1, np.random.uniform(0, 1, 1), x.shape)
         x = x - np.abs(x * np.random.uniform(0, 1, x.shape))
@@ -92,7 +92,7 @@ def test_kaplan_meier_censored_and_truncated_against_lifelines():
             test_params.append(np.random.uniform(*b))
         test_params = np.array(test_params)
         x = surpyval.Weibull.random(
-            int(np.random.uniform(2, 1000, 1)), *test_params
+            int(np.random.uniform(2, 1000)), *test_params
         )
         x, tl = left_truncate(x, surpyval.Weibull, 0.1, test_params)
         x, c = right_censor(x, tl, 0.2)
@@ -111,7 +111,7 @@ def test_nelson_aalen_against_lifelines():
             test_params.append(np.random.uniform(*b))
         test_params = np.array(test_params)
         x = surpyval.Weibull.random(
-            int(np.random.uniform(2, 1000, 1)), *test_params
+            int(np.random.uniform(2, 1000)), *test_params
         )
         n = np.ones_like(x) * int(np.random.uniform(1, 5))
         x_test = np.random.uniform(x.min() / 2, x.max() * 2, 100)
@@ -128,7 +128,7 @@ def test_nelson_aalen_censored_against_lifelines():
             test_params.append(np.random.uniform(*b))
         test_params = np.array(test_params)
         x = surpyval.Weibull.random(
-            int(np.random.uniform(2, 1000, 1)), *test_params
+            int(np.random.uniform(2, 1000)), *test_params
         )
         c = np.random.binomial(1, np.random.uniform(0, 1, 1), x.shape)
         x = x - np.abs(x * np.random.uniform(0, 1, x.shape))
@@ -147,7 +147,7 @@ def test_nelson_aalen_censored_and_truncated_against_lifelines():
             test_params.append(np.random.uniform(*b))
         test_params = np.array(test_params)
         x = surpyval.Weibull.random(
-            int(np.random.uniform(2, 1000, 1)), *test_params
+            int(np.random.uniform(2, 1000)), *test_params
         )
         x, tl = left_truncate(x, surpyval.Weibull, 0.1, test_params)
         x, c = right_censor(x, tl, 0.2)
@@ -166,7 +166,7 @@ def test_fleming_harrington_same_as_nelson_aalen_with_no_counts():
             test_params.append(np.random.uniform(*b))
         test_params = np.array(test_params)
         x = surpyval.Weibull.random(
-            int(np.random.uniform(2, 1000, 1)), *test_params
+            int(np.random.uniform(2, 1000)), *test_params
         )
         x_test = np.random.uniform(x.min() / 2, x.max() * 2, 100)
         ll_est = naf.fit(x).predict(x_test).values

--- a/surpyval/tests/test_regression.py
+++ b/surpyval/tests/test_regression.py
@@ -116,8 +116,8 @@ def test_breslow_p_values_rossi():
 
 def test_formula_interface_matches_Z_cols():
     # fit_from_df with formula= must give the same betas as Z_cols=.
-    # Formula sorts covariates alphabetically, so we reorder Z_cols betas
-    # before comparing.
+    # Formulaic preserves the order covariates appear in the formula, so
+    # the betas can be compared directly.
     rossi = load_rossi_static()
     Z_cols = ["fin", "age", "race", "wexp", "mar", "paro", "prio"]
 
@@ -132,5 +132,4 @@ def test_formula_interface_matches_Z_cols():
         method="efron",
     )
 
-    alpha_idx = [Z_cols.index(c) for c in sorted(Z_cols)]
-    assert np.allclose(model_z.beta[alpha_idx], model_f.beta)
+    assert np.allclose(model_z.beta, model_f.beta)

--- a/surpyval/tests/test_utils.py
+++ b/surpyval/tests/test_utils.py
@@ -252,7 +252,7 @@ def test_xcnt_handler():
     with pytest.raises(
         ValueError,
         match="Each element of 'x' must be either scalar or array-like"
-        "of no more than length 2",
+        " of no more than length 2",
     ):
         xcnt_handler(x=[1, [2, 3, 4]])
 
@@ -277,7 +277,8 @@ def test_xcnt_handler():
     # greater than right interval
     with pytest.raises(
         ValueError,
-        match="All left intervals must be <= to right intervals",
+        match="All left intervals must be less than or equal to right"
+        " intervals",
     ):
         xcnt_handler(x=[[3, 2], [5, 4]])
 

--- a/surpyval/univariate/parametric/fitters/mps.py
+++ b/surpyval/univariate/parametric/fitters/mps.py
@@ -40,17 +40,25 @@ def mps(model):
     hess = hessian(mps_fun)
 
     with np.errstate(all="ignore"):
-        res = minimize(
-            mps_fun,
-            init,
-            method="Newton-CG",
-            jac=jac,
-            hess=hess,
-            tol=1e-15,
-            args=(dist, x, inv_trans, const, c, n, tl, tr, offset),
-        )
+        # Some distributions have all-shape parameters whose autograd
+        # second derivatives are zero (see autograd_gamma_compat); a zero
+        # Hessian makes Newton-CG terminate at the initial guess while
+        # reporting success, so skip straight to BFGS in that case.
+        args = (dist, x, inv_trans, const, c, n, tl, tr, offset)
+        if np.any(hess(np.array(init, dtype=float), *args)):
+            res = minimize(
+                mps_fun,
+                init,
+                method="Newton-CG",
+                jac=jac,
+                hess=hess,
+                tol=1e-15,
+                args=args,
+            )
+        else:
+            res = None
 
-        if (res.success is False) or (np.isnan(res.x).any()):
+        if (res is None) or (res.success is False) or (np.isnan(res.x).any()):
             res = minimize(
                 mps_fun,
                 init,

--- a/surpyval/univariate/parametric/gamma.py
+++ b/surpyval/univariate/parametric/gamma.py
@@ -575,7 +575,7 @@ class Gamma_(ParametricFitter):
                 alpha = res.x[0]
                 beta = np.linalg.lstsq(
                     self.mpp_y_transform(F, alpha, 1.0)[:, np.newaxis], x
-                )[0]
+                )[0][0]
                 beta = 1.0 / beta
 
             results["params"] = [alpha, beta]

--- a/surpyval/univariate/parametric/logistic.py
+++ b/surpyval/univariate/parametric/logistic.py
@@ -364,7 +364,7 @@ class Logistic_(ParametricFitter):
         d = self.mgf
         for i in range(n):
             d = grad(d)
-        return d(np.array([0]), mu, sigma)
+        return d(0.0, mu, sigma)
 
     def mpp_x_transform(self, x, gamma=0):
         return x - gamma


### PR DESCRIPTION
Completes Phase 3 (numpy 2.x) of the DEVELOPMENT.md upgrade plan; the
full test suite (477 tests) now passes against numpy 2.4.6.

Library fixes:
- Logistic.moment: differentiate the MGF at a scalar instead of a
  1-element array, which numpy 2.x no longer accepts as a scalar
- Gamma MPP (rr='x'): extract the lstsq coefficient as a scalar so
  model.params is not a ragged list (np.atleast_1d now raises)
- MPS fitter: skip Newton-CG when the autograd Hessian at the initial
  guess is identically zero (all-shape-parameter distributions such as
  Beta), where Newton-CG reported success without moving; fall back to
  BFGS. Fixes badly biased Beta MPS fits on truncated data
- log_rank_split: replace removed-in-spirit np.in1d with np.isin, fix
  min_leaf_failures off-by-one (<= vs <), guard negative variance in
  the log-rank denominator, and refresh the stale docstring
- Random survival forest: repair the module so it is constructible
  again after the SurpyvalData reorg - SurvivalTree.fit passed
  positional arguments to the wrong parameters, parse_leaf_type
  crashed on the bool the forest passes, max-depth terminal nodes
  dropped the parametric flag, SurvivalTree.sf returned ff, 1-d Z
  training input was oriented as one sample instead of one feature,
  and single-covariate-vector predictions now return 1-d arrays as
  documented
- Add missing joblib dependency (imported by the forest module)

Test fixes:
- Replace int(np.random.uniform(..., size=1)) and size-1 array element
  assignment, both errors under numpy 2.x
- Update forest tests to the SurpyvalData-based fit() API
- CoxPH formula test: formulaic now preserves formula order, so
  compare betas directly instead of alphabetically reordering
- Fix two error-message regexes that never matched

https://claude.ai/code/session_017RBTrtJ54QfxYyVEvNmo5y