### PR TITLE
Expand univariate test coverage, fix bugs found, and repair the docs build

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,11 +27,31 @@ This document tracks known issues, technical debt, and improvement priorities fo
 | Serialization (`to_dict` / `from_dict` / `to_json`) | `test_to_dict.py` is 0 bytes | `to_dict` is abstract on the `Distribution` ABC but has no coverage; `Bernoulli`/`ExactEventTime` round-trips are covered in `test_regressions.py` but the general path is not |
 | Probability plotting (`get_plot_data` / `plot` / `probability_plotting.py`) | `surpyval/univariate/parametric/` | No tests at all; the June 2026 plotting refactor was verified only by ad-hoc before/after output comparison |
 
-Two crash bugs fixed in June 2026 (a `warnings.warng` typo and a `0 * inf = NaN` in `InstantlyOccurs.Hf`) lived in these untested areas — coverage here pays for itself immediately.
+Two crash bugs fixed in June 2026 (a `warnings.warng` typo and a `0 * inf = NaN` in `InstantlyOccurs.Hf`) lived in these untested areas — coverage here pays for itself immediately. The June 2026 univariate fit-matrix expansion (methods × offset/lfp/zi/fixed, Exponential/Rayleigh, left censoring) found five real bugs the same way.
 
 ---
 
-## 2. API Consistency Issues
+## 2. Known Offset Estimation Issues
+
+Found during the June 2026 coverage expansion; each is reproducible
+with `dist.random(10_000, *params) + 10`:
+
+- **MOM with `offset=True` gives badly biased gamma.** e.g. Rayleigh
+  recovers gamma ≈ 6.1 when the true value is 10 (Weibull ≈ 9.6,
+  LogLogistic ≈ 9.0). MOM offset accuracy is deliberately untested;
+  either improve the moment matching or disallow `offset` for MOM.
+- **MPP with `offset=True` fails for Gamma** (recovers gamma ≈ −0.6
+  for a true value of 10) while every other offsettable distribution
+  recovers it well. `test_offset_fit_recovers_gamma` skips this
+  combination.
+- **Beta cannot actually be offset.** `_validate_fit_inputs` allows it
+  (`support[0] == 0`) but `Beta._parameter_initialiser` has no offset
+  path, so `Beta.fit(x, offset=True)` raises. Either support it or
+  validate it away.
+
+---
+
+## 3. API Consistency Issues
 
 ### Weibull/Rayleigh `cs()` convention change needs a release note
 Fixed June 2026: `cs()` now uniformly computes `sf(x + X) / sf(X)`
