### PR TITLE
Fully handle truncation in univariate parametric regression

### DIFF
--- a/surpyval/tests/univariate/regression/test_truncation.py
+++ b/surpyval/tests/univariate/regression/test_truncation.py
@@ -1,0 +1,111 @@
+"""
+Tests for truncation handling in the univariate parametric regression
+fitters: proportional hazards, proportional odds, accelerated failure time
+and accelerated life (parameter substitution).
+
+With covariates fixed at zero the regression term ``phi(Z) = exp(beta'Z)``
+collapses to one, so each model must reproduce the truncation-corrected
+baseline fit produced by the plain parametric distribution. This anchors
+the regression likelihoods to SurPyval's known-correct base implementation.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval import Weibull, WeibullPH, WeibullPO
+from surpyval.univariate.regression import AFT, AcceleratedLife
+from surpyval.univariate.regression.accelerated_life import Power
+
+
+def _left_truncated_data(seed=0, n=1000, alpha=10.0, beta=2.0, tl=3.0):
+    rng = np.random.default_rng(seed)
+    x = alpha * rng.weibull(beta, n)
+    x = x[x > tl]
+    t = np.column_stack([np.full(x.size, tl), np.full(x.size, np.inf)])
+    Z = np.zeros((x.size, 1))
+    return x, Z, t, tl
+
+
+@pytest.mark.parametrize("fitter", [WeibullPH, WeibullPO, AFT(Weibull)])
+def test_left_truncation_matches_baseline(fitter):
+    # phi(0) = 1, so the regression fit must equal the truncated baseline.
+    x, Z, t, tl = _left_truncated_data()
+    baseline = Weibull.fit(x=x, tl=tl)
+    model = fitter.fit(x=x, Z=Z, t=t)
+
+    assert np.allclose(model.params[:2], baseline.params, atol=1e-2)
+    # The regression coefficient should be ~0 for a constant covariate.
+    assert np.allclose(model.params[2:], 0.0, atol=1e-2)
+
+
+@pytest.mark.parametrize("fitter", [WeibullPH, WeibullPO, AFT(Weibull)])
+def test_truncation_changes_estimate(fitter):
+    # Ignoring left truncation biases the scale upward; correcting for it
+    # must pull the estimate back toward the truth.
+    x, Z, t, tl = _left_truncated_data()
+    truncated = fitter.fit(x=x, Z=Z, t=t)
+    naive = fitter.fit(x=x, Z=Z)
+
+    assert not np.allclose(truncated.params[:2], naive.params[:2], atol=1e-2)
+    # Truncation-corrected scale should be the smaller (less biased) one.
+    assert truncated.params[0] < naive.params[0]
+
+
+def test_interval_censoring_matches_baseline():
+    # The interval-censoring term must equal F(xr) - F(xl), matching the
+    # base parametric fit when covariates are zero.
+    rng = np.random.default_rng(1)
+    x = 10.0 * rng.weibull(2.0, 400)
+    xl = np.floor(x)
+    xr = np.ceil(x + 1e-9)
+    baseline = Weibull.fit(xl=xl, xr=xr)
+
+    xc = [[a, b] for a, b in zip(xl, xr)]
+    c = np.full(x.size, 2)
+    Z = np.zeros((x.size, 1))
+    model = WeibullPH.fit(x=xc, Z=Z, c=c)
+
+    assert np.allclose(model.params[:2], baseline.params, atol=1e-2)
+
+
+def test_accelerated_life_handles_truncation():
+    # AcceleratedLife (parameter substitution) must accept truncated data and
+    # produce a different fit than when truncation is ignored.
+    rng = np.random.default_rng(2)
+    tl = 2.0
+    xs, Zs, ts = [], [], []
+    for stress, alpha in [(1.0, 8.0), (2.0, 14.0)]:
+        xi = alpha * rng.weibull(2.0, 500)
+        xi = xi[xi > tl]
+        xs.append(xi)
+        Zs.append(np.full((xi.size, 1), stress))
+        ts.append(
+            np.column_stack(
+                [np.full(xi.size, tl), np.full(xi.size, np.inf)]
+            )
+        )
+    x = np.concatenate(xs)
+    Z = np.concatenate(Zs)
+    t = np.concatenate(ts)
+
+    with_trunc = AcceleratedLife(Weibull, Power).fit(x=x, Z=Z, t=t)
+    ignore_trunc = AcceleratedLife(Weibull, Power).fit(x=x, Z=Z)
+
+    assert np.isfinite(with_trunc.neg_ll())
+    assert not np.allclose(with_trunc.params, ignore_trunc.params, atol=1e-2)
+
+
+def test_right_truncation_runs():
+    # Right truncation (tr finite, tl = -inf) must be handled without error
+    # and recover the baseline fit for zero covariates.
+    rng = np.random.default_rng(3)
+    tr = 18.0
+    x = 10.0 * rng.weibull(2.0, 1000)
+    x = x[x < tr]
+    t = np.column_stack([np.full(x.size, -np.inf), np.full(x.size, tr)])
+    Z = np.zeros((x.size, 1))
+
+    baseline = Weibull.fit(x=x, tr=tr)
+    model = WeibullPH.fit(x=x, Z=Z, t=t)
+
+    assert np.allclose(model.params[:2], baseline.params, atol=1e-2)

--- a/surpyval/tests/univariate/regression/test_truncation.py
+++ b/surpyval/tests/univariate/regression/test_truncation.py
@@ -109,3 +109,50 @@ def test_right_truncation_runs():
     model = WeibullPH.fit(x=x, Z=Z, t=t)
 
     assert np.allclose(model.params[:2], baseline.params, atol=1e-2)
+
+
+def test_interval_truncation_matches_baseline():
+    # Both truncation bounds finite (observation window (tl, tr)); must match
+    # the truncated baseline for zero covariates.
+    rng = np.random.default_rng(4)
+    tl, tr = 2.0, 25.0
+    x = 10.0 * rng.weibull(2.0, 2000)
+    x = x[(x > tl) & (x < tr)]
+    t = np.column_stack([np.full(x.size, tl), np.full(x.size, tr)])
+    Z = np.zeros((x.size, 1))
+
+    baseline = Weibull.fit(x=x, tl=tl, tr=tr)
+    model = WeibullPH.fit(x=x, Z=Z, t=t)
+
+    assert np.allclose(model.params[:2], baseline.params, atol=1e-2)
+
+
+def test_partial_truncation_matches_baseline():
+    # Only a subset of rows is truncated (the rest carry [-inf, inf]); the
+    # correction must apply to the truncated subset alone.
+    rng = np.random.default_rng(5)
+    tl = 3.0
+    x_trunc = 10.0 * rng.weibull(2.0, 1000)
+    x_trunc = x_trunc[x_trunc > tl]
+    x_full = 10.0 * rng.weibull(2.0, 500)
+
+    x = np.concatenate([x_trunc, x_full])
+    t = np.vstack(
+        [
+            np.column_stack(
+                [np.full(x_trunc.size, tl), np.full(x_trunc.size, np.inf)]
+            ),
+            np.column_stack(
+                [np.full(x_full.size, -np.inf), np.full(x_full.size, np.inf)]
+            ),
+        ]
+    )
+    Z = np.zeros((x.size, 1))
+
+    tl_arr = np.concatenate(
+        [np.full(x_trunc.size, tl), np.full(x_full.size, -np.inf)]
+    )
+    baseline = Weibull.fit(x=x, tl=tl_arr)
+    model = WeibullPH.fit(x=x, Z=Z, t=t)
+
+    assert np.allclose(model.params[:2], baseline.params, atol=1e-2)

--- a/surpyval/univariate/regression/_likelihood.py
+++ b/surpyval/univariate/regression/_likelihood.py
@@ -1,0 +1,96 @@
+"""Shared likelihood machinery for parametric regression fitters.
+
+All of SurPyval's parametric regression models (proportional hazards,
+proportional odds, accelerated failure time and accelerated life /
+parameter substitution) share the same observation model: each row may be
+observed, right/left/interval censored, and additionally left, right or
+interval truncated. The only thing that differs between the models is how
+the covariates ``Z`` enter the distribution functions.
+
+``regression_neg_ll`` therefore expresses the negative log-likelihood purely
+in terms of a ``model`` object that exposes the covariate-aware functions
+``log_df``, ``log_sf``, ``log_ff`` and ``ff`` (all with the signature
+``(x, Z, *params)``). This keeps the censoring and truncation handling in a
+single, well-tested place rather than duplicated — and subtly inconsistent —
+across each fitter.
+"""
+
+import autograd.numpy as np
+
+# Smallest positive float; used to floor probability masses so that
+# ``log`` stays finite for impossible (zero-width) intervals.
+_TINY = np.finfo(float).tiny
+
+
+def _ff_safe(model, x, Z, *params):
+    """``model.ff`` evaluated with infinite truncation bounds mapped to the
+    correct limiting probability (0 below the support, 1 above it) without
+    ever calling ``ff`` at a non-finite value.
+    """
+    finite = np.isfinite(x)
+    x_safe = np.where(finite, x, 0.0)
+    # ``x`` only ever holds ``-inf`` on the left bound and ``+inf`` on the
+    # right bound, so a non-finite entry maps to F = 0 or F = 1 respectively.
+    fill = np.where(x > 0, 1.0, 0.0)
+    return np.where(finite, model.ff(x_safe, Z, *params), fill)
+
+
+def truncation_correction(model, data, *params):
+    """Log of the probability mass within each observation's truncation
+    interval, summed over the truncated rows.
+
+    The likelihood of a truncated observation is divided by
+    ``P(tl < X < tr | Z)`` to account for the fact that it could only have
+    been observed within that window. In log space this is a subtraction,
+    so the caller subtracts the value returned here.
+    """
+    if data.x_tl.size == 0:
+        return 0.0
+
+    right = _ff_safe(model, data.x_tr, data.Z_t, *params)
+    left = _ff_safe(model, data.x_tl, data.Z_t, *params)
+    return (data.n_t * np.log(np.maximum(right - left, _TINY))).sum()
+
+
+def regression_neg_ll(model, data, *params):
+    """Negative log-likelihood for a covariate-aware survival model.
+
+    Parameters
+    ----------
+    model : object
+        Must provide ``log_df``, ``log_sf``, ``log_ff`` and ``ff``, each
+        taking ``(x, Z, *params)``.
+    data : SurpyvalData
+        Data split into observation types with covariates attached via
+        ``add_covariates``.
+    *params : float
+        The distribution parameters followed by the regression parameters.
+    """
+    ll = 0.0
+
+    if data.x_o.size > 0:
+        ll = ll + (
+            data.n_o * model.log_df(data.x_o, data.Z_o, *params)
+        ).sum()
+
+    if data.x_r.size > 0:
+        ll = ll + (
+            data.n_r * model.log_sf(data.x_r, data.Z_r, *params)
+        ).sum()
+
+    if data.x_l.size > 0:
+        ll = ll + (
+            data.n_l * model.log_ff(data.x_l, data.Z_l, *params)
+        ).sum()
+
+    if data.x_il.size > 0:
+        # Interval censoring: P(xl < X < xr | Z) = F(xr) - F(xl).
+        right = model.ff(data.x_ir, data.Z_i, *params)
+        left = model.ff(data.x_il, data.Z_i, *params)
+        ll = ll + (
+            data.n_i * np.log(np.maximum(right - left, _TINY))
+        ).sum()
+
+    ll = ll - truncation_correction(model, data, *params)
+
+    return -ll

--- a/surpyval/univariate/regression/_likelihood.py
+++ b/surpyval/univariate/regression/_likelihood.py
@@ -22,16 +22,21 @@ import autograd.numpy as np
 _TINY = np.finfo(float).tiny
 
 
-def _ff_safe(model, x, Z, *params):
-    """``model.ff`` evaluated with infinite truncation bounds mapped to the
-    correct limiting probability (0 below the support, 1 above it) without
-    ever calling ``ff`` at a non-finite value.
+def _ff_safe(model, x, Z, fill, *params):
+    """``model.ff(x, Z, *params)`` with non-finite bounds replaced by their
+    limiting probability without ever evaluating ``ff`` at a non-finite
+    value.
+
+    ``fill`` is the probability a non-finite entry maps to: ``0.0`` for a
+    lower/left truncation bound (``F(-inf) = 0``) and ``1.0`` for an
+    upper/right bound (``F(+inf) = 1``). The caller knows which bound it is
+    passing, so the fill is supplied explicitly rather than inferred from
+    the value of ``x``.
     """
     finite = np.isfinite(x)
