### PR TITLE
Fix bugs and cleanups in univariate module

### DIFF
--- a/surpyval/univariate/parametric/distributions/expo_weibull.py
+++ b/surpyval/univariate/parametric/distributions/expo_weibull.py
@@ -322,7 +322,6 @@ class ExpoWeibull_(ParametricFitter):
         return mu * np.log1p(-np.exp(-((x / alpha) ** beta)))
 
     def log_sf(self, x, alpha, beta, mu):
-        1 - np.power(1 - np.exp(-((x / alpha) ** beta)), mu)
         return np.log1p(-np.power(-np.expm1(-((x / alpha) ** beta)), mu))
 
     def mean(self, alpha, beta, mu):

--- a/surpyval/univariate/parametric/distributions/gamma.py
+++ b/surpyval/univariate/parametric/distributions/gamma.py
@@ -495,7 +495,7 @@ class Gamma_(ParametricFitter):
         init = self._parameter_initialiser(x_pp, c, n)
 
         mask = np.isfinite(F)
-        if mask.any():
+        if not mask.all():
             warnings.warn(
                 "Some Infinite values encountered in plotting "
                 "points and have been ignored.",

--- a/surpyval/univariate/parametric/distributions/logistic.py
+++ b/surpyval/univariate/parametric/distributions/logistic.py
@@ -2,7 +2,6 @@ from autograd import grad
 from autograd.scipy.special import beta as abeta
 from surpyval import np
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
-from surpyval.utils import xcnt_handler
 
 
 class Logistic_(ParametricFitter):
@@ -22,12 +21,6 @@ class Logistic_(ParametricFitter):
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         return self.fit(x, c, n, how="MPP").params
-        x, c, n, _ = xcnt_handler(x, c, n, t)
-        flag = (c == 0).astype(int)
-        if offset:
-            return x.sum() / (n * flag).sum(), 1.0, 1.0
-        else:
-            return x.sum() / (n * flag).sum(), 1.0
 
     def sf(self, x, mu, sigma):
         r"""

--- a/surpyval/univariate/parametric/distributions/lognormal.py
+++ b/surpyval/univariate/parametric/distributions/lognormal.py
@@ -292,7 +292,7 @@ class LogNormal_(ParametricFitter):
     def mean(self, mu, sigma):
         r"""
 
-        Quantile function for the LogNormal Distribution:
+        Mean of the LogNormal Distribution:
 
         .. math::
             E = e^{\mu + \frac{\sigma^2}{2}}
@@ -300,8 +300,6 @@ class LogNormal_(ParametricFitter):
         Parameters
         ----------
 
-        p : numpy array or scalar
-            The percentiles at which the quantile will be calculated
         mu : numpy array or scalar
             The location parameter for the LogNormal distribution
         sigma : numpy array or scalar
@@ -310,8 +308,8 @@ class LogNormal_(ParametricFitter):
         Returns
         -------
 
-        q : scalar or numpy array
-            The quantiles for the LogNormal distribution at each value p.
+        mean : scalar or numpy array
+            The mean of the LogNormal distribution.
 
         Examples
         --------

--- a/surpyval/univariate/regression/accelerated_failure_time/accelerated_failure_time.py
+++ b/surpyval/univariate/regression/accelerated_failure_time/accelerated_failure_time.py
@@ -126,23 +126,27 @@ class AcceleratedFailureTimeFitter:
 
             if params_at_Z == []:
                 dist_init = self._parameter_initialiser_dist(x, c, n, t)
+                if callable(self.acc_model.phi_init):
+                    phi_init = self.acc_model.phi_init(None, stress_data)
+                else:
+                    phi_init = self.acc_model.phi_init
             else:
                 params_at_Z = np.array(params_at_Z)
                 dist_init = params_at_Z.mean(axis=0)
 
-            acc_parameter_data = params_at_Z[
-                :, self.param_map[self.fixed_parameter]
-            ]
-            acc_parameter_data = self.acc_parameter_relationship(
-                acc_parameter_data
-            )
-
-            if callable(self.acc_model.phi_init):
-                phi_init = self.acc_model.phi_init(
-                    acc_parameter_data, stress_data
+                acc_parameter_data = params_at_Z[
+                    :, self.param_map[self.fixed_parameter]
+                ]
+                acc_parameter_data = self.acc_parameter_relationship(
+                    acc_parameter_data
                 )
-            else:
-                phi_init = self.acc_model.phi_init
+
+                if callable(self.acc_model.phi_init):
+                    phi_init = self.acc_model.phi_init(
+                        acc_parameter_data, stress_data
+                    )
+                else:
+                    phi_init = self.acc_model.phi_init
 
             init = np.array([*dist_init, *phi_init])
         else:

--- a/surpyval/univariate/regression/accelerated_life/parameter_substitution.py
+++ b/surpyval/univariate/regression/accelerated_life/parameter_substitution.py
@@ -70,7 +70,7 @@ class ParameterSubstitutionFitter:
         stresses = np.unique(Z, axis=0)
         for stress in stresses:
             life_param_mask = (
-                np.array(range(0, len(dist_params)))
+                np.arange(len(dist_params))
                 == self.param_map[self.life_parameter]
             )
             dist_params_i = np.where(
@@ -96,7 +96,7 @@ class ParameterSubstitutionFitter:
         hf = np.zeros_like(x)
         for stress in np.unique(Z, axis=0):
             life_param_mask = (
-                np.array(range(0, len(dist_params)))
+                np.arange(len(dist_params))
                 == self.param_map[self.life_parameter]
             )
             dist_params_i = np.where(
@@ -176,7 +176,7 @@ class ParameterSubstitutionFitter:
 
         for stress in np.unique(Z, axis=0):
             life_param_mask = (
-                np.array(range(0, len(dist_params)))
+                np.arange(len(dist_params))
                 == self.param_map[self.life_parameter]
             )
             dist_params_i = np.where(


### PR DESCRIPTION
- gamma: fix backwards CDF-infinite warning condition (was warning on
  every fit because `mask.any()` is true whenever any value is finite;
  should warn only when some values are non-finite via `not mask.all()`)
- expo_weibull: remove dead no-op statement in log_sf
- logistic: remove unreachable code after early return in
  _parameter_initialiser and the now-unused xcnt_handler import
- lognormal: correct mean() docstring (was copied from the quantile
  function)
- accelerated_failure_time: avoid IndexError when no stress level has
  enough data to fit (params_at_Z empty); compute phi_init in the
  fallback branch instead of indexing an empty list
- parameter_substitution: use np.arange instead of np.array(range(...))