@@ -53,8 +73,12 @@ correctly carry zero variance, so free-parameter bounds on such fits
 are conditional (narrower than before, which treated fixed parameters
 as estimated), and `fixed={"p": ...}` / `fixed={"f0": ...}` work (they
 previously raised `IndexError` from an off-by-one in
-`Parametric.__init__`'s `param_map`). The next release's notes must
-call out the changed LFP/ZI and fixed-parameter bounds.
+`Parametric.__init__`'s `param_map`). Also fixed June 2026: `zi=True`
+with `offset=True` now optimises correctly — the zero-inflation mass
+was masked *after* the gamma shift, producing NaN likelihoods, a gamma
+bound capped at 0, and a model silently returned at its initial guess.
+The next release's notes must call out the changed LFP/ZI and
+fixed-parameter bounds.
 
 ### Weibull is the only distribution with a closed-form `R_cb`
 **File:** `surpyval/univariate/parametric/distributions/weibull.py`
@@ -102,7 +126,7 @@ The class body is mostly a commented-out likelihood/jacobian/hessian implementat
 
 ---
 
-## 3. Code Quality
+## 4. Code Quality
 
 ### Turnbull heuristic downgrade never takes effect
 **File:** `surpyval/univariate/parametric/parametric_fitter.py` (`_validate_fit_inputs`, ~line 344)
@@ -172,7 +196,7 @@ The broken convergence-failure handling in each copy was fixed (all three now em
 
 ---
 
-## 4. Semi-Parametric Regression — Future Work
+## 5. Semi-Parametric Regression — Future Work
 
 Four semi-parametric models are candidates for addition, in priority order:
 
@@ -190,7 +214,7 @@ The semi-parametric counterpart to Cox PH. Fits `log(T) = β'Z + ε` without ass
 
 ---
 
-## 5. Time-Varying Covariates and Truncation (to be confirmed)
+## 6. Time-Varying Covariates and Truncation (to be confirmed)
 
 Full support for time-varying covariates (TVCs) and left/right truncation across all regression model families needs to be designed and confirmed before implementation. Key points established so far:
 
@@ -204,6 +228,6 @@ Full support for time-varying covariates (TVCs) and left/right truncation across
 
 ---
 
-## 6. Long-term: Replace `autograd` with JAX (deferred)
+## 7. Long-term: Replace `autograd` with JAX (deferred)
 
 `autograd` (HIPS/autograd) is in low-activity maintenance mode with no GPU support. JAX is the spiritual successor and a near-drop-in replacement for `autograd.numpy` patterns. The interim steps (inlining the `autograd_gamma` gradients into `surpyval/utils/autograd_gamma_compat.py` and upgrading to `autograd` 1.8 for numpy 2.x compatibility) are done, so there is no urgency. A JAX migration can be revisited once the library is otherwise stable — it is a multi-week effort touching every gradient computation.

--- a/docs/Competing Risks SurPyval Modelling.rst
+++ b/docs/Competing Risks SurPyval Modelling.rst
@@ -38,7 +38,7 @@ times, a cause indicator, and optional censoring flags:
 
     # Simulated data: two competing causes
     np.random.seed(42)
-    t1 = Weibull.random(100, alpha=50, beta=2.5)   # cause 1 latent times
+    t1 = Weibull.random(100, 50, 2.5)   # cause 1 latent times
     t2 = Exponential.random(100, 1./80)             # cause 2 latent times
 
     # Observed time is the minimum; cause is which latent time was smaller

--- a/docs/Parametric SurPyval Modelling.rst
+++ b/docs/Parametric SurPyval Modelling.rst
@@ -178,7 +178,7 @@ Surpyval has the capacity to handle arbitrary truncated data. A common occurence
     import surpyval as surv
 
     np.random.seed(10)
-    x = surv.Weibull.random(100, alpha=100, beta=0.6)
+    x = surv.Weibull.random(100, 100, 0.6)
     # Keep only those values greater than 250
     threshold = 25
     x = x[x > threshold]
@@ -225,7 +225,7 @@ The example from above can be continued for right-truncated data as well.
     import surpyval as surv
 
     np.random.seed(10)
-    x = surv.Normal.random(100, mu=100, sigma=10)
+    x = surv.Normal.random(100, 100, 10)
     tl = 85
     tr = 115
     # Truncate the data

--- a/docs/Regression Modelling with SurPyval.rst
+++ b/docs/Regression Modelling with SurPyval.rst
@@ -92,22 +92,25 @@ negative makes it slower.
 SurPyval supports all four families, each available as pre-built instances for
 every standard distribution and as factory functions for custom combinations:
 
-+-------------------+--------------------------------------+----------------------------------------+
-| Family            | Effect of covariates                 | Ready-to-use examples                  |
-+===================+======================================+========================================+
-| Proportional      | Multiplies the hazard rate           | ``WeibullPH``, ``ExponentialPH``, …    |
-| Hazards (PH)      | :math:`h(x|Z) = h_0(x)\,\phi(Z)`    |                                        |
-+-------------------+--------------------------------------+----------------------------------------+
-| Accelerated       | Scales the time axis                 | ``WeibullAFT``, ``LogNormalAFT``, …    |
-| Failure Time      | :math:`H(x|Z) = H_0(\phi(Z)\,x)`    |                                        |
-| (AFT)             |                                      |                                        |
-+-------------------+--------------------------------------+----------------------------------------+
-| Proportional      | Scales the survival odds             | ``WeibullPO``, ``LogisticPO``, …       |
-| Odds (PO)         | :math:`O(x|Z) = O_0(x)\,\phi(Z)`    |                                        |
-+-------------------+--------------------------------------+----------------------------------------+
-| Accelerated Life  | Substitutes the life parameter       | ``AcceleratedLife(Weibull, Power)``,   |
-| (AL)              | with a physics-motivated function    | ``AcceleratedLife(Weibull, Eyring)``   |
-+-------------------+--------------------------------------+----------------------------------------+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 42 36
+
+   * - Family
+     - Effect of covariates
+     - Ready-to-use examples
+   * - Proportional Hazards (PH)
+     - Multiplies the hazard rate :math:`h(x|Z) = h_0(x)\,\phi(Z)`
+     - ``WeibullPH``, ``ExponentialPH``, …
+   * - Accelerated Failure Time (AFT)
+     - Scales the time axis :math:`H(x|Z) = H_0(\phi(Z)\,x)`
+     - ``WeibullAFT``, ``LogNormalAFT``, …
+   * - Proportional Odds (PO)
+     - Scales the survival odds :math:`O(x|Z) = O_0(x)\,\phi(Z)`
+     - ``WeibullPO``, ``LogisticPO``, …
+   * - Accelerated Life (AL)
+     - Substitutes the life parameter with a physics-motivated function
+     - ``AcceleratedLife(Weibull, Power)``, ``AcceleratedLife(Weibull, Eyring)``
 
 
 Semi-Parametric — Cox Proportional Hazards
@@ -212,7 +215,7 @@ a parametric PH model for any surpyval distribution:
 .. jupyter-execute::
 
     from surpyval import LogNormal
-    from surpyval.regression import PH
+    from surpyval import PH
 
     model = PH(LogNormal).fit(x=x, Z=Z, c=c)
     model
@@ -274,7 +277,7 @@ For distributions not in the pre-built list:
 .. jupyter-execute::
 
     from surpyval import Gamma
-    from surpyval.regression import AFT
+    from surpyval import AFT
 
     model = AFT(Gamma).fit(x=x, Z=Z, c=c)
     model
@@ -340,7 +343,7 @@ The ``PO`` factory accepts any distribution:
 .. jupyter-execute::
 
     from surpyval import Weibull
-    from surpyval.regression import PO
+    from surpyval import PO
 
     model = PO(Weibull).fit(x=x, Z=Z, c=c)
     model
@@ -386,35 +389,44 @@ Available life models
 
 The choice of life model depends on the physical failure mechanism:
 
-+------------------------+------------------------------------------+--------------------------------------+
-| Life model             | Formula :math:`\phi(Z)`                  | Typical use                          |
-+========================+==========================================+======================================+
-| ``ExponentialLifeModel``| :math:`b \cdot e^{a/Z}` (Arrhenius)    | Thermally-activated (chemical,       |
-|                        |                                          | diffusion, electromigration)         |
-+------------------------+------------------------------------------+--------------------------------------+
-| ``Eyring``             | :math:`Z^{-1} e^{-(c - a/Z)}`           | Quantum-mechanical processes;        |
-|                        |                                          | more accurate than Arrhenius at      |
-|                        |                                          | extreme temperatures                 |
-+------------------------+------------------------------------------+--------------------------------------+
-| ``InversePower``       | :math:`1 / (a \cdot Z^n)`               | Voltage, electrical field,           |
-|                        |                                          | mechanical fatigue                   |
-+------------------------+------------------------------------------+--------------------------------------+
-| ``Power``              | :math:`a \cdot Z^n`                      | Same as InversePower but with        |
-|                        |                                          | life increasing with stress          |
-+------------------------+------------------------------------------+--------------------------------------+
-| ``Linear``             | :math:`a + b \cdot Z`                    | Simple first-order approximation;    |
-|                        |                                          | valid over narrow stress ranges      |
-+------------------------+------------------------------------------+--------------------------------------+
-| ``DualExponential``    | :math:`c \cdot e^{a/Z_1} e^{b/Z_2}`    | Two thermal stresses                 |
-+------------------------+------------------------------------------+--------------------------------------+
-| ``DualPower``          | :math:`c \cdot Z_1^m Z_2^n`             | Two non-thermal stresses             |
-+------------------------+------------------------------------------+--------------------------------------+
-| ``PowerExponential``   | :math:`c \cdot e^{a/Z_1} Z_2^n`        | One thermal + one non-thermal        |
-+------------------------+------------------------------------------+--------------------------------------+
-| ``InverseEyring``      | Reciprocal of Eyring                     | Inverse Eyring relationship          |
-+------------------------+------------------------------------------+--------------------------------------+
-| ``InverseExponential`` | Reciprocal of Arrhenius                  | Inverse Arrhenius relationship       |
-+------------------------+------------------------------------------+--------------------------------------+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 38 36
+
+   * - Life model
+     - Formula :math:`\phi(Z)`
+     - Typical use
+   * - ``ExponentialLifeModel``
+     - :math:`b \cdot e^{a/Z}` (Arrhenius)
+     - Thermally-activated (chemical, diffusion, electromigration)
+   * - ``Eyring``
+     - :math:`Z^{-1} e^{-(c - a/Z)}`
+     - Quantum-mechanical processes; more accurate than Arrhenius at
+       extreme temperatures
+   * - ``InversePower``
+     - :math:`1 / (a \cdot Z^n)`
+     - Voltage, electrical field, mechanical fatigue
+   * - ``Power``
+     - :math:`a \cdot Z^n`
+     - Same as InversePower but with life increasing with stress
+   * - ``Linear``
+     - :math:`a + b \cdot Z`
+     - Simple first-order approximation; valid over narrow stress ranges
+   * - ``DualExponential``
+     - :math:`c \cdot e^{a/Z_1} e^{b/Z_2}`
+     - Two thermal stresses
+   * - ``DualPower``
+     - :math:`c \cdot Z_1^m Z_2^n`
+     - Two non-thermal stresses
+   * - ``PowerExponential``
+     - :math:`c \cdot e^{a/Z_1} Z_2^n`
+     - One thermal + one non-thermal
+   * - ``InverseEyring``
+     - Reciprocal of Eyring
+     - Inverse Eyring relationship
+   * - ``InverseExponential``
+     - Reciprocal of Arrhenius
+     - Inverse Arrhenius relationship
 
 A note on units: the stress variable :math:`Z` for Arrhenius and Eyring should
 be in Kelvin (absolute temperature), not Celsius.
@@ -425,7 +437,7 @@ Using the factory
 .. jupyter-execute::
 
     from surpyval import Weibull
-    from surpyval.regression import AcceleratedLife, Power, ExponentialLifeModel
+    from surpyval import AcceleratedLife, Power, ExponentialLifeModel
 
     # Discrete stress levels — three temperatures in Kelvin
     stress = np.array([358.]*20 + [378.]*20 + [398.]*20)  # 85°C, 105°C, 125°C
@@ -484,7 +496,7 @@ your own by subclassing ``LifeModel``. The two methods you must implement are:
 
 .. jupyter-execute::
 
-    from surpyval.regression import LifeModel, AcceleratedLife
+    from surpyval import LifeModel, AcceleratedLife
     from surpyval import Weibull
     import autograd.numpy as anp
 
@@ -524,7 +536,7 @@ using the same Weibull baseline:
 .. jupyter-execute::
 
     from surpyval import WeibullAFT, WeibullPH
-    from surpyval.regression import PO
+    from surpyval import PO
     from surpyval import Weibull
 
     models = {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,3 @@
-lifelines==0.30.0
-reliability==0.9.0
 matplotlib>=3.10
 sphinx-copybutton
 sphinx==5.3.0

--- a/surpyval/tests/univariate/parametric/test_confidence_bounds.py
+++ b/surpyval/tests/univariate/parametric/test_confidence_bounds.py
@@ -270,6 +270,25 @@ def test_fixed_f0_zi():
     assert np.allclose(model.param_cb("f0"), [model.f0, model.f0])
 
 
+@pytest.mark.parametrize("dist_name", ["Weibull", "Gamma"])
+def test_offset_model_cb(dist_name):
+    # Weibull exercises the closed-form R_cb with an offset; Gamma the
+    # generic delta-method path. gamma carries no variance.
+    np.random.seed(8)
+    dist = getattr(surv, dist_name)
+    params = {"Weibull": (10, 2), "Gamma": (3, 2)}[dist_name]
+    x = dist.random(500, *params) + 10
+    model = dist.fit(x, offset=True)
+    assert model.gamma > 5
+
+    t = np.linspace(np.quantile(x, 0.1), np.quantile(x, 0.9), 8)
+    for on in ["sf", "ff", "Hf", "hf", "df"]:
+        cb = model.cb(t, on=on, bound="two-sided", alpha_ci=0.05)
+        point = getattr(model, on)(t)
+        assert np.all(cb[:, 0] < point)
+        assert np.all(point < cb[:, 1])
+
+
 def test_cb_round_trips_through_serialization(lfp_model):
     model = lfp_model
     t = np.linspace(5, 50, 10)

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -3,6 +3,7 @@ import pytest
 
 from surpyval import (
     Beta,
+    Exponential,
     ExpoWeibull,
     Gamma,
     Gumbel,
@@ -11,6 +12,7 @@ from surpyval import (
     LogLogistic,
     LogNormal,
     Normal,
+    Rayleigh,
     Weibull,
 )
 
@@ -25,6 +27,8 @@ DISTS = [
     Beta,
     ExpoWeibull,
     Gamma,
+    Exponential,
+    Rayleigh,
 ]
 
 parameter_sample_random_parameters = [
@@ -38,6 +42,8 @@ parameter_sample_random_parameters = [
     ((0.1, 30), (0.1, 30)),
     ((1, 30), (0.1, 10), (0.5, 1.5)),
     ((1, 30), (0.1, 10)),
+    ((0.1, 1),),
+    ((1, 30),),
 ]
 FIT_SIZES = [1_000, 10_000, 100_000]
 
@@ -50,7 +56,13 @@ def set_random_seed():
 def generate_mle_test_cases():
     for idx, dist in enumerate(DISTS):
         random_parameters = parameter_sample_random_parameters[idx]
-        for kind in ["full", "censored", "truncated", "interval"]:
+        for kind in [
+            "full",
+            "censored",
+            "left_censored",
+            "truncated",
+            "interval",
+        ]:
             yield dist, random_parameters, kind
 
 
@@ -175,6 +187,9 @@ def test_mle_convergence(dist, random_parameters, kind):
             model = dist.fit(x)
         elif kind == "censored":
             x, c = censor_at(x, 0.025, "right")
+            model = dist.fit(x, c=c)
+        elif kind == "left_censored":
+            x, c = censor_at(x, 0.025, "left")
             model = dist.fit(x, c=c)
         elif kind == "truncated":
             x, tl, tr = truncate_at(x, 0.05, "both")
@@ -315,6 +330,30 @@ def test_mps_truncated(dist, random_parameters):
             break
     else:
         raise AssertionError("MPS fit not very good in %s\n" % dist.name)
+
+
+OFFSET_CASES = [
+    (Weibull, (10.0, 2.0)),
+    (Gamma, (3.0, 2.0)),
+    (LogNormal, (1.0, 0.5)),
+    (LogLogistic, (5.0, 2.0)),
+    (Exponential, (0.5,)),
+    (Rayleigh, (3.0,)),
+]
+
+
+@pytest.mark.parametrize("how", ["MLE", "MPS", "MSE", "MPP"])
+@pytest.mark.parametrize(
+    "dist,dist_params", OFFSET_CASES, ids=[d.name for d, _ in OFFSET_CASES]
+)
+def test_offset_fit_recovers_gamma(dist, dist_params, how):
+    if how == "MPP" and dist is Gamma:
+        pytest.skip("MPP gamma estimation fails for Gamma (see DEVELOPMENT)")
+    gamma = 10.0
+    x = dist.random(10_000, *dist_params) + gamma
+    model = dist.fit(x, offset=True, how=how)
+    assert abs(model.gamma - gamma) < 0.5
+    assert np.allclose(model.params, dist_params, rtol=0.15)
 
 
 @pytest.mark.parametrize(

--- a/surpyval/tests/univariate/parametric/test_fixed.py
+++ b/surpyval/tests/univariate/parametric/test_fixed.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from surpyval import (
     Gamma,
@@ -23,10 +24,37 @@ def test_fixed():
         LogLogistic,
         Normal,
     ]:
-        for method in ["MLE", "MSE", "MPS"]:
+        for method in ["MLE", "MSE", "MPS", "MOM"]:
             for param in dist.param_names:
                 x = dist.random(100, 10, 2)
                 fixed_value = np.random.randint(2, 10)
                 model = dist.fit(x, fixed={param: fixed_value}, how=method)
                 if not model.params[dist.param_map[param]] == fixed_value:
                     raise ValueError(model.params, fixed_value)
+
+
+def test_fixed_gamma():
+    np.random.seed(1)
+    x = Weibull.random(1000, 10, 2) + 10
+    for method in ["MLE", "MSE", "MPS"]:
+        model = Weibull.fit(x, offset=True, how=method, fixed={"gamma": 10.0})
+        assert model.gamma == 10.0
+        assert np.allclose(model.params, [10, 2], rtol=0.1)
+
+
+def test_fixed_all_params():
+    np.random.seed(2)
+    x = Weibull.random(100, 10, 2)
+    model = Weibull.fit(x, fixed={"alpha": 10.0, "beta": 2.0})
+    assert np.allclose(model.params, [10.0, 2.0])
+    # Nothing is estimated, so nothing carries variance
+    assert np.all(model.hess_inv == 0)
+    assert np.all(model.cov_matrix == 0)
+
+
+def test_mpp_fixed_raises():
+    # MPP cannot honour fixed parameters; it used to silently ignore
+    # them and return a fully estimated model
+    x = Weibull.random(100, 10, 2)
+    with pytest.raises(ValueError, match="MPP"):
+        Weibull.fit(x, how="MPP", fixed={"beta": 2.0})

--- a/surpyval/tests/univariate/parametric/test_fixed.py
+++ b/surpyval/tests/univariate/parametric/test_fixed.py
@@ -52,6 +52,26 @@ def test_fixed_all_params():
     assert np.all(model.cov_matrix == 0)
 
 
+def test_fixed_with_free_only_init():
+    # An initial guess covering only the free parameters is merged with
+    # the fixed values. This used to work only when the fixed parameters
+    # came last in the parameter vector (silent zip truncation), and
+    # crashed once the transforms became strict.
+    x = [87.0, 100.0]
+    c = [0, 1]
+    n = [1, 9]
+    model = Weibull.fit(x, c, n, fixed={"beta": 1.3776}, init=[100.0])
+    assert model.params[1] == 1.3776
+
+    np.random.seed(3)
+    x = Weibull.random(100, 10, 2)
+    model = Weibull.fit(x, fixed={"alpha": 10.0}, init=[2.0])
+    assert model.params[0] == 10.0
+    # And a full-length init still works
+    model = Weibull.fit(x, fixed={"alpha": 10.0}, init=[10.0, 2.0])
+    assert model.params[0] == 10.0
+
+
 def test_mpp_fixed_raises():
     # MPP cannot honour fixed parameters; it used to silently ignore
     # them and return a fully estimated model

--- a/surpyval/tests/univariate/parametric/test_lfp_zi.py
+++ b/surpyval/tests/univariate/parametric/test_lfp_zi.py
@@ -14,15 +14,21 @@ from surpyval import (
 
 
 def test_zi():
+    np.random.seed(42)
     for dist in [Beta, Weibull, LogNormal, LogLogistic, Gamma]:
         for zeros in [1, 10, 100, 1000, 10000]:
             x = dist.random(100, 10, 2)
             x = np.concatenate((x, np.zeros(zeros)))
             model = dist.fit(x, zi=True)
             assert model.res.success
+            # The zero-inflation estimate must match the actual
+            # proportion of zeros
+            f0_true = zeros / (100 + zeros)
+            assert abs(model.f0 - f0_true) < 0.05
 
 
 def test_lfp():
+    np.random.seed(42)
     for dist in [
         Beta,
         Gamma,
@@ -40,9 +46,14 @@ def test_lfp():
             x = np.concatenate((x, x.max() * np.ones(censored)))
             model = dist.fit(x, c=c, lfp=True)
             assert model.res.success
+            # All failures are observed before the censor time, so the
+            # max proportion estimate must match the failing fraction
+            p_true = 100 / (100 + censored)
+            assert abs(model.p - p_true) < 0.1
 
 
 def test_lfp_zi():
+    np.random.seed(42)
     for dist in [Gamma, Weibull, LogNormal, LogLogistic]:
         for zi_lfp_values in [1, 10, 100]:
             for num_samples in [100, 1000, 10000]:
@@ -64,3 +75,35 @@ def test_lfp_zi():
                 model = dist.fit(x, c=c, zi=True, lfp=True)
                 if not model.res.success:
                     raise ValueError(model, model.res)
+                total = num_samples + 2 * zi_lfp_values
+                f0_true = zi_lfp_values / total
+                p_true = (num_samples + zi_lfp_values) / total
+                assert abs(model.f0 - f0_true) < 0.05
+                assert abs(model.p - p_true) < 0.1
+
+
+def test_offset_lfp():
+    np.random.seed(1)
+    n = 2000
+    x = Weibull.random(n, 10, 2) + 10
+    c = np.zeros(n)
+    never = np.random.uniform(size=n) > 0.7
+    x[never] = x.max() + 1
+    c[never] = 1
+
+    model = Weibull.fit(x, c=c, lfp=True, offset=True)
+    assert model.res.success
+    assert abs(model.gamma - 10) < 1
+    assert abs(model.p - 0.7) < 0.05
+
+
+def test_offset_zi():
+    # The offset bound and initial guess must come from the nonzero
+    # observations; the zeros belong to the zero-inflation mass
+    np.random.seed(2)
+    x = np.concatenate([Weibull.random(1000, 10, 2) + 10, np.zeros(100)])
+
+    model = Weibull.fit(x, zi=True, offset=True)
+    assert model.res.success
+    assert abs(model.gamma - 10) < 1
+    assert abs(model.f0 - 100 / 1100) < 0.02

--- a/surpyval/tests/univariate/parametric/test_regressions.py
+++ b/surpyval/tests/univariate/parametric/test_regressions.py
@@ -11,6 +11,7 @@ from surpyval import (
     ExactEventTime,
     Exponential,
     LogLogistic,
+    LogNormal,
     Normal,
     Parametric,
     Weibull,
@@ -46,6 +47,15 @@ def test_loglogistic_offset_initial_guess_length():
         np.array([1.0, 2.0, 3.0, 4.0, 5.0]), offset=True
     )
     assert len(init) == LogLogistic.k + 1
+
+
+def test_lognormal_offset_initial_guess_length():
+    # The offset initial guess ignored the offset flag and returned one
+    # parameter too few, so offset fits crashed before optimising.
+    init = LogNormal._parameter_initialiser(
+        np.array([1.0, 2.0, 3.0, 4.0, 5.0]), offset=True
+    )
+    assert len(init) == LogNormal.k + 1
 
 
 def test_mps_right_truncation_clamped_to_support():

--- a/surpyval/tests/univariate/regression/test_regression.py
+++ b/surpyval/tests/univariate/regression/test_regression.py
@@ -133,3 +133,21 @@ def test_formula_interface_matches_Z_cols():
     )
 
     assert np.allclose(model_z.beta, model_f.beta)
+
+
+def test_parametric_ph_aic_bic():
+    # ParametricRegressionModel.aic/bic crashed: the PH fitter never set
+    # model.k, and bic/aic_c indexed SurpyvalData like a dict.
+    from surpyval import Weibull, WeibullPH
+
+    np.random.seed(1)
+    n = 100
+    Z = np.random.binomial(1, 0.5, n).reshape(-1, 1)
+    x = Weibull.random(n, 10, 2) * np.exp(-0.5 * Z[:, 0])
+    model = WeibullPH.fit(x=x, Z=Z)
+
+    assert model.k == 3
+    assert np.isfinite(model.aic())
+    assert np.isfinite(model.aic_c())
+    assert np.isfinite(model.bic())
+    assert model.aic() < model.aic_c()

--- a/surpyval/univariate/parametric/distributions/lognormal.py
+++ b/surpyval/univariate/parametric/distributions/lognormal.py
@@ -34,7 +34,15 @@ class LogNormal_(ParametricFitter):
         )
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
-        # Need an offset mpp function here
+        if offset:
+            # Shift the data so the log transform is defined, then
+            # initialise mu and sigma from the shifted data
+            gamma_init = np.min(x) - 1.0
+            norm_mod = para.Normal.fit(
+                np.log(x - gamma_init), c=c, n=n, how="MLE"
+            )
+            mu, sigma = norm_mod.params
+            return gamma_init, mu, sigma
         norm_mod = para.Normal.fit(np.log(x), c=c, n=n, how="MLE")
         mu, sigma = norm_mod.params
         return mu, sigma

--- a/surpyval/univariate/parametric/distributions/rayleigh.py
+++ b/surpyval/univariate/parametric/distributions/rayleigh.py
@@ -41,10 +41,12 @@ class Rayleigh_(ParametricFitter):
         )
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
+        # sqrt(E[x^2] / 2) is the closed-form uncensored MLE for sigma
         if offset:
-            return 1.0, np.min(x) - 1
-        else:
-            return 1.0
+            gamma_init = np.min(x) - 1.0
+            sigma_init = np.sqrt(np.mean((x - gamma_init) ** 2) / 2)
+            return gamma_init, sigma_init
+        return np.sqrt(np.mean(x**2) / 2)
 
     def sf(self, x, sigma):
         r"""

--- a/surpyval/univariate/parametric/fitters/__init__.py
+++ b/surpyval/univariate/parametric/fitters/__init__.py
@@ -116,7 +116,7 @@ def bounds_convert(x, bounds, fixed, param_map):
     if fixed is not None:
         fixed_idx = [param_map[x] for x in fixed.keys()]
         not_fixed = [x for x in range(n_params) if x not in fixed_idx]
-        not_fixed = np.array(not_fixed)
+        not_fixed = np.array(not_fixed, dtype=int)
 
         def constraints(p):
             params = [0] * (n_params)

--- a/surpyval/univariate/parametric/fitters/mle.py
+++ b/surpyval/univariate/parametric/fitters/mle.py
@@ -3,7 +3,7 @@ import warnings
 from autograd import hessian, jacobian
 from autograd.numpy.linalg import inv
 from numdifftools import Hessian  # type: ignore
-from scipy.optimize import minimize
+from scipy.optimize import OptimizeResult, minimize
 
 from surpyval import np
 
@@ -75,18 +75,36 @@ def mle(model):
     best_method = None
 
     with np.errstate(all="ignore"):
-        # Try easiest, to most complex optimisations. Each method warm
-        # starts from the best point found so far rather than the cold
-        # initial guess.
-        for method, jac_i, hess_i in [
-            ("Nelder-Mead", None, None),
-            ("Powell", None, None),
-            ("BFGS", None, None),
-            ("TNC", jac, None),
-            ("Newton-CG", jac, hess),
-        ]:
+        if len(init) == 0:
+            # Every parameter is fixed; there is nothing to optimise
+            res = OptimizeResult(
+                x=init,
+                success=True,
+                fun=fun(init, offset, lfp, zi, True),
+                message="",
+            )
+            best_result = res
+            best_method = method = "all parameters fixed"
+            methods = []
+        else:
+            methods = [
+                ("Nelder-Mead", None, None),
+                ("Powell", None, None),
+                ("BFGS", None, None),
+                ("TNC", jac, None),
+                ("Newton-CG", jac, hess),
+            ]
+
+        # Try easiest, to most complex optimisations. The derivative
+        # free methods each explore from the cold initial guess so a
+        # poor basin found by one does not trap the rest; the gradient
+        # methods then refine the best point found so far.
+        for method, jac_i, hess_i in methods:
             opts = {"maxfun": 1000} if method == "TNC" else {"maxiter": 1000}
-            x0 = init if best_result is None else best_result.x
+            if method in ("Nelder-Mead", "Powell") or best_result is None:
+                x0 = init
+            else:
+                x0 = best_result.x
             res = minimize(
                 fun,
                 x0,

--- a/surpyval/univariate/parametric/fitters/mom.py
+++ b/surpyval/univariate/parametric/fitters/mom.py
@@ -27,7 +27,13 @@ def mom(model):
 
     x_ = np.repeat(x, n)
 
-    if hasattr(dist, "_mom"):
+    # The closed-form moment estimate cannot honour fixed parameters or
+    # an offset, so only use it for a plain fit
+    if (
+        hasattr(dist, "_mom")
+        and not offset
+        and not model.fitting_info["fixed_idx"]
+    ):
         return {"params": np.atleast_1d(dist._mom(x_)), "gamma": 0.0}
 
     moments = np.zeros(model.k)

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -41,7 +41,12 @@ class Parametric(Distribution):
 
         if offset:
             if data is not None:
-                bounds = ((None, np.min(data["x"])), *bounds)
+                x_min = np.asarray(data["x"])
+                if zi:
+                    # Exact zeros belong to the zero-inflation mass, so
+                    # they must not cap the offset of the continuous part
+                    x_min = x_min[x_min != 0]
+                bounds = ((None, np.min(x_min)), *bounds)
             else:
                 bounds = ((None, None), *bounds)
 

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -923,6 +923,14 @@ class ParametricFitter:
                     init = np.concatenate([init, [f_0_init]])
 
             init = np.atleast_1d(init)
+            if fixed and len(init) == len(not_fixed):
+                # The initial guess covers only the free parameters;
+                # merge it with the fixed values to get the full vector
+                full_init = np.zeros(len(model.param_map))
+                full_init[not_fixed] = init
+                for name, value in fixed.items():
+                    full_init[model.param_map[name]] = value
+                init = full_init
             init = transform(init)
             init = init[not_fixed]
             fitting_info["init"] = init

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -136,15 +136,17 @@ class ParametricFitter:
     @_check_x_not_empty
     def ll_observed(self, x, n, *params):
         *params, gamma, f0, p = params
-        x = x - gamma
         if f0 == 0:
             # Not zero-inflated; x == 0 is an ordinary observation.
             zero_weight = 0
             non_zero_mask = np.full(x.shape, True)
         else:
+            # The zero-inflation mass sits at x == 0 in observed time,
+            # so the mask must be taken before the offset shift
             n_zeros = np.sum(n[x == 0])
             zero_weight = n_zeros * np.log(f0) if n_zeros != 0 else 0
             non_zero_mask = x != 0
+        x = x - gamma
         N = np.sum(n[non_zero_mask])
         return (
             (n[non_zero_mask] * self.log_df(x[non_zero_mask], *params)).sum()
@@ -284,10 +286,25 @@ class ParametricFitter:
         return moments
 
     def _validate_fit_inputs(
-        self, surv_data, how, offset, lfp, zi, heuristic, turnbull_estimator
+        self,
+        surv_data,
+        how,
+        offset,
+        lfp,
+        zi,
+        fixed,
+        heuristic,
+        turnbull_estimator,
     ):
         if offset and (self.support[0] != 0):
             detail = f"{self.name} distribution cannot be offset"
+            raise ValueError(detail)
+
+        if fixed and how == "MPP":
+            detail = (
+                "Probability plotting (MPP) does not support"
+                " fixing parameters"
+            )
             raise ValueError(detail)
 
         if how not in PARA_METHODS:
@@ -785,7 +802,14 @@ class ParametricFitter:
 
         # Validate inputs
         self._validate_fit_inputs(
-            surv_data, how, offset, lfp, zi, heuristic, turnbull_estimator
+            surv_data,
+            how,
+            offset,
+            lfp,
+            zi,
+            fixed,
+            heuristic,
+            turnbull_estimator,
         )
 
         # Passed checks
@@ -859,6 +883,14 @@ class ParametricFitter:
                             x_init = x_init[in_support_mask]
                             c_init = c_init[in_support_mask]
                             n_init = n[in_support_mask]
+                        elif zi:
+                            # Exact zeros belong to the zero-inflation
+                            # mass; including them would drag the offset
+                            # initial guess below zero
+                            nonzero_mask = x_init != 0
+                            x_init = x_init[nonzero_mask]
+                            c_init = c_init[nonzero_mask]
+                            n_init = n_init[nonzero_mask]
 
                         # Create an initial estimate with the new points
                         init = self._parameter_initialiser(
@@ -867,7 +899,8 @@ class ParametricFitter:
                         init = np.array(init)
 
                         if offset:
-                            init[0] = x.min() - 1.0
+                            x_nonzero = x[x != 0] if zi else x
+                            init[0] = x_nonzero.min() - 1.0
 
                 if lfp:
                     _, _, _, F = pp(

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -403,7 +403,7 @@ class ParametricRegressionModel:
             return self._bic
         else:
             self._bic = (
-                self.k * np.log(self.data["n"][self.data["c"] == 0].sum())
+                self.k * np.log(self.data.n[self.data.c == 0].sum())
                 + 2 * self.neg_ll()
             )
             return self._bic
@@ -476,7 +476,7 @@ class ParametricRegressionModel:
             return self._aic_c
         else:
             k = len(self.params)
-            n = self.data["n"].sum()
+            n = self.data.n.sum()
             self._aic_c = self.aic() + (2 * k**2 + 2 * k) / (n - k - 1)
             return self._aic_c
 

--- a/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
+++ b/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
@@ -323,6 +323,7 @@ class ProportionalHazardsFitter:
         model._neg_ll = res["fun"]
         model.fixed = fixed
         model.k_dist = self.k_dist
+        model.k = len(bounds)
         model.phi_param_map = phi_param_map
         model.data = data
 


### PR DESCRIPTION
Follow-up to #68 with the remaining two commits on this branch.

## Test coverage expansion (`fe37dc0`)

Expands the univariate test matrix across methods × offset/lfp/zi/fixed combinations: Exponential and Rayleigh join the full fit matrix, MLE convergence now covers left-censored data, a new gamma-recovery test runs across MLE/MPS/MSE/MPP for all offsettable distributions, lfp/zi tests assert that `p`/`f0` are recovered accurately (not just that the optimizer reported success), and fixed-parameter tests cover MOM, fixed gamma, and all-parameters-fixed.

The new tests found and this PR fixes six bugs:

- Warm-starting Powell from Nelder-Mead's result could trap the whole optimizer cascade in one bad basin (27 nats worse on an LFP fit); derivative-free methods now explore from the cold initial guess, only gradient methods warm-start
- `zi=True` with `offset=True` produced NaN likelihoods (zero-inflation mask applied after the gamma shift) and silently returned its initial guess
- MPP silently ignored `fixed`; it now raises `ValueError`
- The closed-form MOM shortcut silently ignored `fixed` and `offset`
- LogNormal could not be offset-fit at all (initial guess returned one parameter too few)
- Rayleigh's initialiser returned a constant `1.0`, so MPS and interval-censored MLE silently returned `sigma = 1` for any data

Remaining known offset issues (MOM bias, MPP+Gamma, Beta) are recorded in DEVELOPMENT.md.

## Docs build repair (`16a6fcf`)

The Read the Docs deploy failed on executed example cells. Fixes: keyword args passed to `random()`, imports from the removed `surpyval.regression` path, two malformed grid tables, and the unused `lifelines`/`reliability` pins in `docs/requirements.txt` that conflict with `pandas>=3`. The doc examples also exposed two library bugs, both fixed with regression tests: `fixed=` with an init covering only the free parameters crashed in the strict transforms, and `aic()`/`bic()` crashed on all proportional-hazards regression models (`model.k` never set; `SurpyvalData` indexed like a dict).

Verified: full suite green (365 passed), flake8/black/mypy clean, and `sphinx-build` completes with exit 0 on the pinned toolchain.

https://claude.ai/code/session_01BGCRewe3RHysE26SaPfvEx

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGCRewe3RHysE26SaPfvEx)_