### PR TITLE
Univariate parametric: bug fixes, distributions subpackage, and deduplication

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Notes
 
-This document tracks known issues, technical debt, and improvement priorities for surpyval. Issues are grouped by theme and ordered by severity within each section. Implemented items are removed; this reflects the state of the codebase as of 2026-06-11. The full test suite passes on Python 3.11+ with numpy 2.x / scipy 1.17 / pandas 3.x.
+This document tracks known issues, technical debt, and improvement priorities for surpyval. Issues are grouped by theme and ordered by severity within each section. Implemented items are removed; this reflects the state of the codebase as of 2026-06-12. The full test suite passes on Python 3.11+ with numpy 2.x / scipy 1.17 / pandas 3.x.
 
 ---
 
@@ -18,10 +18,10 @@ This document tracks known issues, technical debt, and improvement priorities fo
 
 **File:** `surpyval/univariate/parametric/fitters/mle.py`
 
-### Hessian computed in wrong parameterization space (lines 158-168)
+### Hessian computed in wrong parameterization space (lines 163-173)
 Standard errors should be derived from the Hessian in the *transformed* (unbounded) parameterization used during optimization, then mapped back via the delta method. Computing in physical parameter space (`transform=False`) gives incorrect standard errors for any bounded parameter.
 
-### Optimizer cascade does not warm-start (lines 72-90)
+### Optimizer cascade does not warm-start (lines 78-96)
 All five methods (Nelder-Mead → Powell → BFGS → TNC → Newton-CG) start from the same cold `init`. Gradient methods should warm-start from the best-found point so far.
 
 ---
@@ -36,13 +36,58 @@ All five methods (Nelder-Mead → Powell → BFGS → TNC → Newton-CG) start f
 | `MixtureModel`, `SeriesModel`, `ParallelModel` | `surpyval/univariate/parametric/` | No tests at all |
 | Recurrence/NHPP (`Crow`, `Duane`, `CoxLewis`, `CrowAMSAA`, `HPP`) | `surpyval/recurrent/parametric/` | Only `GeneralizedOneRenewal` has a test (`tests/recurrent/test_counting.py`) |
 | `AcceleratedFailureTime` regression variants | `surpyval/univariate/regression/accelerated_failure_time/` | `test_regression.py` covers ALT/PH paths only |
-| Serialization (`to_dict` / `from_dict` / `to_json`) | `test_to_dict.py` is 0 bytes | `to_dict` is abstract on the `Distribution` ABC but has no coverage |
+| Serialization (`to_dict` / `from_dict` / `to_json`) | `test_to_dict.py` is 0 bytes | `to_dict` is abstract on the `Distribution` ABC but has no coverage; `Bernoulli`/`ExactEventTime` round-trips are covered in `test_regressions.py` but the general path is not |
+| Probability plotting (`get_plot_data` / `plot` / `probability_plotting.py`) | `surpyval/univariate/parametric/` | No tests at all; the June 2026 plotting refactor was verified only by ad-hoc before/after output comparison |
 
 Two crash bugs fixed in June 2026 (a `warnings.warng` typo and a `0 * inf = NaN` in `InstantlyOccurs.Hf`) lived in these untested areas — coverage here pays for itself immediately.
 
 ---
 
 ## 3. API Consistency Issues