+    # Substitute a finite placeholder so ``ff`` is never called at +/-inf;
+    # the placeholder's result is discarded for those entries below.
     x_safe = np.where(finite, x, 0.0)
-    # ``x`` only ever holds ``-inf`` on the left bound and ``+inf`` on the
-    # right bound, so a non-finite entry maps to F = 0 or F = 1 respectively.
-    fill = np.where(x > 0, 1.0, 0.0)
     return np.where(finite, model.ff(x_safe, Z, *params), fill)
 
 
@@ -47,8 +52,9 @@ def truncation_correction(model, data, *params):
     if data.x_tl.size == 0:
         return 0.0
 
-    right = _ff_safe(model, data.x_tr, data.Z_t, *params)
-    left = _ff_safe(model, data.x_tl, data.Z_t, *params)
+    # Upper bound: F(+inf) = 1; lower bound: F(-inf) = 0.
+    right = _ff_safe(model, data.x_tr, data.Z_t, 1.0, *params)
+    left = _ff_safe(model, data.x_tl, data.Z_t, 0.0, *params)
     return (data.n_t * np.log(np.maximum(right - left, _TINY))).sum()
 
 

--- a/surpyval/univariate/regression/accelerated_failure_time/aft_fitter.py
+++ b/surpyval/univariate/regression/accelerated_failure_time/aft_fitter.py
@@ -4,6 +4,7 @@ from scipy.optimize import minimize
 from surpyval.univariate.parametric.fitters import bounds_convert
 from surpyval.utils.surpyval_data import SurpyvalData
 
