### PR TITLE
Improve non-parametric confidence bounds and fix module bugs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -188,7 +188,76 @@ The broken convergence-failure handling in each copy was fixed (all three now em
 
 ---
 
-## 5. Semi-Parametric Regression — Future Work
+## 5. Univariate Non-Parametric Module — Remaining Work
+
+The June 2026 confidence-bound review fixed the per-estimator variance
+formulas (Greenwood for KM, Aalen for NA, tie-corrected for FH), the
+`random()`/`qf`/`mean` correctness bugs, and added quantile and RMST
+intervals, a bootstrap, simultaneous confidence bands, the log-rank
+test, and a smoothed hazard estimator. The following engineering debt
+in `surpyval/univariate/nonparametric/` remains.
+
+### Turnbull EM performance and convergence control
+**File:** `surpyval/univariate/nonparametric/turnbull.py`
+
+The EM loop builds `dok_matrix` sparse matrices and iterates over
+`.keys()`/`.values()` in Python, which dominates runtime (the bootstrap
+and any simulation involving Turnbull are noticeably slow). The
+convergence criterion is hardcoded — `np.allclose(p, p_prev,
+rtol=1e-30, atol=1e-30)` with a silent `iters < 1000` cap — so a
+non-converged fit is returned without warning, and callers cannot
+trade accuracy for speed. Expose `tol` and `max_iter` as `fit`
+parameters, emit a `warnings.warn` when the cap is hit without
+convergence, and act on the existing in-file TODO to do row-wise
+iteration on the sparse matrices.
+
+### `random()` uses the legacy global RNG
+**File:** `nonparametric.py` (`NonParametric.random`, ~line 454)
+
+`random()` calls `np.random.choice`, drawing on the legacy global
+random state, so it cannot be seeded locally and is inconsistent with
+the new `bootstrap_cb`/`band` methods that already accept a
+`random_state`. Add a `random_state` argument and route through
+`np.random.default_rng`, matching the parametric side.
+
+### No serialization
+Parametric models expose `to_dict`/`to_json`; `NonParametric` has
+nothing. A fitted non-parametric model (its `x`, `R`, `r`, `d`,
+`greenwood`, and estimator metadata) cannot be persisted or
+round-tripped. Add `to_dict`/`from_dict` (and the JSON wrappers) and
+fold the result into the empty `test_to_dict.py` once the general
+parametric path is also covered.
+
+### `interp='cubic'` can violate monotonicity
+**File:** `nonparametric.py` (`interp_function`)
+
+The survival function is monotone non-increasing, but `interp1d(...,
+kind='cubic')` can overshoot and produce a non-monotone — even
+out-of-`[0, 1]` — interpolated curve, which then propagates into `Hf`,
+`hf`, and the interpolated confidence bounds. Switch the smooth
+interpolation to a shape-preserving monotone scheme
+(`scipy.interpolate.PchipInterpolator`) so interpolated curves remain
+valid survival functions.
+
+### `dist='t'` confidence-bound heuristic
+**File:** `nonparametric.py` (`R_cb`)
+
+The `dist='t'` option is documented as an unfounded conservative
+heuristic (degrees of freedom from the at-risk count, undefined at the
+last point). It is retained only for backward compatibility; decide
+whether to formally deprecate and remove it, or keep it and accept the
+maintenance of a statistically unjustified path.
+
+### Type hints and residual test gaps
+The module is untyped despite the package shipping `py.typed` (see also
+section 4). The new behaviour is well covered, but `plot()` with
+non-step `interp`, the `set_lower_limit` path in
+`NonParametricFitter.fit`, and the `from_xrd` entry point still have no
+direct tests.
+
+---
+
+## 6. Semi-Parametric Regression — Future Work
 
 Four semi-parametric models are candidates for addition, in priority order:
 
@@ -206,7 +275,7 @@ The semi-parametric counterpart to Cox PH. Fits `log(T) = β'Z + ε` without ass
 
 ---
 
-## 6. Time-Varying Covariates and Truncation (to be confirmed)
+## 7. Time-Varying Covariates and Truncation (to be confirmed)
 
 Full support for time-varying covariates (TVCs) and left/right truncation across all regression model families needs to be designed and confirmed before implementation. Key points established so far:
 
@@ -220,6 +289,6 @@ Full support for time-varying covariates (TVCs) and left/right truncation across
 
 ---
 
-## 7. Long-term: Replace `autograd` with JAX (deferred)
+## 8. Long-term: Replace `autograd` with JAX (deferred)
 
 `autograd` (HIPS/autograd) is in low-activity maintenance mode with no GPU support. JAX is the spiritual successor and a near-drop-in replacement for `autograd.numpy` patterns. The interim steps (inlining the `autograd_gamma` gradients into `surpyval/utils/autograd_gamma_compat.py` and upgrading to `autograd` 1.8 for numpy 2.x compatibility) are done, so there is no urgency. A JAX migration can be revisited once the library is otherwise stable — it is a multi-week effort touching every gradient computation.

--- a/docs/Non-Parametric SurPyval Modelling.rst
+++ b/docs/Non-Parametric SurPyval Modelling.rst
@@ -62,7 +62,7 @@ The above shows that approximately 80% will survive up to a stress of 34. Theref
 
 It is up to the designer to determine whether this is acceptable.
 
-What if we want to take into account our uncertainty about the reliability. The non-parametric class automatically computes the Greenwood variance and uses that to compute the upper and lower confidence intervals. Let's plot the intervals to see.
+What if we want to take into account our uncertainty about the reliability. The non-parametric class automatically computes the variance of the estimate using the formula appropriate to the estimator (Greenwood's formula for Kaplan-Meier, Aalen's variance for Nelson-Aalen, and the tie-corrected variance for Fleming-Harrington) and uses that to compute the upper and lower confidence intervals. Let's plot the intervals to see.
 
 .. jupyter-execute::
 
@@ -81,9 +81,11 @@ The confidence bounds can also be used to estimate the probability of survival u
 
     print(str(bofors_steel_na.R_cb(34, bound='lower', interp='linear', alpha_ci=0.05).round(4).item() * 100) + "%")
 
-Therefore we can be 95% confident that the reliability at 34 is above 76%. You can also see that
-the confidence interval stretches the entire span of the possible [0, 1] interval at the higest value.
-This is because the variance at the final value is infinite using the Greenwood confidence interval.
+Therefore we can be 95% confident that the reliability at 34 is above 76%. For a Kaplan-Meier
+model with no right censoring the variance at the final value is undefined with Greenwood's
+formula, so the bounds at the last observation are filled with the last finite upper bound and
+zero for the lower bound. The Nelson-Aalen and Fleming-Harrington variances remain finite at
+the final value so their bounds are defined all the way to the last observation.
 
 
 Right Censored Data

--- a/surpyval/__init__.py
+++ b/surpyval/__init__.py
@@ -6,9 +6,11 @@ from surpyval.distribution import Distribution
 from surpyval.univariate.nonparametric import (
     FlemingHarrington,
     KaplanMeier,
+    LogRankResult,
     NelsonAalen,
     NonParametric,
     Turnbull,
+    logrank,
     success_run,
 )
 from surpyval.univariate.parametric import (

--- a/surpyval/tests/univariate/nonparametric/test_bands_and_hazard.py
+++ b/surpyval/tests/univariate/nonparametric/test_bands_and_hazard.py
@@ -1,0 +1,118 @@
+import numpy as np
+import pytest
+
+import surpyval
+from surpyval.univariate.nonparametric.nonparametric import NonParametric
+
+
+def _censored_model():
+    x = np.array([4.0, 7, 9, 13, 16, 21, 28, 33, 41, 50])
+    c = np.array([0, 0, 1, 0, 0, 1, 0, 1, 0, 0])
+    return surpyval.KaplanMeier.fit(x, c=c)
+
+
+def test_hall_wellner_critical_value_approaches_kolmogorov():
+    # Over the whole [0, 1] interval the supremum of |Brownian bridge|
+    # has the Kolmogorov distribution; its 0.95 quantile is ~1.358.
+    cv = NonParametric._band_critical_value(
+        1e-4,
+        1 - 1e-4,
+        0.05,
+        standardized=False,
+        n_sims=20000,
+        random_state=1,
+    )
+    assert np.isclose(cv, 1.358, atol=0.05)
+
+
+def test_band_contains_pointwise_bounds():
+    model = _censored_model()
+    pw = model.cb(model.x)
+    for method in ["hall-wellner", "nair"]:
+        band = model.band(method=method)
+        finite = np.isfinite(band[:, 0]) & np.isfinite(pw[:, 0])
+        assert np.all(band[finite, 0] <= pw[finite, 0] + 1e-9)
+        assert np.all(band[finite, 1] >= pw[finite, 1] - 1e-9)
+
+
+def test_band_reproducible_with_fixed_seed():
+    model = _censored_model()
+    assert np.allclose(model.band(), model.band(), equal_nan=True)
+
+
+def test_band_normal_bound_type_shape():
+    model = _censored_model()
+    band = model.band(bound_type="normal")
+    assert band.shape == (model.x.size, 2)
+
+
+def test_band_invalid_args():
+    model = _censored_model()
+    with pytest.raises(ValueError):
+        model.band(method="nope")
+    with pytest.raises(ValueError):
+        model.band(bound_type="regular")
+
+
+def test_band_fit_from_ecdf_raises():
+    model = NonParametric.fit_from_ecdf(
+        np.array([1.0, 2, 3]), np.array([0.9, 0.5, 0.1])
+    )
+    with pytest.raises(ValueError, match="variance"):
+        model.band()
+
+
+def test_band_simultaneous_coverage():
+    # The whole-curve coverage of the band should be close to nominal,
+    # and markedly better than the pointwise bounds which are not
+    # designed for simultaneous coverage.
+    rng = np.random.default_rng(3)
+    n, reps = 50, 150
+    pw_cover = 0
+    band_cover = 0
+    for _ in range(reps):
+        x = rng.exponential(1.0, n)
+        cens = rng.exponential(2.0, n)
+        obs = np.minimum(x, cens)
+        c = (x > cens).astype(int)
+        model = surpyval.KaplanMeier.fit(obs, c=c)
+        grid = model.x
+        S_true = np.exp(-grid)
+        pw = model.cb(grid)
+        band = model.band(n_sims=2000, random_state=1)
+        f = np.isfinite(band[:, 0])
+        pw_cover += np.all((pw[f, 0] <= S_true[f]) & (S_true[f] <= pw[f, 1]))
+        band_cover += np.all(
+            (band[f, 0] <= S_true[f]) & (S_true[f] <= band[f, 1])
+        )
+    assert band_cover / reps > 0.88
+    assert band_cover / reps > pw_cover / reps
+
+
+def test_smoothed_hazard_recovers_constant():
+    rng = np.random.default_rng(4)
+    x = rng.exponential(1.0, 2000)
+    model = surpyval.NelsonAalen.fit(x)
+    h = model.smoothed_hf([0.3, 0.6, 1.0, 1.5], bandwidth=0.5)
+    assert np.allclose(h, 1.0, atol=0.15)
+
+
+def test_smoothed_hazard_recovers_linear_weibull():
+    # Weibull with shape 2 has hazard h(t) = 2t.
+    x = surpyval.Weibull.random(4000, 1.0, 2.0)
+    model = surpyval.NelsonAalen.fit(x)
+    t = np.array([0.5, 1.0, 1.5])
+    h = model.smoothed_hf(t, bandwidth=0.3)
+    assert np.allclose(h, 2 * t, rtol=0.15)
+
+
+def test_smoothed_hazard_nan_outside_range():
+    model = surpyval.NelsonAalen.fit(np.array([1.0, 2, 3, 4, 5]))
+    h = model.smoothed_hf([-1.0, 1e6])
+    assert np.isnan(h).all()
+
+
+def test_smoothed_hazard_bad_bandwidth():
+    model = surpyval.NelsonAalen.fit(np.array([1.0, 2, 3]))
+    with pytest.raises(ValueError):
+        model.smoothed_hf([2.0], bandwidth=-1)

--- a/surpyval/tests/univariate/nonparametric/test_confidence_bounds.py
+++ b/surpyval/tests/univariate/nonparametric/test_confidence_bounds.py
@@ -1,0 +1,222 @@
+import numpy as np
+import pytest
+from scipy.stats import norm
+
+import surpyval
+from surpyval.univariate.nonparametric.nonparametric import NonParametric
+
+
+def test_kaplan_meier_greenwood_variance():
+    # Greenwood's formula: cumsum(d / (r * (r - d))). With no censoring
+    # the variance is undefined (NaN) at the last point where d == r.
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    model = surpyval.KaplanMeier.fit(x)
+    r = np.array([5.0, 4.0, 3.0, 2.0, 1.0])
+    d = np.ones(5)
+    with np.errstate(all="ignore"):
+        expected = np.cumsum(d / (r * (r - d)))
+    assert np.allclose(model.greenwood[:-1], expected[:-1], atol=1e-12)
+    assert np.isnan(model.greenwood[-1])
+
+
+def test_nelson_aalen_aalen_variance():
+    # Aalen's (Poisson) variance: cumsum(d / r**2). Klein (1991).
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    model = surpyval.NelsonAalen.fit(x)
+    r = np.array([5.0, 4.0, 3.0, 2.0, 1.0])
+    d = np.ones(5)
+    expected = np.cumsum(d / r**2)
+    assert np.allclose(model.greenwood, expected, atol=1e-12)
+
+
+def test_fleming_harrington_tie_corrected_variance():
+    # Tie-split variance: sum(1 / (r - j)**2 for j in 0 .. d - 1),
+    # mirroring the FH hazard increment sum(1 / (r - j)).
+    x = [1, 2, 3, 4]
+    n = [3, 2, 4, 1]
+    model = surpyval.FlemingHarrington.fit(x=x, n=n)
+    expected = np.cumsum(
+        [
+            1.0 / 10**2 + 1.0 / 9**2 + 1.0 / 8**2,
+            1.0 / 7**2 + 1.0 / 6**2,
+            1.0 / 5**2 + 1.0 / 4**2 + 1.0 / 3**2 + 1.0 / 2**2,
+            1.0,
+        ]
+    )
+    assert np.allclose(model.greenwood, expected, atol=1e-12)
+
+
+def test_fleming_harrington_variance_equals_nelson_aalen_without_ties():
+    x = np.array([2.0, 4.0, 6.0, 8.0, 9.0, 13.0, 17.0, 22.0, 30.0, 45.0])
+    c = np.array([0, 0, 1, 0, 0, 1, 0, 0, 0, 0])
+    fh = surpyval.FlemingHarrington.fit(x, c=c)
+    na = surpyval.NelsonAalen.fit(x, c=c)
+    assert np.allclose(fh.greenwood, na.greenwood, atol=1e-12)
+
+
+def test_cb_exp_bounds_match_manual_formula():
+    # The default ('exp') bounds are the log(-log) transformed interval:
+    # exp(-exp(log(-log(R)) -/+ z * sqrt(var) / -log(R)))
+    x = np.array([4.0, 7.0, 9.0, 13.0, 16.0, 21.0, 28.0])
+    c = np.array([0, 0, 1, 0, 0, 1, 0])
+    model = surpyval.KaplanMeier.fit(x, c=c)
+    z = norm.ppf(0.975)
+    R = model.R
+    var = model.greenwood
+    with np.errstate(all="ignore"):
+        theta = np.log(-np.log(R))
+        se = np.sqrt(var / np.log(R) ** 2)
+        lower = np.exp(-np.exp(theta + z * se))
+        upper = np.exp(-np.exp(theta - z * se))
+    cb = model.cb(model.x)
+    finite = np.isfinite(var)
+    assert np.allclose(cb[finite, 0], lower[finite], atol=1e-12)
+    assert np.allclose(cb[finite, 1], upper[finite], atol=1e-12)
+
+
+def test_cb_normal_bounds_match_manual_formula():
+    # The 'normal' bounds are R -/+ z * sqrt(var * R**2)
+    x = np.array([4.0, 7.0, 9.0, 13.0, 16.0, 21.0, 28.0])
+    c = np.array([0, 0, 1, 0, 0, 1, 0])
+    model = surpyval.NelsonAalen.fit(x, c=c)
+    z = norm.ppf(0.975)
+    R = model.R
+    se = np.sqrt(model.greenwood * R**2)
+    cb = model.cb(model.x, bound_type="normal")
+    assert np.allclose(cb[:, 0], R - z * se, atol=1e-12)
+    assert np.allclose(cb[:, 1], R + z * se, atol=1e-12)
+
+
+def test_cb_hf_bounds_match_log_transformed_hazard_interval():
+    # On the cumulative hazard the 'exp' bounds are equivalent to the
+    # log-transformed interval H * exp(-/+ z * sqrt(var) / H), the
+    # standard interval for the Nelson-Aalen estimator (and the one
+    # used by lifelines).
+    x = np.array([2.0, 4.0, 6.0, 8.0, 9.0, 13.0, 17.0, 22.0, 30.0])
+    c = np.array([0, 0, 1, 0, 0, 1, 0, 0, 1])
+    model = surpyval.NelsonAalen.fit(x, c=c)
+    z = norm.ppf(0.975)
+    H = -np.log(model.R)
+    se = np.sqrt(model.greenwood)
+    expected_lower = H * np.exp(-z * se / H)
+    expected_upper = H * np.exp(z * se / H)
+    cb = model.cb(model.x, on="Hf")
+    assert np.allclose(cb[:, 0], expected_lower, atol=1e-12)
+    assert np.allclose(cb[:, 1], expected_upper, atol=1e-12)
+
+
+def test_cb_two_sided_ordering_and_consistency():
+    x = np.array([4.0, 7.0, 9.0, 13.0, 16.0, 21.0, 28.0])
+    c = np.array([0, 0, 1, 0, 0, 1, 0])
+    model = surpyval.KaplanMeier.fit(x, c=c)
+    x_test = np.array([5.0, 10.0, 20.0])
+
+    cb_sf = model.cb(x_test, on="sf")
+    cb_ff = model.cb(x_test, on="ff")
+    cb_hf = model.cb(x_test, on="Hf")
+
+    # Columns are [lower, upper] and bracket the point estimate
+    assert (cb_sf[:, 0] <= model.sf(x_test)).all()
+    assert (model.sf(x_test) <= cb_sf[:, 1]).all()
+    assert (cb_hf[:, 0] <= model.Hf(x_test)).all()
+    assert (model.Hf(x_test) <= cb_hf[:, 1]).all()
+
+    # ff bounds are the complement of the sf bounds
+    assert np.allclose(cb_ff, 1 - cb_sf[:, ::-1], atol=1e-12)
+
+    # One sided bounds match the relevant side of a one sided interval
+    lower = model.cb(x_test, bound="lower")
+    upper = model.cb(x_test, bound="upper")
+    assert (lower <= model.sf(x_test)).all()
+    assert (upper >= model.sf(x_test)).all()
+
+
+def test_cb_last_point_defined_for_na_and_fh():
+    # The NA and FH variances remain finite when d == r so, unlike
+    # Kaplan-Meier, the bounds at the last point need no fill values.
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    for est in [surpyval.NelsonAalen, surpyval.FlemingHarrington]:
+        model = est.fit(x)
+        assert np.isfinite(model.greenwood).all()
+        cb = model.cb(model.x)
+        assert np.isfinite(cb).all()
+
+
+def test_cb_invalid_bound_type_raises():
+    model = surpyval.KaplanMeier.fit(np.array([1.0, 2.0, 3.0]))
+    with pytest.raises(ValueError):
+        model.cb([2.0], bound_type="regular")
+
+
+def test_cb_turnbull_uses_selected_estimator_variance():
+    left = np.array([1, 8, 8, 7, 7, 17, 37, 46, 46, 45.0])
+    right = np.array([7, 8, 10, 16, 14, np.inf, 44, np.inf, np.inf, np.inf])
+    for est in ["Kaplan-Meier", "Nelson-Aalen", "Fleming-Harrington"]:
+        model = surpyval.Turnbull.fit(
+            xl=left, xr=right, turnbull_estimator=est
+        )
+        cb = model.cb([10.0, 20.0])
+        assert np.isfinite(cb).all()
+        assert (cb[:, 0] <= cb[:, 1]).all()
+
+
+def test_cb_coverage_of_default_bounds():
+    # Simulation check that the default (exponential Greenwood, z) two
+    # sided 95% bounds cover the true survival function at close to the
+    # nominal rate. Loose tolerance to keep the runtime low.
+    rng = np.random.default_rng(123)
+    n, reps = 40, 200
+    t_eval = np.array([0.2877, 0.6931])
+    S_true = np.exp(-t_eval)
+    covered = np.zeros((reps, t_eval.size), dtype=bool)
+    for i in range(reps):
+        lifetimes = rng.exponential(1.0, n)
+        censoring = rng.exponential(2.0, n)
+        obs = np.minimum(lifetimes, censoring)
+        c = (lifetimes > censoring).astype(int)
+        model = surpyval.KaplanMeier.fit(obs, c=c)
+        cb = model.cb(t_eval)
+        covered[i] = (cb[:, 0] <= S_true) & (S_true <= cb[:, 1])
+    coverage = covered.mean(axis=0)
+    assert (coverage > 0.88).all()
+    assert (coverage <= 1.0).all()
+
+
+def test_random_samples_with_estimated_probabilities():
+    # random() must respect the estimated probability masses, not
+    # sample uniformly from the unique observed values.
+    x = np.array([1.0] * 8 + [2.0, 3.0])
+    model = surpyval.KaplanMeier.fit(x)
+    np.random.seed(42)
+    samples = model.random(20000)
+    freqs = np.array([(samples == v).mean() for v in model.x])
+    assert np.allclose(freqs, [0.8, 0.1, 0.1], atol=0.02)
+
+
+def test_random_with_right_censoring():
+    # With right censoring the survival estimate does not reach zero;
+    # sampling renormalises over the observed event masses.
+    x = np.array([1.0, 2.0, 3.0, 4.0])
+    c = np.array([0, 0, 0, 1])
+    model = surpyval.KaplanMeier.fit(x, c=c)
+    samples = model.random(1000)
+    assert np.isin(samples, model.x).all()
+
+
+def test_scalar_input_to_hf_and_df():
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    model = surpyval.NelsonAalen.fit(x)
+    # Must not raise; with a single point there is no neighbouring step
+    # so the rate is undefined.
+    assert model.hf(2).shape == (1,)
+    assert model.df(2).shape == (1,)
+    # Array input remains well defined
+    assert np.isfinite(model.hf([1.5, 2.5, 3.5])).all()
+
+
+def test_fit_from_ecdf_cb_raises_informative_error():
+    model = NonParametric.fit_from_ecdf(
+        np.array([1.0, 2.0, 3.0]), np.array([0.9, 0.5, 0.1])
+    )
+    with pytest.raises(ValueError, match="variance"):
+        model.cb([2.0])

--- a/surpyval/tests/univariate/nonparametric/test_logrank.py
+++ b/surpyval/tests/univariate/nonparametric/test_logrank.py
@@ -1,0 +1,108 @@
+import numpy as np
+import pytest
+from scipy.stats import CensoredData
+from scipy.stats import logrank as scipy_logrank
+
+import surpyval
+
+
+def _to_scipy(obs, c):
+    # surpyval c==1 is right censored; scipy wants uncensored/right
+    return CensoredData(uncensored=obs[c == 0], right=obs[c == 1])
+
+
+def test_logrank_matches_scipy_two_groups():
+    rng = np.random.default_rng(0)
+    oa = np.minimum(rng.exponential(10, 40), rng.exponential(15, 40))
+    da = rng.integers(0, 2, 40)
+    ob = np.minimum(rng.exponential(7, 35), rng.exponential(15, 35))
+    db = rng.integers(0, 2, 35)
+    # build censoring flags (1 == censored)
+    ca = 1 - da
+    cb = 1 - db
+
+    sp = scipy_logrank(_to_scipy(oa, ca), _to_scipy(ob, cb))
+
+    x = np.concatenate([oa, ob])
+    c = np.concatenate([ca, cb])
+    Z = np.array([0] * 40 + [1] * 35)
+    res = surpyval.logrank(x, Z, c=c)
+
+    # scipy reports a z statistic; the chi-squared statistic is z**2
+    assert np.isclose(res.statistic, sp.statistic**2, atol=1e-6)
+    assert np.isclose(res.p_value, sp.pvalue, atol=1e-6)
+    assert res.dof == 1
+
+
+def test_logrank_known_example():
+    x = [9, 13, 13, 18, 23, 28, 31, 34, 45, 48, 161]
+    x += [5, 5, 8, 8, 12, 16, 23, 27, 30, 33, 43, 45]
+    c = [0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1]
+    c += [0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0]
+    Z = [1] * 11 + [2] * 12
+    res = surpyval.logrank(x, Z, c=c)
+    assert np.isclose(res.statistic, 3.3964, atol=1e-3)
+    assert np.isclose(res.p_value, 0.0653, atol=1e-3)
+
+
+def test_logrank_fh_zero_equals_standard():
+    rng = np.random.default_rng(1)
+    x = rng.exponential(5, 60)
+    Z = rng.integers(0, 2, 60)
+    standard = surpyval.logrank(x, Z)
+    fh = surpyval.logrank(x, Z, weighting="fleming-harrington", rho=0, gamma=0)
+    assert np.isclose(standard.statistic, fh.statistic, atol=1e-9)
+
+
+def test_logrank_weightings_run_and_differ():
+    rng = np.random.default_rng(2)
+    x = rng.exponential(5, 80)
+    c = rng.integers(0, 2, 80)
+    Z = rng.integers(0, 2, 80)
+    stats = {}
+    for w in ["log-rank", "gehan", "tarone-ware", "fleming-harrington"]:
+        res = surpyval.logrank(x, Z, c=c, weighting=w)
+        assert res.statistic >= 0
+        assert 0 <= res.p_value <= 1
+        stats[w] = res.statistic
+    # Gehan weights early events more heavily, so it should differ from
+    # the unweighted log-rank in general.
+    assert stats["gehan"] != stats["log-rank"]
+
+
+def test_logrank_three_groups_dof():
+    rng = np.random.default_rng(3)
+    x = rng.exponential(5, 90)
+    Z = rng.integers(0, 3, 90)
+    res = surpyval.logrank(x, Z)
+    assert res.dof == 2
+
+
+def test_logrank_identical_groups_small_statistic():
+    x = np.array([1.0, 2, 3, 4, 5, 1, 2, 3, 4, 5])
+    Z = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
+    res = surpyval.logrank(x, Z)
+    assert res.statistic < 1e-9
+    assert res.p_value > 0.99
+
+
+def test_logrank_rejects_interval_censoring():
+    x = np.array([1.0, 2, 3, 4])
+    c = np.array([0, 2, 0, 0])
+    Z = np.array([0, 0, 1, 1])
+    with pytest.raises(ValueError):
+        surpyval.logrank(x, Z, c=c)
+
+
+def test_logrank_requires_two_groups():
+    x = np.array([1.0, 2, 3])
+    Z = np.array([0, 0, 0])
+    with pytest.raises(ValueError):
+        surpyval.logrank(x, Z)
+
+
+def test_logrank_bad_weighting():
+    x = np.array([1.0, 2, 3, 4])
+    Z = np.array([0, 0, 1, 1])
+    with pytest.raises(ValueError):
+        surpyval.logrank(x, Z, weighting="not-a-weighting")

--- a/surpyval/tests/univariate/nonparametric/test_model_methods.py
+++ b/surpyval/tests/univariate/nonparametric/test_model_methods.py
@@ -1,0 +1,183 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+import surpyval  # noqa: E402
+
+
+def test_qf_uncensored():
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    model = surpyval.KaplanMeier.fit(x)
+    assert np.allclose(model.qf([0.1, 0.5, 0.9]), [1.0, 3.0, 5.0])
+    assert model.median == 3.0
+
+
+def test_qf_not_reached_is_nan():
+    # With heavy right censoring the CDF never reaches 0.5
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    c = np.array([0, 0, 1, 1, 1])
+    model = surpyval.KaplanMeier.fit(x, c=c)
+    assert np.isnan(model.qf(0.5)).all()
+    assert np.isnan(model.median)
+
+
+def test_qf_invalid_p_raises():
+    model = surpyval.KaplanMeier.fit(np.array([1.0, 2.0, 3.0]))
+    with pytest.raises(ValueError):
+        model.qf(0.0)
+    with pytest.raises(ValueError):
+        model.qf(1.5)
+
+
+def test_quantile_cb_brookmeyer_crowley_inversion():
+    # The quantile interval limits must be the first observed times at
+    # which the survival bounds cross 1 - p.
+    x = np.array([4.0, 7.0, 9.0, 13.0, 16.0, 21.0, 28.0, 33.0, 41.0, 50.0])
+    c = np.array([0, 0, 1, 0, 0, 1, 0, 1, 0, 0])
+    model = surpyval.KaplanMeier.fit(x, c=c)
+    p = 0.5
+    bounds = model.cb(model.x)
+    level = 1 - p
+    expected_lower = model.x[np.argmax(bounds[:, 0] <= level)]
+    if (bounds[:, 1] < level).any():
+        expected_upper = model.x[np.argmax(bounds[:, 1] < level)]
+    else:
+        expected_upper = np.nan
+    cb = model.quantile_cb(p)
+    assert cb.shape == (1, 2)
+    assert cb[0, 0] == expected_lower
+    assert np.isnan(cb[0, 1]) == np.isnan(expected_upper)
+    # The interval contains the point estimate when the median is reached
+    assert cb[0, 0] <= model.median
+
+
+def test_quantile_cb_brackets_estimate_large_sample():
+    rng = np.random.default_rng(5)
+    x = rng.exponential(1.0, 200)
+    model = surpyval.KaplanMeier.fit(x)
+    cb = model.quantile_cb(0.5)
+    assert cb[0, 0] <= model.median <= cb[0, 1]
+    # With n=200 the median CI should be reasonably tight around ln(2)
+    assert cb[0, 0] > 0.4
+    assert cb[0, 1] < 1.1
+
+
+def test_mean_uncensored_equals_sample_mean():
+    # With no censoring the KM restricted mean to the largest
+    # observation is the sample mean.
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    model = surpyval.KaplanMeier.fit(x)
+    assert np.isclose(model.mean(), 3.0, atol=1e-12)
+
+
+def test_mean_restricted_to_tau():
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    model = surpyval.KaplanMeier.fit(x)
+    # integral of S over [0, 3): 1*1 + 1*0.8 + 1*0.6
+    assert np.isclose(model.mean(tau=3.0), 2.4, atol=1e-12)
+
+
+def test_mean_cb_matches_manual_variance():
+    # Klein & Moeschberger RMST variance: sum(A_i^2 * v_i) with A_i the
+    # area under S from x_i to tau and v_i the Greenwood increments.
+    # For uncensored x = 1..5: A = [2.0, 1.2, 0.6, 0.2, 0] and
+    # v = [1/20, 1/12, 1/6, 1/2, nan] giving var = 0.4 (the final term
+    # is zero since A is zero there).
+    from scipy.stats import norm
+
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    model = surpyval.KaplanMeier.fit(x)
+    z = norm.ppf(0.975)
+    se = np.sqrt(0.4)
+    cb = model.mean_cb()
+    assert np.allclose(cb, [3.0 - z * se, 3.0 + z * se], atol=1e-12)
+
+
+def test_mean_with_censoring_below_uncensored_mean():
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    c = np.array([0, 0, 0, 0, 1])
+    model = surpyval.KaplanMeier.fit(x, c=c)
+    # S now plateaus at 0.2 after x=4; RMST to 5 is
+    # 1 + .8 + .6 + .4 + .2 = 3.0
+    assert np.isclose(model.mean(), 3.0, atol=1e-12)
+    lower, upper = model.mean_cb()
+    assert lower < model.mean() < upper
+
+
+def test_mean_negative_support_raises():
+    model = surpyval.KaplanMeier.fit(np.array([-1.0, 2.0, 3.0]))
+    with pytest.raises(ValueError):
+        model.mean()
+
+
+def test_bootstrap_cb_kaplan_meier():
+    x = np.array([4.0, 7.0, 9.0, 13.0, 16.0, 21.0, 28.0, 33.0, 41.0, 50.0])
+    c = np.array([0, 0, 1, 0, 0, 1, 0, 1, 0, 0])
+    model = surpyval.KaplanMeier.fit(x, c=c)
+    x_test = [10.0, 30.0]
+    cb = model.bootstrap_cb(x_test, B=100, random_state=42)
+    assert cb.shape == (2, 2)
+    assert (cb[:, 0] <= cb[:, 1]).all()
+    # Bootstrap interval should contain the point estimate
+    sf = model.sf(x_test)
+    assert (cb[:, 0] <= sf).all()
+    assert (sf <= cb[:, 1]).all()
+    # Reproducible with the same seed
+    cb2 = model.bootstrap_cb(x_test, B=100, random_state=42)
+    assert np.allclose(cb, cb2)
+
+
+def test_bootstrap_cb_turnbull():
+    left = np.array([1, 8, 8, 7, 7, 17, 37, 46, 46, 45.0])
+    right = np.array([7, 8, 10, 16, 14, np.inf, 44, np.inf, np.inf, np.inf])
+    model = surpyval.Turnbull.fit(xl=left, xr=right)
+    cb = model.bootstrap_cb([10.0, 20.0], B=30, random_state=7)
+    assert cb.shape == (2, 2)
+    assert (cb[:, 0] <= cb[:, 1]).all()
+    sf = model.sf([10.0, 20.0])
+    assert (cb[:, 0] <= sf + 1e-12).all()
+    assert (sf <= cb[:, 1] + 1e-12).all()
+
+
+def test_bootstrap_cb_one_sided():
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    model = surpyval.KaplanMeier.fit(x)
+    lower = model.bootstrap_cb([2.5], bound="lower", B=50, random_state=1)
+    upper = model.bootstrap_cb([2.5], bound="upper", B=50, random_state=1)
+    assert lower.shape == (1,)
+    assert (lower <= upper).all()
+    with pytest.raises(ValueError):
+        model.bootstrap_cb([2.5], bound="middle")
+
+
+def test_bootstrap_cb_requires_data():
+    model = surpyval.KaplanMeier.from_xrd([1, 2, 3], [10, 8, 6], [2, 1, 1])
+    with pytest.raises(ValueError, match="data"):
+        model.bootstrap_cb([2.0])
+
+
+def test_plot_with_bounds_and_censors():
+    x = np.array([4.0, 7.0, 9.0, 13.0, 16.0, 21.0, 28.0, 33.0, 41.0, 50.0])
+    c = np.array([0, 0, 1, 0, 0, 1, 0, 1, 0, 0])
+    model = surpyval.KaplanMeier.fit(x, c=c)
+    fig, ax = plt.subplots()
+    out = model.plot(ax=ax, color="C2", label="KM")
+    assert out is ax
+    # survival curve + censor markers, and the shaded bound band
+    assert len(ax.lines) == 2
+    assert len(ax.collections) == 1
+    assert ax.lines[0].get_color() == "C2"
+    plt.close(fig)
+
+
+def test_plot_without_bounds_or_censors():
+    model = surpyval.KaplanMeier.fit(np.array([1.0, 2.0, 3.0]))
+    fig, ax = plt.subplots()
+    model.plot(ax=ax, plot_bounds=False, show_censors=False)
+    assert len(ax.lines) == 1
+    assert len(ax.collections) == 0
+    plt.close(fig)

--- a/surpyval/tests/univariate/nonparametric/test_plotting_positions.py
+++ b/surpyval/tests/univariate/nonparametric/test_plotting_positions.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+
+from surpyval.univariate.nonparametric.plotting_positions import (
+    plotting_positions,
+)
+
+
+def test_filliben_heuristic():
+    # Values from the Filliben (1975) estimate:
+    # F[0] = 1 - 0.5**(1/N), F[-1] = 0.5**(1/N),
+    # F[i] = (i + 1 - 0.3175) / (N + 0.365) otherwise.
+    x = np.array([1.0, 2, 3, 4, 5, 6, 7, 8])
+    _, _, _, F = plotting_positions(x, heuristic="Filliben")
+    expected = [
+        0.08299596,
+        0.20113568,
+        0.32068141,
+        0.44022714,
+        0.55977286,
+        0.67931859,
+        0.79886432,
+        0.91700404,
+    ]
+    assert np.allclose(F, expected, atol=1e-7)
+
+
+def test_ecdf_adj_heuristic_is_accepted():
+    x = np.array([1.0, 2, 3, 4, 5])
+    _, _, _, F = plotting_positions(x, heuristic="ECDF_Adj")
+    expected = (np.arange(1, 6) - 0) / (5 + 1)
+    assert np.allclose(F, expected, atol=1e-12)
+
+
+def test_unknown_heuristic_rejected():
+    with pytest.raises(ValueError):
+        plotting_positions(np.array([1.0, 2, 3]), heuristic="NotAMethod")
+
+
+def test_blom_heuristic_unchanged():
+    x = np.array([1.0, 2, 3, 4, 5])
+    _, _, _, F = plotting_positions(x, heuristic="Blom")
+    expected = (np.arange(1, 6) - 0.375) / (5 + 0.25)
+    assert np.allclose(F, expected, atol=1e-12)

--- a/surpyval/univariate/nonparametric/__init__.py
+++ b/surpyval/univariate/nonparametric/__init__.py
@@ -1,7 +1,11 @@
 from .filliben import filliben
-from .fleming_harrington import FlemingHarrington, fleming_harrington
-from .kaplan_meier import KaplanMeier, kaplan_meier
-from .nelson_aalen import NelsonAalen, nelson_aalen
+from .fleming_harrington import (
+    FlemingHarrington,
+    fleming_harrington,
+    fleming_harrington_variance,
+)
+from .kaplan_meier import KaplanMeier, greenwood_variance, kaplan_meier
+from .nelson_aalen import NelsonAalen, nelson_aalen, nelson_aalen_variance
 from .nonparametric import NonParametric
 from .plotting_positions import plotting_positions
 from .rank_adjust import rank_adjust
@@ -15,10 +19,17 @@ FIT_FUNCS = {
     "Turnbull": turnbull,
 }
 
+VAR_FUNCS = {
+    "Nelson-Aalen": nelson_aalen_variance,
+    "Kaplan-Meier": greenwood_variance,
+    "Fleming-Harrington": fleming_harrington_variance,
+}
+
 PLOTTING_METHODS = [
     "Blom",
     "Median",
     "ECDF",
+    "ECDF_Adj",
     "Modal",
     "Midpoint",
     "Mean",

--- a/surpyval/univariate/nonparametric/__init__.py
+++ b/surpyval/univariate/nonparametric/__init__.py
@@ -5,6 +5,7 @@ from .fleming_harrington import (
     fleming_harrington_variance,
 )
 from .kaplan_meier import KaplanMeier, greenwood_variance, kaplan_meier
+from .logrank import LogRankResult, logrank
 from .nelson_aalen import NelsonAalen, nelson_aalen, nelson_aalen_variance
 from .nonparametric import NonParametric
 from .plotting_positions import plotting_positions

--- a/surpyval/univariate/nonparametric/filliben.py
+++ b/surpyval/univariate/nonparametric/filliben.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from surpyval.univariate.nonparametric import rank_adjust
+from surpyval.univariate.nonparametric.rank_adjust import rank_adjust
 from surpyval.utils import xcnt_handler
 
 

--- a/surpyval/univariate/nonparametric/fleming_harrington.py
+++ b/surpyval/univariate/nonparametric/fleming_harrington.py
@@ -15,6 +15,36 @@ def fh_h(r_i, d_i):
     return out
 
 
+def fh_var_h(r_i, d_i):
+    # Variance increment with the same tie-splitting as fh_h, i.e.
+    # each of the d tied events contributes 1/r**2 with a risk set
+    # that shrinks by one for each event.
+    out = 0
+    while d_i > 1:
+        out += 1.0 / r_i**2
+        r_i -= 1
+        d_i -= 1
+    out += d_i / r_i**2
+    return out
+
+
+def fleming_harrington_variance(r, d):
+    """
+    Variance of the Fleming-Harrington cumulative hazard estimator
+    using the same tie correction as the estimator itself:
+
+    Var(H) = sum(sum(1 / (r - i)**2 for i in 0 ... d - 1))
+
+    This is the variance used by R's ``survfit`` with ``ctype=2`` and
+    reduces to the Nelson-Aalen (Aalen/Poisson) variance, sum(d / r**2),
+    when there are no tied events.
+    """
+    with np.errstate(all="ignore"):
+        var = np.array([fh_var_h(r_i, d_i) for r_i, d_i in zip(r, d)])
+        var = np.where(np.isfinite(var), var, np.nan)
+        return np.cumsum(var)
+
+
 def fleming_harrington(r, d):
     Y = np.array([fh_h(r_i, d_i) for r_i, d_i in zip(r, d)])
     H = Y.cumsum()
@@ -34,6 +64,14 @@ class FlemingHarrington_(NonParametricFitter):
         R = e^{-\sum_{i:x_{i} \leq x} \sum_{i=0}^{d_x-1} \frac{1}{r_x - i}}
 
     See 'NonParametric section for detailed estimate of how H is computed.'
+
+    The variance of the cumulative hazard used for confidence bounds is
+    estimated with the same tie correction as the estimator itself
+    (as used by R's ``survfit`` with ``ctype=2``):
+
+    .. math::
+        \widehat{Var}(H(x)) = \sum_{i:x_{i} \leq x}
+            \sum_{j=0}^{d_i-1} \frac{1}{\left ( r_i - j \right )^{2}}
 
     Examples
     --------

--- a/surpyval/univariate/nonparametric/kaplan_meier.py
+++ b/surpyval/univariate/nonparametric/kaplan_meier.py
@@ -5,6 +5,22 @@ from surpyval.univariate.nonparametric.nonparametric_fitter import (
 )
 
 
+def greenwood_variance(r, d):
+    """
+    Greenwood's formula for the variance of the cumulative hazard
+    (equivalently, of -log(R)) of the Kaplan-Meier estimator:
+
+    Var(H) = sum(d / (r * (r - d)))
+
+    Where d == r (i.e. the survival function reaches zero) the variance
+    is undefined and NaN is returned at, and after, that point.
+    """
+    with np.errstate(all="ignore"):
+        var = d / (r * (r - d))
+        var = np.where(np.isfinite(var), var, np.nan)
+        return np.cumsum(var)
+
+
 def kaplan_meier(r, d):
     R = 1 - (d / r)
     R[np.isnan(R)] = 0
@@ -28,6 +44,13 @@ class KaplanMeier_(NonParametricFitter):
     .. math::
         R(x) = \prod_{i:x_{i} \leq x}^{}
             \left ( 1 - \frac{d_{i} }{r_{i}}  \right )
+
+    The variance of the cumulative hazard used for confidence bounds is
+    estimated with Greenwood's formula:
+
+    .. math::
+        \widehat{Var}(H(x)) = \sum_{i:x_{i} \leq x}
+            \frac{d_{i}}{r_{i} \left ( r_{i} - d_{i} \right )}
 
     Examples
     --------

--- a/surpyval/univariate/nonparametric/logrank.py
+++ b/surpyval/univariate/nonparametric/logrank.py
@@ -1,0 +1,207 @@
+import numpy as np
+from scipy.stats import chi2
+
+from surpyval.univariate.nonparametric.kaplan_meier import kaplan_meier
+from surpyval.utils import xcnt_handler
+
+
+class LogRankResult:
+    """
+    Result of a (weighted) log-rank test.
+
+    Attributes
+    ----------
+
+    statistic : float
+        The chi-squared test statistic.
+    dof : int
+        The degrees of freedom (number of groups - 1).
+    p_value : float
+        The p-value of the test.
+    weighting : str
+        The weighting used for the test.
+    """
+
+    def __init__(self, statistic, dof, p_value, weighting):
+        self.statistic = statistic
+        self.dof = dof
+        self.p_value = p_value
+        self.weighting = weighting
+
+    def __repr__(self):
+        return (
+            "Log-Rank Test"
+            + "\n============="
+            + "\nWeighting        : {w}".format(w=self.weighting)
+            + "\nStatistic        : {s:.6g}".format(s=self.statistic)
+            + "\nDoF              : {d}".format(d=self.dof)
+            + "\np-value          : {p:.6g}".format(p=self.p_value)
+        )
+
+
+def logrank(x, Z, c=None, n=None, weighting="log-rank", rho=0, gamma=0):
+    r"""
+    The k-sample (weighted) log-rank test for the equality of survival
+    distributions of right censored data.
+
+    At each distinct event time the observed number of events in each
+    group is compared with the number expected under the null
+    hypothesis that all groups share the same survival distribution.
+    The weighted sums of these differences form a chi-squared statistic
+    with k - 1 degrees of freedom.
+
+    Parameters
+    ----------
+
+    x : array like
+        Array of observations of the random variables.
+    Z : array like
+        Array of group labels for each observation. Any hashable values
+        can be used; the test has len(unique(Z)) - 1 degrees of
+        freedom.
+    c : array like, optional
+        Array of censoring flags. 0 is observed and 1 is right
+        censored. Left or interval censored data cannot be used with
+        the log-rank test. If not provided assumes all values are
+        observed.
+    n : array like, optional
+        Array of counts for each x. If :code:`None` assumes each
+        observation is 1.
+    weighting : str, optional
+        The weighting to use at each event time. One of:
+
+        - "log-rank": weight 1 (the standard log-rank test; sensitive
+          to proportional hazards alternatives),
+        - "gehan": weight r (a.k.a. Gehan-Breslow-Wilcoxon; emphasises
+          early differences),
+        - "tarone-ware": weight sqrt(r),
+        - "fleming-harrington": weight S(t-)**rho * (1 - S(t-))**gamma
+          where S is the pooled Kaplan-Meier estimate; rho > 0
+          emphasises early differences and gamma > 0 late differences.
+
+        Defaults to "log-rank".
+    rho, gamma : scalar, optional
+        The parameters of the Fleming-Harrington weighting. Only used
+        when weighting is "fleming-harrington". Defaults to 0, 0 (which
+        is identical to the log-rank weighting).
+
+    Returns
+    -------
+
+    result : LogRankResult
+        Object with the chi-squared ``statistic``, the degrees of
+        freedom ``dof``, and the ``p_value``.
+
+    Examples
+    --------
+    >>> from surpyval import logrank
+    >>> x = [9, 13, 13, 18, 23, 28, 31, 34, 45, 48, 161,
+    ...      5, 5, 8, 8, 12, 16, 23, 27, 30, 33, 43, 45]
+    >>> c = [0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1,
+    ...      0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0]
+    >>> Z = [1] * 11 + [2] * 12
+    >>> res = logrank(x, Z, c=c)
+    >>> print(round(res.statistic, 2), round(res.p_value, 4))
+    3.4 0.0653
+
+    References
+    ----------
+
+    Klein, J. P. and Moeschberger, M. L. (2003), "Survival Analysis:
+    Techniques for Censored and Truncated Data", 2nd ed., Chapter 7.
+    """
+    weightings = ["log-rank", "gehan", "tarone-ware", "fleming-harrington"]
+    if weighting not in weightings:
+        raise ValueError("'weighting' must be in {}".format(weightings))
+
+    Z = np.asarray(Z)
+    if Z.ndim != 1:
+        raise ValueError("'Z' must be a 1D array of group labels")
+    if len(Z) != len(np.atleast_1d(x)):
+        raise ValueError("'Z' must have a label for each observation")
+
+    groups = np.unique(Z)
+    if groups.size < 2:
+        raise ValueError("Test requires at least two groups")
+
+    x_g, c_g, n_g = [], [], []
+    for g in groups:
+        mask = Z == g
+        x_i = np.atleast_1d(x)[mask]
+        c_i = None if c is None else np.atleast_1d(c)[mask]
+        n_i = None if n is None else np.atleast_1d(n)[mask]
+        x_i, c_i, n_i, _ = xcnt_handler(x=x_i, c=c_i, n=n_i)
+        if ((c_i != 0) & (c_i != 1)).any():
+            raise ValueError(
+                "Log-rank test can only be used with observed and "
+                + "right censored data"
+            )
+        x_g.append(x_i)
+        c_g.append(c_i)
+        n_g.append(n_i)
+
+    # Pooled, distinct event times
+    event_times = np.unique(
+        np.concatenate([x_i[c_i == 0] for x_i, c_i in zip(x_g, c_g)])
+    )
+
+    k = groups.size
+    m = event_times.size
+    # Risk and death counts per group at each pooled event time
+    r_gt = np.empty((k, m))
+    d_gt = np.empty((k, m))
+    for j, (x_i, c_i, n_i) in enumerate(zip(x_g, c_g, n_g)):
+        r_gt[j] = (n_i[:, None] * (x_i[:, None] >= event_times)).sum(axis=0)
+        d_gt[j] = (
+            n_i[:, None]
+            * ((x_i[:, None] == event_times) & (c_i == 0)[:, None])
+        ).sum(axis=0)
+
+    r_t = r_gt.sum(axis=0)
+    d_t = d_gt.sum(axis=0)
+
+    if weighting == "log-rank":
+        w = np.ones(m)
+    elif weighting == "gehan":
+        w = r_t
+    elif weighting == "tarone-ware":
+        w = np.sqrt(r_t)
+    else:
+        # Pooled left-continuous Kaplan-Meier, i.e. the value of the
+        # estimate just prior to each event time.
+        S = kaplan_meier(r_t, d_t)
+        S_prev = np.hstack([[1.0], S[:-1]])
+        w = S_prev**rho * (1 - S_prev) ** gamma
+
+    # Observed minus expected per group
+    with np.errstate(all="ignore"):
+        expected = d_t * r_gt / r_t
+    z = (w * (d_gt - expected)).sum(axis=1)
+
+    # Covariance of the (weighted) observed minus expected, using the
+    # hypergeometric variance of the deaths at each event time
+    with np.errstate(all="ignore"):
+        hyper = np.where(r_t > 1, d_t * (r_t - d_t) / (r_t - 1), 0.0)
+        prop = r_gt / r_t
+    V = np.zeros((k, k))
+    for a in range(k):
+        for b in range(k):
+            delta = 1.0 if a == b else 0.0
+            V[a, b] = (w**2 * hyper * prop[a] * (delta - prop[b])).sum()
+
+    # The covariance matrix is singular (rows sum to zero); drop the
+    # last group
+    z_r = z[:-1]
+    V_r = V[:-1, :-1]
+    try:
+        statistic = float(z_r @ np.linalg.solve(V_r, z_r))
+    except np.linalg.LinAlgError:
+        statistic = float(z_r @ np.linalg.pinv(V_r) @ z_r)
+
+    dof = k - 1
+    p_value = float(chi2.sf(statistic, dof))
+
+    if weighting == "fleming-harrington":
+        weighting = "fleming-harrington(rho={}, gamma={})".format(rho, gamma)
+
+    return LogRankResult(statistic, dof, p_value, weighting)

--- a/surpyval/univariate/nonparametric/nelson_aalen.py
+++ b/surpyval/univariate/nonparametric/nelson_aalen.py
@@ -5,6 +5,25 @@ from surpyval.univariate.nonparametric.nonparametric_fitter import (
 )
 
 
+def nelson_aalen_variance(r, d):
+    """
+    Aalen's (Poisson) estimate of the variance of the Nelson-Aalen
+    cumulative hazard estimator:
+
+    Var(H) = sum(d / r**2)
+
+    Recommended by Klein (1991) for its small sample performance.
+
+    Klein, J. P. (1991), "Small sample moments of some estimators of
+    the variance of the Kaplan-Meier and Nelson-Aalen estimators",
+    Scandinavian Journal of Statistics, 18(4), 333-340.
+    """
+    with np.errstate(all="ignore"):
+        var = d / r**2
+        var = np.where(np.isfinite(var), var, np.nan)
+        return np.cumsum(var)
+
+
 def nelson_aalen(r, d):
     H = np.cumsum(d / r)
     H[np.isnan(H)] = np.inf
@@ -20,6 +39,13 @@ class NelsonAalen_(NonParametricFitter):
 
     .. math::
         R(x) = e^{-\sum_{i:x_{i} \leq x}^{} \frac{d_{i} }{r_{i}}}
+
+    The variance of the cumulative hazard used for confidence bounds is
+    estimated with Aalen's (Poisson) estimator, as recommended by
+    Klein (1991):
+
+    .. math::
+        \widehat{Var}(H(x)) = \sum_{i:x_{i} \leq x} \frac{d_{i}}{r_{i}^{2}}
 
     Examples
     --------

--- a/surpyval/univariate/nonparametric/nonparametric.py
+++ b/surpyval/univariate/nonparametric/nonparametric.py
@@ -140,11 +140,10 @@ class NonParametric:
         >>> from surpyval import NelsonAalen
         >>> x = np.array([1, 2, 3, 4, 5])
         >>> model = NelsonAalen.fit(x)
-        >>> model.ff(2)
-        array([0.36237185])
-        >>> model.ff([1., 1.5, 2., 2.5])
-        array([0.18126925, 0.18126925, 0.36237185, 0.36237185])
+        >>> model.hf([1.5, 2.5, 3.5])
+        array([0.25      , 0.25      , 0.33333333])
         """
+        x = np.atleast_1d(x)
         idx = np.argsort(x)
         rev = np.argsort(idx)
         x = x[idx]
@@ -153,7 +152,8 @@ class NonParametric:
                 [self.Hf(x[0], interp=interp), self.Hf(x, interp=interp)]
             )
         )
-        hf[0] = hf[1]
+        if hf.size > 1:
+            hf[0] = hf[1]
         hf = pd.Series(hf)
         hf[hf == 0] = np.nan
         hf = hf.ffill().values
@@ -188,10 +188,8 @@ class NonParametric:
         >>> from surpyval import NelsonAalen
         >>> x = np.array([1, 2, 3, 4, 5])
         >>> model = NelsonAalen.fit(x)
-        >>> model.df(2)
-        array([0.28693267])
-        >>> model.df([1., 1.5, 2., 2.5])
-        array([0.16374615, 0.        , 0.15940704, 0.        ])
+        >>> model.df([1.5, 2.5, 3.5])
+        array([0.20468269, 0.15940704, 0.15229351])
         """
         return self.hf(x, interp=interp) * np.exp(-self.Hf(x, interp=interp))
 
@@ -225,8 +223,8 @@ class NonParametric:
         >>> model = NelsonAalen.fit(x)
         >>> model.Hf(2)
         array([0.45])
-        >>> model.df([1., 1.5, 2., 2.5])
-        model.Hf([1., 1.5, 2., 2.5])
+        >>> model.Hf([1., 1.5, 2., 2.5])
+        array([0.2 , 0.2 , 0.45, 0.45])
         """
         return -np.log(self.sf(x, interp=interp))
 
@@ -243,10 +241,15 @@ class NonParametric:
         r"""
 
         Confidence bounds of the ``on`` function at the
-        ``alpa_ci`` level of significance. Can be the upper,
+        ``alpha_ci`` level of significance. Can be the upper,
         lower, or two-sided confidence by changing value of ``bound``.
-        Can change the bound type to be regular or exponential
+        Can change the bound type to be regular (normal) or exponential
         using either the 't' or 'z' statistic.
+
+        The variance used is the one appropriate to the estimator with
+        which the model was fitted: Greenwood's formula for Kaplan-Meier,
+        Aalen's (Poisson) variance for Nelson-Aalen, and the tie-corrected
+        variance for Fleming-Harrington.
 
         Parameters
         ----------
@@ -265,33 +268,52 @@ class NonParametric:
             interpolated values if desired. Defaults to step.
         alpha_ci : scalar, optional
             The level of significance at which the bound will be computed.
-        bound_type : ('exp', 'regular'), str, optional
-            The method with which the bounds will be calculated. Using regular
-            will allow for the bounds to exceed 1 or be less than 0. Defaults
-            to exp as this ensures the bounds are within 0 and 1.
+        bound_type : ('exp', 'normal'), str, optional
+            The method with which the bounds will be calculated. Using
+            'normal' (i.e. the plain Greenwood-style interval) will allow
+            for the bounds to exceed 1 or be less than 0 and tends to
+            undercover in small samples. Defaults to 'exp' (the
+            log(-log) transformed interval) as this ensures the bounds
+            are within 0 and 1 and has better coverage.
         dist : ('t', 'z'), str, optional
             The statistic to use in calculating the bounds (student-t or
-            normal). Defaults to the normal (z).
+            normal). Defaults to the normal (z). The 't' option is a
+            conservative heuristic which uses the at risk count minus one
+            at each point as the degrees of freedom; it is not supported
+            by asymptotic theory, widens (overcovers) as the at risk
+            count falls, and is undefined when only one item remains at
+            risk.
 
         Returns
         -------
 
         cb : scalar or numpy array
             The value(s) of the upper, lower, or both confidence bound(s) of
-            the selected function at x
+            the selected function at x. For two-sided bounds the result has
+            one row per value of x with the columns being the
+            ``[lower, upper]`` bounds of the ``on`` function.
+
+        Notes
+        -----
+
+        If the last observation is an event (i.e. there is no right
+        censoring) the Kaplan-Meier variance is undefined at, and after,
+        that point. The bounds there are filled with the last finite
+        upper bound and 0 for the lower bound, rather than NaN, so that
+        bounds can be drawn up to the last observation.
 
         Examples
         --------
         >>> from surpyval import NelsonAalen
         >>> x = np.array([1, 2, 3, 4, 5])
         >>> model = NelsonAalen.fit(x)
-        >>> model.cb([1., 1.5, 2., 2.5], bound='lower', dist='t')
-        array([0.11434813, 0.11434813, 0.04794404, 0.04794404])
+        >>> model.cb([1., 1.5, 2., 2.5], bound='lower')
+        array([0.35485348, 0.35485348, 0.2345113 , 0.2345113 ])
         >>> model.cb([1., 1.5, 2., 2.5])
-        array([[0.97789387, 0.16706394],
-               [0.97789387, 0.16706394],
-               [0.91235117, 0.10996882],
-               [0.91235117, 0.10996882]])
+        array([[0.24175891, 0.97222045],
+               [0.24175891, 0.97222045],
+               [0.16288538, 0.89441253],
+               [0.16288538, 0.89441253]])
 
         References
         ----------
@@ -350,6 +372,13 @@ class NonParametric:
             raise ValueError("'bound_type' must be in ['exp', 'normal']")
         if dist not in ["t", "z"]:
             raise ValueError("'dist' must be in ['t', 'z']")
+        if getattr(self, "greenwood", None) is None:
+            raise ValueError(
+                "Model has no variance estimate so confidence bounds "
+                + "cannot be computed. This occurs for models created "
+                + "with 'fit_from_ecdf' since the at risk and death "
+                + "counts are unknown."
+            )
 
         confidence = 1.0 - alpha_ci
 
@@ -423,14 +452,26 @@ class NonParametric:
         return R_out
 
     def random(self, size):
-        return np.random.choice(self.x, size=size)
+        r"""
+        Draws random samples from the fitted distribution. Each observed
+        value x is drawn with the probability mass the estimated survival
+        function assigns to it. If the estimate does not reach zero (e.g.
+        due to right censoring) the remaining mass is distributed over the
+        observed values, i.e. sampling is conditional on an event occurring
+        at one of the observed values.
+        """
+        with np.errstate(all="ignore"):
+            p = -np.diff(np.hstack([[1.0], self.R]))
+        p = np.where(np.isfinite(p), p, 0)
+        p = p / p.sum()
+        return np.random.choice(self.x, size=size, p=p)
 
     def get_plot_data(self, **kwargs):
         y_scale_min = 0
         y_scale_max = 1
 
         # x-axis
-        x_min = 0
+        x_min = min(0, np.min(self.x))
         x_max = np.max(self.x)
 
         diff = (x_max - x_min) / 10
@@ -498,5 +539,8 @@ class NonParametric:
         out.F = 1 - out.R
         with np.errstate(all="ignore"):
             out.H = -np.log(out.R)
+        # Without r and d there is no variance estimate, and therefore
+        # no confidence bounds, for the model.
+        out.greenwood = None
 
         return out

--- a/surpyval/univariate/nonparametric/nonparametric.py
+++ b/surpyval/univariate/nonparametric/nonparametric.py
@@ -466,6 +466,326 @@ class NonParametric:
         p = p / p.sum()
         return np.random.choice(self.x, size=size, p=p)
 
+    def qf(self, p):
+        r"""
+        Quantile function of the non-parametric estimate. Returns the
+        smallest observed value at which the estimated CDF reaches, or
+        exceeds, the probability p.
+
+        Parameters
+        ----------
+
+        p : array like or scalar
+            The probabilities at which the quantile will be computed.
+            Values must be in (0, 1].
+
+        Returns
+        -------
+
+        q : numpy array
+            The value(s) of the quantile at each p. NaN where the
+            estimated CDF never reaches p (e.g. due to right censoring).
+
+        Examples
+        --------
+        >>> from surpyval import KaplanMeier
+        >>> x = np.array([1, 2, 3, 4, 5])
+        >>> model = KaplanMeier.fit(x)
+        >>> model.qf(0.5)
+        array([3.])
+        >>> model.qf([0.1, 0.5, 0.9])
+        array([1., 3., 5.])
+        """
+        p = np.atleast_1d(p).astype(float)
+        if ((p <= 0) | (p > 1)).any():
+            raise ValueError("'p' must be in the range (0, 1]")
+        idx = np.searchsorted(self.F, p, side="left")
+        x_padded = np.hstack([self.x.astype(float), [np.nan]])
+        return x_padded[np.minimum(idx, len(self.x))]
+
+    @property
+    def median(self):
+        r"""
+        The median survival time; the smallest observed value at which
+        the estimated CDF reaches, or exceeds, 0.5. NaN if the estimate
+        never reaches 0.5 (e.g. due to right censoring).
+        """
+        return self.qf(0.5)[0]
+
+    def quantile_cb(self, p, alpha_ci=0.05, bound_type="exp", dist="z"):
+        r"""
+        Two-sided confidence interval of the quantile at each
+        probability p using the Brookmeyer-Crowley method: the interval
+        is the set of times at which the pointwise confidence interval
+        of the survival function contains 1 - p.
+
+        Parameters
+        ----------
+
+        p : array like or scalar
+            The probabilities at which the quantile interval will be
+            computed. Values must be in (0, 1].
+        alpha_ci : scalar, optional
+            The level of significance at which the interval will be
+            computed. Defaults to 0.05.
+        bound_type : ('exp', 'normal'), str, optional
+            The method for the underlying survival function bounds.
+        dist : ('t', 'z'), str, optional
+            The statistic used in the underlying survival function
+            bounds.
+
+        Returns
+        -------
+
+        cb : numpy array
+            Array of shape (len(p), 2) with the ``[lower, upper]``
+            interval of the quantile for each p. The upper limit is NaN
+            where the relevant bound of the survival function never
+            crosses 1 - p (i.e. the interval is open to the right).
+        """
+        p = np.atleast_1d(p).astype(float)
+        if ((p <= 0) | (p > 1)).any():
+            raise ValueError("'p' must be in the range (0, 1]")
+
+        bounds = self.cb(
+            self.x,
+            on="sf",
+            bound="two-sided",
+            alpha_ci=alpha_ci,
+            bound_type=bound_type,
+            dist=dist,
+        )
+        lower_sf, upper_sf = bounds[:, 0], bounds[:, 1]
+
+        out = np.empty((p.size, 2))
+        for i, p_i in enumerate(p):
+            level = 1.0 - p_i
+            # Times enter the interval when the lower survival bound
+            # falls to the level, and leave it once the upper survival
+            # bound falls below the level.
+            in_lower = lower_sf <= level
+            in_upper = upper_sf < level
+            out[i, 0] = (
+                self.x[np.argmax(in_lower)] if in_lower.any() else np.nan
+            )
+            out[i, 1] = (
+                self.x[np.argmax(in_upper)] if in_upper.any() else np.nan
+            )
+        return out
+
+    def mean(self, tau=None):
+        r"""
+        The (restricted) mean survival time: the area under the
+        estimated survival function from 0 to tau.
+
+        If the survival function reaches zero this is the mean of the
+        estimated distribution. With right censoring the survival
+        function does not reach zero and the unrestricted mean is
+        undefined; the restricted mean up to tau (defaulting to the
+        largest observed value) is reported instead, which is the
+        standard restricted mean survival time (RMST).
+
+        Parameters
+        ----------
+
+        tau : scalar, optional
+            The horizon up to which the survival function is
+            integrated. Defaults to the largest observed value. If tau
+            is beyond the last observation the survival function is
+            extended at its final value.
+
+        Returns
+        -------
+
+        mean : float
+            The restricted mean survival time.
+
+        Examples
+        --------
+        >>> from surpyval import KaplanMeier
+        >>> x = np.array([1, 2, 3, 4, 5])
+        >>> model = KaplanMeier.fit(x)
+        >>> model.mean()
+        3.0
+        """
+        if np.min(self.x) < 0:
+            raise ValueError(
+                "Mean survival time requires non-negative observations"
+            )
+        if tau is None:
+            tau = np.max(self.x)
+
+        xs = self.x[self.x < tau].astype(float)
+        times = np.hstack([[0.0], xs, [tau]])
+        surv = np.hstack([[1.0], self.R[: xs.size]])
+        return float(np.sum(np.diff(times) * surv))
+
+    def mean_cb(self, tau=None, alpha_ci=0.05):
+        r"""
+        Two-sided confidence interval of the (restricted) mean survival
+        time, using the normal approximation with the standard variance
+        estimate:
+
+        .. math::
+            \widehat{Var}(\hat{\mu}) = \sum_{i: x_i \leq \tau}
+                A_i^2 v_i
+
+        where :math:`A_i` is the area under the survival function from
+        :math:`x_i` to :math:`\tau` and :math:`v_i` is the variance
+        increment of the cumulative hazard at :math:`x_i` (e.g. the
+        Greenwood increment for the Kaplan-Meier estimator).
+
+        Parameters
+        ----------
+
+        tau : scalar, optional
+            The horizon up to which the survival function is
+            integrated. Defaults to the largest observed value.
+        alpha_ci : scalar, optional
+            The level of significance at which the interval will be
+            computed. Defaults to 0.05.
+
+        Returns
+        -------
+
+        cb : numpy array
+            The ``[lower, upper]`` interval of the (restricted) mean.
+        """
+        if getattr(self, "greenwood", None) is None:
+            raise ValueError(
+                "Model has no variance estimate so confidence bounds "
+                + "cannot be computed. This occurs for models created "
+                + "with 'fit_from_ecdf' since the at risk and death "
+                + "counts are unknown."
+            )
+        if tau is None:
+            tau = np.max(self.x)
+
+        mu = self.mean(tau=tau)
+
+        # Area under the survival curve from each observation to tau
+        xs = self.x.astype(float)
+        upper_t = np.minimum(np.hstack([xs[1:], [np.inf]]), tau)
+        widths = np.clip(upper_t - np.minimum(xs, tau), 0, None)
+        seg_area = widths * self.R
+        # A[i] is the area from x[i] to tau
+        A = np.cumsum(seg_area[::-1])[::-1]
+
+        v = np.diff(np.hstack([[0.0], self.greenwood]))
+        with np.errstate(all="ignore"):
+            terms = np.where(A > 0, A**2 * v, 0.0)
+        var = np.sum(terms)
+
+        z = norm.ppf(1 - alpha_ci / 2)
+        se = np.sqrt(var)
+        return np.array([mu - z * se, mu + z * se])
+
+    def bootstrap_cb(
+        self,
+        x,
+        bound="two-sided",
+        alpha_ci=0.05,
+        B=200,
+        random_state=None,
+    ):
+        r"""
+        Confidence bounds of the survival function computed with a
+        non-parametric bootstrap: the data are resampled with
+        replacement, the model is refitted with the same estimator, and
+        the percentile interval across the refits is taken at each x.
+
+        This is the recommended way to compute bounds for the Turnbull
+        estimator. The Greenwood-style bounds from ``cb()`` treat the
+        expected (fractional) at risk and death counts from the
+        Turnbull EM as if they were observed counts, which ignores the
+        uncertainty in the EM allocation itself; the bootstrap does
+        not.
+
+        Parameters
+        ----------
+
+        x : array like or scalar
+            The values at which the confidence bounds will be
+            calculated.
+        bound : ('two-sided', 'upper', 'lower'), str, optional
+            Compute either the two-sided, upper or lower confidence
+            bound(s). Defaults to two-sided.
+        alpha_ci : scalar, optional
+            The level of significance at which the bound will be
+            computed. Defaults to 0.05.
+        B : int, optional
+            The number of bootstrap resamples. Defaults to 200. Larger
+            values give smoother bounds at a linear cost in runtime;
+            note that refitting the Turnbull estimator is relatively
+            expensive.
+        random_state : int or numpy.random.Generator, optional
+            Seed or generator for reproducible resampling.
+
+        Returns
+        -------
+
+        cb : numpy array
+            For two-sided bounds an array of shape (len(x), 2) with
+            ``[lower, upper]`` columns; otherwise an array of the
+            requested bound at each x.
+        """
+        if getattr(self, "data", None) is None or "x" not in self.data:
+            raise ValueError(
+                "Bootstrap requires the data the model was fitted "
+                + "with. Models created with 'from_xrd' or "
+                + "'fit_from_ecdf' cannot be bootstrapped."
+            )
+        # Imported here as the package imports this module on init.
+        from surpyval.univariate import nonparametric as nonp
+        from surpyval.utils import xcnt_to_xrd
+
+        x_eval = np.atleast_1d(x).astype(float)
+        x_data = self.data["x"]
+        c_data = self.data["c"]
+        n_data = self.data["n"]
+        t_data = self.data["t"]
+
+        rng = np.random.default_rng(random_state)
+        N = int(n_data.sum())
+        probs = n_data / n_data.sum()
+
+        old_err_state = np.seterr(all="ignore")
+        R_boot = np.empty((B, x_eval.size))
+        for b in range(B):
+            n_b = rng.multinomial(N, probs)
+            keep = n_b > 0
+            if self.model == "Turnbull":
+                fitted = nonp.turnbull(
+                    x_data[keep],
+                    c_data[keep],
+                    n_b[keep],
+                    t_data[keep],
+                    estimator=self.data["estimator"],
+                )
+                x_b, R_b = fitted["x"], fitted["R"]
+            else:
+                x_b, r_b, d_b = xcnt_to_xrd(
+                    x_data[keep], c_data[keep], n_b[keep], t_data[keep]
+                )
+                R_b = nonp.FIT_FUNCS[self.model](r_b, d_b)
+            idx = np.searchsorted(x_b, x_eval, side="right") - 1
+            R_boot[b, :] = np.where(
+                idx < 0, 1.0, R_b[np.clip(idx, 0, len(x_b) - 1)]
+            )
+        np.seterr(**old_err_state)
+
+        if bound == "two-sided":
+            qs = np.quantile(R_boot, [alpha_ci / 2, 1 - alpha_ci / 2], axis=0)
+            return qs.T
+        elif bound == "lower":
+            return np.quantile(R_boot, alpha_ci, axis=0)
+        elif bound == "upper":
+            return np.quantile(R_boot, 1 - alpha_ci, axis=0)
+        else:
+            raise ValueError(
+                "'bound' must be in ['two-sided', 'upper', 'lower']"
+            )
+
     def get_plot_data(self, **kwargs):
         y_scale_min = 0
         y_scale_max = 1
@@ -494,11 +814,39 @@ class NonParametric:
     def plot(self, ax=None, **kwargs):
         r"""
         Creates a plot of the survival function.
+
+        Two-sided confidence bounds are drawn as a shaded band in the
+        same colour as the survival curve, and right censored
+        observations are marked with ticks on the curve. Any keyword
+        arguments not listed below (e.g. ``color`` or ``label``) are
+        passed to the matplotlib plotting call for the survival curve.
+
+        Parameters
+        ----------
+
+        ax : matplotlib axis, optional
+            The axis on which the plot will be drawn. Defaults to the
+            current axis.
+        plot_bounds : bool, optional
+            Whether to draw the confidence bounds. Defaults to True.
+        show_censors : bool, optional
+            Whether to mark right censored observations on the curve.
+            Defaults to True.
+        interp : ('step', 'linear', 'cubic'), optional
+            How to draw the curve between observations.
+        bound, alpha_ci, bound_type, dist : optional
+            Passed to the confidence bound calculation; see ``cb()``.
+
+        Returns
+        -------
+
+        ax : matplotlib axis
         """
         if ax is None:
             ax = plt.gcf().gca()
 
         plot_bounds = kwargs.pop("plot_bounds", True)
+        show_censors = kwargs.pop("show_censors", True)
         interp = kwargs.pop("interp", "step")
         bound = kwargs.pop("bound", "two-sided")
         alpha_ci = kwargs.pop("alpha_ci", 0.05)
@@ -520,13 +868,39 @@ class NonParametric:
         ax.set_title("Model Survival Plot")
         ax.set_ylabel("R")
         if interp != "step":
-            ax.plot(d["x_"], d["R"])
-            if plot_bounds:
-                ax.plot(d["x_"], d["cbs"], color="r")
+            (line,) = ax.plot(d["x_"], d["R"], **kwargs)
         else:
-            ax.step(d["x_"], d["R"], where="post")
-            if plot_bounds:
-                ax.step(d["x_"], d["cbs"], color="r", where="post")
+            (line,) = ax.step(d["x_"], d["R"], where="post", **kwargs)
+        color = line.get_color()
+
+        if plot_bounds:
+            cbs = d["cbs"]
+            band_kwargs = {"alpha": 0.3, "color": color, "linewidth": 0}
+            if interp == "step":
+                band_kwargs["step"] = "post"
+            if np.ndim(cbs) == 2:
+                ax.fill_between(d["x_"], cbs[:, 0], cbs[:, 1], **band_kwargs)
+            elif interp == "step":
+                ax.step(
+                    d["x_"], cbs, where="post", color=color, linestyle="--"
+                )
+            else:
+                ax.plot(d["x_"], cbs, color=color, linestyle="--")
+
+        if show_censors and getattr(self, "data", None) is not None:
+            x_data = self.data["x"]
+            c_data = self.data["c"]
+            if np.ndim(x_data) == 1 and (c_data == 1).any():
+                x_cens = x_data[c_data == 1]
+                ax.plot(
+                    x_cens,
+                    self.sf(x_cens, interp=interp),
+                    linestyle="",
+                    marker="|",
+                    markersize=10,
+                    markeredgewidth=1.5,
+                    color=color,
+                )
 
         return ax
 

--- a/surpyval/univariate/nonparametric/nonparametric.py
+++ b/surpyval/univariate/nonparametric/nonparametric.py
@@ -793,6 +793,265 @@ class NonParametric:
                 "'bound' must be in ['two-sided', 'upper', 'lower']"
             )
 
+    @staticmethod
+    def _band_critical_value(
+        a_l, a_u, alpha_ci, standardized, n_sims, random_state
+    ):
+        # Critical value of the supremum of a Brownian bridge (for the
+        # Hall-Wellner band), or of a standardized Brownian bridge
+        # B(u)/sqrt(u(1 - u)) (for the equal precision band), over
+        # [a_l, a_u]. Computed by Monte Carlo simulation of bridge
+        # paths on a grid.
+        rng = np.random.default_rng(random_state)
+        m = 1000
+        u = np.arange(1, m + 1) / m
+        in_band = (u >= a_l) & (u <= a_u)
+        sups = np.empty(n_sims)
+        chunk = 1000
+        for start in range(0, n_sims, chunk):
+            size = min(chunk, n_sims - start)
+            W = np.cumsum(rng.standard_normal((size, m)) / np.sqrt(m), axis=1)
+            bridge = W - u * W[:, -1:]
+            paths = np.abs(bridge[:, in_band])
+            if standardized:
+                paths = paths / np.sqrt(u[in_band] * (1 - u[in_band]))
+            sups[start : start + size] = paths.max(axis=1)
+        return np.quantile(sups, 1 - alpha_ci)
+
+    def band(
+        self,
+        x=None,
+        method="hall-wellner",
+        bound_type="exp",
+        alpha_ci=0.05,
+        n_sims=10_000,
+        random_state=1,
+    ):
+        r"""
+        Simultaneous confidence band of the survival function.
+
+        The pointwise bounds from ``cb()`` cover the true value of the
+        survival function at each single time with probability
+        1 - alpha_ci, but the probability that the *whole* true curve
+        lies between them is lower, since the curve has many
+        opportunities to escape. A confidence band is widened so that,
+        with probability 1 - alpha_ci, the entire survival function
+        lies within the band over the observed range. Use the band, not
+        the pointwise bounds, to assess whether a hypothesised curve
+        (e.g. a fitted parametric distribution) is consistent with the
+        data as a whole.
+
+        Two classical bands are available:
+
+        - "hall-wellner": width proportional to
+          :math:`(1 + n\sigma^2(t))/\sqrt{n}`; tends to be relatively
+          wider in the middle of the curve.
+        - "nair" (equal precision): width proportional to the pointwise
+          standard error, i.e. the band is the pointwise interval
+          scaled by a larger critical value, so its width follows the
+          pointwise bounds everywhere.
+
+        Critical values are computed by Monte Carlo simulation of the
+        limiting Brownian bridge process, with a fixed default seed so
+        results are reproducible.
+
+        The band is only defined between the first and last observed
+        events (where the variance estimate is positive and finite);
+        NaN is returned outside that range. The asymptotic theory for
+        these bands is for right censored data; for Turnbull models
+        with interval censoring prefer ``bootstrap_cb()``.
+
+        Parameters
+        ----------
+
+        x : array like or scalar, optional
+            The values at which the band will be evaluated. Defaults to
+            the observed values.
+        method : ('hall-wellner', 'nair'), str, optional
+            The type of band. Defaults to 'hall-wellner'.
+        bound_type : ('exp', 'normal'), str, optional
+            As for ``cb()``: 'exp' applies the band on the log(-log)
+            scale, keeping it within [0, 1]. Defaults to 'exp'.
+        alpha_ci : scalar, optional
+            The level of significance of the band. Defaults to 0.05.
+        n_sims : int, optional
+            Number of simulated paths for the critical value.
+        random_state : int or numpy.random.Generator, optional
+            Seed for the critical value simulation. Defaults to a fixed
+            seed for reproducibility.
+
+        Returns
+        -------
+
+        band : numpy array
+            Array of shape (len(x), 2) with the ``[lower, upper]`` band
+            values for the survival function at each x.
+
+        References
+        ----------
+
+        Hall, W. J. and Wellner, J. A. (1980), "Confidence bands for a
+        survival curve from censored data", Biometrika 67, 133-143.
+
+        Nair, V. N. (1984), "Confidence bands for survival functions
+        with censored data: a comparative study", Technometrics 26,
+        265-275.
+
+        Klein, J. P. and Moeschberger, M. L. (2003), "Survival
+        Analysis", 2nd ed., Section 4.4.
+        """
+        if method not in ["hall-wellner", "nair"]:
+            raise ValueError("'method' must be in ['hall-wellner', 'nair']")
+        if bound_type not in ["exp", "normal"]:
+            raise ValueError("'bound_type' must be in ['exp', 'normal']")
+        if getattr(self, "greenwood", None) is None:
+            raise ValueError(
+                "Model has no variance estimate so confidence bands "
+                + "cannot be computed. This occurs for models created "
+                + "with 'fit_from_ecdf' since the at risk and death "
+                + "counts are unknown."
+            )
+
+        if getattr(self, "data", None) is not None and "n" in self.data:
+            N = float(self.data["n"].sum())
+        else:
+            N = float(np.max(self.r))
+
+        old_err_state = np.seterr(all="ignore")
+
+        sigma2 = self.greenwood
+        valid = (
+            np.isfinite(sigma2) & (sigma2 > 0) & (self.R > 0) & (self.R < 1)
+        )
+
+        if not valid.any():
+            np.seterr(**old_err_state)
+            raise ValueError(
+                "Band is undefined: no observations with a positive, "
+                + "finite variance estimate"
+            )
+
+        a = N * sigma2 / (1 + N * sigma2)
+        a_l = a[valid].min()
+        a_u = a[valid].max()
+
+        crit = self._band_critical_value(
+            a_l,
+            a_u,
+            alpha_ci,
+            standardized=(method == "nair"),
+            n_sims=n_sims,
+            random_state=random_state,
+        )
+
+        if method == "nair":
+            half_width = crit * np.sqrt(sigma2)
+        else:
+            half_width = crit * (1 + N * sigma2) / np.sqrt(N)
+
+        if bound_type == "exp":
+            # Band applied on the log(-log) scale, mirroring the
+            # pointwise exponential Greenwood bounds.
+            theta = np.log(-np.log(self.R))
+            se = half_width / np.abs(np.log(self.R))
+            lower = np.exp(-np.exp(theta + se))
+            upper = np.exp(-np.exp(theta - se))
+        else:
+            lower = self.R - half_width * self.R
+            upper = self.R + half_width * self.R
+
+        lower = np.where(valid, lower, np.nan)
+        upper = np.where(valid, upper, np.nan)
+
+        if x is None:
+            x = self.x
+        x = np.atleast_1d(x).astype(float)
+        idx = np.searchsorted(self.x, x, side="right") - 1
+        idx_c = np.clip(idx, 0, len(self.x) - 1)
+        out = np.empty((x.size, 2))
+        out[:, 0] = np.where(idx < 0, np.nan, lower[idx_c])
+        out[:, 1] = np.where(idx < 0, np.nan, upper[idx_c])
+        outside = (x < self.x.min()) | (x > self.x.max())
+        out[outside] = np.nan
+
+        np.seterr(**old_err_state)
+
+        return out
+
+    def smoothed_hf(self, x, bandwidth=None):
+        r"""
+        Kernel smoothed estimate of the hazard rate, using an
+        Epanechnikov kernel over the increments of the cumulative
+        hazard estimate:
+
+        .. math::
+            \hat{h}(t) = \frac{1}{b} \sum_{i} K\left (
+                \frac{t - x_i}{b} \right ) \Delta \hat{H}(x_i)
+
+        Contributions are renormalised near the boundaries of the
+        observed range so the estimate is not biased downward where the
+        kernel window extends past the data.
+
+        This is a better estimate of the hazard rate than ``hf()``,
+        which simply differences the cumulative hazard between the
+        requested points.
+
+        Parameters
+        ----------
+
+        x : array like or scalar
+            The values at which the hazard rate will be estimated.
+        bandwidth : scalar, optional
+            The kernel bandwidth in the units of x. Defaults to a rough
+            rule of thumb (one eighth of the observed range); for
+            serious use choose by inspection or cross-validation.
+
+        Returns
+        -------
+
+        hf : numpy array
+            The estimated hazard rate at each x. NaN outside the
+            observed range.
+
+        References
+        ----------
+
+        Klein, J. P. and Moeschberger, M. L. (2003), "Survival
+        Analysis", 2nd ed., Section 6.2.
+        """
+        x = np.atleast_1d(x).astype(float)
+
+        with np.errstate(all="ignore"):
+            dH = np.diff(np.hstack([[0.0], self.H]))
+        dH = np.where(np.isfinite(dH), dH, 0.0)
+
+        x_min = self.x.min()
+        x_max = self.x.max()
+        if bandwidth is None:
+            bandwidth = (x_max - x_min) / 8
+        if bandwidth <= 0:
+            raise ValueError("'bandwidth' must be positive")
+
+        u = (x[:, None] - self.x[None, :]) / bandwidth
+        kern = np.where(np.abs(u) <= 1, 0.75 * (1 - u**2), 0.0)
+        h = (kern * dH).sum(axis=1) / bandwidth
+
+        # Renormalise by the kernel mass that lies within the observed
+        # range, correcting the downward bias near the boundaries. The
+        # Epanechnikov CDF is (2 + 3v - v^3) / 4 on [-1, 1].
+        def epa_cdf(v):
+            v = np.clip(v, -1, 1)
+            return (2 + 3 * v - v**3) / 4
+
+        lo = (x - x_max) / bandwidth
+        hi = (x - x_min) / bandwidth
+        mass = epa_cdf(hi) - epa_cdf(lo)
+        with np.errstate(all="ignore"):
+            h = np.where(mass > 0, h / mass, np.nan)
+
+        h = np.where((x < x_min) | (x > x_max), np.nan, h)
+        return h
+
     def get_plot_data(self, **kwargs):
         y_scale_min = 0
         y_scale_max = 1

--- a/surpyval/univariate/nonparametric/nonparametric.py
+++ b/surpyval/univariate/nonparametric/nonparametric.py
@@ -701,6 +701,13 @@ class NonParametric:
         uncertainty in the EM allocation itself; the bootstrap does
         not.
 
+        Note that the Turnbull NPMLE only identifies the probability
+        mass within each Turnbull interval, not how it is distributed
+        inside one. Point estimates and bounds evaluated strictly
+        inside an interval therefore reflect the step convention rather
+        than an estimate of the underlying continuous survival
+        function, and are best evaluated at the interval bounds.
+
         Parameters
         ----------
 

--- a/surpyval/univariate/nonparametric/nonparametric_fitter.py
+++ b/surpyval/univariate/nonparametric/nonparametric_fitter.py
@@ -19,15 +19,16 @@ class NonParametricFitter:
         with np.errstate(all="ignore"):
             out.H = -np.log(out.R)
 
-        out.greenwood = self._compute_var(out.R, r, d)
+        out.greenwood = self._compute_var(estimator, r, d)
         return out
 
-    def _compute_var(self, R, r, d):
-        with np.errstate(all="ignore"):
-            var = d / (r * (r - d))
-            var = np.where(np.isfinite(var), var, np.nan)
-            greenwood = np.cumsum(var)
-        return greenwood
+    def _compute_var(self, estimator, r, d):
+        # Variance of the cumulative hazard estimate using the formula
+        # appropriate to the estimator, e.g. Greenwood's formula for
+        # Kaplan-Meier. See VAR_FUNCS for each.
+        return nonp.VAR_FUNCS[estimator](
+            np.asarray(r, dtype=float), np.asarray(d, dtype=float)
+        )
 
     def fit(
         self,
@@ -137,7 +138,7 @@ class NonParametricFitter:
             t_obj = self._fit(x, c, n, t, turnbull_estimator)
 
             out.greenwood = self._compute_var(
-                t_obj["R"], t_obj["r"], t_obj["d"]
+                turnbull_estimator, t_obj["r"], t_obj["d"]
             )
             for k, v in t_obj.items():
                 setattr(out, k, v)
@@ -195,7 +196,7 @@ class NonParametricFitter:
         >>> x = [1, 2, 3, 4, 5, 6]
         >>> r = [10, 8, 6, 4, 3, 2]
         >>> d = [2, 1, 1, 1, 1, 1]
-        >>> model = NelsonAalen.from_xrd(x)
+        >>> model = NelsonAalen.from_xrd(x, r, d)
         >>> print(model)
         Non-Parametric SurPyval Model
         =============================

--- a/surpyval/univariate/nonparametric/plotting_positions.py
+++ b/surpyval/univariate/nonparametric/plotting_positions.py
@@ -114,8 +114,7 @@ def plotting_positions(
     N = n.sum()
 
     if heuristic == "Filliben":
-        # Needs work
-        out = nonp.filliben(x, c, n)
+        out = nonp.filliben(x, c, n, t)
     elif heuristic == "Nelson-Aalen":
         x, r, d = xcnt_to_xrd(x, c, n, t)
         R = nonp.nelson_aalen(r, d)


### PR DESCRIPTION
Confidence bounds now use the variance formula appropriate to each
estimator instead of applying Greenwood's Kaplan-Meier formula to all
of them:

- Kaplan-Meier: Greenwood's formula (unchanged)
- Nelson-Aalen: Aalen's (Poisson) variance, sum(d/r^2), as recommended
  by Klein (1991) and used by R's survfit (ctype=1)
- Fleming-Harrington: the tie-corrected variance
  sum(1/(r-j)^2, j=0..d-1), matching the estimator's own tie
  correction and R's survfit (ctype=2)
- Turnbull: the variance matching the selected inner estimator

A side benefit is that Nelson-Aalen and Fleming-Harrington bounds are
now defined at the final observation since their variances remain
finite when d == r.

Also fixes a number of bugs found while reviewing the module:

- random() now samples observed values with the estimated probability
  masses instead of uniformly from the unique values
- the Filliben heuristic was unusable: plotting_positions did not pass
  the truncation array and filliben.py bound the rank_adjust module
  instead of the function
- ECDF_Adj was implemented and documented but missing from
  PLOTTING_METHODS so it was rejected
- scalar input to hf() and df() raised a TypeError
- models created with fit_from_ecdf now raise an informative error
  from cb() instead of an AttributeError
- cb() docstring: bound_type option is 'normal' (not 'regular'),
  two-sided results are documented as [lower, upper] columns, the
  dist='t' heuristic and last-point fill behaviour are documented,
  and stale examples were recomputed
- get_plot_data no longer assumes the support starts at zero

Adds test coverage for the bound formulas, bound ordering and
consistency, the per-estimator variances, a seeded Monte Carlo
coverage check of the default bounds, and the fixed bugs.

https://claude.ai/code/session_01TZ6UCFcvvQ7ndp9dhq5aLj