+
+### `cs()` means different things in different distributions
+The conditional survival function is `sf(x + X) / sf(X)` ("survive a
+further `x` given survival to `X`") in ten distributions, but
+`sf(x) / sf(X)` (absolute time, returns values > 1 for `x < X`) in
+Weibull and Rayleigh (`distributions/weibull.py`,
+`distributions/rayleigh.py`). The same method name silently computes
+different quantities depending on the distribution. `Parametric.cs`'s
+docstring example assumes the absolute-time convention; note also that
+its gamma handling (`self.dist.cs(x - gamma, X - gamma, ...)`) is only
+correct under that convention. Pick one definition (the
+further-survival form is the majority and the more standard), fix the
+two outliers, and document it. This changes results for existing
+Weibull/Rayleigh `cs` users, so it needs a release note.
+
+### Weibull is the only distribution with a closed-form `R_cb`
+**File:** `surpyval/univariate/parametric/distributions/weibull.py`
+
+Every other distribution's closed-form confidence bound was dead code
+(removed June 2026) and they all use the generic autograd delta-method
+bound in `Parametric.cb`. Weibull's survives because it is actually
+reachable. The two methods differ by up to ~7% (the closed form
+expands in log-log "u-space", the generic in logit-space; both are
+valid first-order delta methods). Decide whether to delete Weibull's
+closed form so all distributions are consistent — a user-visible
+change to Weibull confidence bounds — or keep it and document why
+Weibull is special.
+
+### `entropy` is declared by the ABC but implemented by four distributions
+`Distribution` (`distribution.py`) declares `entropy()`, and
+`Parametric.entropy` delegates to the underlying distribution, but only
+Bernoulli, Exponential, Rayleigh and Weibull implement it. Calling
+`model.entropy()` on the other ten raises `AttributeError`. Either
+implement the closed forms (all are textbook), provide a numerical
+default on `ParametricFitter`, or stop declaring it on the ABC.
+
+### `SeriesModel` / `ParallelModel` are unexported and undocumented
+**Files:** `surpyval/univariate/parametric/series.py`, `parallel.py`
+
+They support a nice composition API (`model_a | model_b`,
+`model_a & model_b`) but are not exported from
+`surpyval.univariate.parametric`, have no docstrings, and implement
+only `sf/ff/df/hf/Hf` (no `params`, `fit`, serialization or bounds).
+Either make them public properly or mark them experimental.
 
 ### `cb()` default `on` parameter differs between `Parametric` and `NonParametric`
 `Parametric.cb()` (`parametric.py`) defaults to `on='R'`; `NonParametric.cb()` (`nonparametric.py`) defaults to `on='sf'`. Both strings refer to the survival function in the same conditional.
@@ -61,6 +106,58 @@ The class body is mostly a commented-out likelihood/jacobian/hessian implementat
 ---
 
 ## 4. Code Quality
+
+### Turnbull heuristic downgrade never takes effect
+**File:** `surpyval/univariate/parametric/parametric_fitter.py` (`_validate_fit_inputs`, ~line 344)
+
+The block that swaps the memory-hungry Turnbull heuristic for the
+plain estimator when there is no left/interval censoring or
+right-truncation assigns to a local variable and returns `True`, so the
+caller never sees the downgrade — the optimization has never applied.
+Fix by returning the adjusted heuristic and using it in
+`fit_from_surpyval_data`. Results should be equivalent, but plotting
+points and performance change, so verify against a Turnbull fixture.
+
+### Structural refactors in the univariate parametric module
+Deferred from the June 2026 clean-up (sections 1–5 of that review are
+done):
+
+- `ParametricFitter.fit_from_surpyval_data` (~200 lines) mixes
+  truncation clamping, validation, initial-guess derivation, fitter
+  dispatch and support assignment. Extract `_initial_guess(...)` and
+  `_set_support(model)`; the LFP/ZI guess blocks are already
+  self-contained.
+- `Parametric.cb` (~135 lines) builds nested closures for the hf/df
+  bounds. Extract the per-function bound computations.
+- `probability_plotting.probability_plot_data` special-cases
+  distributions by name with `dist.name in ("Beta")` — string
+  membership on a *string*, not a tuple, so any distribution whose name
+  is a substring of "Beta" would match. Replace the name-based
+  branching with a `plot_x_limits` hook on the distribution.
+- `Uniform` declares `support=(-np.inf, np.inf)` as a workaround (see
+  the comment in `distributions/uniform.py`), and the NaN-support
+  branch in `fit_from_surpyval_data` (with its `TODO: More general
+  support setting. i.e. 4 parameter Beta`) appears unreachable now.
+  Design proper data-dependent support setting.
+- `MixtureModel` composes rather than inherits: it now shares the
+  probability-plot code but still reimplements `sf/ff/df/mean/random`
+  aggregation and its own `R_cb`, and sets most attributes outside
+  `__init__`.
+
+### Type hints are vestigial
+The package ships `py.typed`, but only `ParametricFitter.__init__` is
+annotated. Either grow annotations outward (fitter signatures and
+`fit()` are the highest-value targets) or remove the `py.typed`
+marker; the current state advertises typing that doesn't exist.
+
+### Docstring examples are not doctested
+Most distribution docstring examples now execute correctly (Rayleigh's
+and GumbelLEV's were rewritten with verified outputs in June 2026),
+but scalar-returning examples (`mean`, `moment`) print pre-numpy-2
+style plain floats, so `pytest --doctest-modules` fails on them.
+Decide a policy: either render with `np.float64(...)` reprs and run
+doctests in CI, or keep the readable plain-float style and accept that
+examples are unchecked.
 
 ### Triplicated simulation block
 The same "simulate timelines to `T`" loop appears three times:

--- a/surpyval/tests/univariate/parametric/test_distributions_math.py
+++ b/surpyval/tests/univariate/parametric/test_distributions_math.py
@@ -16,6 +16,7 @@ import pytest
 from surpyval import (
     Beta,
     ExpoWeibull,
+    Exponential,
     Gamma,
     Gumbel,
     GumbelLEV,
@@ -23,6 +24,8 @@ from surpyval import (
     LogLogistic,
     LogNormal,
     Normal,
+    Rayleigh,
+    Uniform,
     Weibull,
 )
 
@@ -38,6 +41,9 @@ DIST_PARAMS = [
     (Beta, (2.0, 5.0)),
     (ExpoWeibull, (3.0, 1.5, 0.8)),
     (Gamma, (3.0, 2.0)),
+    (Exponential, (0.5,)),
+    (Rayleigh, (3.0,)),
+    (Uniform, (2.0, 8.0)),
 ]
 
 DIST_PARAM_IDS = [d.name for d, _ in DIST_PARAMS]

--- a/surpyval/tests/univariate/parametric/test_regressions.py
+++ b/surpyval/tests/univariate/parametric/test_regressions.py
@@ -4,7 +4,14 @@ Regression tests for specific bug fixes in the univariate parametric module.
 import numpy as np
 import pytest
 
-from surpyval import Beta, ExactEventTime, LogLogistic, Normal, Weibull
+from surpyval import (
+    Beta,
+    ExactEventTime,
+    Exponential,
+    LogLogistic,
+    Normal,
+    Weibull,
+)
 
 
 def test_mse_with_offset():
@@ -68,3 +75,16 @@ def test_mpp_left_censoring_heuristic_error_message():
     c = np.array([-1, 0, 0, 0, 0])
     with pytest.raises(ValueError, match="Turnbull"):
         Weibull.fit(x, c, how="MPP", heuristic="Nelson-Aalen")
+
+
+def test_exponential_mpp():
+    # Exponential's custom mpp returned a bare tuple instead of a results
+    # dict, so fitting with how="MPP" raised an AttributeError.
+    np.random.seed(1)
+    x = Exponential.random(100, 0.2)
+
+    model = Exponential.fit(x, how="MPP")
+    assert np.isclose(model.params[0], 0.2, rtol=0.3)
+
+    model = Exponential.fit(x + 3, how="MPP", offset=True)
+    assert np.isclose(model.gamma, 3, atol=1)

--- a/surpyval/tests/univariate/parametric/test_regressions.py
+++ b/surpyval/tests/univariate/parametric/test_regressions.py
@@ -1,15 +1,18 @@
 """
 Regression tests for specific bug fixes in the univariate parametric module.
 """
+
 import numpy as np
 import pytest
 
 from surpyval import (
+    Bernoulli,
     Beta,
     ExactEventTime,
     Exponential,
     LogLogistic,
     Normal,
+    Parametric,
     Weibull,
 )
 
@@ -88,3 +91,17 @@ def test_exponential_mpp():
 
     model = Exponential.fit(x + 3, how="MPP", offset=True)
     assert np.isclose(model.gamma, 3, atol=1)
+
+
+def test_bernoulli_dict_round_trip():
+    # Bernoulli_ did not subclass ParametricFitter, so from_dict rejected
+    # its own to_dict output as an unknown distribution.
+    model = Bernoulli.from_params(0.3)
+    recovered = Parametric.from_dict(model.to_dict())
+    assert np.allclose(recovered.params, model.params)
+
+
+def test_exact_event_time_dict_round_trip():
+    model = ExactEventTime.from_params(10)
+    recovered = Parametric.from_dict(model.to_dict())
+    assert np.allclose(recovered.params, model.params)

--- a/surpyval/univariate/parametric/distributions/bernoulli.py
+++ b/surpyval/univariate/parametric/distributions/bernoulli.py
@@ -70,7 +70,7 @@ class Bernoulli_(ParametricFitter):
         Returns
         -------
 
-        sf : scalar or numpy array
+        ff : scalar or numpy array
             The value(s) of the failure function at x.
 
         Examples
@@ -78,7 +78,7 @@ class Bernoulli_(ParametricFitter):
         >>> import numpy as np
         >>> from surpyval import Bernoulli
         >>> x = np.array([1, 2, 3, 4, 5])
-        >>> Bernoulli.sf(x, 0.5)
+        >>> Bernoulli.ff(x, 0.5)
         array([0.5, 0.5, 0.5, 0.5, 0.5])
         """
         return np.ones_like(x).astype(float) * p

--- a/surpyval/univariate/parametric/distributions/bernoulli.py
+++ b/surpyval/univariate/parametric/distributions/bernoulli.py
@@ -1,21 +1,22 @@
 from scipy.stats import uniform
 
 from surpyval import np
+from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
 
 from ..parametric import Parametric
 
 
-class Bernoulli_:
+class Bernoulli_(ParametricFitter):
     def __init__(self, name):
-        self.name = name
-        # Set 'k', the number of parameters
-        self.k = 1
-        self.bounds = ((0, 1),)
-        self.support = (0, 1)
-        self.param_names = ["p"]
-        self.param_map = {
-            "p": 0,
-        }
+        super().__init__(
+            name=name,
+            k=1,
+            bounds=((0, 1),),
+            support=(0, 1),
+            param_names=["p"],
+            param_map={"p": 0},
+            plot_x_scale="linear",
+        )
 
     def sf(self, x, p):
         r"""
@@ -145,9 +146,9 @@ class Bernoulli_:
         if not np.equal(x, np.array([0, 1])).all():
             raise ValueError("'x' must be either 0 or 1")
 
-        model = Parametric(self, "MLE", {}, False, False, False)
+        model = Parametric(self, "MLE", None, False, False, False)
         p = (x * n).sum() / n.sum()
-        model.params = [p]
+        model.params = np.array([p])
         return model
 
     def from_params(self, p):
@@ -159,8 +160,8 @@ class Bernoulli_:
         if p < 0:
             raise ValueError("'p' must be greater than 0")
 
-        model = Parametric(self, "given parameters", {}, False, False, False)
-        model.params = p.tolist()
+        model = Parametric(self, "given parameters", None, False, False, False)
+        model.params = p
         return model
 
 

--- a/surpyval/univariate/parametric/distributions/beta.py
+++ b/surpyval/univariate/parametric/distributions/beta.py
@@ -375,15 +375,5 @@ class Beta_(ParametricFitter):
 
         return alpha, beta
 
-    def var_R(self, dR, cv_matrix):
-        dr_dalpha = dR[:, 0]
-        dr_dbeta = dR[:, 1]
-        var_r = (
-            dr_dalpha**2 * cv_matrix[0, 0]
-            + dr_dbeta**2 * cv_matrix[1, 1]
-            + 2 * dr_dalpha * dr_dbeta * cv_matrix[0, 1]
-        )
-        return var_r
-
 
 Beta: ParametricFitter = Beta_("Beta")

--- a/surpyval/univariate/parametric/distributions/beta.py
+++ b/surpyval/univariate/parametric/distributions/beta.py
@@ -2,8 +2,6 @@ from autograd.scipy.special import beta as abeta
 from autograd.scipy.special import betaln as abetaln
 from scipy.special import betaincinv
 from scipy.special import gamma as gamma_func
-from scipy.stats import uniform
-
 from surpyval import np
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
 from surpyval.utils.autograd_gamma_compat import betainc as abetainc
@@ -20,32 +18,6 @@ class Beta_(ParametricFitter):
             param_names=["alpha", "beta"],
             param_map={"alpha": 0, "beta": 1},
             plot_x_scale="linear",
-            y_ticks=[
-                0.0001,
-                0.0002,
-                0.0003,
-                0.001,
-                0.002,
-                0.003,
-                0.005,
-                0.01,
-                0.02,
-                0.03,
-                0.05,
-                0.1,
-                0.2,
-                0.3,
-                0.4,
-                0.5,
-                0.6,
-                0.7,
-                0.8,
-                0.9,
-                0.95,
-                0.99,
-                0.999,
-                0.9999,
-            ],
         )
 
     def _parameter_initialiser(self, x, c=None, n=None):
@@ -358,43 +330,6 @@ class Beta_(ParametricFitter):
         0.75
         """
         return gamma_func(n + alpha) / (beta**n * gamma_func(alpha))
-
-    def random(self, size, alpha, beta):
-        r"""
-        Draws random samples from the distribution in shape `size`
-
-        Parameters
-        ----------
-
-        size : integer or tuple of positive integers
-            Shape or size of the random draw
-        alpha : numpy array or scalar
-            One shape parameter for the Beta distribution
-        beta : numpy array or scalar
-            Another scale parameter for the Beta distribution
-
-        Returns
-        -------
-
-        random : scalar or numpy array
-            Random values drawn from the distribution in shape `size`
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from surpyval import Beta
-        >>> Beta.random(10, 3, 4)
-        array([0.48969376, 0.50266801, 0.66913503, 0.3031257 , 0.60897905,
-               0.34901845, 0.34196432, 0.37401123, 0.06191741, 0.17604693])
-        >>> Beta.random((5, 5), 3, 4)
-        array([[0.68575237, 0.39409872, 0.18546004, 0.51266116, 0.55043579],
-               [0.62656723, 0.69497065, 0.68958488, 0.37330801, 0.57053267],
-               [0.07330674, 0.68020665, 0.42907148, 0.51884251, 0.12159803],
-               [0.3566228 , 0.55493446, 0.59288881, 0.43542773, 0.31740851],
-               [0.82044756, 0.23062323, 0.35342936, 0.2902573 , 0.54522114]])
-        """
-        U = uniform.rvs(size=size)
-        return self.qf(U, alpha, beta)
 
     def log_df(self, x, alpha, beta):
         return (

--- a/surpyval/univariate/parametric/distributions/beta.py
+++ b/surpyval/univariate/parametric/distributions/beta.py
@@ -20,7 +20,7 @@ class Beta_(ParametricFitter):
             plot_x_scale="linear",
         )
 
-    def _parameter_initialiser(self, x, c=None, n=None):
+    def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         if (c is not None) & ((c == 0).all()):
             x = np.repeat(x, n)
             p = self._mom(x)
@@ -341,11 +341,11 @@ class Beta_(ParametricFitter):
     def log_ff(self, x, alpha, beta):
         return abetaincln(alpha, beta, x)
 
-    def mpp_y_transform(self, y, alpha, beta):
-        return self.qf(y, alpha, beta)
+    def mpp_y_transform(self, y, *params):
+        return self.qf(y, *params)
 
-    def mpp_inv_y_transform(self, y, alpha, beta):
-        return abetainc(y, alpha, beta)
+    def mpp_inv_y_transform(self, y, *params):
+        return abetainc(y, *params)
 
     def mpp_x_transform(self, x, gamma=0):
         return x - gamma

--- a/surpyval/univariate/parametric/distributions/beta.py
+++ b/surpyval/univariate/parametric/distributions/beta.py
@@ -50,7 +50,7 @@ class Beta_(ParametricFitter):
         Returns
         -------
 
-        df : scalar or numpy array
+        sf : scalar or numpy array
             The value(s) of the reliability function at x.
 
         Examples
@@ -87,7 +87,7 @@ class Beta_(ParametricFitter):
         Returns
         -------
 
-        df : scalar or numpy array
+        cs : scalar or numpy array
             The value(s) of the conditional survival function at x.
 
         Examples
@@ -121,7 +121,7 @@ class Beta_(ParametricFitter):
         Returns
         -------
 
-        df : scalar or numpy array
+        ff : scalar or numpy array
             The value(s) of the failure function at x.
 
         Examples
@@ -190,7 +190,7 @@ class Beta_(ParametricFitter):
         Returns
         -------
 
-        df : scalar or numpy array
+        hf : scalar or numpy array
             The value(s) of the instantaneous hazard rate at x.
 
         Examples
@@ -224,8 +224,8 @@ class Beta_(ParametricFitter):
         Returns
         -------
 
-        df : scalar or numpy array
-            The value(s) of the cumulative hazard function at x.
+        Hf : scalar or numpy array
+            The value(s) of the cumulative hazard rate at x.
 
         Examples
         --------

--- a/surpyval/univariate/parametric/distributions/beta.py
+++ b/surpyval/univariate/parametric/distributions/beta.py
@@ -21,7 +21,7 @@ class Beta_(ParametricFitter):
         )
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
-        if (c is not None) & ((c == 0).all()):
+        if (c is not None) and (c == 0).all():
             x = np.repeat(x, n)
             p = self._mom(x)
         else:

--- a/surpyval/univariate/parametric/distributions/custom_distribution.py
+++ b/surpyval/univariate/parametric/distributions/custom_distribution.py
@@ -74,7 +74,7 @@ class CustomDistribution(ParametricFitter):
         if "f0" in param_names:
             detail = (
                 "'f0' reserved parameter name for zero"
-                + "inflated or hurdle models"
+                "inflated or hurdle models"
             )
             raise ValueError(detail)
 

--- a/surpyval/univariate/parametric/distributions/exact_event_time.py
+++ b/surpyval/univariate/parametric/distributions/exact_event_time.py
@@ -1,20 +1,21 @@
 import surpyval
 from surpyval import np
+from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
 
 from ..parametric import Parametric
 
 
-class ExactEventTime_:
+class ExactEventTime_(ParametricFitter):
     def __init__(self, name):
-        self.name = name
-        # Set 'k', the number of parameters
-        self.k = 1
-        self.bounds = ((-np.inf, np.inf),)
-        self.support = (-np.inf, np.inf)
-        self.param_names = ["T"]
-        self.param_map = {
-            "T": 0,
-        }
+        super().__init__(
+            name=name,
+            k=1,
+            bounds=((None, None),),
+            support=(-np.inf, np.inf),
+            param_names=["T"],
+            param_map={"T": 0},
+            plot_x_scale="linear",
+        )
 
     def sf(self, x, T):
         x = np.atleast_1d(x)
@@ -63,13 +64,13 @@ class ExactEventTime_:
 
         T = (max_r + min_l) / 2.0
 
-        model = Parametric(self, "MLE", {}, False, False, False)
-        model.params = [T]
+        model = Parametric(self, "MLE", None, False, False, False)
+        model.params = np.array([T])
         return model
 
     def from_params(self, T):
-        model = Parametric(self, "from_params", {}, False, False, False)
-        model.params = [T]
+        model = Parametric(self, "from_params", None, False, False, False)
+        model.params = np.array([T])
         return model
 
 

--- a/surpyval/univariate/parametric/distributions/expo_weibull.py
+++ b/surpyval/univariate/parametric/distributions/expo_weibull.py
@@ -1,6 +1,4 @@
 from scipy import integrate
-from scipy.stats import uniform
-
 from surpyval import np
 from surpyval.univariate import parametric as para
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
@@ -20,32 +18,6 @@ class ExpoWeibull_(ParametricFitter):
             param_names=["alpha", "beta", "mu"],
             param_map={"alpha": 0, "beta": 1, "mu": 2},
             plot_x_scale="log",
-            y_ticks=[
-                0.0001,
-                0.0002,
-                0.0003,
-                0.001,
-                0.002,
-                0.003,
-                0.005,
-                0.01,
-                0.02,
-                0.03,
-                0.05,
-                0.1,
-                0.2,
-                0.3,
-                0.4,
-                0.5,
-                0.6,
-                0.7,
-                0.8,
-                0.9,
-                0.95,
-                0.99,
-                0.999,
-                0.9999,
-            ],
         )
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
@@ -356,10 +328,6 @@ class ExpoWeibull_(ParametricFitter):
 
         top = 2 * self.qf(0.999, alpha, beta, mu)
         return integrate.quadrature(func, 0, top)[0]
-
-    def random(self, size, alpha, beta, mu):
-        U = uniform.rvs(size=size)
-        return self.qf(U, alpha, beta, mu)
 
     def mpp_x_transform(self, x, gamma=0):
         return np.log(x - gamma)

--- a/surpyval/univariate/parametric/distributions/expo_weibull.py
+++ b/surpyval/univariate/parametric/distributions/expo_weibull.py
@@ -101,7 +101,7 @@ class ExpoWeibull_(ParametricFitter):
         Returns
         -------
 
-        sf : scalar or numpy array
+        ff : scalar or numpy array
             The value(s) of the failure function at x.
 
         Examples
@@ -138,8 +138,8 @@ class ExpoWeibull_(ParametricFitter):
         Returns
         -------
 
-        sf : scalar or numpy array
-            The value(s) of the reliability function at x.
+        cs : scalar or numpy array
+            The value(s) of the conditional survival function at x.
 
         Examples
         --------

--- a/surpyval/univariate/parametric/distributions/exponential.py
+++ b/surpyval/univariate/parametric/distributions/exponential.py
@@ -1,7 +1,6 @@
 import warnings
 
 from scipy.special import factorial
-from scipy.special import ndtri as z
 from surpyval import np
 from surpyval.univariate.nonparametric import plotting_positions
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
@@ -443,16 +442,6 @@ class Exponential_(ParametricFitter):
                 mttf = np.linalg.lstsq(y_pp, x_pp, rcond=None)[0]
                 failure_rate = 1.0 / mttf
             return tuple([failure_rate[0]])
-
-    def lambda_cb(self, x, failure_rate, cv_matrix, alpha_ci=0.05):
-        return failure_rate * np.exp(
-            np.array([-1, 1]).reshape(2, 1)
-            * (z(alpha_ci / 2) * np.sqrt(cv_matrix.item()) / failure_rate)
-        )
-
-    # def R_cb(self, x, failure_rate, cv_matrix, alpha_ci=0.05):
-    # return np.exp(-self.lambda_cb(x, failure_rate, cv_matrix,
-    # alpha_ci=alpha_ci) * x).T
 
 
 Exponential: ParametricFitter = Exponential_("Exponential")

--- a/surpyval/univariate/parametric/distributions/exponential.py
+++ b/surpyval/univariate/parametric/distributions/exponential.py
@@ -40,7 +40,7 @@ class Exponential_(ParametricFitter):
             ],
         )
 
-    def _parameter_initialiser(self, x, c=None, n=None, offset=False):
+    def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         rate = 1.0 / x[np.isfinite(x)].mean()
         if offset:
             return np.min(x) - (np.max(x) - np.min(x)) / 10.0, rate

--- a/surpyval/univariate/parametric/distributions/exponential.py
+++ b/surpyval/univariate/parametric/distributions/exponential.py
@@ -2,8 +2,6 @@ import warnings
 
 from scipy.special import factorial
 from scipy.special import ndtri as z
-from scipy.stats import uniform
-
 from surpyval import np
 from surpyval.univariate.nonparametric import plotting_positions
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
@@ -378,42 +376,6 @@ class Exponential_(ParametricFitter):
         -0.09861228866810978
         """
         return 1 - np.log(failure_rate)
-
-    def random(self, size, failure_rate):
-        r"""
-
-        Draws random samples from the distribution in shape `size`
-
-        Parameters
-        ----------
-
-        size : integer or tuple of positive integers
-            Shape or size of the random draw
-        failure_rate : numpy array or scalar
-            The scale parameter for the Exponential distribution
-
-        Returns
-        -------
-
-        random : scalar or numpy array
-            Random values drawn from the distribution in shape `size`
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from surpyval import Exponential
-        >>> Exponential.random(10, 3)
-        array([0.32480264, 0.03186663, 0.41807108, 0.74221745, 0.06133774,
-               0.2128422 , 0.36299424, 0.12250138, 0.61431089, 0.02266754])
-        >>> Exponential.random((5, 5), 3)
-        array([[0.25425552, 0.16867629, 0.21692401, 0.07020826, 0.03676643],
-               [0.65528908, 0.20774767, 0.00625475, 0.04122388, 0.07089254],
-               [1.22844679, 0.36199751, 0.564159  , 1.86811492, 0.08132478],
-               [0.33541878, 0.38614518, 0.09285907, 0.33422975, 0.32515494],
-               [0.03529228, 0.63134988, 0.45528738, 0.05037512, 0.7338039 ]])
-        """
-        U = uniform.rvs(size=size)
-        return self.qf(U, failure_rate)
 
     def log_df(self, x, failure_rate):
         return np.log(failure_rate) - failure_rate * x

--- a/surpyval/univariate/parametric/distributions/exponential.py
+++ b/surpyval/univariate/parametric/distributions/exponential.py
@@ -50,7 +50,7 @@ class Exponential_(ParametricFitter):
     def sf(self, x, failure_rate):
         r"""
 
-        Surival (or Reliability) function for the Exponential Distribution:
+        Survival (or Reliability) function for the Exponential Distribution:
 
         .. math::
             R(x) = e^{-\lambda x}

--- a/surpyval/univariate/parametric/distributions/exponential.py
+++ b/surpyval/univariate/parametric/distributions/exponential.py
@@ -152,7 +152,7 @@ class Exponential_(ParametricFitter):
         >>> Exponential.ff(x, 3)
         array([0.95021293, 0.99752125, 0.99987659, 0.99999386, 0.99999969])
         """
-        return 1 - np.exp(-failure_rate * x)
+        return -np.expm1(-failure_rate * x)
 
     def df(self, x, failure_rate):
         r"""

--- a/surpyval/univariate/parametric/distributions/exponential.py
+++ b/surpyval/univariate/parametric/distributions/exponential.py
@@ -416,7 +416,7 @@ class Exponential_(ParametricFitter):
         y_pp = self.mpp_y_transform(F)
 
         mask = np.isfinite(y_pp)
-        if mask.any():
+        if not mask.all():
             warnings.warn(
                 "Some Infinite values encountered in plotting points and have \
                 been ignored.",
@@ -431,8 +431,8 @@ class Exponential_(ParametricFitter):
             elif rr == "x":
                 params = np.polyfit(y_pp, x_pp, 1)
             failure_rate = params[0]
-            offset = -params[1] * (1.0 / failure_rate)
-            return tuple([offset, failure_rate])
+            gamma = -params[1] * (1.0 / failure_rate)
+            return {"params": np.array([failure_rate]), "gamma": gamma}
         else:
             if rr == "y":
                 x_pp = x_pp[:, np.newaxis]
@@ -441,7 +441,7 @@ class Exponential_(ParametricFitter):
                 y_pp = y_pp[:, np.newaxis]
                 mttf = np.linalg.lstsq(y_pp, x_pp, rcond=None)[0]
                 failure_rate = 1.0 / mttf
-            return tuple([failure_rate[0]])
+            return {"params": np.array([failure_rate[0]])}
 
 
 Exponential: ParametricFitter = Exponential_("Exponential")

--- a/surpyval/univariate/parametric/distributions/gamma.py
+++ b/surpyval/univariate/parametric/distributions/gamma.py
@@ -52,7 +52,7 @@ class Gamma_(ParametricFitter):
     def sf(self, x, alpha, beta):
         r"""
 
-        Surival (or Reliability) function for the Gamma Distribution:
+        Survival (or Reliability) function for the Gamma Distribution:
 
         .. math::
             R(x) = 1 - \frac{\gamma \left ( \alpha, \beta x \right )
@@ -224,7 +224,7 @@ class Gamma_(ParametricFitter):
         Returns
         -------
 
-        Hf : scalar or numpy array
+        hf : scalar or numpy array
             The instantaneous hazard rate of the distribution at each x
 
         Examples

--- a/surpyval/univariate/parametric/distributions/gamma.py
+++ b/surpyval/univariate/parametric/distributions/gamma.py
@@ -485,7 +485,7 @@ class Gamma_(ParametricFitter):
                 gamma = -params[1] / beta
 
             results["gamma"] = gamma
-            results["params"] = [alpha, beta]
+            results["params"] = np.array([alpha, beta])
 
             return results
         else:
@@ -514,7 +514,7 @@ class Gamma_(ParametricFitter):
                 )[0][0]
                 beta = 1.0 / beta
 
-            results["params"] = [alpha, beta]
+            results["params"] = np.array([alpha, beta])
 
             return results
 

--- a/surpyval/univariate/parametric/distributions/gamma.py
+++ b/surpyval/univariate/parametric/distributions/gamma.py
@@ -6,7 +6,7 @@ from autograd.scipy.special import gammaln as agammaln
 from scipy.optimize import minimize
 from scipy.special import gammaincinv
 from scipy.special import ndtri as z
-from scipy.stats import pearsonr, uniform
+from scipy.stats import pearsonr
 
 from surpyval import np
 from surpyval.univariate.nonparametric import plotting_positions
@@ -36,32 +36,6 @@ class Gamma_(ParametricFitter):
             param_names=["alpha", "beta"],
             param_map={"alpha": 0, "beta": 1},
             plot_x_scale="linear",
-            y_ticks=[
-                0.0001,
-                0.0002,
-                0.0003,
-                0.001,
-                0.002,
-                0.003,
-                0.005,
-                0.01,
-                0.02,
-                0.03,
-                0.05,
-                0.1,
-                0.2,
-                0.3,
-                0.4,
-                0.5,
-                0.6,
-                0.7,
-                0.8,
-                0.9,
-                0.95,
-                0.99,
-                0.999,
-                0.9999,
-            ],
         )
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
@@ -398,42 +372,6 @@ class Gamma_(ParametricFitter):
         0.9375
         """
         return agamma(n + alpha) / (beta**n * agamma(alpha))
-
-    def random(self, size, alpha, beta):
-        r"""
-
-        Draws random samples from the Gamma distribution in shape `size`
-
-        Parameters
-        ----------
-
-        alpha : numpy array or scalar
-            The shape parameter for the Gamma distribution
-        beta : numpy array or scalar
-            The scale parameter for the Gamma distribution
-
-        Returns
-        -------
-
-        random : scalar or numpy array
-            Random values drawn from the distribution in shape `size`
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from surpyval import Gamma
-        >>> Gamma.random(10, 3, 4)
-        array([0.22856155, 1.69542468, 0.70894789, 0.75552168, 0.76634128,
-               0.58624638, 1.03288812, 0.85768925, 0.75071764, 0.91979151])
-        >>> Gamma.random((5, 5), 3, 4)
-        array([[0.55481976, 1.02867642, 1.25525161, 0.5141736 , 0.7227451 ],
-               [1.59192864, 1.22897457, 0.80820007, 0.39872068, 0.53656654],
-               [0.80703614, 0.75406597, 0.87307426, 1.88748737, 0.78115455],
-               [1.3233755 , 0.29908068, 1.88304902, 2.65690385, 0.51018073],
-               [0.36070265, 0.48834586, 0.45623895, 0.30104303, 0.49942908]])
-        """
-        U = uniform.rvs(size=size)
-        return self.qf(U, alpha, beta)
 
     def log_df(self, x, alpha, beta):
         r"""

--- a/surpyval/univariate/parametric/distributions/gamma.py
+++ b/surpyval/univariate/parametric/distributions/gamma.py
@@ -446,8 +446,8 @@ class Gamma_(ParametricFitter):
             mask = F != 1
             warnings.warn(
                 "Some heuristic values for CDF = 1 have been "
-                + "encountered in plotting points and have been "
-                + "ignored.",
+                "encountered in plotting points and have been "
+                "ignored.",
                 stacklevel=2,
             )
             F = F[mask]
@@ -459,7 +459,7 @@ class Gamma_(ParametricFitter):
         if mask.any():
             warnings.warn(
                 "Some Infinite values encountered in plotting "
-                + "points and have been ignored.",
+                "points and have been ignored.",
                 stacklevel=2,
             )
             F = F[mask]

--- a/surpyval/univariate/parametric/distributions/gamma.py
+++ b/surpyval/univariate/parametric/distributions/gamma.py
@@ -1,11 +1,9 @@
 import warnings
 
-from autograd import jacobian
 from autograd.scipy.special import gamma as agamma
 from autograd.scipy.special import gammaln as agammaln
 from scipy.optimize import minimize
 from scipy.special import gammaincinv
-from scipy.special import ndtri as z
 from scipy.stats import pearsonr
 
 from surpyval import np
@@ -519,42 +517,6 @@ class Gamma_(ParametricFitter):
             results["params"] = [alpha, beta]
 
             return results
-
-    def var_R(self, dR, cv_matrix):
-        dr_dalpha = dR[:, 0]
-        dr_dbeta = dR[:, 1]
-        var_r = (
-            dr_dalpha**2 * cv_matrix[0, 0]
-            + dr_dbeta**2 * cv_matrix[1, 1]
-            + 2 * dr_dalpha * dr_dbeta * cv_matrix[0, 1]
-        )
-        return var_r
-
-    def R_cb_(self, x, alpha, beta, cv_matrix, alpha_ci=0.05):
-        R_hat = self.sf(x, alpha, beta)
-
-        def dR_f(t):
-            return self.sf(*t)
-
-        jac = jacobian(dR_f)
-        x_ = np.array(x)
-        if x_.size == 1:
-            dR = jac(np.array((x_, alpha, beta))[1::])
-            dR = dR.reshape(1, 2)
-        else:
-            out = []
-            for xx in x_:
-                out.append(jac(np.array((xx, alpha, beta)))[1::])
-            dR = np.array(out)
-        K = z(alpha_ci / 2)
-        exponent = (
-            K
-            * np.array([-1, 1]).reshape(2, 1)
-            * np.sqrt(self.var_R(dR, cv_matrix))
-        )
-        exponent = exponent / (R_hat * (1 - R_hat))
-        R_cb = R_hat / (R_hat + (1 - R_hat) * np.exp(exponent))
-        return R_cb.T
 
 
 Gamma: ParametricFitter = Gamma_("Gamma")

--- a/surpyval/univariate/parametric/distributions/gumbel.py
+++ b/surpyval/univariate/parametric/distributions/gumbel.py
@@ -27,7 +27,7 @@ class Gumbel_(ParametricFitter):
     def sf(self, x, mu, sigma):
         r"""
 
-        Surival (or Reliability) function for the Gumbel Distribution:
+        Survival (or Reliability) function for the Gumbel Distribution:
 
         .. math::
             R(x) = 1 - e^{e^{-\left ( x - \mu \right ) / \sigma}}

--- a/surpyval/univariate/parametric/distributions/gumbel.py
+++ b/surpyval/univariate/parametric/distributions/gumbel.py
@@ -1,6 +1,6 @@
 from numpy import euler_gamma
 from scipy.special import ndtri as z
-from scipy.stats import gumbel_l, uniform
+from scipy.stats import gumbel_l
 
 from surpyval import np
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
@@ -16,32 +16,6 @@ class Gumbel_(ParametricFitter):
             param_names=["mu", "sigma"],
             param_map={"mu": 0, "sigma": 1},
             plot_x_scale="linear",
-            y_ticks=[
-                0.0001,
-                0.0002,
-                0.0003,
-                0.001,
-                0.002,
-                0.003,
-                0.005,
-                0.01,
-                0.02,
-                0.03,
-                0.05,
-                0.1,
-                0.2,
-                0.3,
-                0.4,
-                0.5,
-                0.6,
-                0.7,
-                0.8,
-                0.9,
-                0.95,
-                0.99,
-                0.999,
-                0.9999,
-            ],
         )
 
     def _parameter_initialiser(self, x, c=None, n=None, offset=True):
@@ -311,44 +285,6 @@ class Gumbel_(ParametricFitter):
         4.1544313298030655
         """
         return mu + sigma * euler_gamma
-
-    def random(self, size, mu, sigma):
-        r"""
-
-        Draws random samples from the distribution in shape `size`
-
-        Parameters
-        ----------
-
-        size : integer or tuple of positive integers
-            Shape or size of the random draw
-        mu : numpy array like or scalar
-            The location parameter(s) of the distribution
-        sigma : numpy array like or scalar
-            The scale parameter(s) of the distribution
-
-        Returns
-        -------
-
-        random : scalar or numpy array
-            Random values drawn from the distribution in shape `size`
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from surpyval import Gumbel
-        >>> Gumbel.random(10, 3, 2)
-        array([1.50706388, 3.3098799 , 4.32358009, 2.9914246 , 4.47216839,
-               3.56676358, 4.19781514, 4.49123942, 7.29849677, 6.32996653])
-        >>> Gumbel.random((5, 5), 3, 2)
-        array([[ 5.97265715, 5.89177067, 2.95883424, 2.46315557, 5.15250379],
-               [ 2.33808212, 7.42817091, 0.90560051, 8.05897841, 6.30714544],
-               [ 6.13076426, 6.31925048, 4.34031705, 3.01309504, -0.70053049],
-               [ 5.84888474, 5.95097491, 6.23960618, 6.24830057, 4.89655192],
-               [ 6.29507963, 4.21798292, 4.22835474, 5.23521822, 2.76053242]])
-        """
-        U = uniform.rvs(size=size)
-        return self.qf(U, mu, sigma)
 
     def log_df(self, x, mu, sigma):
         z = (x - mu) / sigma

--- a/surpyval/univariate/parametric/distributions/gumbel.py
+++ b/surpyval/univariate/parametric/distributions/gumbel.py
@@ -17,7 +17,7 @@ class Gumbel_(ParametricFitter):
             plot_x_scale="linear",
         )
 
