### PR TITLE
Fix conditional survival convention in Weibull and Rayleigh

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,19 +45,13 @@ Two crash bugs fixed in June 2026 (a `warnings.warng` typo and a `0 * inf = NaN`
 
 ## 3. API Consistency Issues
 
-### `cs()` means different things in different distributions
-The conditional survival function is `sf(x + X) / sf(X)` ("survive a
-further `x` given survival to `X`") in ten distributions, but
-`sf(x) / sf(X)` (absolute time, returns values > 1 for `x < X`) in
-Weibull and Rayleigh (`distributions/weibull.py`,
-`distributions/rayleigh.py`). The same method name silently computes
-different quantities depending on the distribution. `Parametric.cs`'s
-docstring example assumes the absolute-time convention; note also that
-its gamma handling (`self.dist.cs(x - gamma, X - gamma, ...)`) is only
-correct under that convention. Pick one definition (the
-further-survival form is the majority and the more standard), fix the
-two outliers, and document it. This changes results for existing
-Weibull/Rayleigh `cs` users, so it needs a release note.
+### Weibull/Rayleigh `cs()` convention change needs a release note
+Fixed June 2026: `cs()` now uniformly computes `sf(x + X) / sf(X)`
+("survive a further `x` given survival to `X`"). Weibull and Rayleigh
+previously computed `sf(x) / sf(X)` (absolute time), and
+`Parametric.cs` shifted `x` by gamma accordingly. This changes results
+for existing Weibull/Rayleigh `cs` users, so the next release's notes
+must call it out.
 
 ### Weibull is the only distribution with a closed-form `R_cb`
 **File:** `surpyval/univariate/parametric/distributions/weibull.py`

--- a/surpyval/tests/univariate/parametric/test_distributions_math.py
+++ b/surpyval/tests/univariate/parametric/test_distributions_math.py
@@ -6,6 +6,7 @@ Checks closed-form identities independent of fitting:
   2. ff(qf(p)) ≈ p       qf/ff roundtrip across the probability range
   3. qf(0.5)             equals the known closed-form median
   4. random() samples    have mean and variance matching analytical values
+  5. cs(x, X)            equals sf(x + X) / sf(X) (further survival)
 """
 
 import math
@@ -162,3 +163,30 @@ def test_random_sample_statistics(dist, params, true_mean, true_var):
     assert math.isclose(
         sample_var, true_var, rel_tol=VAR_REL_TOL
     ), f"{dist.name}: sample var {sample_var:.4f} vs expected {true_var}"
+
+
+# ---------------------------------------------------------------------------
+# 5. cs(x, X) == sf(x + X) / sf(X)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dist, params", DIST_PARAMS, ids=DIST_PARAM_IDS)
+def test_cs_is_further_survival(dist, params):
+    """cs(x, X) must be the probability of surviving a further x given
+    survival to X, i.e. sf(x + X) / sf(X), for every distribution."""
+    X = dist.qf(0.3, *params)
+    x = np.array([dist.qf(p, *params) for p in [0.4, 0.5, 0.6]]) - X
+    expected = dist.sf(x + X, *params) / dist.sf(X, *params)
+    computed = dist.cs(x, X, *params)
+    assert np.allclose(
+        computed, expected, rtol=1e-9
+    ), f"{dist.name}: cs(x, X) != sf(x + X) / sf(X)"
+
+
+def test_parametric_cs_with_offset():
+    """Parametric.cs must honour the further-survival convention when the
+    distribution has a location offset (gamma)."""
+    model = Weibull.from_params([10.0, 3.0], gamma=2.0)
+    x, X = 3.0, 5.0
+    expected = model.sf(x + X) / model.sf(X)
+    assert np.allclose(model.cs(x, X), expected)

--- a/surpyval/univariate/parametric/distributions/rayleigh.py
+++ b/surpyval/univariate/parametric/distributions/rayleigh.py
@@ -117,13 +117,15 @@ class Rayleigh_(ParametricFitter):
         Conditional survival function for the Rayleigh Distribution:
 
         .. math::
-            R(x, X) = \frac{R(x)}{R(X)}
+            R(x, X) = \frac{R(x + X)}{R(X)}
 
         Parameters
         ----------
 
         x : numpy array or scalar
             The values at which the function will be calculated
+        X : numpy array or scalar
+            The values at which the item is known to have survived
         sigma : numpy array or scalar
             scale parameter for the Rayleigh distribution
 
@@ -139,9 +141,9 @@ class Rayleigh_(ParametricFitter):
         >>> from surpyval import Rayleigh
         >>> x = np.array([1, 2, 3, 4, 5])
         >>> Rayleigh.cs(x, 5, 3)
-        array([3.79366789, 3.21127054, 2.43242545, 1.64872127, 1.        ])
+        array([0.54274748, 0.26359714, 0.11455884, 0.04455143, 0.01550385])
         """
-        return self.sf(x, sigma) / self.sf(X, sigma)
+        return self.sf(x + X, sigma) / self.sf(X, sigma)
 
     def df(self, x, sigma):
         r"""

--- a/surpyval/univariate/parametric/distributions/weibull.py
+++ b/surpyval/univariate/parametric/distributions/weibull.py
@@ -129,10 +129,10 @@ class Weibull_(ParametricFitter):
         >>> from surpyval import Weibull
         >>> x = np.array([1, 2, 3, 4, 5])
         >>> Weibull.cs(x, 5, 3, 4)
-        array([2.21654222e+03, 1.84183662e+03, 8.25549630e+02, 9.51596070e+01,
-               1.00000000e+00])
+        array([2.52537548e-04, 3.00394073e-10, 2.45288508e-19, 1.48999440e-32,
+               5.42544000e-51])
         """
-        return self.sf(x, alpha, beta) / self.sf(X, alpha, beta)
+        return self.sf(x + X, alpha, beta) / self.sf(X, alpha, beta)
 
     def df(self, x, alpha, beta):
         r"""

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -469,13 +469,18 @@ class Parametric(Distribution):
     def cs(self, x, X):
         r"""
 
-        The conditional survival of the model.
+        The conditional survival of the model; that is, the probability
+        that an item that has survived to ``X`` survives a further ``x``:
+
+        .. math::
+            R(x, X) = \frac{R(x + X)}{R(X)}
 
         Parameters
         ----------
 
         x : array like or scalar
-            The values at which conditional survival is to be calculated.
+            The further durations at which conditional survival is to be
+            calculated.
         X : array like or scalar
             The value(s) at which it is known the item has survived
 
@@ -494,9 +499,7 @@ class Parametric(Distribution):
         0.00025840046151723767
         """
         x = np.array(x)
-        cs = np.array(
-            self.dist.cs(x - self.gamma, X - self.gamma, *self.params)
-        )
+        cs = np.array(self.dist.cs(x, X - self.gamma, *self.params))
         cs[cs > 1.0] = 1
         return cs
 


### PR DESCRIPTION
cs() computed sf(x + X) / sf(X) (survive a further x given survival
to X) in eleven distributions but sf(x) / sf(X) in Weibull and
Rayleigh, silently returning values greater than one for x < X. Fix
the two outliers to the further-survival form, correct the gamma
handling in Parametric.cs which assumed the absolute-time convention,
and document the convention. Add identity tests covering cs for all
distributions and the offset path.

https://claude.ai/code/session_01VEebEmx4HH9aev6zgixQJM