+from .._likelihood import regression_neg_ll
 from ..parametric_regression_model import ParametricRegressionModel
 
 
@@ -83,12 +84,8 @@ class AFTFitter:
     def log_df(self, x, Z, *params):
         return np.log(self.hf(x, Z, *params)) - self.Hf(x, Z, *params)
 
-    def neg_ll(self, Z, x, c, n, *params):
-        like = np.zeros_like(x, dtype=float)
-        like = np.where(c == 0, self.log_df(x, Z, *params), like)
-        like = np.where(c == 1, self.log_sf(x, Z, *params), like)
-        like = np.where(c == -1, self.log_ff(x, Z, *params), like)
-        return -np.sum(n * like)
+    def neg_ll(self, data, *params):
+        return regression_neg_ll(self, data, *params)
 
     def fit(self, x, Z, c=None, n=None, t=None, init=None, fixed=None):
         data = SurpyvalData(x, c, n, t, group_and_sort=False)
@@ -121,9 +118,7 @@ class AFTFitter:
         with np.errstate(all="ignore"):
 
             def fun(params):
-                return self.neg_ll(
-                    data.Z, data.x, data.c, data.n, *inv_trans(const(params))
-                )
+                return self.neg_ll(data, *inv_trans(const(params)))
 
             res = minimize(
                 fun, init, method="Nelder-Mead", options={"maxiter": 1000}

--- a/surpyval/univariate/regression/accelerated_life/parameter_substitution.py
+++ b/surpyval/univariate/regression/accelerated_life/parameter_substitution.py
@@ -7,6 +7,7 @@ from scipy.optimize import minimize
 from surpyval.univariate.parametric.fitters import bounds_convert
 from surpyval.utils.surpyval_data import SurpyvalData
 
+from .._likelihood import regression_neg_ll
 from ..parametric_regression_model import ParametricRegressionModel
 
 
@@ -193,14 +194,8 @@ class ParameterSubstitutionFitter:
             Z_out.append(np.ones((size, cols)) * stress)
         return np.array(x).flatten(), np.concatenate(Z_out)
 
-    def neg_ll(self, Z, x, c, n, *params):
-        like = np.zeros_like(x).astype(float)
-        like = np.where(c == 0, self.log_df(x, Z, *params), like)
-        like = np.where(c == 1, self.log_sf(x, Z, *params), like)
-        like = np.where(c == -1, self.log_ff(x, Z, *params), like)
-        like = np.multiply(n, like)
-        like = -np.sum(like)
-        return like
+    def neg_ll(self, data, *params):
+        return regression_neg_ll(self, data, *params)
 
     def fit(self, x, Z, c=None, n=None, t=None, init=None, fixed=None):
         data = SurpyvalData(x=x, c=c, n=n, t=t, group_and_sort=False)
@@ -297,9 +292,7 @@ class ParameterSubstitutionFitter:
         with np.errstate(all="ignore"):
 
             def fun(params):
-                return self.neg_ll(
-                    data.Z, data.x, data.c, data.n, *inv_trans(const(params))
-                )
+                return self.neg_ll(data, *inv_trans(const(params)))
 
             res1 = minimize(
                 fun, init, method="Nelder-Mead", options={"maxiter": 1000}

--- a/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
+++ b/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
@@ -6,6 +6,7 @@ from scipy.optimize import minimize
 from surpyval.univariate.parametric.fitters import bounds_convert
 from surpyval.utils.surpyval_data import SurpyvalData
 
+from .._likelihood import regression_neg_ll
 from ..parametric_regression_model import ParametricRegressionModel
 
 
@@ -109,27 +110,7 @@ class ProportionalHazardsFitter:
         return x.flatten(), Z_out.flatten()
 
     def neg_ll(self, data, *params):
-        ll = (
-            (data.n_o * self.log_df(data.x_o, data.Z_o, *params)).sum()
-            + (data.n_r * self.log_sf(data.x_r, data.Z_r, *params)).sum()
-            + (data.n_l * self.log_ff(data.x_l, data.Z_l, *params)).sum()
-            + (
-                data.n_i
-                * (
-                    self.log_ff(data.x_ir, data.Z_i, *params)
-                    - self.log_ff(data.x_il, data.Z_i, *params)
-                )
-            ).sum()
-        )
-        if (np.isfinite(data.tl).any()) | (np.isfinite(data.tr).any()):
-            ll -= (
-                data.n
-                * (
-                    self.log_ff(data.tr, data.Z, *params)
-                    - self.log_ff(data.tl, data.Z, *params)
-                )
-            ).sum()
-        return -ll
+        return regression_neg_ll(self, data, *params)
 
     @staticmethod
     def create(distribution):

--- a/surpyval/univariate/regression/proportional_hazards/proportional_odds_fitter.py
+++ b/surpyval/univariate/regression/proportional_hazards/proportional_odds_fitter.py
@@ -4,6 +4,7 @@ from scipy.optimize import minimize
 from surpyval.univariate.parametric.fitters import bounds_convert
 from surpyval.utils.surpyval_data import SurpyvalData
 
+from .._likelihood import regression_neg_ll
 from ..parametric_regression_model import ParametricRegressionModel
 
 
@@ -125,27 +126,7 @@ class ProportionalOddsFitter:
         return np.log(phi) + np.log(f0) - 2.0 * np.log(denom)
 
     def neg_ll(self, data, *params):
-        ll = (
-            (data.n_o * self.log_df(data.x_o, data.Z_o, *params)).sum()
-            + (data.n_r * self.log_sf(data.x_r, data.Z_r, *params)).sum()
-            + (data.n_l * self.log_ff(data.x_l, data.Z_l, *params)).sum()
-            + (
-                data.n_i
-                * (
-                    self.log_ff(data.x_ir, data.Z_i, *params)
-                    - self.log_ff(data.x_il, data.Z_i, *params)
-                )
-            ).sum()
-        )
-        if (np.isfinite(data.tl).any()) | (np.isfinite(data.tr).any()):
-            ll -= (
-                data.n
-                * (
-                    self.log_ff(data.tr, data.Z, *params)
-                    - self.log_ff(data.tl, data.Z, *params)
-                )
-            ).sum()
-        return -ll
+        return regression_neg_ll(self, data, *params)
 
     def fit(self, x, Z, c=None, n=None, t=None, init=None, fixed=None):
         data = SurpyvalData(x, c, n, t, group_and_sort=False)

--- a/surpyval/utils/surpyval_data.py
+++ b/surpyval/utils/surpyval_data.py
@@ -137,6 +137,10 @@ class SurpyvalData:
         self.Z_r = Z_arr[self.c == 1]
         self.Z_l = Z_arr[self.c == -1]
         self.Z_i = Z_arr[self.c == 2]
+        # Covariates of the truncated subset, aligned with x_tl/x_tr/n_t so
+        # that regression likelihoods can apply the truncation correction
+        # using each truncated observation's own covariates.
+        self.Z_t = Z_arr[self.truncated_mask]
 
     def _split_to_observation_types(self) -> None:
         self.x_o, self.n_o = self._split_by_mask(self.c == 0)
@@ -151,11 +155,11 @@ class SurpyvalData:
             self.x_il = np.array([], dtype=float)
             self.x_ir = np.array([], dtype=float)
             self.n_i = np.array([], dtype=int)
-        truncated_mask = np.isfinite(self.t).any(axis=1)
+        self.truncated_mask = np.isfinite(self.t).any(axis=1)
         self.x_tl, self.x_tr, self.n_t = (
-            self.t[truncated_mask, 0],
-            self.t[truncated_mask, 1],
-            self.n[truncated_mask],
+            self.t[self.truncated_mask, 0],
+            self.t[self.truncated_mask, 1],
+            self.n[self.truncated_mask],
         )
 
     def to_xrd(self, estimator="Nelson-Aalen") -> tuple:


### PR DESCRIPTION
Route all four parametric regression fitters (proportional hazards,
proportional odds, accelerated failure time and accelerated life /
parameter substitution) through a single shared negative
log-likelihood that supports right/left/interval censoring and
left/right/interval truncation.

Previously the AFT and parameter-substitution fitters ignored
truncation (and interval censoring) entirely, while the PH and PO
fitters applied an incorrect correction: they used
log(F(tr)) - log(F(tl)) for both interval censoring and truncation
instead of log(F(tr) - F(tl)), and applied the truncation term across
all rows rather than only the truncated subset.

The new shared helper computes the correct truncation correction
P(tl < X < tr | Z) over only the truncated observations, using each
observation's own covariates via a new SurpyvalData.Z_t split.