-    def _parameter_initialiser(self, x, c=None, n=None, offset=True):
+    def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         if (2 in c) or (-1 in c):
             heuristic = "Turnbull"
         else:

--- a/surpyval/univariate/parametric/distributions/gumbel.py
+++ b/surpyval/univariate/parametric/distributions/gumbel.py
@@ -1,5 +1,4 @@
 from numpy import euler_gamma
-from scipy.special import ndtri as z
 from scipy.stats import gumbel_l
 
 from surpyval import np
@@ -320,23 +319,6 @@ class Gumbel_(ParametricFitter):
             sigma = params[0]
             mu = params[1]
         return mu, sigma
-
-    def var_z(self, x, mu, sigma, cv_matrix):
-        z_hat = (x - mu) / sigma
-        var_z = (1.0 / sigma) ** 2 * (
-            cv_matrix[0, 0]
-            + z_hat**2 * cv_matrix[1, 1]
-            + 2 * z_hat * cv_matrix[0, 1]
-        )
-        return var_z
-
-    def z_cb(self, x, mu, sigma, cv_matrix, alpha_ci=0.05):
-        z_hat = (x - mu) / sigma
-        var_z = self.var_z(x, mu, sigma, cv_matrix)
-        bounds = z_hat + np.array([1.0, -1.0]).reshape(2, 1) * z(
-            alpha_ci / 2
-        ) * np.sqrt(var_z)
-        return bounds
 
 
 Gumbel: ParametricFitter = Gumbel_("Gumbel")

--- a/surpyval/univariate/parametric/distributions/gumbel_lev.py
+++ b/surpyval/univariate/parametric/distributions/gumbel_lev.py
@@ -24,10 +24,10 @@ class GumbelLEV_(ParametricFitter):
     def sf(self, x, mu, sigma):
         r"""
 
-        Surival (or Reliability) function for the Gumbel Distribution:
+        Survival (or reliability) function for the Gumbel LEV Distribution:
 
         .. math::
-            R(x) = 1 - e^{e^{-\left ( x - \mu \right ) / \sigma}}
+            R(x) = 1 - e^{-e^{-\left ( x - \mu \right ) / \sigma}}
 
         Parameters
         ----------
@@ -53,10 +53,10 @@ class GumbelLEV_(ParametricFitter):
         Examples
         --------
         >>> import numpy as np
-        >>> from surpyval import Gumbel
+        >>> from surpyval import GumbelLEV
         >>> x = np.array([1, 2, 3, 4, 5])
-        >>> Gumbel.sf(x, 3, 2)
-        array([0.69220063, 0.54523921, 0.36787944, 0.19229565, 0.06598804])
+        >>> GumbelLEV.sf(x, 3, 2)
+        array([0.93401196, 0.80770435, 0.63212056, 0.45476079, 0.30779937])
         """
         return 1 - self.ff(x, mu, sigma)
 
@@ -66,10 +66,10 @@ class GumbelLEV_(ParametricFitter):
     def ff(self, x, mu, sigma):
         r"""
 
-        CDF (or Failure) function for the Gumbel Distribution:
+        CDF (or Failure) function for the Gumbel LEV Distribution:
 
         .. math::
-            F(x) = e^{e^{-\left ( x - \mu \right )/\sigma}}
+            F(x) = e^{-e^{-\left ( x - \mu \right )/\sigma}}
 
         Parameters
         ----------
@@ -95,10 +95,10 @@ class GumbelLEV_(ParametricFitter):
         Examples
         --------
         >>> import numpy as np
-        >>> from surpyval import Gumbel
+        >>> from surpyval import GumbelLEV
         >>> x = np.array([1, 2, 3, 4, 5])
-        >>> Gumbel.ff(x, 3, 2)
-        array([0.30779937, 0.45476079, 0.63212056, 0.80770435, 0.93401196])
+        >>> GumbelLEV.ff(x, 3, 2)
+        array([0.06598804, 0.19229565, 0.36787944, 0.54523921, 0.69220063])
         """
         z = (x - mu) / sigma
         return np.exp(-np.exp(-z))
@@ -106,11 +106,11 @@ class GumbelLEV_(ParametricFitter):
     def df(self, x, mu, sigma):
         r"""
 
-        Density function (pdf) for the Gumbel Distribution:
+        Density function (pdf) for the Gumbel LEV Distribution:
 
         .. math::
-            f(x) = \frac{1}{\sigma}e^{\left (\frac{x - \mu}{\sigma} -
-            e^{\frac{x-\mu}{\sigma}} \right)}
+            f(x) = \frac{1}{\sigma}e^{-\left (\frac{x - \mu}{\sigma} +
+            e^{-\frac{x-\mu}{\sigma}} \right)}
 
         Parameters
         ----------
@@ -135,10 +135,10 @@ class GumbelLEV_(ParametricFitter):
         Examples
         --------
         >>> import numpy as np
-        >>> from surpyval import Gumbel
+        >>> from surpyval import GumbelLEV
         >>> x = np.array([1, 2, 3, 4, 5])
-        >>> Gumbel.df(x, 3, 2)
-        array([0.12732319, 0.16535215, 0.18393972, 0.15852096, 0.08968704])
+        >>> GumbelLEV.df(x, 3, 2)
+        array([0.08968704, 0.15852096, 0.18393972, 0.16535215, 0.12732319])
         """
         z = (x - mu) / sigma
         return (1.0 / sigma) * np.exp(-(z + np.exp(-z)))
@@ -146,10 +146,10 @@ class GumbelLEV_(ParametricFitter):
     def hf(self, x, mu, sigma):
         r"""
 
-        Instantaneous hazard rate for the Gumbel Distribution:
+        Instantaneous hazard rate for the Gumbel LEV Distribution:
 
         .. math::
-            h(x) = \frac{1}{\sigma} e^{\frac{x-\mu}{\sigma}}
+            h(x) = \frac{f(x)}{R(x)}
 
         Parameters
         ----------
@@ -166,26 +166,26 @@ class GumbelLEV_(ParametricFitter):
         -------
 
         hf : scalar or numpy array
-            The value(s) for the instantaneous hazard rate for the Gumbel
+            The value(s) for the instantaneous hazard rate for the Gumbel LEV
             distribution.
 
         Examples
         --------
         >>> import numpy as np
-        >>> from surpyval import Gumbel
+        >>> from surpyval import GumbelLEV
         >>> x = np.array([1, 2, 3, 4, 5])
-        >>> Gumbel.hf(x, 3, 2)
-        array([0.18393972, 0.30326533, 0.5       , 0.82436064, 1.35914091])
+        >>> GumbelLEV.hf(x, 3, 2)
+        array([0.09602344, 0.19626112, 0.29098835, 0.36360248, 0.41365643])
         """
         return self.df(x, mu, sigma) / self.sf(x, mu, sigma)
 
     def Hf(self, x, mu, sigma):
         r"""
 
-        Cumulative hazard rate for the Gumbel Distribution:
+        Cumulative hazard rate for the Gumbel LEV Distribution:
 
         .. math::
-            H(x) = e^{\frac{x-\mu}{\sigma}}
+            H(x) = -\ln \left ( R(x) \right )
 
         Parameters
         ----------
@@ -202,23 +202,23 @@ class GumbelLEV_(ParametricFitter):
         -------
 
         Hf : scalar or numpy array
-            The value(s) for the cumulative hazard rate for the Gumbel
+            The value(s) for the cumulative hazard rate for the Gumbel LEV
             distribution.
 
         Examples
         --------
         >>> import numpy as np
-        >>> from surpyval import Gumbel
+        >>> from surpyval import GumbelLEV
         >>> x = np.array([1, 2, 3, 4, 5])
-        >>> Gumbel.Hf(x, 3, 2)
-        array([0.36787944, 0.60653066, 1.        , 1.64872127, 2.71828183])
+        >>> GumbelLEV.Hf(x, 3, 2)
+        array([0.06826603, 0.21355919, 0.45867515, 0.78798374, 1.1783071 ])
         """
         return -np.log(self.sf(x, mu, sigma))
 
     def qf(self, p, mu, sigma):
         r"""
 
-        Quantile function for the Gumbel Distribution:
+        Quantile function for the Gumbel LEV Distribution:
 
         .. math::
             q(p) = \mu - \sigma\ln\left ( -\ln\left ( p \right ) \right )
@@ -245,14 +245,15 @@ class GumbelLEV_(ParametricFitter):
         >>> from surpyval import GumbelLEV
         >>> p = np.array([.1, .2, .3, .4, .5])
         >>> GumbelLEV.qf(p, 3, 2)
-        array([0.17472351, 1.28168877, 2.05427538, 2.70479498, 3.36651292])
+        array([1.33193511, 2.04823001, 2.62874648, 3.17484314, 3.73302584])
         """
         return mu - sigma * np.log(-np.log(p))
 
     def mean(self, mu, sigma):
         r"""
 
-        Calculates the mean of the Gumbel distribution with given parameters.
+        Calculates the mean of the Gumbel LEV distribution with given
+        parameters.
 
         .. math::
             E = \mu + \sigma\gamma
@@ -271,12 +272,12 @@ class GumbelLEV_(ParametricFitter):
         -------
 
         mean : scalar or numpy array
-            The mean(s) of the Gumbel distribution
+            The mean(s) of the Gumbel LEV distribution
 
         Examples
         --------
-        >>> from surpyval import Gumbel
-        >>> Gumbel.mean(3, 2)
+        >>> from surpyval import GumbelLEV
+        >>> GumbelLEV.mean(3, 2)
         4.1544313298030655
         """
         return mu + sigma * euler_gamma

--- a/surpyval/univariate/parametric/distributions/gumbel_lev.py
+++ b/surpyval/univariate/parametric/distributions/gumbel_lev.py
@@ -1,5 +1,5 @@
 from numpy import euler_gamma
-from scipy.stats import gumbel_r, uniform
+from scipy.stats import gumbel_r
 
 from surpyval import np
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
@@ -15,32 +15,6 @@ class GumbelLEV_(ParametricFitter):
             param_names=["mu", "sigma"],
             param_map={"mu": 0, "sigma": 1},
             plot_x_scale="linear",
-            y_ticks=[
-                0.0001,
-                0.0002,
-                0.0003,
-                0.001,
-                0.002,
-                0.003,
-                0.005,
-                0.01,
-                0.02,
-                0.03,
-                0.05,
-                0.1,
-                0.2,
-                0.3,
-                0.4,
-                0.5,
-                0.6,
-                0.7,
-                0.8,
-                0.9,
-                0.95,
-                0.99,
-                0.999,
-                0.9999,
-            ],
         )
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
@@ -306,44 +280,6 @@ class GumbelLEV_(ParametricFitter):
         4.1544313298030655
         """
         return mu + sigma * euler_gamma
-
-    def random(self, size, mu, sigma):
-        r"""
-
-        Draws random samples from the distribution in shape `size`
-
-        Parameters
-        ----------
-
-        size : integer or tuple of positive integers
-            Shape or size of the random draw
-        mu : numpy array like or scalar
-            The location parameter(s) of the distribution
-        sigma : numpy array like or scalar
-            The scale parameter(s) of the distribution
-
-        Returns
-        -------
-
-        random : scalar or numpy array
-            Random values drawn from the distribution in shape `size`
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from surpyval import Gumbel
-        >>> Gumbel.random(10, 3, 2)
-        array([1.50706388, 3.3098799 , 4.32358009, 2.9914246 , 4.47216839,
-               3.56676358, 4.19781514, 4.49123942, 7.29849677, 6.32996653])
-        >>> Gumbel.random((5, 5), 3, 2)
-        array([[ 5.97265715, 5.89177067, 2.95883424, 2.46315557, 5.15250379],
-               [ 2.33808212, 7.42817091, 0.90560051, 8.05897841, 6.30714544],
-               [ 6.13076426, 6.31925048, 4.34031705, 3.01309504,-0.70053049],
-               [ 5.84888474, 5.95097491, 6.23960618, 6.24830057, 4.89655192],
-               [ 6.29507963, 4.21798292, 4.22835474, 5.23521822, 2.76053242]])
-        """
-        U = uniform.rvs(size=size)
-        return self.qf(U, mu, sigma)
 
     def log_sf(self, x, mu, sigma):
         return -self.Hf(x, mu, sigma)

--- a/surpyval/univariate/parametric/distributions/logistic.py
+++ b/surpyval/univariate/parametric/distributions/logistic.py
@@ -1,7 +1,5 @@
 from autograd import grad
 from autograd.scipy.special import beta as abeta
-from scipy.stats import uniform
-
 from surpyval import np
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
 from surpyval.utils import xcnt_handler
@@ -20,32 +18,6 @@ class Logistic_(ParametricFitter):
             param_names=["mu", "sigma"],
             param_map={"mu": 0, "sigma": 1},
             plot_x_scale="linear",
-            y_ticks=[
-                0.0001,
-                0.0002,
-                0.0003,
-                0.001,
-                0.002,
-                0.003,
-                0.005,
-                0.01,
-                0.02,
-                0.03,
-                0.05,
-                0.1,
-                0.2,
-                0.3,
-                0.4,
-                0.5,
-                0.6,
-                0.7,
-                0.8,
-                0.9,
-                0.95,
-                0.99,
-                0.999,
-                0.9999,
-            ],
         )
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
@@ -299,51 +271,6 @@ class Logistic_(ParametricFitter):
         3
         """
         return mu
-
-    def random(self, size, mu, sigma):
-        """
-
-        Draws random samples from the distribution in shape `size`
-
-        Parameters
-        ----------
-
-        size : integer or tuple of positive integers
-            Shape or size of the random draw
-        mu : numpy array or scalar
-            The location parameter for the Logistic distribution
-        sigma : numpy array or scalar
-            The scale parameter for the Logistic distribution
-
-        Returns
-        -------
-
-        random : scalar or numpy array
-            Random values drawn from the distribution in shape `size`
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from surpyval import Logistic
-        >>> Logistic.random(10, 3, 4)
-        array([-8.03085073, -1.69001847,  5.25971637,  4.49119392,
-                3.92027233,
-               -0.8320818 , -7.08778338,  5.01180405,  0.82373259,
-                8.51506487])
-        >>> Logistic.random((5, 5), 3, 4)
-        array([[ 7.11691946, 14.31662627,  8.5383889 ,  1.26608344,
-         0.97633704],
-               [-7.11229405,  8.56748118,  1.5959416 , -3.89229554,
-               -2.44623464],
-               [ 5.58805039, -0.11768336, -0.55000158,  8.5302643 ,
-                6.92591024],
-               [-2.88281091, -9.79724128, -3.80713019,  1.74120972,
-               15.37924263],
-               [-4.42521443, -0.69577732,  3.54658395,  2.82310964,
-                3.95850831]])
-        """
-        U = uniform.rvs(size=size)
-        return self.qf(U, mu, sigma)
 
     def log_df(self, x, mu, sigma):
         z = (x - mu) / sigma

--- a/surpyval/univariate/parametric/distributions/logistic.py
+++ b/surpyval/univariate/parametric/distributions/logistic.py
@@ -30,7 +30,7 @@ class Logistic_(ParametricFitter):
             return x.sum() / (n * flag).sum(), 1.0
 
     def sf(self, x, mu, sigma):
-        """
+        r"""
 
         Survival (or reliability) function for the Logistic Distribution:
 
@@ -69,7 +69,7 @@ class Logistic_(ParametricFitter):
         return self.sf(x + X, mu, sigma) / self.sf(X, mu, sigma)
 
     def ff(self, x, mu, sigma):
-        """
+        r"""
 
         Failure (CDF or unreliability) function for the Logistic Distribution:
 
@@ -104,7 +104,7 @@ class Logistic_(ParametricFitter):
         return 1.0 / (1 + np.exp(-z))
 
     def df(self, x, mu, sigma):
-        """
+        r"""
 
         Failure (CDF or unreliability) function for the Logistic Distribution:
 
@@ -141,7 +141,7 @@ class Logistic_(ParametricFitter):
         return np.exp(-z) / (sigma * (1 + np.exp(-z)) ** 2)
 
     def hf(self, x, mu, sigma):
-        """
+        r"""
 
         Instantaneous hazard rate for the Logistic Distribution:
 
@@ -175,7 +175,7 @@ class Logistic_(ParametricFitter):
         return self.df(x, mu, sigma) / self.sf(x, mu, sigma)
 
     def Hf(self, x, mu, sigma):
-        """
+        r"""
 
         Cumulative hazard rate for the Logistic distribution:
 
@@ -195,7 +195,7 @@ class Logistic_(ParametricFitter):
         Returns
         -------
 
-        hf : scalar or numpy array
+        Hf : scalar or numpy array
             The value(s) of the cumulative hazard rate at x.
 
         Examples
@@ -209,7 +209,7 @@ class Logistic_(ParametricFitter):
         return -np.log(self.sf(x, mu, sigma))
 
     def qf(self, p, mu, sigma):
-        """
+        r"""
 
         Quantile function for the Logistic distribution:
 

--- a/surpyval/univariate/parametric/distributions/loglogistic.py
+++ b/surpyval/univariate/parametric/distributions/loglogistic.py
@@ -157,7 +157,7 @@ class LogLogistic_(ParametricFitter):
         -------
 
         df : scalar or numpy array
-            The value(s) of the failure function at x.
+            The value(s) of the density function at x.
 
         Examples
         --------

--- a/surpyval/univariate/parametric/distributions/loglogistic.py
+++ b/surpyval/univariate/parametric/distributions/loglogistic.py
@@ -1,4 +1,4 @@
-from scipy.stats import fisk, uniform
+from scipy.stats import fisk
 
 from surpyval import np
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
@@ -15,66 +15,7 @@ class LogLogistic_(ParametricFitter):
             param_names=["alpha", "beta"],
             param_map={"alpha": 0, "beta": 1},
             plot_x_scale="log",
-            y_ticks=[
-                0.0001,
-                0.0002,
-                0.0003,
-                0.001,
-                0.002,
-                0.003,
-                0.005,
-                0.01,
-                0.02,
-                0.03,
-                0.05,
-                0.1,
-                0.2,
-                0.3,
-                0.4,
-                0.5,
-                0.6,
-                0.7,
-                0.8,
-                0.9,
-                0.95,
-                0.99,
-                0.999,
-                0.9999,
-            ],
         )
-        self.k = 2
-        self.bounds = (
-            (0, None),
-            (0, None),
-        )
-        self.support = (0, np.inf)
-        self.plot_x_scale = "log"
-        self.y_ticks = [
-            0.0001,
-            0.0002,
-            0.0003,
-            0.001,
-            0.002,
-            0.003,
-            0.005,
-            0.01,
-            0.02,
-            0.03,
-            0.05,
-            0.1,
-            0.2,
-            0.3,
-            0.4,
-            0.5,
-            0.6,
-            0.7,
-            0.8,
-            0.9,
-            0.95,
-            0.99,
-            0.999,
-            0.9999,
-        ]
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         if offset:
@@ -364,44 +305,6 @@ class LogLogistic_(ParametricFitter):
             return (alpha * np.pi / beta) / (np.sin(np.pi / beta))
         else:
             return np.nan
