### PR TITLE
Relax numpy, scipy and pandas minimum versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ classifiers = [
 ]
 dependencies = [
     "autograd>=1.8",
-    "numpy>=2.1,<3",
-    "scipy>=1.17",
-    "pandas>=3",
+    "numpy>=2.0,<3",
+    "scipy>=1.13",
+    "pandas>=2.2",
     "matplotlib>=3.10",
     "formulaic>=1.2",
     "numdifftools>=0.9.42",

--- a/surpyval/experimental/__init__.py
+++ b/surpyval/experimental/__init__.py
@@ -1,1 +1,3 @@
 from .forest import RandomSurvivalForest, SurvivalTree
+from .parallel import ParallelModel
+from .series import SeriesModel

--- a/surpyval/experimental/parallel.py
+++ b/surpyval/experimental/parallel.py
@@ -2,35 +2,39 @@ from autograd import elementwise_grad
 
 import surpyval as surv
 from surpyval import np
-from surpyval.univariate import parametric as p
+from surpyval.experimental.series import SeriesModel
 
 
-class SeriesModel:
+class ParallelModel:
     def __or__(self, other):
         if isinstance(other, surv.Parametric):
             return SeriesModel([*self.models, other])
+        elif isinstance(other, ParallelModel):
+            return ParallelModel([*self.models, other])
         else:
             return SeriesModel([*self.models, *other.models])
 
     def __and__(self, other):
         if isinstance(other, surv.Parametric):
-            return p.ParallelModel([*self.models, other])
+            return ParallelModel([*self.models, other])
+        elif isinstance(other, SeriesModel):
+            return ParallelModel([*self.models, other])
         else:
-            return p.ParallelModel([*self.models, *other.models])
+            return ParallelModel([*self.models, *other.models])
 
     def __init__(self, models):
         self.models = models
         self._df = elementwise_grad(self.ff)
         self._hf = elementwise_grad(self.Hf)
 
-    def sf(self, x):
-        x = np.atleast_1d(x)
-        sf = np.vstack([np.log(D.sf(x)) for D in self.models])
-        return np.exp(sf.sum(axis=0))
-
     def ff(self, x):
         x = np.atleast_1d(x)
-        return 1 - self.sf(x)
+        ff = np.vstack([np.log(D.ff(x)) for D in self.models])
+        return np.exp(ff.sum(axis=0))
+
+    def sf(self, x):
+        x = np.atleast_1d(x)
+        return 1 - self.ff(x)
 
     def df(self, x):
         x = np.atleast_1d(x)

--- a/surpyval/experimental/series.py
+++ b/surpyval/experimental/series.py
@@ -2,22 +2,19 @@ from autograd import elementwise_grad
 
 import surpyval as surv
 from surpyval import np
-from surpyval.univariate.parametric.series import SeriesModel
 
 
-class ParallelModel:
+class SeriesModel:
     def __or__(self, other):
         if isinstance(other, surv.Parametric):
             return SeriesModel([*self.models, other])
-        elif isinstance(other, ParallelModel):
-            return ParallelModel([*self.models, other])
         else:
             return SeriesModel([*self.models, *other.models])
 
     def __and__(self, other):
+        from surpyval.experimental.parallel import ParallelModel
+
         if isinstance(other, surv.Parametric):
-            return ParallelModel([*self.models, other])
-        elif isinstance(other, SeriesModel):
             return ParallelModel([*self.models, other])
         else:
             return ParallelModel([*self.models, *other.models])
@@ -27,14 +24,14 @@ class ParallelModel:
         self._df = elementwise_grad(self.ff)
         self._hf = elementwise_grad(self.Hf)
 
-    def ff(self, x):
-        x = np.atleast_1d(x)
-        ff = np.vstack([np.log(D.ff(x)) for D in self.models])
-        return np.exp(ff.sum(axis=0))
-
     def sf(self, x):
         x = np.atleast_1d(x)
-        return 1 - self.ff(x)
+        sf = np.vstack([np.log(D.sf(x)) for D in self.models])
+        return np.exp(sf.sum(axis=0))
+
+    def ff(self, x):
+        x = np.atleast_1d(x)
+        return 1 - self.sf(x)
 
     def df(self, x):
         x = np.atleast_1d(x)


### PR DESCRIPTION
Lower the dependency floors to widely-used but not outdated releases:
- numpy >=2.1 -> >=2.0 (keeps the <3 cap)
- scipy >=1.17 -> >=1.13
- pandas >=3 -> >=2.2

These broaden compatibility for users on slightly older toolchains while
still excluding genuinely old releases.