-
-    def random(self, size, alpha, beta):
-        r"""
-
-        Draws random samples from the distribution in shape `size`
-
-        Parameters
-        ----------
-
-        size : integer or tuple of positive integers
-            Shape or size of the random draw
-        alpha : numpy array or scalar
-            scale parameter for the LogLogistic distribution
-        beta : numpy array or scalar
-            shape parameter for the LogLogistic distribution
-
-        Returns
-        -------
-
-        random : scalar or numpy array
-            Random values drawn from the distribution in shape `size`
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from surpyval import LogLogistic
-        >>> LogLogistic.random(10, 3, 4)
-        array([4.46072122, 2.1336253 , 2.74159711, 2.90125715, 3.2390347 ,
-               5.45223664, 4.28281376, 2.7017541 , 3.023811  , 2.16225601])
-        >>> LogLogistic.random((5, 5), 3, 4)
-        array([[1.97744499, 4.02823921, 1.95761719, 1.20481591, 3.7166738 ],
-               [2.94863864, 3.02609811, 3.30563774, 2.39100075, 3.24937459],
-               [3.16102391, 1.77003533, 4.73831093, 0.36936215, 1.41566853],
-               [3.88505024, 2.88183095, 2.43977804, 2.62385959, 3.40881857],
-               [1.2349273 , 1.83914641, 3.68502568, 6.49834769, 8.62995574]])
-        """
-        U = uniform.rvs(size=size)
-        return self.qf(U, alpha, beta)
 
     def log_df(self, x, alpha, beta):
         return (

--- a/surpyval/univariate/parametric/distributions/lognormal.py
+++ b/surpyval/univariate/parametric/distributions/lognormal.py
@@ -346,49 +346,6 @@ class LogNormal_(ParametricFitter):
         """
         return np.exp(n * mu + (n**2 * sigma**2) / 2)
 
-    def random(self, size, mu, sigma):
-        r"""
-
-        Draws random samples from the distribution in shape `size`
-
-        Parameters
-        ----------
-
-        size : integer or tuple of positive integers
-            Shape or size of the random draw
-        mu : numpy array or scalar
-            The location parameter for the LogNormal distribution
-        sigma : numpy array or scalar
-            The scale parameter for the LogNormal distribution
-
-        Returns
-        -------
-
-        random : scalar or numpy array
-            Random values drawn from the distribution in shape `size`
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from surpyval import LogNormal
-        >>> LogNormal.random(10, 3, 4)
-        array([1.74605298e+00, 1.90729963e+02, 1.90090366e+03, 2.59154042e-02,
-               3.71460694e-02, 3.38580771e+03, 7.58826512e+04, 7.23252303e+00,
-               1.21226718e+03, 4.15054624e+00])
-        >>> LogNormal.random((5, 5), 3, 4)
-        array([[4.59689256e+00, 2.91472936e-01, 4.66833783e+02, 9.88539048e+01,
-                3.88094471e+01],
-               [7.10705735e-01, 5.00788529e-02, 2.49032431e+01, 2.19196376e+01,
-                2.05043988e+02],
-               [1.32193999e+03, 7.38943238e-01, 5.16503535e-01, 9.09249819e+02,
-                2.69407879e+03],
-               [7.29473033e+00, 5.68246498e+03, 1.74464896e+00, 1.26043004e+00,
-                3.84009666e+03],
-               [1.47997384e+00, 2.21809242e+02, 1.32564564e+02, 8.06883052e-02,
-                1.05118538e+02]])
-        """
-        return np.exp(para.Normal.random(size, mu, sigma))
-
     def log_df(self, x, mu, sigma):
         return -np.log(x) + norm.logpdf(np.log(x), mu, sigma)
 

--- a/surpyval/univariate/parametric/distributions/lognormal.py
+++ b/surpyval/univariate/parametric/distributions/lognormal.py
@@ -42,7 +42,7 @@ class LogNormal_(ParametricFitter):
     def sf(self, x, mu, sigma):
         r"""
 
-        Surival (or Reliability) function for the LogNormal Distribution:
+        Survival (or Reliability) function for the LogNormal Distribution:
 
         .. math::
             R(x) = 1 - \Phi \left( \frac{\ln(x) - \mu}{\sigma} \right )
@@ -61,7 +61,7 @@ class LogNormal_(ParametricFitter):
         -------
 
         sf : scalar or numpy array
-            The value(s) of the survival function at x.
+            The value(s) of the reliability function at x.
 
         Examples
         --------

--- a/surpyval/univariate/parametric/distributions/lognormal.py
+++ b/surpyval/univariate/parametric/distributions/lognormal.py
@@ -1,5 +1,4 @@
 from autograd.scipy.stats import norm
-from scipy.special import ndtri as z
 from scipy.stats import norm as scipy_norm
 
 from surpyval import np
@@ -373,28 +372,6 @@ class LogNormal_(ParametricFitter):
             sigma, mu = params
         return mu, sigma
 
-    def var_z(self, x, mu, sigma, cv_matrix):
-        z_hat = (x - mu) / sigma
-        var_z = (1.0 / sigma) ** 2 * (
-            cv_matrix[0, 0]
-            + z_hat**2 * cv_matrix[1, 1]
-            + 2 * z_hat * cv_matrix[0, 1]
-        )
-        return var_z
-
-    def z_cb(self, x, mu, sigma, cv_matrix, alpha_ci=0.05):
-        z_hat = (x - mu) / sigma
-        var_z = self.var_z(x, mu, sigma, cv_matrix)
-        bounds = z_hat + np.array([1.0, -1.0]).reshape(2, 1) * z(
-            alpha_ci / 2
-        ) * np.sqrt(var_z)
-        return bounds
-
-    # def R_cb(self, x, mu, sigma, cv_matrix, alpha_ci=0.05):
-    # t = np.log(x)
-    # return para.Normal.sf(self.z_cb(t, mu, sigma, cv_matrix,
-    # alpha_ci=alpha_ci), 0, 1).T
-
     def _mom(self, x):
         norm_mod = para.Normal.fit(np.log(x), how="MOM")
         mu, sigma = norm_mod.params
@@ -402,4 +379,6 @@ class LogNormal_(ParametricFitter):
 
 
 LogNormal: ParametricFitter = LogNormal_("LogNormal")
+
+
 Galton: ParametricFitter = LogNormal_("Galton")

--- a/surpyval/univariate/parametric/distributions/normal.py
+++ b/surpyval/univariate/parametric/distributions/normal.py
@@ -42,7 +42,7 @@ class Normal_(ParametricFitter):
             ],
         )
 
-    def _parameter_initialiser(self, x, c=None, n=None, t=None):
+    def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         if 2 in c:
             raise ValueError(c)
         return para.Normal.fit(

--- a/surpyval/univariate/parametric/distributions/normal.py
+++ b/surpyval/univariate/parametric/distributions/normal.py
@@ -1,5 +1,4 @@
 from autograd.scipy.stats import norm
-from scipy.special import ndtri as z
 from scipy.stats import norm as scipy_norm
 from surpyval import np
 from surpyval.univariate import parametric as para
@@ -383,27 +382,8 @@ class Normal_(ParametricFitter):
             sigma, mu = params
         return mu, sigma
 
-    def var_z(self, x, mu, sigma, cv_matrix):
-        z_hat = (x - mu) / sigma
-        var_z = (1.0 / sigma) ** 2 * (
-            cv_matrix[0, 0]
-            + z_hat**2 * cv_matrix[1, 1]
-            + 2 * z_hat * cv_matrix[0, 1]
-        )
-        return var_z
-
-    def z_cb(self, x, mu, sigma, cv_matrix, alpha_ci=0.05):
-        z_hat = (x - mu) / sigma
-        var_z = self.var_z(x, mu, sigma, cv_matrix)
-        bounds = z_hat + np.array([1.0, -1.0]).reshape(2, 1) * z(
-            alpha_ci / 2
-        ) * np.sqrt(var_z)
-        return bounds
-
-    # def R_cb(self, x, mu, sigma, cv_matrix, alpha_ci=0.05):
-    # return self.sf(self.z_cb(x, mu, sigma, cv_matrix, alpha_ci=alpha_ci), 0,
-    # 1).T
-
 
 Normal: ParametricFitter = Normal_("Normal")
+
+
 Gauss: ParametricFitter = Normal_("Gauss")

--- a/surpyval/univariate/parametric/distributions/normal.py
+++ b/surpyval/univariate/parametric/distributions/normal.py
@@ -1,8 +1,6 @@
 from autograd.scipy.stats import norm
 from scipy.special import ndtri as z
 from scipy.stats import norm as scipy_norm
-from scipy.stats import uniform
-
 from surpyval import np
 from surpyval.univariate import parametric as para
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
@@ -357,51 +355,6 @@ class Normal_(ParametricFitter):
         25.0
         """
         return scipy_norm.moment(n, mu, sigma)
-
-    def random(self, size, mu, sigma):
-        r"""
-
-        Draws random samples from the distribution in shape `size`
-
-        Parameters
-        ----------
-
-        size : integer or tuple of positive integers
-            Shape or size of the random draw
-        mu : numpy array or scalar
-            The location parameter for the Normal distribution
-        sigma : numpy array or scalar
-            The scale parameter for the Normal distribution
-
-        Returns
-        -------
-
-        random : scalar or numpy array
-            Random values drawn from the distribution in shape `size`
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from surpyval import Normal
-        >>> Normal.random(10, 3, 4)
-        array([-1.28484969, -1.68138703,  0.13414348,  6.53416927,
-                -1.95649712,
-                3.09951162,  6.90469836,  4.90063467,  1.11075072,
-                4.97841115])
-        >>> Normal.random((5, 5), 3, 4)
-        array([[ 1.57569952,  4.98472487,  3.19475597,  5.12581251,
-                -0.98020861],
-               [ 6.73877217,  1.08561611,  3.07634125,  3.54656313,
-               13.32064634],
-               [-0.45094731,  2.52588422, -1.61414841,  8.39084564,
-               -1.35261631],
-               [ 1.98090151,  8.22151826,  5.59184063, -2.62221656,
-               0.20879673],
-               [-2.0790734 ,  2.67886095,  2.54115153,  5.49853925,
-               4.57056015]])
-        """
-        U = uniform.rvs(size=size)
-        return self.qf(U, mu, sigma)
 
     def log_df(self, x, mu, sigma):
         return norm.logpdf(x, mu, sigma)

--- a/surpyval/univariate/parametric/distributions/normal.py
+++ b/surpyval/univariate/parametric/distributions/normal.py
@@ -52,7 +52,7 @@ class Normal_(ParametricFitter):
     def sf(self, x, mu, sigma):
         r"""
 
-        Surival (or Reliability) function for the Normal Distribution:
+        Survival (or Reliability) function for the Normal Distribution:
 
         .. math::
             R(x) = 1 - \Phi \left( \frac{x - \mu}{\sigma} \right )
@@ -71,7 +71,7 @@ class Normal_(ParametricFitter):
         -------
 
         sf : scalar or numpy array
-            The value(s) of the survival function at x.
+            The value(s) of the reliability function at x.
 
         Examples
         --------
@@ -212,7 +212,7 @@ class Normal_(ParametricFitter):
         -------
 
         hf : scalar or numpy array
-            The value(s) of the instantaneous hazard rate function at x.
+            The value(s) of the instantaneous hazard rate at x.
 
         Examples
         --------
@@ -246,8 +246,8 @@ class Normal_(ParametricFitter):
         Returns
         -------
 
-        ff : scalar or numpy array
-            The value(s) of the cumulative hazard rate function at x.
+        Hf : scalar or numpy array
+            The value(s) of the cumulative hazard rate at x.
 
         Examples
         --------

--- a/surpyval/univariate/parametric/distributions/rayleigh.py
+++ b/surpyval/univariate/parametric/distributions/rayleigh.py
@@ -393,12 +393,12 @@ class Rayleigh_(ParametricFitter):
                 params = np.polyfit(x_pp, y_pp, 1)
                 sigma = np.sqrt(0.5) * (1.0 / params[0])
                 gamma = -params[1] / params[0]
-                params = [sigma]
+                params = np.array([sigma])
             elif rr == "x":
                 params = np.polyfit(y_pp, x_pp, 1)
                 sigma = np.sqrt(0.5) * (params[0])
                 gamma = params[1]
-                params = [sigma]
+                params = np.array([sigma])
 
             return {"params": params, "gamma": gamma}
 
@@ -412,7 +412,7 @@ class Rayleigh_(ParametricFitter):
                 gradient = np.linalg.lstsq(y_pp, x_pp, rcond=None)[0]
                 sigma = np.sqrt(0.5) * (gradient[0])
 
-            params = [sigma]
+            params = np.array([sigma])
 
             return {"params": params}
 

--- a/surpyval/univariate/parametric/distributions/rayleigh.py
+++ b/surpyval/univariate/parametric/distributions/rayleigh.py
@@ -113,7 +113,7 @@ class Rayleigh_(ParametricFitter):
         >>> Weibull.ff(x, 3, 4)
         array([0.01226978, 0.17924519, 0.63212056, 0.9575952 , 0.99955438])
         """
-        return -np.expm1(np.exp(-(x**2) / (2 * sigma**2)))
+        return -np.expm1(-(x**2) / (2 * sigma**2))
 
     def cs(self, x, X, sigma):
         r"""

--- a/surpyval/univariate/parametric/distributions/rayleigh.py
+++ b/surpyval/univariate/parametric/distributions/rayleigh.py
@@ -1,7 +1,5 @@
 from numpy import euler_gamma
 from scipy.special import gamma as gamma_func
-from scipy.stats import uniform
-
 from surpyval import np
 from surpyval.univariate.nonparametric import plotting_positions
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
@@ -355,44 +353,6 @@ class Rayleigh_(ParametricFitter):
 
     def entropy(self, sigma):
         return euler_gamma / 2 + 1 + np.log(sigma / (np.sqrt(2)))
-
-    def random(self, size, sigma):
-        r"""
-
-        Draws random samples from the distribution in shape `size`
-
-        Parameters
-        ----------
-
-        size : integer or tuple of positive integers
-            Shape or size of the random draw
-        alpha : numpy array or scalar
-            scale parameter for the Weibull distribution
-        beta : numpy array or scalar
-            shape parameter for the Weibull distribution
-
-        Returns
-        -------
-
-        random : scalar or numpy array
-            Random values drawn from the distribution in shape `size`
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from surpyval import Weibull
-        >>> Weibull.random(10, 3, 4)
-        array([1.79782451, 1.7143211 , 2.84778674, 3.12226231, 2.61000839,
-               3.05456332, 3.00280851, 2.61910071, 1.37991527, 4.17488394])
-        >>> Weibull.random((5, 5), 3, 4)
-        array([[1.64782514, 2.79157632, 1.85500681, 2.91908736, 2.46089933],
-               [1.85880127, 0.96787742, 2.29677031, 2.42394129, 2.63889601],
-               [2.14351859, 3.90677225, 2.24013855, 2.49467774, 3.43755278],
-               [3.24417396, 1.40775181, 2.49584969, 3.07603353, 2.54679499],
-               [1.98330076, 2.95002633, 3.35402601, 3.11429283, 3.45706789]])
-        """
-        U = uniform.rvs(size=size)
-        return self.qf(U, sigma)
 
     def log_df(self, x, sigma):
         return np.log(x) - 2 * np.log(sigma) - 0.5 * (x / sigma) ** 2

--- a/surpyval/univariate/parametric/distributions/rayleigh.py
+++ b/surpyval/univariate/parametric/distributions/rayleigh.py
@@ -49,20 +49,18 @@ class Rayleigh_(ParametricFitter):
     def sf(self, x, sigma):
         r"""
 
-        Survival (or reliability) function for the Weibull Distribution:
+        Survival (or reliability) function for the Rayleigh Distribution:
 
         .. math::
-            R(x) = e^{-\left ( \frac{x}{\alpha} \right )^\beta}
+            R(x) = e^{-\frac{x^2}{2\sigma^2}}
 
         Parameters
         ----------
 
         x : numpy array or scalar
             The values at which the function will be calculated
-        alpha : numpy array or scalar
-            scale parameter for the Weibull distribution
-        beta : numpy array or scalar
-            shape parameter for the Weibull distribution
+        sigma : numpy array or scalar
+            scale parameter for the Rayleigh distribution
 
         Returns
         -------
@@ -73,65 +71,61 @@ class Rayleigh_(ParametricFitter):
         Examples
         --------
         >>> import numpy as np
-        >>> from surpyval import Weibull
+        >>> from surpyval import Rayleigh
         >>> x = np.array([1, 2, 3, 4, 5])
-        >>> Weibull.sf(x, 3, 4)
-        array([9.87730216e-01, 8.20754808e-01, 3.67879441e-01, 4.24047953e-02,
-               4.45617596e-04])
+        >>> Rayleigh.sf(x, 3)
+        array([0.94595947, 0.8007374 , 0.60653066, 0.41111229, 0.24935221])
         """
         return np.exp(-(x**2) / (2 * sigma**2))
 
     def ff(self, x, sigma):
         r"""
 
-        Failure (CDF or unreliability) function for the Weibull Distribution:
+        Failure (CDF or unreliability) function for the Rayleigh
+        Distribution:
 
         .. math::
-            F(x) = 1 - e^{-\left ( \frac{x}{\alpha} \right )^\beta}
+            F(x) = 1 - e^{-\frac{x^2}{2\sigma^2}}
 
         Parameters
         ----------
 
         x : numpy array or scalar
             The values at which the function will be calculated
-        alpha : numpy array or scalar
-            scale parameter for the Weibull distribution
-        beta : numpy array or scalar
-            shape parameter for the Weibull distribution
+        sigma : numpy array or scalar
+            scale parameter for the Rayleigh distribution
 
         Returns
         -------
 
-        sf : scalar or numpy array
+        ff : scalar or numpy array
             The value(s) of the failure function at x.
 
         Examples
         --------
         >>> import numpy as np
-        >>> from surpyval import Weibull
+        >>> from surpyval import Rayleigh
         >>> x = np.array([1, 2, 3, 4, 5])
-        >>> Weibull.ff(x, 3, 4)
-        array([0.01226978, 0.17924519, 0.63212056, 0.9575952 , 0.99955438])
+        >>> Rayleigh.ff(x, 3)
+        array([0.05404053, 0.1992626 , 0.39346934, 0.58888771, 0.75064779])
         """
         return -np.expm1(-(x**2) / (2 * sigma**2))
 
     def cs(self, x, X, sigma):
         r"""
 
-        Conditional survival function for the Weibull Distribution:
+        Conditional survival function for the Rayleigh Distribution:
 
         .. math::
-            R(x, X) = \frac{R(x + X)}{R(X)}
+            R(x, X) = \frac{R(x)}{R(X)}
 
         Parameters
         ----------
 
         x : numpy array or scalar
             The values at which the function will be calculated
-        alpha : numpy array or scalar
-            scale parameter for the Weibull distribution
-        beta : numpy array or scalar
-            shape parameter for the Weibull distribution
+        sigma : numpy array or scalar
+            scale parameter for the Rayleigh distribution
 
         Returns
         -------
@@ -142,212 +136,196 @@ class Rayleigh_(ParametricFitter):
         Examples
         --------
         >>> import numpy as np
-        >>> from surpyval import Weibull
+        >>> from surpyval import Rayleigh
         >>> x = np.array([1, 2, 3, 4, 5])
-        >>> Weibull.cs(x, 5, 3, 4)
-        array([2.21654222e+03, 1.84183662e+03, 8.25549630e+02, 9.51596070e+01,
-               1.00000000e+00])
+        >>> Rayleigh.cs(x, 5, 3)
+        array([3.79366789, 3.21127054, 2.43242545, 1.64872127, 1.        ])
         """
         return self.sf(x, sigma) / self.sf(X, sigma)
 
     def df(self, x, sigma):
         r"""
 
-        Density function for the Weibull Distribution:
+        Density function for the Rayleigh Distribution:
 
         .. math::
-            f(x) = \frac{\beta}{\alpha} \frac{x}{\alpha}^{\beta - 1} e^{-\left
-            ( \frac{x}{\alpha} \right )^\beta}
+            f(x) = \frac{x}{\sigma^2} e^{-\frac{x^2}{2\sigma^2}}
 
         Parameters
         ----------
 
         x : numpy array or scalar
             The values at which the function will be calculated
-        alpha : numpy array or scalar
-            scale parameter for the Weibull distribution
-        beta : numpy array or scalar
-            shape parameter for the Weibull distribution
+        sigma : numpy array or scalar
+            scale parameter for the Rayleigh distribution
 
         Returns
         -------
 
         df : scalar or numpy array
-            The value(s) of the conditional survival function at x.
+            The value(s) of the density function at x.
 
         Examples
         --------
         >>> import numpy as np
-        >>> from surpyval import Weibull
+        >>> from surpyval import Rayleigh
         >>> x = np.array([1, 2, 3, 4, 5])
-        >>> Weibull.df(x, 5, 3, 4)
-        array([0.0487768 , 0.32424881, 0.49050592, 0.13402009, 0.00275073])
+        >>> Rayleigh.df(x, 3)
+        array([0.10510661, 0.17794165, 0.20217689, 0.18271657, 0.138529  ])
         """
         return (x / (sigma**2)) * self.sf(x, sigma)
 
     def hf(self, x, sigma):
         r"""
 
-        Instantaneous hazard rate for the Weibull Distribution:
+        Instantaneous hazard rate for the Rayleigh Distribution:
 
         .. math::
-            h(x) = \frac{\beta}{\alpha} \left ( \frac{x}{\alpha} \right
-            )^{\beta - 1}
+            h(x) = \frac{x}{\sigma^2}
 
         Parameters
         ----------
 
         x : numpy array or scalar
             The values at which the function will be calculated
-        alpha : numpy array or scalar
-            scale parameter for the Weibull distribution
-        beta : numpy array or scalar
-            shape parameter for the Weibull distribution
+        sigma : numpy array or scalar
+            scale parameter for the Rayleigh distribution
 
         Returns
         -------
 
-        df : scalar or numpy array
+        hf : scalar or numpy array
             The value(s) of the instantaneous hazard rate at x.
 
         Examples
         --------
         >>> import numpy as np
-        >>> from surpyval import Weibull
+        >>> from surpyval import Rayleigh
         >>> x = np.array([1, 2, 3, 4, 5])
-        >>> Weibull.hf(x, 3, 4)
-        array([0.04938272, 0.39506173, 1.33333333, 3.16049383, 6.17283951])
+        >>> Rayleigh.hf(x, 3)
+        array([0.11111111, 0.22222222, 0.33333333, 0.44444444, 0.55555556])
         """
         return x / (sigma**2)
 
     def Hf(self, x, sigma):
         r"""
 
-        Cumulative hazard rate for the Weibull Distribution:
+        Cumulative hazard rate for the Rayleigh Distribution:
 
         .. math::
-            h(x) = \frac{x}{\alpha}^{\beta}
+            H(x) = \frac{x^2}{2\sigma^2}
 
         Parameters
         ----------
 
         x : numpy array or scalar
             The values at which the function will be calculated
-        alpha : numpy array or scalar
-            scale parameter for the Weibull distribution
-        beta : numpy array or scalar
-            shape parameter for the Weibull distribution
+        sigma : numpy array or scalar
+            scale parameter for the Rayleigh distribution
 
         Returns
         -------
 
-        df : scalar or numpy array
+        Hf : scalar or numpy array
             The value(s) of the cumulative hazard rate at x.
 
         Examples
         --------
         >>> import numpy as np
-        >>> from surpyval import Weibull
+        >>> from surpyval import Rayleigh
         >>> x = np.array([1, 2, 3, 4, 5])
-        >>> Weibull.Hf(x, 3, 4)
-        array([0.01234568, 0.19753086, 1.        , 3.16049383, 7.71604938])
+        >>> Rayleigh.Hf(x, 3)
+        array([0.05555556, 0.22222222, 0.5       , 0.88888889, 1.38888889])
         """
         return x**2 / (2 * sigma**2)
 
     def qf(self, p, sigma):
         r"""
 
-        Quantile function for the Weibull distribution:
+        Quantile function for the Rayleigh distribution:
 
         .. math::
-            q(p) = \alpha \left ( -\ln \left ( 1 - p \right ) \right )^{1/
-            \beta}
+            q(p) = \sigma \sqrt{-2 \ln \left ( 1 - p \right )}
 
         Parameters
         ----------
 
         p : numpy array or scalar
             The percentiles at which the quantile will be calculated
-        alpha : numpy array or scalar
-            scale parameter for the Weibull distribution
-        beta : numpy array or scalar
-            shape parameter for the Weibull distribution
+        sigma : numpy array or scalar
+            scale parameter for the Rayleigh distribution
 
         Returns
         -------
 
         q : scalar or numpy array
-            The quantiles for the Weibull distribution at each value p
+            The quantiles for the Rayleigh distribution at each value p
 
         Examples
         --------
         >>> import numpy as np
-        >>> from surpyval import Weibull
+        >>> from surpyval import Rayleigh
         >>> p = np.array([.1, .2, .3, .4, .5])
-        >>> Weibull.qf(p, 3, 4)
-        array([1.70919151, 2.06189877, 2.31840554, 2.5362346 , 2.73733292])
+        >>> Rayleigh.qf(p, 3)
+        array([1.37713082, 2.00414169, 2.53380129, 3.03230296, 3.53223007])
         """
         return sigma * np.sqrt(2 * np.log(1 / (1 - p)))
 
     def mean(self, sigma):
         r"""
 
-        Mean of the Weibull distribution
+        Mean of the Rayleigh distribution
 
         .. math::
-            E = \alpha \Gamma \left ( 1 + \frac{1}{\beta} \right )
+            E = \sigma \sqrt{\frac{\pi}{2}}
 
         Parameters
         ----------
 
-        alpha : numpy array or scalar
-            scale parameter for the Weibull distribution
-        beta : numpy array or scalar
-            shape parameter for the Weibull distribution
+        sigma : numpy array or scalar
+            scale parameter for the Rayleigh distribution
 
         Returns
         -------
 
         mean : scalar or numpy array
-            The mean(s) of the Weibull distribution
+            The mean(s) of the Rayleigh distribution
 
         Examples
         --------
-        >>> from surpyval import Weibull
-        >>> Weibull.mean(3, 4)
-        2.7192074311664314
+        >>> from surpyval import Rayleigh
+        >>> Rayleigh.mean(3)
+        3.7599424119465006
         """
         return sigma * np.sqrt(np.pi / 2)
 
     def moment(self, n, sigma):
         r"""
 
-        n-th moment of the Weibull distribution
+        n-th moment of the Rayleigh distribution
 
         .. math::
-            M(n) = \alpha^n \Gamma \left ( 1 + \frac{n}{\beta} \right )
+            M(n) = \sigma^n 2^{n/2} \Gamma \left ( 1 + \frac{n}{2} \right )
 
         Parameters
         ----------
 
         n : integer or numpy array of integers
             The ordinal of the moment to calculate
-        alpha : numpy array or scalar
-            scale parameter for the Weibull distribution
-        beta : numpy array or scalar
-            shape parameter for the Weibull distribution
+        sigma : numpy array or scalar
+            scale parameter for the Rayleigh distribution
 
         Returns
         -------
 
-        mean : scalar or numpy array
-            The moment(s) of the Weibull distribution
+        moment : scalar or numpy array
+            The moment(s) of the Rayleigh distribution
 
         Examples
         --------
-        >>> from surpyval import Weibull
-        >>> Weibull.moment(2, 3, 4)
-        7.976042329074821
+        >>> from surpyval import Rayleigh
+        >>> Rayleigh.moment(2, 3)
+        18.0
         """
         return (sigma**n) * (2 ** (n / 2)) * gamma_func(1 + n / 2)
 

--- a/surpyval/univariate/parametric/distributions/rayleigh.py
+++ b/surpyval/univariate/parametric/distributions/rayleigh.py
@@ -359,13 +359,6 @@ class Rayleigh_(ParametricFitter):
         y_pp = self.mpp_y_transform(F)
         x_pp = self.mpp_x_transform(x_pp)
 
-        # mask = np.isinfinite(y_pp)
-        # if mask.any():
-        #     warnings.warn("Some Infinite values encountered in plotting
-        # points and have been ignored.", stacklevel=2)
-        #     y_pp = y_pp[mask]
-        #     x_pp = x_pp[mask]
-
         if offset:
             if rr == "y":
                 params = np.polyfit(x_pp, y_pp, 1)

--- a/surpyval/univariate/parametric/distributions/uniform.py
+++ b/surpyval/univariate/parametric/distributions/uniform.py
@@ -16,7 +16,7 @@ class Uniform_(ParametricFitter):
             y_ticks=np.linspace(0, 1, 21)[1:-1],
         )
 
-    def _parameter_initialiser(self, x, c=None, n=None):
+    def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         return np.min(x) - 1.0, np.max(x) + 1.0
 
     def sf(self, x, a, b):

--- a/surpyval/univariate/parametric/distributions/uniform.py
+++ b/surpyval/univariate/parametric/distributions/uniform.py
@@ -1,6 +1,4 @@
 from scipy.optimize import minimize
-from scipy.stats import uniform
-
 from surpyval import np
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
 
@@ -338,44 +336,6 @@ class Uniform_(ParametricFitter):
 
     def p(self, c, n):
         return 1 - 2 * (1 + c) ** (1.0 - n) + (1 + 2 * c) ** (1.0 - n)
-
-    def random(self, size, a, b):
-        r"""
-
-        Draws random samples from the distribution in shape `size`
-
-        Parameters
-        ----------
-
-        size : integer or tuple of positive integers
-            Shape or size of the random draw
-        a : numpy array or scalar
-            The lower parameter for the Uniform distribution
-        b : numpy array or scalar
-            The upper parameter for the Uniform distribution
-
-        Returns
-        -------
-
-        random : scalar or numpy array
-            Random values drawn from the distribution in shape `size`
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from surpyval import Uniform
-        >>> Uniform.random(10, 0, 6)
-        array([3.50214341, 3.7978912 , 5.12238656, 4.27185221, 3.05507685,
-               2.71236199, 4.89311322, 1.11373047, 4.90549424, 1.76321338])
-        >>> Uniform.random((5, 5), 0, 6)
-        array([[4.76809829, 4.42155933, 2.59469997, 4.31525748, 5.53469545],
-               [0.06222942, 1.26267164, 1.74188626, 1.05235807, 0.92461476],
-               [2.06215303, 0.02184135, 0.97058002, 3.02219656, 3.22137982],
-               [2.14951891, 3.18096661, 2.37105309, 0.65710124, 0.68828779],
-               [0.58827207, 3.7633596 , 5.62330526, 5.24481753, 4.23162212]])
-        """
-        U = uniform.rvs(size=size)
-        return self.qf(U, a, b)
 
     def ab_cb(self, x, a, b, N, alpha=0.05):
         # Parameter confidence intervals from here:

--- a/surpyval/univariate/parametric/distributions/uniform.py
+++ b/surpyval/univariate/parametric/distributions/uniform.py
@@ -1,4 +1,3 @@
-from scipy.optimize import minimize
 from surpyval import np
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
 
@@ -333,21 +332,6 @@ class Uniform_(ParametricFitter):
             for i in range(n):
                 out[i] = a**i * b ** (n - i)
             return np.sum(out) / (n + 1)
-
-    def p(self, c, n):
-        return 1 - 2 * (1 + c) ** (1.0 - n) + (1 + 2 * c) ** (1.0 - n)
-
-    def ab_cb(self, x, a, b, N, alpha=0.05):
-        # Parameter confidence intervals from here:
-        # https://mathoverflow.net/questions/278675/confidence-intervals-for-the-endpoints-of-the-uniform-distribution
-        #
-        sample_range = np.max(x) - np.min(x)
-
-        def fun(c):
-            return self.p(c, N)
-
-        c_hat = minimize(fun, 1.0).x
-        return a - c_hat * sample_range, b + c_hat * sample_range
 
     def mle(self, data):
         if (data.c[data.x == data.x.max()] == 1).all():

--- a/surpyval/univariate/parametric/distributions/uniform.py
+++ b/surpyval/univariate/parametric/distributions/uniform.py
@@ -22,7 +22,7 @@ class Uniform_(ParametricFitter):
     def sf(self, x, a, b):
         r"""
 
-        Surival (or Reliability) function for the Uniform Distribution:
+        Survival (or Reliability) function for the Uniform Distribution:
 
         .. math::
             R(x) = \frac{b - x}{b - a}
@@ -41,7 +41,7 @@ class Uniform_(ParametricFitter):
         -------
 
         sf : scalar or numpy array
-            The value(s) of the survival function at x.
+            The value(s) of the reliability function at x.
 
         Examples
         --------
@@ -56,7 +56,7 @@ class Uniform_(ParametricFitter):
     def cs(self, x, X, a, b):
         r"""
 
-        Surival (or Reliability) function for the Uniform Distribution:
+        Survival (or Reliability) function for the Uniform Distribution:
 
         .. math::
             R(x, X) = \frac{R(x + X)}{R(X)}
@@ -218,8 +218,8 @@ class Uniform_(ParametricFitter):
         Returns
         -------
 
-        hf : scalar or numpy array
-            The value(s) of the instantaneous hazard rate at x.
+        Hf : scalar or numpy array
+            The value(s) of the cumulative hazard rate at x.
 
         Examples
         --------

--- a/surpyval/univariate/parametric/distributions/uniform.py
+++ b/surpyval/univariate/parametric/distributions/uniform.py
@@ -337,13 +337,13 @@ class Uniform_(ParametricFitter):
         if (data.c[data.x == data.x.max()] == 1).all():
             raise ValueError(
                 "Uniform distribution cannot be estimated using MLE when"
-                + " the highest value is right censored"
+                " the highest value is right censored"
             )
 
         if (data.c[data.x == data.x.min()] == -1).all():
             raise ValueError(
                 "Uniform distribution cannot be estimated using MLE when"
-                + " the lowest value is left censored"
+                " the lowest value is left censored"
             )
 
         tl = data.t[:, 0]
@@ -352,13 +352,13 @@ class Uniform_(ParametricFitter):
         if np.isfinite(tr[data.x == data.x.max()]).all():
             raise ValueError(
                 "Uniform distribution cannot be estimated using MLE when"
-                + " the highest value is right truncated"
+                " the highest value is right truncated"
             )
 
         if np.isfinite(tl[data.x == data.x.min()]).all():
             raise ValueError(
                 "Uniform distribution cannot be estimated using MLE when"
-                + " the lowest value is left truncated"
+                " the lowest value is left truncated"
             )
 
         params = np.array([np.min(data.x), np.max(data.x)])

--- a/surpyval/univariate/parametric/distributions/weibull.py
+++ b/surpyval/univariate/parametric/distributions/weibull.py
@@ -82,7 +82,7 @@ class Weibull_(ParametricFitter):
         Returns
         -------
 
-        sf : scalar or numpy array
+        ff : scalar or numpy array
             The value(s) of the failure function at x.
 
         Examples
@@ -157,14 +157,14 @@ class Weibull_(ParametricFitter):
         -------
 
         df : scalar or numpy array
-            The value(s) of the conditional survival function at x.
+            The value(s) of the density function at x.
 
         Examples
         --------
         >>> import numpy as np
         >>> from surpyval import Weibull
         >>> x = np.array([1, 2, 3, 4, 5])
-        >>> Weibull.df(x, 5, 3, 4)
+        >>> Weibull.df(x, 3, 4)
         array([0.0487768 , 0.32424881, 0.49050592, 0.13402009, 0.00275073])
         """
         return (
@@ -195,7 +195,7 @@ class Weibull_(ParametricFitter):
         Returns
         -------
 
-        df : scalar or numpy array
+        hf : scalar or numpy array
             The value(s) of the instantaneous hazard rate at x.
 
         Examples
@@ -229,7 +229,7 @@ class Weibull_(ParametricFitter):
         Returns
         -------
 
-        df : scalar or numpy array
+        Hf : scalar or numpy array
             The value(s) of the cumulative hazard rate at x.
 
         Examples

--- a/surpyval/univariate/parametric/distributions/weibull.py
+++ b/surpyval/univariate/parametric/distributions/weibull.py
@@ -1,8 +1,6 @@
 from numpy import euler_gamma
 from scipy.special import gamma as gamma_func
 from scipy.special import ndtri as z
-from scipy.stats import uniform
-
 from surpyval import np
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
 
@@ -17,32 +15,6 @@ class Weibull_(ParametricFitter):
             param_names=["alpha", "beta"],
             param_map={"alpha": 0, "beta": 1},
             plot_x_scale="log",
-            y_ticks=[
-                0.0001,
-                0.0002,
-                0.0003,
-                0.001,
-                0.002,
-                0.003,
-                0.005,
-                0.01,
-                0.02,
-                0.03,
-                0.05,
-                0.1,
-                0.2,
-                0.3,
-                0.4,
-                0.5,
-                0.6,
-                0.7,
-                0.8,
-                0.9,
-                0.95,
-                0.99,
-                0.999,
-                0.9999,
-            ],
         )
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
@@ -369,44 +341,6 @@ class Weibull_(ParametricFitter):
 
     def entropy(self, alpha, beta):
         return euler_gamma * (1 - 1 / beta) + np.log(alpha) - np.log(beta) + 1
-
-    def random(self, size, alpha, beta):
-        r"""
-
-        Draws random samples from the distribution in shape `size`
-
-        Parameters
-        ----------
-
-        size : integer or tuple of positive integers
-            Shape or size of the random draw
-        alpha : numpy array or scalar
-            scale parameter for the Weibull distribution
-        beta : numpy array or scalar
-            shape parameter for the Weibull distribution
-
-        Returns
-        -------
-
-        random : scalar or numpy array
-            Random values drawn from the distribution in shape `size`
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from surpyval import Weibull
-        >>> Weibull.random(10, 3, 4)
-        array([1.79782451, 1.7143211 , 2.84778674, 3.12226231, 2.61000839,
-               3.05456332, 3.00280851, 2.61910071, 1.37991527, 4.17488394])
-        >>> Weibull.random((5, 5), 3, 4)
-        array([[1.64782514, 2.79157632, 1.85500681, 2.91908736, 2.46089933],
-               [1.85880127, 0.96787742, 2.29677031, 2.42394129, 2.63889601],
-               [2.14351859, 3.90677225, 2.24013855, 2.49467774, 3.43755278],
-               [3.24417396, 1.40775181, 2.49584969, 3.07603353, 2.54679499],
-               [1.98330076, 2.95002633, 3.35402601, 3.11429283, 3.45706789]])
-        """
-        U = uniform.rvs(size=size)
-        return self.qf(U, alpha, beta)
 
     def log_df(self, x, alpha, beta):
         scaled = x / alpha

--- a/surpyval/univariate/parametric/fitters/__init__.py
+++ b/surpyval/univariate/parametric/fitters/__init__.py
@@ -1,4 +1,40 @@
+from scipy.optimize import minimize
+
 from surpyval import np
+
+
+def fallback_minimize(fun, init, args, jac, hess, newton_tol=None):
+    """
+    Minimise ``fun`` trying Newton-CG with the supplied jacobian and
+    hessian first, then falling back to BFGS, then Nelder-Mead, whenever
+    a method fails or returns nan parameters.
+
+    Some distributions have all-shape parameters whose autograd second
+    derivatives are zero (see autograd_gamma_compat); a zero hessian
+    makes Newton-CG terminate at the initial guess while reporting
+    success, so skip straight to BFGS in that case.
+    """
+    with np.errstate(all="ignore"):
+        if np.any(hess(np.array(init, dtype=float), *args)):
+            res = minimize(
+                fun,
+                init,
+                method="Newton-CG",
+                jac=jac,
+                hess=hess,
+                tol=newton_tol,
+                args=args,
+            )
+        else:
+            res = None
+
+        if (res is None) or (res.success is False) or (np.isnan(res.x).any()):
+            res = minimize(fun, init, method="BFGS", jac=jac, args=args)
+
+        if (res.success is False) or (np.isnan(res.x).any()):
+            res = minimize(fun, init, args=args)
+
+    return res
 
 
 def adj_relu(x):

--- a/surpyval/univariate/parametric/fitters/__init__.py
+++ b/surpyval/univariate/parametric/fitters/__init__.py
@@ -93,12 +93,22 @@ def bounds_convert(x, bounds, fixed, param_map):
 
     def transform_params_to_unbounded(params):
         return np.array(
-            [f(p) for p, f in zip(params, bounded_to_unbounded_transforms)]
+            [
+                f(p)
+                for p, f in zip(
+                    params, bounded_to_unbounded_transforms, strict=True
+                )
+            ]
         )
 
     def transform_unbounded_value_to_params(params):
         return np.array(
-            [f(p) for p, f in zip(params, unbounded_to_bounded_transforms)]
+            [
+                f(p)
+                for p, f in zip(
+                    params, unbounded_to_bounded_transforms, strict=True
+                )
+            ]
         )
 
     n_params = len(param_map)

--- a/surpyval/univariate/parametric/fitters/mle.py
+++ b/surpyval/univariate/parametric/fitters/mle.py
@@ -110,23 +110,23 @@ def mle(model):
         if "Desired error not necessarily" in winning_message:
             warnings.warn(
                 "Precision was lost, try:"
-                + "\n- Using alternate fitting method"
-                + "\n- visually checking model fit"
-                + "\n- change data to be closer to 1."
+                "\n- Using alternate fitting method"
+                "\n- visually checking model fit"
+                "\n- change data to be closer to 1."
             )
 
         elif (not res.success) or (np.isnan(res.x).any()):
             warnings.warn(
                 "MLE Failed, using MPP results instead. "
-                + "Try making the values of the data closer to "
-                + "1 by dividing or multiplying by some constant."
-                + "\n\nAlternately try setting the `init` keyword in"
-                + " the `fit()`"
-                + " method to a value you believe is closer."
-                + "A good way to do this is to set any shape parameter to 1. "
-                + "and any scale parameter to be the mean of the data "
-                + "(or it's inverse)"
-                + "\n\nModel returned with inital guesses (MPP)"
+                "Try making the values of the data closer to "
+                "1 by dividing or multiplying by some constant."
+                "\n\nAlternately try setting the `init` keyword in"
+                " the `fit()`"
+                " method to a value you believe is closer."
+                "A good way to do this is to set any shape parameter to 1. "
+                "and any scale parameter to be the mean of the data "
+                "(or it's inverse)"
+                "\n\nModel returned with inital guesses (MPP)"
             )
 
             use_initial = True

--- a/surpyval/univariate/parametric/fitters/mle.py
+++ b/surpyval/univariate/parametric/fitters/mle.py
@@ -24,7 +24,12 @@ def mle(model):
     offset, lfp, zi = model.offset, model.lfp, model.zi
 
     if hasattr(model.dist, "mle"):
-        return model.dist.mle(model.surv_data)
+        results = model.dist.mle(model.surv_data)
+        results["params"] = np.atleast_1d(results["params"])
+        results.setdefault("gamma", 0.0)
+        results.setdefault("f0", 0.0)
+        results.setdefault("p", 1.0)
+        return results
 
     results = {}
 

--- a/surpyval/univariate/parametric/fitters/mom.py
+++ b/surpyval/univariate/parametric/fitters/mom.py
@@ -28,7 +28,7 @@ def mom(model):
     x_ = np.repeat(x, n)
 
     if hasattr(dist, "_mom"):
-        return {"params": dist._mom(x_)}
+        return {"params": np.atleast_1d(dist._mom(x_)), "gamma": 0.0}
 
     moments = np.zeros(model.k)
 
@@ -49,9 +49,9 @@ def mom(model):
         results["gamma"] = params[0]
         results["params"] = params[1:]
     else:
+        results["gamma"] = 0.0
         results["params"] = params
 
     results["res"] = res
-    results["offset"] = offset
 
     return results

--- a/surpyval/univariate/parametric/fitters/mpp.py
+++ b/surpyval/univariate/parametric/fitters/mpp.py
@@ -53,7 +53,7 @@ def mpp(model):
         raise ValueError("rr must be either 'x' or 'y'")
 
     if hasattr(dist, "mpp"):
-        return dist.mpp(
+        results = dist.mpp(
             x,
             c,
             n,
@@ -62,6 +62,9 @@ def mpp(model):
             on_d_is_0=on_d_is_0,
             offset=offset,
         )
+        results["params"] = np.atleast_1d(results["params"])
+        results.setdefault("gamma", 0.0)
+        return results
 
     x_, r, d, F = plotting_positions(
         x=x,
@@ -116,8 +119,9 @@ def mpp(model):
 
     if offset:
         results["gamma"] = gamma
+    else:
+        results["gamma"] = 0.0
 
     results["params"] = params
-    results["rr"] = rr
 
     return results

--- a/surpyval/univariate/parametric/fitters/mpp.py
+++ b/surpyval/univariate/parametric/fitters/mpp.py
@@ -93,10 +93,8 @@ def mpp(model):
     y_pp = dist.mpp_y_transform(y_pp)
 
     if offset:
-        # I think this should be x[c != 1] and not in xl
         x_min = np.min(x_pp)
 
-        # fun = lambda gamma : -pearsonr(np.log(x - gamma), y_)[0]
         def fun(gamma):
             g = x_min - np.exp(-gamma)
             out = -pearsonr(dist.mpp_x_transform(x_pp - g), y_pp)[0]

--- a/surpyval/univariate/parametric/fitters/mps.py
+++ b/surpyval/univariate/parametric/fitters/mps.py
@@ -1,9 +1,10 @@
 import warnings
 
 from autograd import hessian, jacobian
-from scipy.optimize import minimize
 
 from surpyval import np
+
+from . import fallback_minimize
 
 
 def mps_fun(params, dist, x, inv_trans, const, c, n, tl, tr, offset):
@@ -39,43 +40,11 @@ def mps(model):
     jac = jacobian(mps_fun)
     hess = hessian(mps_fun)
 
-    with np.errstate(all="ignore"):
-        # Some distributions have all-shape parameters whose autograd
-        # second derivatives are zero (see autograd_gamma_compat); a zero
-        # Hessian makes Newton-CG terminate at the initial guess while
-        # reporting success, so skip straight to BFGS in that case.
-        args = (dist, x, inv_trans, const, c, n, tl, tr, offset)
-        if np.any(hess(np.array(init, dtype=float), *args)):
-            res = minimize(
-                mps_fun,
-                init,
-                method="Newton-CG",
-                jac=jac,
-                hess=hess,
-                tol=1e-15,
-                args=args,
-            )
-        else:
-            res = None
+    args = (dist, x, inv_trans, const, c, n, tl, tr, offset)
+    res = fallback_minimize(mps_fun, init, args, jac, hess, newton_tol=1e-15)
 
-        if (res is None) or (res.success is False) or (np.isnan(res.x).any()):
-            res = minimize(
-                mps_fun,
-                init,
-                method="BFGS",
-                jac=jac,
-                args=(dist, x, inv_trans, const, c, n, tl, tr, offset),
-            )
-
-        if (res.success is False) or (np.isnan(res.x).any()):
-            res = minimize(
-                mps_fun,
-                init,
-                args=(dist, x, inv_trans, const, c, n, tl, tr, offset),
-            )
-
-        if (res.success is False) or (np.isnan(res.x).any()):
-            warnings.warn("MPS FAILED: Try alternate estimation method")
+    if (res.success is False) or (np.isnan(res.x).any()):
+        warnings.warn("MPS FAILED: Try alternate estimation method")
 
     results = {}
     params = inv_trans(const(res.x))

--- a/surpyval/univariate/parametric/fitters/mps.py
+++ b/surpyval/univariate/parametric/fitters/mps.py
@@ -54,8 +54,7 @@ def mps(model):
         results["gamma"] = params[0]
         results["params"] = params[1::]
     else:
+        results["gamma"] = 0.0
         results["params"] = params
-
-    results["jac"] = jac
 
     return results

--- a/surpyval/univariate/parametric/fitters/mse.py
+++ b/surpyval/univariate/parametric/fitters/mse.py
@@ -1,9 +1,10 @@
 from autograd import hessian, jacobian
-from scipy.optimize import minimize
 
 from surpyval import np
 from surpyval.univariate.nonparametric import fleming_harrington, turnbull
 from surpyval.utils import xcnt_to_xrd
+
+from . import fallback_minimize
 
 
 def mse_fun(params, dist, x, F, inv_trans, const, offset):
@@ -53,28 +54,8 @@ def mse(model):
     jac = jacobian(mse_fun)
     hess = hessian(mse_fun)
 
-    with np.errstate(all="ignore"):
-        args = (dist, x, F, inv_trans, const, offset)
-        res = minimize(
-            mse_fun,
-            init,
-            method="Newton-CG",
-            jac=jac,
-            hess=hess,
-            args=args,
-        )
-
-        if (res.success is False) or (np.isnan(res.x).any()):
-            res = minimize(
-                mse_fun,
-                init,
-                method="BFGS",
-                jac=jac,
-                args=args,
-            )
-
-        if (res.success is False) or (np.isnan(res.x).any()):
-            res = minimize(mse_fun, init, args=args)
+    args = (dist, x, F, inv_trans, const, offset)
+    res = fallback_minimize(mse_fun, init, args, jac, hess)
 
     results = {}
     results["res"] = res

--- a/surpyval/univariate/parametric/fitters/mse.py
+++ b/surpyval/univariate/parametric/fitters/mse.py
@@ -65,6 +65,7 @@ def mse(model):
         results["gamma"] = params[0]
         results["params"] = params[1:]
     else:
+        results["gamma"] = 0.0
         results["params"] = params
 
     return results

--- a/surpyval/univariate/parametric/mixture_model.py
+++ b/surpyval/univariate/parametric/mixture_model.py
@@ -1,16 +1,18 @@
-import re
 import warnings
 
 from autograd import jacobian
 from matplotlib import pyplot as plt
-from matplotlib.ticker import FixedLocator
 from scipy.optimize import minimize
 from scipy.special import ndtri as z
 
 from surpyval import np
-from surpyval.univariate.nonparametric import plotting_positions
-from surpyval.utils import _round_vals
 from surpyval.utils.surpyval_data import SurpyvalData
+
+from .probability_plotting import (
+    adjust_heuristic,
+    draw_probability_plot,
+    probability_plot_data,
+)
 
 
 class MixtureModel:
@@ -361,121 +363,16 @@ class MixtureModel:
         return self.sf(x + X) / self.sf(X)
 
     def get_plot_data(self, heuristic="Nelson-Aalen"):
-        x_, r, d, F = plotting_positions(
+        return probability_plot_data(
+            dist=self.dist,
+            ff=self.ff,
             x=self.data.x,
             c=self.data.c,
             n=self.data.n,
             t=self.data.t,
             heuristic=heuristic,
+            params=self.params,
         )
-
-        mask = np.isfinite(x_)
-        x_ = x_[mask]
-        r = r[mask]
-        d = d[mask]
-        F = F[mask]
-
-        # Adjust the plotting points in event data is truncated.
-        tl_min = self.data.t[0][0]
-        if np.isfinite(tl_min):
-            Ftl = self.ff(tl_min)
-        else:
-            Ftl = 0
-
-        tr_max = self.data.t[-1][-1]
-        if np.isfinite(tr_max):
-            Ftr = self.ff(tr_max)
-        else:
-            Ftr = 1
-
-        # Adjust the plotting points due to truncation
-        F = Ftl + F * (Ftr - Ftl)
-
-        y_scale_min = np.min(F[F > 0]) / 2
-        y_scale_max = 1 - (1 - np.max(F[F < 1])) / 10
-
-        # x-axis
-        if self.dist.plot_x_scale == "log":
-            log_x = np.log10(x_[x_ > 0])
-            x_min = np.min(log_x)
-            x_max = np.max(log_x)
-            vals_non_sig = 10 ** np.linspace(x_min, x_max, 7)
-            x_minor_ticks = np.arange(np.floor(x_min), np.ceil(x_max))
-            x_minor_ticks = (
-                10**x_minor_ticks * np.array(np.arange(1, 11)).reshape((10, 1))
-            ).flatten()
-            diff = (x_max - x_min) / 10
-            x_scale_min = 10 ** (x_min - diff)
-            x_scale_max = 10 ** (x_max + diff)
-            x_model = 10 ** np.linspace(x_min - diff, x_max + diff, 100)
-        elif self.dist.name in ("Beta"):
-            x_min = np.min(x_)
-            x_max = np.max(x_)
-            x_scale_min = 0
-            x_scale_max = 1
-            vals_non_sig = np.linspace(x_scale_min, x_scale_max, 11)[1:-1]
-            x_minor_ticks = np.linspace(x_scale_min, x_scale_max, 22)[1:-1]
-            x_model = np.linspace(x_scale_min, x_scale_max, 102)[1:-1]
-        elif self.dist.name in ("Uniform"):
-            x_min = np.min(self.params)
-            x_max = np.max(self.params)
-            x_scale_min = x_min
-            x_scale_max = x_max
-            vals_non_sig = np.linspace(x_scale_min, x_scale_max, 11)[1:-1]
-            x_minor_ticks = np.linspace(x_scale_min, x_scale_max, 22)[1:-1]
-            x_model = np.linspace(x_scale_min, x_scale_max, 102)[1:-1]
-        else:
-            x_min = np.min(x_)
-            x_max = np.max(x_)
-            vals_non_sig = np.linspace(x_min, x_max, 7)
-            x_minor_ticks = np.arange(np.floor(x_min), np.ceil(x_max))
-            diff = (x_max - x_min) / 10
-            x_scale_min = x_min - diff
-            x_scale_max = x_max + diff
-            x_model = np.linspace(x_scale_min, x_scale_max, 100)
-
-        cdf = self.ff(x_model)
-
-        x_ticks = _round_vals(vals_non_sig)
-        x_ticks_labels = [
-            (
-                str(int(x))
-                if (re.match(r"([0-9]+\.0+)", str(x)) is not None) & (x > 1)
-                else str(x)
-            )
-            for x in _round_vals(vals_non_sig)
-        ]
-
-        y_ticks = np.array(self.dist.y_ticks)
-        y_ticks = y_ticks[
-            np.where((y_ticks > y_scale_min) & (y_ticks < y_scale_max))[0]
-        ]
-
-        y_ticks_labels = [
-            (
-                str(int(y)) + "%"
-                if (re.match(r"([0-9]+\.0+)", str(y)) is not None) & (y > 1)
-                else str(y)
-            )
-            for y in y_ticks * 100
-        ]
-
-        return {
-            "x_scale_min": x_scale_min,
-            "x_scale_max": x_scale_max,
-            "y_scale_min": y_scale_min,
-            "y_scale_max": y_scale_max,
-            "y_ticks": y_ticks,
-            "y_ticks_labels": y_ticks_labels,
-            "x_ticks": x_ticks,
-            "x_ticks_labels": x_ticks_labels,
-            "cdf": cdf,
-            "x_model": x_model,
-            "x_minor_ticks": x_minor_ticks,
-            "x_scale": self.dist.plot_x_scale,
-            "x_": x_,
-            "F": F,
-        }
 
     def plot(
         self,
@@ -510,56 +407,14 @@ class MixtureModel:
         if not hasattr(self, "params"):
             raise Exception("Can't plot model that failed to fit")
 
-        if 2 in self.data.c:
-            if heuristic != "Turnbull":
-                warnings.warn(
-                    "Interval censored data, heuristic changed to Turnbull'",
-                    stacklevel=1,
-                )
-                heuristic = "Turnbull"
-
-        if np.isfinite(self.data.t).any():
-            if heuristic != "Turnbull":
-                warnings.warn(
-                    "Truncated censored data, heuristic changed to Turnbull'",
-                    stacklevel=1,
-                )
-                heuristic = "Turnbull"
+        heuristic = adjust_heuristic(self.data.c, self.data.t, heuristic)
 
         d = self.get_plot_data(heuristic=heuristic)
 
-        # Set limits and scale
-        ax.set_ylim(
-            [max(d["y_scale_min"], 1e-4), min(d["y_scale_max"], 0.9999)]
-        )
-        ax.set_xscale(d["x_scale"])
-        functions = (
+        return draw_probability_plot(
+            ax,
+            d,
             lambda x: self.dist.mpp_y_transform(x, *self.params),
             lambda x: self.dist.mpp_inv_y_transform(x, *self.params),
+            title="{} Mixture Probability Plot".format(self.dist.name),
         )
-        ax.set_yscale("function", functions=functions)
-        ax.set_yticks(d["y_ticks"])
-        ax.set_yticklabels(d["y_ticks_labels"])
-        ax.yaxis.set_minor_locator(FixedLocator(np.linspace(0, 1, 51)))
-        ax.set_xticks(d["x_ticks"])
-        ax.set_xticklabels(d["x_ticks_labels"])
-
-        if d["x_scale"] == "log":
-            ax.set_xticks(d["x_minor_ticks"], minor=True)
-            ax.set_xticklabels([], minor=True)
-
-        ax.grid(
-            visible=True, which="major", color="g", alpha=0.4, linestyle="-"
-        )
-        ax.grid(
-            visible=True, which="minor", color="g", alpha=0.1, linestyle="-"
-        )
-
-        ax.set_title("{} Mixture Probability Plot".format(self.dist.name))
-        ax.set_ylabel("CDF")
-        ax.scatter(d["x_"], d["F"])
-
-        ax.set_xlim([d["x_scale_min"], d["x_scale_max"]])
-
-        ax.plot(d["x_model"], d["cdf"], color="k", linestyle="--")
-        return ax

--- a/surpyval/univariate/parametric/mixture_model.py
+++ b/surpyval/univariate/parametric/mixture_model.py
@@ -46,30 +46,19 @@ class MixtureModel:
         if hasattr(self, "params"):
             param_string = "\n".join(
                 [
-                    "{:>10}".format(name) + ": " + str(p)
+                    f"{name:>10}: {p}"
                     for p, name in zip(self.params.T, self.dist.param_names)
                 ]
             )
+            weight_string = ",\n\t".join([str(w) for w in self.w])
             out = (
                 "Parametric Mixture SurPyval Model"
-                + "\n================================="
-                + "\nDistribution        : {dist}"
-                + "\nSub-Distributions   : {m}"
-                + "\nFitted by           : EM"
-            ).format(dist=self.dist.name, m=self.m)
-
-            out = (
-                out
-                + "\nWeights             : "
-                + "\n\t{params}".format(
-                    params=",\n\t".join([str(w) for w in self.w])
-                )
-            )
-
-            out = (
-                out
-                + "\nParameters          :\n"
-                + "{params}".format(params=param_string)
+                "\n================================="
+                f"\nDistribution        : {self.dist.name}"
+                f"\nSub-Distributions   : {self.m}"
+                "\nFitted by           : EM"
+                f"\nWeights             : \n\t{weight_string}"
+                f"\nParameters          :\n{param_string}"
             )
 
             return out
@@ -405,7 +394,7 @@ class MixtureModel:
             ax = plt.gcf().gca()
 
         if not hasattr(self, "params"):
-            raise Exception("Can't plot model that failed to fit")
+            raise ValueError("Can't plot model that failed to fit")
 
         heuristic = adjust_heuristic(self.data.c, self.data.t, heuristic)
 
@@ -416,5 +405,5 @@ class MixtureModel:
             d,
             lambda x: self.dist.mpp_y_transform(x, *self.params),
             lambda x: self.dist.mpp_inv_y_transform(x, *self.params),
-            title="{} Mixture Probability Plot".format(self.dist.name),
+            title=f"{self.dist.name} Mixture Probability Plot",
         )

--- a/surpyval/univariate/parametric/mixture_model.py
+++ b/surpyval/univariate/parametric/mixture_model.py
@@ -171,7 +171,7 @@ class MixtureModel:
             right censored, and 2 is intervally censored. If not provided
             will assume all values are observed.
         n : array like, optional
-            Array of counts for each x. If data is proivded as counts, then
+            Array of counts for each x. If data is provided as counts, then
             this can be provided. If :code:`None` will assume each
             observation is 1.
         t : 2D-array like, optional
@@ -388,7 +388,7 @@ class MixtureModel:
             'Weibull', 'Benard', 'Beard', 'Hazen', 'Gringorten', 'None',\
             'Tukey', 'DPW', 'Fleming-Harrington', 'Kaplan-Meier',\
             'Nelson-Aalen', 'Filliben', 'Larsen', 'Turnbull'}, optional
-            The method that the plotting point on the probablility plot will
+            The method that the plotting point on the probability plot will
             be calculated.
 
         ax: matplotlib.axes.Axes, optional

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -1069,9 +1069,7 @@ class Parametric(Distribution):
             detail = "Can't plot model that was given parameters and no data"
             raise Exception(detail)
 
-        heuristic = adjust_heuristic(
-            self.data["c"], self.data["t"], heuristic
-        )
+        heuristic = adjust_heuristic(self.data["c"], self.data["t"], heuristic)
 
         d = self.get_plot_data(heuristic=heuristic, alpha_ci=alpha_ci)
 

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -1069,6 +1069,16 @@ class Parametric(Distribution):
             detail = "Can't plot model that was given parameters and no data"
             raise Exception(detail)
 
+        if not (
+            hasattr(self.dist, "mpp_y_transform")
+            and hasattr(self.dist, "mpp_inv_y_transform")
+        ):
+            raise NotImplementedError(
+                "{} does not support probability plotting".format(
+                    self.dist.name
+                )
+            )
+
         heuristic = adjust_heuristic(self.data["c"], self.data["t"], heuristic)
 
         d = self.get_plot_data(heuristic=heuristic, alpha_ci=alpha_ci)

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -1,20 +1,20 @@
 import json
-import re
-import warnings
 from copy import copy, deepcopy
 
 import matplotlib.pyplot as plt
 from autograd import elementwise_grad, jacobian
-from matplotlib.ticker import FixedLocator
 from scipy.special import ndtri as z
 from scipy.stats import uniform
 
 import surpyval as surv
 from surpyval import Distribution, np
-from surpyval.univariate.nonparametric import plotting_positions
-from surpyval.utils import _round_vals, fsli_to_xcnt
+from surpyval.utils import fsli_to_xcnt
 
-CB_COLOUR = "#e94c54"
+from .probability_plotting import (
+    adjust_heuristic,
+    draw_probability_plot,
+    probability_plot_data,
+)
 
 
 class Parametric(Distribution):
@@ -989,130 +989,29 @@ class Parametric(Distribution):
         >>> model = Weibull.fit(x)
         >>> data = model.get_plot_data()
         """
-        x_, r, d, F = plotting_positions(
+        if hasattr(self, "hess_inv") & (self.method == "MLE"):
+            if self.hess_inv is not None:
+
+                def cb_func(x_model):
+                    return self.cb(x_model, on="ff", alpha_ci=alpha_ci)
+
+            else:
+                cb_func = None
+        else:
+            cb_func = None
+
+        return probability_plot_data(
+            dist=self.dist,
+            ff=self.ff,
             x=self.data["x"],
             c=self.data["c"],
             n=self.data["n"],
             t=self.data["t"],
             heuristic=heuristic,
+            gamma=self.gamma,
+            params=self.params,
+            cb_func=cb_func,
         )
-
-        mask = np.isfinite(x_)
-        x_ = x_[mask] - self.gamma
-        r = r[mask]
-        d = d[mask]
-        F = F[mask]
-
-        # Adjust the plotting points in event data is truncated.
-        tl_min = self.data["t"][0][0]
-        if np.isfinite(tl_min):
-            Ftl = self.ff(tl_min)
-        else:
-            Ftl = 0
-
-        tr_max = self.data["t"][-1][-1]
-        if np.isfinite(tr_max):
-            Ftr = self.ff(tr_max)
-        else:
-            Ftr = 1
-
-        # Adjust the plotting points due to truncation
-        F = Ftl + F * (Ftr - Ftl)
-
-        y_scale_min = np.min(F[F > 0]) / 2
-        y_scale_max = 1 - (1 - np.max(F[F < 1])) / 10
-
-        # x-axis
-        if self.dist.plot_x_scale == "log":
-            log_x = np.log10(x_[x_ > 0])
-            x_min = np.min(log_x)
-            x_max = np.max(log_x)
-            vals_non_sig = 10 ** np.linspace(x_min, x_max, 7)
-            x_minor_ticks = np.arange(np.floor(x_min), np.ceil(x_max))
-            x_minor_ticks = (
-                10**x_minor_ticks * np.array(np.arange(1, 11)).reshape((10, 1))
-            ).flatten()
-            diff = (x_max - x_min) / 10
-            x_scale_min = 10 ** (x_min - diff)
-            x_scale_max = 10 ** (x_max + diff)
-            x_model = 10 ** np.linspace(x_min - diff, x_max + diff, 100)
-        elif self.dist.name in ("Beta"):
-            x_min = np.min(x_)
-            x_max = np.max(x_)
-            x_scale_min = 0
-            x_scale_max = 1
-            vals_non_sig = np.linspace(x_scale_min, x_scale_max, 11)[1:-1]
-            x_minor_ticks = np.linspace(x_scale_min, x_scale_max, 22)[1:-1]
-            x_model = np.linspace(x_scale_min, x_scale_max, 102)[1:-1]
-        elif self.dist.name in ("Uniform"):
-            x_min = np.min(self.params)
-            x_max = np.max(self.params)
-            x_scale_min = x_min
-            x_scale_max = x_max
-            vals_non_sig = np.linspace(x_scale_min, x_scale_max, 11)[1:-1]
-            x_minor_ticks = np.linspace(x_scale_min, x_scale_max, 22)[1:-1]
-            x_model = np.linspace(x_scale_min, x_scale_max, 102)[1:-1]
-        else:
-            x_min = np.min(x_)
-            x_max = np.max(x_)
-            vals_non_sig = np.linspace(x_min, x_max, 7)
-            x_minor_ticks = np.arange(np.floor(x_min), np.ceil(x_max))
-            diff = (x_max - x_min) / 10
-            x_scale_min = x_min - diff
-            x_scale_max = x_max + diff
-            x_model = np.linspace(x_scale_min, x_scale_max, 100)
-
-        cdf = self.ff(x_model + self.gamma)
-
-        x_ticks = _round_vals(vals_non_sig)
-        x_ticks_labels = [
-            (
-                str(int(x))
-                if (re.match(r"([0-9]+\.0+)", str(x)) is not None) & (x > 1)
-                else str(x)
-            )
-            for x in _round_vals(vals_non_sig + self.gamma)
-        ]
-
-        y_ticks = np.array(self.dist.y_ticks)
-        y_ticks = y_ticks[
-            np.where((y_ticks > y_scale_min) & (y_ticks < y_scale_max))[0]
-        ]
-
-        y_ticks_labels = [
-            (
-                str(int(y)) + "%"
-                if (re.match(r"([0-9]+\.0+)", str(y)) is not None) & (y > 1)
-                else str(y)
-            )
-            for y in y_ticks * 100
-        ]
-
-        if hasattr(self, "hess_inv") & (self.method == "MLE"):
-            if self.hess_inv is not None:
-                cbs = self.cb(x_model + self.gamma, on="ff", alpha_ci=alpha_ci)
-            else:
-                cbs = []
-        else:
-            cbs = []
-
-        return {
-            "x_scale_min": x_scale_min,
-            "x_scale_max": x_scale_max,
-            "y_scale_min": y_scale_min,
-            "y_scale_max": y_scale_max,
-            "y_ticks": y_ticks,
-            "y_ticks_labels": y_ticks_labels,
-            "x_ticks": x_ticks,
-            "x_ticks_labels": x_ticks_labels,
-            "cdf": cdf,
-            "x_model": x_model,
-            "x_minor_ticks": x_minor_ticks,
-            "cbs": cbs,
-            "x_scale": self.dist.plot_x_scale,
-            "x_": x_,
-            "F": F,
-        }
 
     def plot(
         self,
@@ -1170,58 +1069,17 @@ class Parametric(Distribution):
             detail = "Can't plot model that was given parameters and no data"
             raise Exception(detail)
 
-        if 2 in self.data["c"]:
-            if heuristic != "Turnbull":
-                warnings.warn(
-                    "Interval censored data, heuristic changed to Turnbull'",
-                    stacklevel=1,
-                )
-                heuristic = "Turnbull"
-
-        if np.isfinite(self.data["t"]).any():
-            if heuristic != "Turnbull":
-                warnings.warn(
-                    "Truncated censored data, heuristic changed to Turnbull'",
-                    stacklevel=1,
-                )
-                heuristic = "Turnbull"
+        heuristic = adjust_heuristic(
+            self.data["c"], self.data["t"], heuristic
+        )
 
         d = self.get_plot_data(heuristic=heuristic, alpha_ci=alpha_ci)
 
-        # Set limits and scale
-        ax.set_ylim(
-            [max(d["y_scale_min"], 1e-4), min(d["y_scale_max"], 0.9999)]
-        )
-        ax.set_xscale(d["x_scale"])
-        functions = (
+        return draw_probability_plot(
+            ax,
+            d,
             lambda x: self.dist.mpp_y_transform(x, *self.params),
             lambda x: self.dist.mpp_inv_y_transform(x, *self.params),
+            title="{} Probability Plot".format(self.dist.name),
+            plot_bounds=plot_bounds,
         )
-        ax.set_yscale("function", functions=functions)
-        ax.set_yticks(d["y_ticks"])
-        ax.set_yticklabels(d["y_ticks_labels"])
-        ax.yaxis.set_minor_locator(FixedLocator(np.linspace(0, 1, 51)))
-        ax.set_xticks(d["x_ticks"])
-        ax.set_xticklabels(d["x_ticks_labels"])
-
-        if d["x_scale"] == "log":
-            ax.set_xticks(d["x_minor_ticks"], minor=True)
-            ax.set_xticklabels([], minor=True)
-
-        ax.grid(
-            visible=True, which="major", color="g", alpha=0.4, linestyle="-"
-        )
-        ax.grid(
-            visible=True, which="minor", color="g", alpha=0.1, linestyle="-"
-        )
-
-        ax.set_title("{} Probability Plot".format(self.dist.name))
-        ax.set_ylabel("CDF")
-        ax.scatter(d["x_"], d["F"])
-
-        ax.set_xlim([d["x_scale_min"], d["x_scale_max"]])
-        if plot_bounds & (len(d["cbs"]) != 0):
-            ax.plot(d["x_model"], d["cbs"], color=CB_COLOUR)
-
-        ax.plot(d["x_model"], d["cdf"], color="k", linestyle="--")
-        return ax

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -90,7 +90,7 @@ class Parametric(Distribution):
         dist = getattr(surv, model_dict["distribution"], None)
         if not isinstance(dist, ParametricFitter):
             raise ValueError(
-                "Unknown distribution '{}'".format(model_dict["distribution"])
+                f"Unknown distribution '{model_dict['distribution']}'"
             )
         how = model_dict["how"]
         if "data" in model_dict:
@@ -176,30 +176,26 @@ class Parametric(Distribution):
         if hasattr(self, "params"):
             param_string = "\n".join(
                 [
-                    "{:>10}".format(name) + ": " + str(p)
+                    f"{name:>10}: {p}"
                     for p, name in zip(self.params, self.dist.param_names)
                 ]
             )
             out = (
                 "Parametric SurPyval Model"
-                + "\n========================="
-                + "\nDistribution        : {dist}"
-                + "\nFitted by           : {method}"
-            ).format(dist=self.dist.name, method=self.method)
+                "\n========================="
+                f"\nDistribution        : {self.dist.name}"
+                f"\nFitted by           : {self.method}"
+            )
             if self.offset:
-                out += "\nOffset (gamma)      : {g}".format(g=self.gamma)
+                out += f"\nOffset (gamma)      : {self.gamma}"
 
             if self.lfp:
-                out += "\nMax Proportion (p)  : {p}".format(p=self.p)
+                out += f"\nMax Proportion (p)  : {self.p}"
 
             if self.zi:
-                out += "\nZero-Inflation (f0) : {f0}".format(f0=self.f0)
+                out += f"\nZero-Inflation (f0) : {self.f0}"
 
-            out = (
-                out
-                + "\nParameters          :\n"
-                + "{params}".format(params=param_string)
-            )
+            out = out + "\nParameters          :\n" + param_string
 
             return out
         else:
@@ -538,16 +534,15 @@ class Parametric(Distribution):
         array([10.84103403,  0.48542084,  7.11387062,  5.41420125, 4.59286657,
                 5.90703589,  7.5124326 ,  7.96575225,  9.18134126, 8.16000438])
         """
-        if ((a is not None) | (b is not None)) & (
-            (self.p != 1) | (self.f0 != 0)
+        if ((a is not None) or (b is not None)) and (
+            (self.p != 1) or (self.f0 != 0)
         ):
             raise NotImplementedError(
-                "Truncated sampling not supported with" + " LFP or ZI models"
+                "Truncated sampling not supported with LFP or ZI models"
             )
-        elif ((a is not None) | (b is not None)) & (self.offset):
+        elif ((a is not None) or (b is not None)) and self.offset:
             raise NotImplementedError(
-                "Truncated sampling not supported with"
-                + " offset distributions"
+                "Truncated sampling not supported with offset distributions"
             )
 
         if (self.p == 1) and (self.f0 == 0):
@@ -721,7 +716,7 @@ class Parametric(Distribution):
         """
         t = np.atleast_1d(t)
         if self.method != "MLE":
-            raise Exception("Only MLE has confidence bounds")
+            raise ValueError("Only MLE has confidence bounds")
 
         hess_inv = np.copy(self.hess_inv)
 
@@ -753,9 +748,6 @@ class Parametric(Distribution):
                     j = np.atleast_2d(j).T * j
                     j = j[np.triu_indices(j.shape[0])]
                     var_R.append(np.sum(j * pvars))
-
-                # First-Order Taylor Series Expansion of Variance
-                # var_R = (jac**2 * np.diag(hess_inv)).sum(axis=1).T
 
                 R_hat = self.sf(x)
                 if bound == "two-sided":
@@ -989,7 +981,7 @@ class Parametric(Distribution):
         >>> model = Weibull.fit(x)
         >>> data = model.get_plot_data()
         """
-        if hasattr(self, "hess_inv") & (self.method == "MLE"):
+        if hasattr(self, "hess_inv") and (self.method == "MLE"):
             if self.hess_inv is not None:
 
                 def cb_func(x_model):
@@ -1063,20 +1055,18 @@ class Parametric(Distribution):
             ax = plt.gcf().gca()
 
         if not hasattr(self, "params"):
-            raise Exception("Can't plot model that failed to fit")
+            raise ValueError("Can't plot model that failed to fit")
 
         if self.method == "given parameters":
             detail = "Can't plot model that was given parameters and no data"
-            raise Exception(detail)
+            raise ValueError(detail)
 
         if not (
             hasattr(self.dist, "mpp_y_transform")
             and hasattr(self.dist, "mpp_inv_y_transform")
         ):
             raise NotImplementedError(
-                "{} does not support probability plotting".format(
-                    self.dist.name
-                )
+                f"{self.dist.name} does not support probability plotting"
             )
 
         heuristic = adjust_heuristic(self.data["c"], self.data["t"], heuristic)
@@ -1088,6 +1078,6 @@ class Parametric(Distribution):
             d,
             lambda x: self.dist.mpp_y_transform(x, *self.params),
             lambda x: self.dist.mpp_inv_y_transform(x, *self.params),
-            title="{} Probability Plot".format(self.dist.name),
+            title=f"{self.dist.name} Probability Plot",
             plot_bounds=plot_bounds,
         )

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -232,7 +232,7 @@ class Parametric(Distribution):
     def sf(self, x):
         r"""
 
-        Surival (or Reliability) function for a distribution using the
+        Survival (or Reliability) function for a distribution using the
         parameters found in the ``.params`` attribute.
 
         Parameters
@@ -617,8 +617,8 @@ class Parametric(Distribution):
 
     def mean(self):
         r"""
-        A method to draw random samples from the distributions using the
-        parameters found in the ``.params`` attribute.
+        The mean of the distribution using the parameters found in the
+        ``.params`` attribute.
 
         Returns
         -------
@@ -639,8 +639,8 @@ class Parametric(Distribution):
     def moment(self, n):
         r"""
 
-        A method to draw random samples from the distributions using the
-        parameters found in the ``.params`` attribute.
+        The n-th moment of the distribution using the parameters found
+        in the ``.params`` attribute.
 
         Parameters
         ----------
@@ -669,8 +669,8 @@ class Parametric(Distribution):
 
     def entropy(self):
         r"""
-        A method to draw random samples from the distributions using the
-        parameters found in the ``.params`` attribute.
+        The entropy of the distribution using the parameters found in
+        the ``.params`` attribute.
 
         Returns
         -------
@@ -831,7 +831,7 @@ class Parametric(Distribution):
     def neg_ll(self):
         r"""
 
-        The the negative log-likelihood for the model, if it was fit with the
+        The negative log-likelihood for the model, if it was fit with the
         ``fit()`` method. Not available if fit with the ``from_params()``
         method.
 
@@ -860,7 +860,7 @@ class Parametric(Distribution):
     def bic(self):
         r"""
 
-        The the Bayesian Information Criterion (BIC) for the model, if it
+        The Bayesian Information Criterion (BIC) for the model, if it
         was fit with the ``fit()`` method. Not available if fit with the
         ``from_params()`` method.
 
@@ -899,7 +899,7 @@ class Parametric(Distribution):
 
     def aic(self):
         r"""
-        The the Aikake Information Criterion (AIC) for the model, if it was
+        The Aikake Information Criterion (AIC) for the model, if it was
         fit with the ``fit()`` method. Not available if fit with the
         ``from_params()`` method.
 
@@ -928,7 +928,7 @@ class Parametric(Distribution):
 
     def aic_c(self):
         r"""
-        The the Corrected Aikake Information Criterion (AIC) for the model,
+        The Corrected Aikake Information Criterion (AIC) for the model,
         if it was fit with the ``fit()`` method. Not available if fit with
         the ``from_params()`` method.
 
@@ -969,12 +969,12 @@ class Parametric(Distribution):
             'Weibull', 'Benard', 'Beard', 'Hazen', 'Gringorten', 'None',\
             'Tukey', 'DPW', 'Fleming-Harrington', 'Kaplan-Meier',\
             'Nelson-Aalen', 'Filliben', 'Larsen', 'Turnbull'}, optional
-            The method that the plotting point on the probablility plot will
+            The method that the plotting point on the probability plot will
             be calculated. Default is "Nelson-Aalen".
 
         alpha_ci : float, optional
-            The confidence with which the confidence bounds, if able, will
-            be calculated. Defaults to 0.95.
+            The level of significance at which the confidence bounds, if
+            able, will be calculated. Defaults to 0.05.
 
         Returns
         -------
@@ -1030,16 +1030,16 @@ class Parametric(Distribution):
             'Weibull', 'Benard', 'Beard', 'Hazen', 'Gringorten', 'None',\
             'Tukey', 'DPW', 'Fleming-Harrington', 'Kaplan-Meier',\
             'Nelson-Aalen', 'Filliben', 'Larsen', 'Turnbull'}, optional
-            The method that the plotting point on the probablility plot will
+            The method that the plotting point on the probability plot will
             be calculated.
 
         plot_bounds : Boolean, optional
-            A Boolean value to indicate whehter you want the probability
+            A Boolean value to indicate whether you want the probability
             bounds to be calculated.
 
         alpha_ci : float, optional
-            The confidence with which the confidence bounds, if able, will
-            be calculated. Defaults to 0.95.
+            The level of significance at which the confidence bounds, if
+            able, will be calculated. Defaults to 0.05.
 
         ax: matplotlib.axes.Axes, optional
             The axis onto which the plot will be created. Optional, if not

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -889,13 +889,8 @@ class ParametricFitter:
         for k, v in results.items():
             setattr(model, k, v)
 
-        # Only needed since not all models return the params
-        # as a numpy array... which ought to be fixed.
-        model.params = np.atleast_1d(model.params)
-
-        if hasattr(model, "params"):
-            for k, v in zip(self.param_names, model.params):
-                setattr(model, k, v)
+        for k, v in zip(self.param_names, model.params):
+            setattr(model, k, v)
 
         # Set the support of the distribution.
         if offset:

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from scipy.integrate import quad
 from scipy.special import expit
+from scipy.stats import uniform
 
 import surpyval
 from surpyval import np
@@ -19,6 +20,33 @@ from .parametric import Parametric
 PARA_METHODS = ["MPP", "MLE", "MPS", "MSE", "MOM"]
 METHOD_FUNC_DICT = {"MPP": mpp, "MOM": mom, "MLE": mle, "MPS": mps, "MSE": mse}
 
+DEFAULT_Y_TICKS = [
+    0.0001,
+    0.0002,
+    0.0003,
+    0.001,
+    0.002,
+    0.003,
+    0.005,
+    0.01,
+    0.02,
+    0.03,
+    0.05,
+    0.1,
+    0.2,
+    0.3,
+    0.4,
+    0.5,
+    0.6,
+    0.7,
+    0.8,
+    0.9,
+    0.95,
+    0.99,
+    0.999,
+    0.9999,
+]
+
 
 class ParametricFitter:
     def __init__(
@@ -30,7 +58,7 @@ class ParametricFitter:
         param_names: list[str],
         param_map: dict[str, int],
         plot_x_scale: str,
-        y_ticks: list[float],
+        y_ticks: list[float] | None = None,
     ):
         self.name: str = name
         self.k = k
@@ -39,7 +67,39 @@ class ParametricFitter:
         self.param_names = param_names
         self.param_map = param_map
         self.plot_x_scale = plot_x_scale
-        self.y_ticks = y_ticks
+        self.y_ticks = DEFAULT_Y_TICKS if y_ticks is None else y_ticks
+
+    def random(self, size, *params):
+        r"""
+
+        Draws random samples from the distribution in shape `size`, using
+        the inverse transform method with the distribution's quantile
+        function.
+
+        Parameters
+        ----------
+
+        size : integer or tuple of positive integers
+            Shape or size of the random draw
+        params : numpy array or scalar
+            The parameters of the distribution
+
+        Returns
+        -------
+
+        random : scalar or numpy array
+            Random values drawn from the distribution in shape `size`
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from surpyval import Weibull
+        >>> np.random.seed(1)
+        >>> Weibull.random(5, 3, 4)
+        array([2.57122697, 3.18730986, 0.31024877, 2.32381059, 1.89352939])
+        """
+        U = uniform.rvs(size=size)
+        return self.qf(U, *params)
 
     def log_df(self, x, *params):
         return np.log(self.hf(x, *params)) - self.Hf(x, *params)

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -49,6 +49,29 @@ DEFAULT_Y_TICKS = [
 
 
 class ParametricFitter:
+    """
+    Base class for all parametric distributions.
+
+    A distribution needs only ``hf`` and ``Hf`` (or ``sf``, ``ff`` and
+    ``df``) plus a ``_parameter_initialiser`` with the signature
+    ``(self, x, c=None, n=None, t=None, offset=False)`` for fitting to
+    work; ``log_df``, ``log_sf``, ``log_ff`` and ``random`` have generic
+    implementations here that subclasses can override with closed forms.
+    Probability plotting (the MPP fit method and ``Parametric.plot``)
+    additionally requires ``mpp_x_transform``, ``mpp_y_transform(y,
+    *params)`` and ``mpp_inv_y_transform(y, *params)``.
+
+    A subclass can take over an entire estimation method by defining
+    ``mle(data)`` or ``mpp(x, c, n, heuristic, rr, on_d_is_0, offset)``,
+    both returning a results dict with at least a ``params`` numpy
+    array.
+
+    Implementations must do their math with ``surpyval.np``, which is
+    ``autograd.numpy``: maximum likelihood estimation differentiates
+    through these functions, and plain numpy silently breaks the
+    gradients.
+    """
+
     def __init__(
         self,
         name: str,

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -443,7 +443,7 @@ class ParametricFitter:
             right censored, and 2 is intervally censored. If not provided
             will assume all values are observed.
         n : array like, optional
-            Array of counts for each x. If data is proivded as counts, then
+            Array of counts for each x. If data is provided as counts, then
             this can be provided. If :code:`None` will assume each
             observation is 1.
         t : 2D-array like, optional

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -160,8 +160,6 @@ class ParametricFitter:
             return np.sum(n * (np.log1p(-f0) + self.log_sf(x, *params)))
         else:
             F = self.ff(x, *params)
-            # ALso could be:
-            # np.sum(n * np.log((1 - p + (p - f0)*self.sf(x, *params))))
             return np.sum(n * np.log(1 - f0 - (p - f0) * F))
 
     @_check_x_not_empty
@@ -240,7 +238,6 @@ class ParametricFitter:
         if (n_obs > 1).any():
             n_ties = (n_obs - 1).sum()
             Df = self.df(x_obs, *params)
-            # Df = Df[Df != 0]
             LL = np.concatenate([Dl, Df, Dr])
             ll_n = np.concatenate([n[c == -1], (n_obs - 1), n[c == 1]])
         else:
@@ -290,7 +287,7 @@ class ParametricFitter:
         self, surv_data, how, offset, lfp, zi, heuristic, turnbull_estimator
     ):
         if offset and (self.support[0] != 0):
-            detail = "{} distribution cannot be offset".format(self.name)
+            detail = f"{self.name} distribution cannot be offset"
             raise ValueError(detail)
 
         if how not in PARA_METHODS:
@@ -299,7 +296,7 @@ class ParametricFitter:
         if how == "MPP" and self.name == "ExpoWeibull":
             detail = (
                 "ExpoWeibull distribution does not work"
-                + " with probability plot fitting"
+                " with probability plot fitting"
             )
             raise ValueError(detail)
 
@@ -311,17 +308,16 @@ class ParametricFitter:
             detail = "Method of moments doesn't support truncation"
             raise ValueError(detail)
 
-        if (lfp or zi) & (how != "MLE"):
+        if (lfp or zi) and (how != "MLE"):
             detail = (
                 "Limited failure or zero-inflated models"
-                + " can only be made with MLE"
+                " can only be made with MLE"
             )
             raise ValueError(detail)
 
-        if zi & (self.support[0] != 0):
+        if zi and (self.support[0] != 0):
             detail = (
-                "zero-inflated models can only work"
-                + " with models starting at 0"
+                "zero-inflated models can only work with models starting at 0"
             )
             raise ValueError(detail)
 
@@ -341,7 +337,7 @@ class ParametricFitter:
         ):
             detail = (
                 "Probability plotting estimation with left or "
-                + "interval censoring only works with Turnbull heuristic"
+                "interval censoring only works with Turnbull heuristic"
             )
             raise ValueError(detail)
 
@@ -355,7 +351,7 @@ class ParametricFitter:
             # then this is equivalent.
             heuristic = turnbull_estimator
 
-        if (not offset) & (not zi):
+        if (not offset) and (not zi):
             detail_template = """
             Some of your data is outside support of distribution, observed
             values must be within [{lower}, {upper}].
@@ -994,13 +990,11 @@ class ParametricFitter:
               beta: 4
         """
         if self.k != len(params):
-            msg_base = "Must have {k} params for {dist} distribution"
-            detail = msg_base.format(k=self.k, dist=self.name)
+            detail = f"Must have {self.k} params for {self.name} distribution"
             raise ValueError(detail)
 
         if gamma is not None and np.isinf(self.support).all():
-            msg_base = "{dist} distribution cannot be offset"
-            detail = msg_base.format(dist=self.name)
+            detail = f"{self.name} distribution cannot be offset"
             raise ValueError(detail)
 
         if gamma is not None:
@@ -1043,10 +1037,11 @@ class ParametricFitter:
             else:
                 upper_limit = upp
 
-            if not ((lower_limit < params[i]) & (params[i] < upper_limit)):
-                params = ", ".join(self.param_names)
-                base = "Params {params} must be in bounds {bounds}"
-                detail = base.format(params=params, bounds=self.bounds)
+            if not (lower_limit < params[i] < upper_limit):
+                param_names = ", ".join(self.param_names)
+                detail = (
+                    f"Params {param_names} must be in" f" bounds {self.bounds}"
+                )
                 raise ValueError(detail)
         model.dist = self
         return model

--- a/surpyval/univariate/parametric/probability_plotting.py
+++ b/surpyval/univariate/parametric/probability_plotting.py
@@ -25,7 +25,7 @@ def adjust_heuristic(c, t, heuristic):
     if 2 in c:
         if heuristic != "Turnbull":
             warnings.warn(
-                "Interval censored data, heuristic changed to Turnbull'",
+                "Interval censored data, heuristic changed to Turnbull",
                 stacklevel=2,
             )
             heuristic = "Turnbull"
@@ -33,7 +33,7 @@ def adjust_heuristic(c, t, heuristic):
     if np.isfinite(t).any():
         if heuristic != "Turnbull":
             warnings.warn(
-                "Truncated censored data, heuristic changed to Turnbull'",
+                "Truncated censored data, heuristic changed to Turnbull",
                 stacklevel=2,
             )
             heuristic = "Turnbull"

--- a/surpyval/univariate/parametric/probability_plotting.py
+++ b/surpyval/univariate/parametric/probability_plotting.py
@@ -142,7 +142,7 @@ def probability_plot_data(
     x_ticks_labels = [
         (
             str(int(x))
-            if (re.match(r"([0-9]+\.0+)", str(x)) is not None) & (x > 1)
+            if (re.match(r"([0-9]+\.0+)", str(x)) is not None) and (x > 1)
             else str(x)
         )
         for x in _round_vals(vals_non_sig + gamma)
@@ -156,7 +156,7 @@ def probability_plot_data(
     y_ticks_labels = [
         (
             str(int(y)) + "%"
-            if (re.match(r"([0-9]+\.0+)", str(y)) is not None) & (y > 1)
+            if (re.match(r"([0-9]+\.0+)", str(y)) is not None) and (y > 1)
             else str(y)
         )
         for y in y_ticks * 100
@@ -220,7 +220,7 @@ def draw_probability_plot(
     ax.scatter(d["x_"], d["F"])
 
     ax.set_xlim([d["x_scale_min"], d["x_scale_max"]])
-    if plot_bounds & (len(d["cbs"]) != 0):
+    if plot_bounds and (len(d["cbs"]) != 0):
         ax.plot(d["x_model"], d["cbs"], color=CB_COLOUR)
 
     ax.plot(d["x_model"], d["cdf"], color="k", linestyle="--")

--- a/surpyval/univariate/parametric/probability_plotting.py
+++ b/surpyval/univariate/parametric/probability_plotting.py
@@ -1,0 +1,226 @@
+"""
+Shared probability plot construction for parametric models.
+
+Used by both ``Parametric`` and ``MixtureModel`` which previously each
+carried their own near-identical copy of this logic.
+"""
+import re
+import warnings
+
+from matplotlib.ticker import FixedLocator
+
+from surpyval import np
+from surpyval.univariate.nonparametric import plotting_positions
+from surpyval.utils import _round_vals
+
+CB_COLOUR = "#e94c54"
+
+
+def adjust_heuristic(c, t, heuristic):
+    """
+    Force the Turnbull heuristic when the data is interval censored or
+    truncated, warning that the requested heuristic was changed.
+    """
+    if 2 in c:
+        if heuristic != "Turnbull":
+            warnings.warn(
+                "Interval censored data, heuristic changed to Turnbull'",
+                stacklevel=2,
+            )
+            heuristic = "Turnbull"
+
+    if np.isfinite(t).any():
+        if heuristic != "Turnbull":
+            warnings.warn(
+                "Truncated censored data, heuristic changed to Turnbull'",
+                stacklevel=2,
+            )
+            heuristic = "Turnbull"
+
+    return heuristic
+
+
+def probability_plot_data(
+    dist,
+    ff,
+    x,
+    c,
+    n,
+    t,
+    heuristic="Nelson-Aalen",
+    gamma=0.0,
+    params=None,
+    cb_func=None,
+):
+    """
+    Compute everything needed to draw a probability plot of the data
+    against the fitted CDF ``ff``.
+
+    ``dist`` provides the plotting configuration (``plot_x_scale``,
+    ``y_ticks`` and the special cased ``name``). ``gamma`` shifts the
+    plotting positions for offset distributions. ``cb_func``, if given,
+    is called with the model x values to compute confidence bounds on
+    the CDF.
+    """
+    x_, r, d, F = plotting_positions(
+        x=x,
+        c=c,
+        n=n,
+        t=t,
+        heuristic=heuristic,
+    )
+
+    mask = np.isfinite(x_)
+    x_ = x_[mask] - gamma
+    r = r[mask]
+    d = d[mask]
+    F = F[mask]
+
+    # Adjust the plotting points in event data is truncated.
+    tl_min = t[0][0]
+    if np.isfinite(tl_min):
+        Ftl = ff(tl_min)
+    else:
+        Ftl = 0
+
+    tr_max = t[-1][-1]
+    if np.isfinite(tr_max):
+        Ftr = ff(tr_max)
+    else:
+        Ftr = 1
+
+    # Adjust the plotting points due to truncation
+    F = Ftl + F * (Ftr - Ftl)
+
+    y_scale_min = np.min(F[F > 0]) / 2
+    y_scale_max = 1 - (1 - np.max(F[F < 1])) / 10
+
+    # x-axis
+    if dist.plot_x_scale == "log":
+        log_x = np.log10(x_[x_ > 0])
+        x_min = np.min(log_x)
+        x_max = np.max(log_x)
+        vals_non_sig = 10 ** np.linspace(x_min, x_max, 7)
+        x_minor_ticks = np.arange(np.floor(x_min), np.ceil(x_max))
+        x_minor_ticks = (
+            10**x_minor_ticks * np.array(np.arange(1, 11)).reshape((10, 1))
+        ).flatten()
+        diff = (x_max - x_min) / 10
+        x_scale_min = 10 ** (x_min - diff)
+        x_scale_max = 10 ** (x_max + diff)
+        x_model = 10 ** np.linspace(x_min - diff, x_max + diff, 100)
+    elif dist.name in ("Beta"):
+        x_min = np.min(x_)
+        x_max = np.max(x_)
+        x_scale_min = 0
+        x_scale_max = 1
+        vals_non_sig = np.linspace(x_scale_min, x_scale_max, 11)[1:-1]
+        x_minor_ticks = np.linspace(x_scale_min, x_scale_max, 22)[1:-1]
+        x_model = np.linspace(x_scale_min, x_scale_max, 102)[1:-1]
+    elif dist.name in ("Uniform"):
+        x_min = np.min(params)
+        x_max = np.max(params)
+        x_scale_min = x_min
+        x_scale_max = x_max
+        vals_non_sig = np.linspace(x_scale_min, x_scale_max, 11)[1:-1]
+        x_minor_ticks = np.linspace(x_scale_min, x_scale_max, 22)[1:-1]
+        x_model = np.linspace(x_scale_min, x_scale_max, 102)[1:-1]
+    else:
+        x_min = np.min(x_)
+        x_max = np.max(x_)
+        vals_non_sig = np.linspace(x_min, x_max, 7)
+        x_minor_ticks = np.arange(np.floor(x_min), np.ceil(x_max))
+        diff = (x_max - x_min) / 10
+        x_scale_min = x_min - diff
+        x_scale_max = x_max + diff
+        x_model = np.linspace(x_scale_min, x_scale_max, 100)
+
+    cdf = ff(x_model + gamma)
+
+    x_ticks = _round_vals(vals_non_sig)
+    x_ticks_labels = [
+        (
+            str(int(x))
+            if (re.match(r"([0-9]+\.0+)", str(x)) is not None) & (x > 1)
+            else str(x)
+        )
+        for x in _round_vals(vals_non_sig + gamma)
+    ]
+
+    y_ticks = np.array(dist.y_ticks)
+    y_ticks = y_ticks[
+        np.where((y_ticks > y_scale_min) & (y_ticks < y_scale_max))[0]
+    ]
+
+    y_ticks_labels = [
+        (
+            str(int(y)) + "%"
+            if (re.match(r"([0-9]+\.0+)", str(y)) is not None) & (y > 1)
+            else str(y)
+        )
+        for y in y_ticks * 100
+    ]
+
+    if cb_func is not None:
+        cbs = cb_func(x_model + gamma)
+    else:
+        cbs = []
+
+    return {
+        "x_scale_min": x_scale_min,
+        "x_scale_max": x_scale_max,
+        "y_scale_min": y_scale_min,
+        "y_scale_max": y_scale_max,
+        "y_ticks": y_ticks,
+        "y_ticks_labels": y_ticks_labels,
+        "x_ticks": x_ticks,
+        "x_ticks_labels": x_ticks_labels,
+        "cdf": cdf,
+        "x_model": x_model,
+        "x_minor_ticks": x_minor_ticks,
+        "cbs": cbs,
+        "x_scale": dist.plot_x_scale,
+        "x_": x_,
+        "F": F,
+    }
+
+
+def draw_probability_plot(
+    ax,
+    d,
+    y_transform,
+    inv_y_transform,
+    title,
+    plot_bounds=False,
+):
+    """
+    Draw the probability plot described by the ``probability_plot_data``
+    dictionary ``d`` onto the matplotlib axes ``ax``.
+    """
+    # Set limits and scale
+    ax.set_ylim([max(d["y_scale_min"], 1e-4), min(d["y_scale_max"], 0.9999)])
+    ax.set_xscale(d["x_scale"])
+    ax.set_yscale("function", functions=(y_transform, inv_y_transform))
+    ax.set_yticks(d["y_ticks"])
+    ax.set_yticklabels(d["y_ticks_labels"])
+    ax.yaxis.set_minor_locator(FixedLocator(np.linspace(0, 1, 51)))
+    ax.set_xticks(d["x_ticks"])
+    ax.set_xticklabels(d["x_ticks_labels"])
+
+    if d["x_scale"] == "log":
+        ax.set_xticks(d["x_minor_ticks"], minor=True)
+        ax.set_xticklabels([], minor=True)
+
+    ax.grid(visible=True, which="major", color="g", alpha=0.4, linestyle="-")
+    ax.grid(visible=True, which="minor", color="g", alpha=0.1, linestyle="-")
+
+    ax.set_title(title)
+    ax.set_ylabel("CDF")
+    ax.scatter(d["x_"], d["F"])
+
+    ax.set_xlim([d["x_scale_min"], d["x_scale_max"]])
+    if plot_bounds & (len(d["cbs"]) != 0):
+        ax.plot(d["x_model"], d["cbs"], color=CB_COLOUR)
+
+    ax.plot(d["x_model"], d["cdf"], color="k", linestyle="--")
+    return ax

--- a/surpyval/univariate/parametric/probability_plotting.py
+++ b/surpyval/univariate/parametric/probability_plotting.py
@@ -4,6 +4,7 @@ Shared probability plot construction for parametric models.
 Used by both ``Parametric`` and ``MixtureModel`` which previously each
 carried their own near-identical copy of this logic.
 """
+
 import re
 import warnings
 


### PR DESCRIPTION
Clean-up of the univariate parametric module following a deep-dive review. Work is split into independent commits, roughly in the order of the review's recommendations. No intended public API change.

## Bug fixes (`61389e4`, plus more found along the way)

- Right-truncation values beyond the distribution's support were clamped by comparing the **left** truncation array (`tl` instead of `tr`).
- Two validation paths raised `ValueError()` with an empty message (zero-inflated support check, MPP/Turnbull heuristic check).
- The MOM truncation error claimed to be about "Maximum product spacing", plus two "tuncation" typos.
- `fit(how="MSE", offset=True)` crashed with a `TypeError`: the MSE objective passed gamma straight into the distribution's `ff`. It now shifts `x` and splits gamma out of the results, mirroring MPS.
- `ExactEventTime.Hf` dropped its `T` parameter and crashed.
- LogLogistic's offset initial guess returned one parameter too many (ExpoWeibull copy-paste), silently truncated by the transform zip.
- **`Exponential.fit(how="MPP")` was entirely broken** (`a234a99`): its custom `mpp` returned a bare tuple where the framework expects a results dict. Its inverted finite-value warning mask is also fixed.
- **`to_dict`/`from_dict` round-trips failed for `Bernoulli` and `ExactEventTime`** (`aba7783`): `from_dict` requires `isinstance(dist, ParametricFitter)` but both were duck-typed plain classes.
- **`Rayleigh.ff` returned values outside [0, 1]** (`58cde9f`): it computed `-expm1(exp(-x²/2σ²))` — a spurious inner `exp` — breaking the user-facing CDF and every fit path that evaluates `ff` (MSE, MPS, interval/truncated MLE). Found by computing the docstring examples; Rayleigh, Exponential and Uniform were missing from the mathematical-identity test matrix and are now included.

Every fix has a regression test; each fails on the pre-fix code.

## Restructure (`73b49c0`)

Move-only commit: the 16 distribution modules now live in `surpyval/univariate/parametric/distributions/`. All names are re-exported so the public API is unchanged; `to_dict`/`from_dict` are path-independent. Sphinx autoclass paths updated. Note: deep imports such as `surpyval.univariate.parametric.weibull` and pickles of pre-move models will no longer resolve.

## Deduplication (`fad61ff`, `1256237`, `22ede63`, `aa16b45`)

- Default `random()` (inverse-transform via `qf`) on `ParametricFitter`; 13 identical copies removed. Sampling is bit-identical for a given random state.
- `DEFAULT_Y_TICKS` constant replaces the identical 24-element list pasted into eight modules; LogLogistic's constructor no longer re-assigns everything `super().__init__` just set.
- One `fallback_minimize` (Newton-CG → BFGS → Nelder-Mead) shared by the MSE and MPS fitters; MPS's zero-Hessian guard now also protects MSE.
- `Parametric` and `MixtureModel` shared ~200 duplicated lines of probability-plot construction; both now delegate to a new `probability_plotting` module. Verified `get_plot_data` output is numerically identical before/after for Weibull (plain and offset), Normal, Beta, Uniform, and a Weibull mixture.
- Removed dead confidence-bound helpers: only Weibull's closed-form `R_cb` is actually reachable — Normal/LogNormal/Exponential have theirs commented out and Gamma's is named `R_cb_`, so all four already use the generic autograd bounds. **Open question:** remove Weibull's closed-form too? It differs from the generic bound by up to ~7% (log-log vs logit-space delta method) — a user-visible change, left out of this PR.

## Interface normalization (`138dd09`, `a234a99`, `aba7783`)

- All `_parameter_initialiser`s share `(self, x, c=None, n=None, t=None, offset=False)` (all no-ops — Gumbel's odd `offset=True` default was unused); Beta's mpp transforms take `*params` like every other distribution.
- Every fitter returns `params` as a numpy array and always includes `gamma`; the "ought to be fixed" coercion in `fit_from_surpyval_data` is gone, never-read result keys (`rr`, `jac`, `offset`) dropped, custom `mle`/`mpp` hooks normalized centrally.
- `Bernoulli_`/`ExactEventTime_` are real `ParametricFitter` subclasses; the distribution contract (including the `surpyval.np` = `autograd.numpy` requirement) is documented on the base class; `Parametric.plot` raises a clear `NotImplementedError` without plotting transforms; transform zips are strict so wrong-length initial guesses raise instead of truncating.

## Docstrings (`2d85d13`)

- Rayleigh's docstrings were wholesale Weibull copies (titles, formulas, parameters, examples); rewritten with Rayleigh formulas and verified outputs. GumbelLEV's showed Gumbel-SEV values and signs; corrected to LEV forms (examples now pass doctest).
- Returns sections across distributions carried wrong names from copy-paste (Beta's `sf/cs/ff/hf/Hf` all labelled "df", Normal/LogNormal/Uniform's `Hf` labelled "ff", etc.) — normalized to match each method.
- `Weibull.df`'s example passed four arguments to a three-argument method; Bernoulli's `ff` example called `sf`; `Parametric.mean/.moment/.entropy` opened with "A method to draw random samples" copied from `random()`; `alpha_ci` described as "confidence… defaults to 0.95" when it is the 0.05 significance level; typo sweep (Surival, probablility, whehter, proivded, "The the"); Logistic docstrings now raw strings so Sphinx renders LaTeX.

## Style (`74037c2`)

`and`/`or` instead of `&`/`|` on plain booleans (numpy masks untouched); `ValueError` instead of bare `Exception`; numerically stable `-expm1` form for the Exponential CDF; f-strings/implicit concatenation instead of `.format()` and `+` chains; commented-out alternative implementations deleted.

Verification: full test suite passes (239 tests; `tests/experimental` requires the optional `scikit-survival` extra), flake8 and black clean at every commit.

https://claude.ai/code/session_01Y8ihQrK2VafKUXWpqjdZzF