### PR TITLE
Disallow offsetting Beta; add 4-parameter Beta distribution

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -48,17 +48,38 @@ with `dist.random(10_000, *params) + 10`:
 A note on severity: these are *parameter*-recovery problems, not
 *distribution*-recovery problems. The threshold parameter `gamma` is
 non-regular and trades off against the shape/scale parameters, so a
-fit can land on the wrong `(gamma, *params)` tuple while the fitted
-distribution it implies is still very close to the truth. The
-discrepancy that actually matters to a user — the divergence between
-the true and inferred distributions (KL divergence, or the
-Wasserstein / earth-mover distance between the two CDFs) — is expected
-to be small even when the individual parameters are visibly off. So
-the practical impact of the biases above is likely minor: predictions,
-quantiles, and survival probabilities from the fitted model stay
-usable. Before investing in better moment matching or a different
-offset initialiser, quantify the divergence (not the parameter error)
-to confirm it is worth the effort.
+fit can land on a wildly wrong `(gamma, *params)` tuple while the
+fitted distribution it implies stays close to the truth. What matters
+to a user is the divergence between the true and inferred
+distributions (KL divergence, or the Wasserstein / earth-mover
+distance between the two CDFs), not the parameter error — and the two
+can be orders of magnitude apart.
+
+Measured on `dist.random(10_000, *params) + 10` (200k-sample
+Wasserstein, Monte-Carlo KL, fresh seeds):
+
+- **MPP-offset Gamma**, the spectacular case. The parameters are off
+  by ~6000 % (`gamma` ≈ −0.6 vs 10, `alpha` ≈ 189 vs 3 — a near-normal
+  high-shape Gamma sitting at the origin mimics the offset Gamma), yet
+  the *distribution* barely moves: mean matches to ~0.2 %, std to
+  ~3 %, KL ≈ 0.10 nats, Wasserstein ≈ 1.2 % of the data scale. Central
+  quantiles (p10–p90) land within ~2 %; only the tails (p1/p99) slip
+  to ~7 %.
+- **MOM-offset Rayleigh** is milder in parameters (~22 % off) but,
+  paradoxically, diverges *more* in distribution: the spread is
+  genuinely wrong (std off ~22 %), KL ≈ 0.066 nats, Wasserstein ≈ 18 %
+  of the std, tail quantiles off ~6–8 % (median still within ~1 %).
+
+So the headline — a huge parameter error need not mean a bad fit — is
+real and worth keeping in mind, but the impact is *modest, not
+negligible*: central predictions (mean, median) stay accurate to ~1 %,
+while tail quantiles and (for MOM) the spread can be off 5–20 %. Before
+investing in better moment matching or a different offset initialiser,
+measure the divergence (not the parameter error); whether 0.06–0.10
+nats / 5–20 % tail error is acceptable depends on the application. The
+check used to produce these numbers is straightforward to reproduce
+with `from_params(..., gamma=10)` for the truth and
+`fit(x, offset=True, how=...)` for the estimate.
 
 **Resolved June 2026 — Beta can no longer be offset.**
 `_validate_fit_inputs` previously allowed it (`support[0] == 0`) but

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,10 +44,34 @@ with `dist.random(10_000, *params) + 10`:
   for a true value of 10) while every other offsettable distribution
   recovers it well. `test_offset_fit_recovers_gamma` skips this
   combination.
-- **Beta cannot actually be offset.** `_validate_fit_inputs` allows it
-  (`support[0] == 0`) but `Beta._parameter_initialiser` has no offset
-  path, so `Beta.fit(x, offset=True)` raises. Either support it or
-  validate it away.
+
+A note on severity: these are *parameter*-recovery problems, not
+*distribution*-recovery problems. The threshold parameter `gamma` is
+non-regular and trades off against the shape/scale parameters, so a
+fit can land on the wrong `(gamma, *params)` tuple while the fitted
+distribution it implies is still very close to the truth. The
+discrepancy that actually matters to a user — the divergence between
+the true and inferred distributions (KL divergence, or the
+Wasserstein / earth-mover distance between the two CDFs) — is expected
+to be small even when the individual parameters are visibly off. So
+the practical impact of the biases above is likely minor: predictions,
+quantiles, and survival probabilities from the fitted model stay
+usable. Before investing in better moment matching or a different
+offset initialiser, quantify the divergence (not the parameter error)
+to confirm it is worth the effort.
+
+**Resolved June 2026 — Beta can no longer be offset.**
+`_validate_fit_inputs` previously allowed it (`support[0] == 0`) but
+`Beta._parameter_initialiser` had no offset path, so
+`Beta.fit(x, offset=True)` raised an opaque `zip()` error. Offsetting
+only makes sense for distributions on the half-line `[0, inf)` — the
+check now requires `support[0] == 0 and isinf(support[1])`, so Beta
+(and any other finite-upper-bound distribution) raises a clear
+"cannot be offset" `ValueError`. The use case offsetting was reaching
+for — a Beta on an arbitrary `[a, b]` interval — is now served by the
+new four-parameter Beta (`Beta4`, `distributions/beta4.py`), which
+estimates the support bounds `a` and `b` alongside the two shape
+parameters.
 
 ---
 
@@ -149,11 +173,16 @@ done):
   membership on a *string*, not a tuple, so any distribution whose name
   is a substring of "Beta" would match. Replace the name-based
   branching with a `plot_x_limits` hook on the distribution.
-- `Uniform` declares `support=(-np.inf, np.inf)` as a workaround (see
-  the comment in `distributions/uniform.py`), and the NaN-support
-  branch in `fit_from_surpyval_data` (with its `TODO: More general
-  support setting. i.e. 4 parameter Beta`) appears unreachable now.
-  Design proper data-dependent support setting.
+- Data-dependent support setting now works for the general case
+  (June 2026): a distribution declares `support=(np.nan, np.nan)` and
+  a `support_param_index` naming which fitted parameters supply the
+  bounds, and `fit_from_surpyval_data`/`from_params` resolve the
+  support from them. The new four-parameter Beta (`Beta4`) uses this
+  path with `support_param_index=(2, 3)`. `Uniform` still declares
+  `support=(-np.inf, np.inf)` rather than NaN (see the comment in
+  `distributions/uniform.py`); it could be migrated to the NaN path
+  with `support_param_index=(0, 1)` (the default) for consistency, but
+  the current workaround is harmless.
 - `MixtureModel` composes rather than inherits: it now shares the
   probability-plot code but still reimplements `sf/ff/df/mean/random`
   aggregation and its own `R_cb`, and sets most attributes outside

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ SurPyval also offers many different distributions for users, and because of the 
 | **LogNormal** | Yes |
 | **Gamma**     | Yes |
 | **Beta**      | No |
+| **Beta (4 parameter)** | No |
 | **Uniform**   | No |
 | **Exponential** | Yes |
 | **Exponentiated Weibull** | Yes |

--- a/docs/Parametric SurPyval Modelling.rst
+++ b/docs/Parametric SurPyval Modelling.rst
@@ -371,6 +371,42 @@ Offsets only make sense for distributions supported on the half real line ``[0, 
     model = surv.Beta4.fit(x)
     print(model)
 
+A caution: offset parameters can be unidentifiable
+--------------------------------------------------
+
+The offset ``gamma`` is a *threshold* parameter, and threshold parameters are statistically awkward. ``gamma`` trades off against the shape and scale parameters, so two very different parameter tuples can describe almost the same distribution. This means a fit can report parameters that are badly wrong while the distribution it implies is still an excellent fit to your data. It is important to understand this so you are not alarmed by - or misled by - the printed parameters.
+
+The clearest way to see this is to fit the same offset data with different estimation methods. Below we generate Gamma data shifted by ``gamma = 10`` and fit it both with maximum product of spacings (``MPP``) and maximum likelihood (``MLE``):
+
+.. jupyter-execute::
+
+    import surpyval as surv
+    import numpy as np
+
+    np.random.seed(0)
+    x = surv.Gamma.random(10_000, 3.0, 2.0) + 10.0
+
+    mpp = surv.Gamma.fit(x, offset=True, how='MPP')
+    mle = surv.Gamma.fit(x, offset=True, how='MLE')
+
+    print('Truth : gamma=10.000, alpha=3.000, beta=2.000')
+    print('MPP   : gamma={:.3f}, alpha={:.3f}, beta={:.3f}'.format(mpp.gamma, *mpp.params))
+    print('MLE   : gamma={:.3f}, alpha={:.3f}, beta={:.3f}'.format(mle.gamma, *mle.params))
+
+The ``MPP`` parameters look like nonsense: a negative ``gamma`` and a shape parameter inflated by two orders of magnitude. But a high-shape Gamma sitting near the origin is, by the central limit theorem, almost the same bell-shaped curve as a moderate Gamma shifted out to 10. If we compare what the models actually *predict*, the two fits are nearly indistinguishable - and both are close to the truth:
+
+.. jupyter-execute::
+
+    truth = surv.Gamma.from_params([3.0, 2.0], gamma=10.0)
+
+    for name, m in [('Truth', truth), ('MPP', mpp), ('MLE', mle)]:
+        print('{:5s} mean={:.3f}  median={:.3f}  90th percentile={:.3f}'.format(
+            name, float(m.mean()), float(m.qf(0.5)), float(m.qf(0.9))))
+
+Despite the ``MPP`` parameters being off by thousands of percent, its mean, median and upper percentile all agree with the truth to better than 2%. The lesson is that when you use an offset, **judge the fit by what it predicts, not by the printed parameters**. Plot it against the non-parametric estimate, or compare the survival function, quantiles, mean and variance, rather than reading meaning into ``gamma`` and the shape parameters individually.
+
+This unidentifiability is also why the estimation method matters more than usual for offset fits. ``MLE`` is the most reliable for recovering the parameters themselves; the method-of-moments (``MOM``) and probability-plotting (``MPP``) initialisers can be badly biased on the parameters even when the resulting distribution is acceptable. If you need the threshold ``gamma`` to be meaningful - for example you are interpreting it as a guaranteed minimum life - prefer ``MLE`` and treat any single parameter estimate with care. The library's test suite pins this behaviour down with measured KL and Wasserstein distances in ``test_offset_divergence.py``.
+
 Fixing parameters
 -----------------
 

--- a/docs/Parametric SurPyval Modelling.rst
+++ b/docs/Parametric SurPyval Modelling.rst
@@ -359,6 +359,18 @@ A four parameter exponentiated Weibull can also be found:
 
     model.plot()
 
+Offsets only make sense for distributions supported on the half real line ``[0, inf)`` - the offset ``gamma`` simply slides the lower bound of the support. A distribution with a finite upper bound, such as the Beta distribution on ``[0, 1]``, therefore cannot be offset, and ``surv.Beta.fit(x, offset=True)`` will raise a ``ValueError``. Sliding the lower bound while pinning the upper bound at 1 does not produce another member of the Beta family. If your data are bounded on both sides and you need to estimate where those bounds are, use the four parameter Beta distribution (``Beta4``) instead, which estimates the lower bound ``a`` and upper bound ``b`` along with the two shape parameters:
+
+.. jupyter-execute::
+
+    import surpyval as surv
+    import numpy as np
+
+    np.random.seed(10)
+    x = surv.Beta4.random(10000, 3., 4., 10., 20.)
+    model = surv.Beta4.fit(x)
+    print(model)
+
 Fixing parameters
 -----------------
 

--- a/docs/surpyval.parametric.rst
+++ b/docs/surpyval.parametric.rst
@@ -27,6 +27,7 @@ Distribution Classes
    univariate/logistic
    univariate/loglogistic
    univariate/uniform
+   univariate/beta4
 
 Custom Distributions
 --------------------

--- a/docs/univariate/beta4.rst
+++ b/docs/univariate/beta4.rst
@@ -1,0 +1,3 @@
+.. autoclass:: surpyval.univariate.parametric.distributions.beta4.Beta4_
+   :members:
+   :inherited-members:

--- a/surpyval/__init__.py
+++ b/surpyval/__init__.py
@@ -16,6 +16,7 @@ from surpyval.univariate.nonparametric import (
 from surpyval.univariate.parametric import (
     Bernoulli,
     Beta,
+    Beta4,
     CustomDistribution,
     ExactEventTime,
     Exponential,

--- a/surpyval/fit_best.py
+++ b/surpyval/fit_best.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from surpyval.univariate.parametric import (
     Beta,
+    Beta4,
     Exponential,
     ExpoWeibull,
     Gamma,
@@ -20,6 +21,7 @@ from surpyval.univariate.parametric import (
 
 distributions: list[ParametricFitter] = [
     Beta,
+    Beta4,
     Exponential,
     ExpoWeibull,
     Gamma,

--- a/surpyval/tests/univariate/parametric/test_distributions_math.py
+++ b/surpyval/tests/univariate/parametric/test_distributions_math.py
@@ -20,6 +20,7 @@ from scipy.special import xlogy
 
 from surpyval import (
     Beta,
+    Beta4,
     ExpoWeibull,
     Exponential,
     Gamma,
@@ -44,6 +45,7 @@ DIST_PARAMS = [
     (Logistic, (4.0, 1.0)),
     (LogLogistic, (5.0, 2.0)),
     (Beta, (2.0, 5.0)),
+    (Beta4, (2.0, 5.0, 10.0, 20.0)),
     (ExpoWeibull, (3.0, 1.5, 0.8)),
     (Gamma, (3.0, 2.0)),
     (Exponential, (0.5,)),
@@ -140,6 +142,8 @@ RANDOM_STATS = [
     (Weibull, (10.0, 1.0), 10.0, 100.0),
     # Beta(1,1) = Uniform(0,1): mean=0.5, var=1/12
     (Beta, (1.0, 1.0), 0.5, 1.0 / 12.0),
+    # Beta4(1,1,10,20) = Uniform(10,20): mean=15, var=100/12
+    (Beta4, (1.0, 1.0, 10.0, 20.0), 15.0, 100.0 / 12.0),
     # Gamma(alpha, beta) rate-parameterised: mean=alpha/beta, var=alpha/beta^2
     (Gamma, (4.0, 2.0), 2.0, 1.0),
 ]
@@ -273,6 +277,7 @@ MOMENT_PARAMS = [
     (Logistic, (4.0, 1.0)),
     (LogLogistic, (5.0, 5.0)),
     (Beta, (2.0, 5.0)),
+    (Beta4, (2.0, 5.0, 10.0, 20.0)),
     (Gamma, (3.0, 2.0)),
     (Exponential, (0.5,)),
     (Rayleigh, (3.0,)),

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -3,6 +3,7 @@ import pytest
 
 from surpyval import (
     Beta,
+    Beta4,
     Exponential,
     ExpoWeibull,
     Gamma,
@@ -354,6 +355,45 @@ def test_offset_fit_recovers_gamma(dist, dist_params, how):
     model = dist.fit(x, offset=True, how=how)
     assert abs(model.gamma - gamma) < 0.5
     assert np.allclose(model.params, dist_params, rtol=0.15)
+
+
+@pytest.mark.parametrize("how", ["MLE", "MPS", "MSE", "MOM"])
+def test_beta_cannot_be_offset(how):
+    # Beta is supported on [0, 1]; a one-sided offset cannot move the
+    # lower bound while pinning the upper bound at 1, so it must raise a
+    # clear error rather than the opaque failure it used to.
+    x = Beta.random(100, 2.0, 5.0)
+    with pytest.raises(ValueError, match="cannot be offset"):
+        Beta.fit(x, offset=True, how=how)
+
+
+def test_beta4_recovers_parameters():
+    # The four-parameter Beta estimates the support bounds (a, b) along
+    # with the two shape parameters.
+    np.random.seed(0)
+    alpha, beta, a, b = 3.0, 4.0, 2.0, 7.0
+    x = Beta4.random(10_000, alpha, beta, a, b)
+    model = Beta4.fit(x)
+    assert np.allclose(model.params, [alpha, beta, a, b], rtol=0.1)
+    # Support is read off the fitted bounds.
+    assert np.allclose(model.support, [model.params[2], model.params[3]])
+
+
+def test_beta4_cannot_be_offset():
+    x = Beta4.random(100, 2.0, 5.0, 1.0, 4.0)
+    with pytest.raises(ValueError, match="cannot be offset"):
+        Beta4.fit(x, offset=True)
+
+
+def test_beta4_handles_right_censoring():
+    np.random.seed(1)
+    alpha, beta, a, b = 2.5, 3.0, 1.0, 5.0
+    x = Beta4.random(5_000, alpha, beta, a, b)
+    threshold = 4.0
+    c = np.where(x > threshold, 1, 0)
+    x = np.where(x > threshold, threshold, x)
+    model = Beta4.fit(x, c=c)
+    assert np.allclose(model.params, [alpha, beta, a, b], rtol=0.15)
 
 
 @pytest.mark.parametrize(

--- a/surpyval/tests/univariate/parametric/test_offset_divergence.py
+++ b/surpyval/tests/univariate/parametric/test_offset_divergence.py
@@ -1,0 +1,117 @@
+"""
+Demonstration tests for the offset parameter-vs-distribution divergence.
+
+The threshold/location parameter ``gamma`` of an offset distribution is
+non-regular: it trades off against the shape and scale parameters. A fit
+can therefore land on a wildly wrong ``(gamma, *params)`` tuple while the
+*distribution* it implies is still close to the truth. These tests pin
+that behaviour down with numbers so it does not surprise anyone, and so a
+future "fix" to the offset initialisers can be judged on the divergence
+that actually matters (KL / Wasserstein) rather than on the parameter
+error alone.
+
+See DEVELOPMENT.md section 2.
+"""
+
+import numpy as np
+from scipy.stats import wasserstein_distance
+
+from surpyval import Gamma, Rayleigh
+
+N_FIT = 10_000
+N_EVAL = 100_000
+TRUE_GAMMA = 10.0
+
+
+def _kl_true_vs_fit(dist, true_params, true_gamma, fit_model, n=N_EVAL):
+    """Monte-Carlo KL(true || fit) in nats, using the offset log-density."""
+    x = dist.random(n, *true_params) + true_gamma
+    log_true = dist.log_df(x - true_gamma, *true_params)
+    log_fit = fit_model.dist.log_df(x - fit_model.gamma, *fit_model.params)
+    mask = np.isfinite(log_true) & np.isfinite(log_fit)
+    return float(np.mean(log_true[mask] - log_fit[mask]))
+
+
+def _summary(dist, true_params, how, seed=0):
+    """Fit with an offset and return parameter vs distribution metrics."""
+    np.random.seed(seed)
+    x = dist.random(N_FIT, *true_params) + TRUE_GAMMA
+    fit = dist.fit(x, offset=True, how=how)
+    true = dist.from_params(list(true_params), gamma=TRUE_GAMMA)
+
+    # Worst relative error across gamma and the shape/scale parameters.
+    param_errs = [abs(fit.gamma - TRUE_GAMMA) / abs(TRUE_GAMMA)]
+    for fp, tp in zip(fit.params, true_params):
+        param_errs.append(abs(float(fp) - tp) / abs(tp))
+    max_param_rel_err = max(param_errs)
+
+    # Distribution-level divergence.
+    xs_true = dist.random(N_EVAL, *true_params) + TRUE_GAMMA
+    xs_fit = fit.random(N_EVAL)
+    w1 = wasserstein_distance(xs_true, xs_fit)
+    kl = _kl_true_vs_fit(dist, true_params, TRUE_GAMMA, fit)
+
+    return {
+        "fit": fit,
+        "true": true,
+        "max_param_rel_err": max_param_rel_err,
+        "mean_rel_err": abs(fit.mean() - true.mean()) / true.mean(),
+        "median_rel_err": abs(float(fit.qf(0.5)) - float(true.qf(0.5)))
+        / float(true.qf(0.5)),
+        "std_rel_err": abs(xs_fit.std() - xs_true.std()) / xs_true.std(),
+        "wasserstein": w1,
+        "wasserstein_frac_std": w1 / xs_true.std(),
+        "kl_nats": kl,
+    }
+
+
+def test_mpp_offset_gamma_parameters_absurd_but_distribution_close():
+    """MPP offset on Gamma recovers an absurd parameter tuple
+    (gamma far negative, shape inflated by orders of magnitude) yet the
+    implied distribution is almost indistinguishable from the truth: a
+    high-shape Gamma parked near the origin mimics the offset Gamma."""
+    s = _summary(Gamma, (3.0, 2.0), how="MPP")
+
+    # The parameters are wildly wrong - this is the "failure".
+    assert s["fit"].gamma < 5.0, s["fit"].gamma
+    assert s["max_param_rel_err"] > 5.0  # >500% off
+
+    # ...but the distribution barely moves.
+    assert s["mean_rel_err"] < 0.01  # mean within 1%
+    assert s["median_rel_err"] < 0.03  # median within 3%
+    assert s["std_rel_err"] < 0.10  # spread within 10%
+    assert s["kl_nats"] < 0.20  # KL well under a fifth of a nat
+    assert s["wasserstein_frac_std"] < 0.25
+
+    # The headline: distribution error is far smaller than parameter error.
+    assert s["mean_rel_err"] < s["max_param_rel_err"] / 100
+
+
+def test_mom_offset_rayleigh_biased_but_central_predictions_hold():
+    """MOM offset on Rayleigh biases gamma low and, unlike the Gamma
+    case, the divergence is *modest, not negligible*: the spread is
+    visibly wrong even though the central predictions stay accurate."""
+    s = _summary(Rayleigh, (3.0,), how="MOM")
+
+    # gamma is biased away from the truth.
+    assert abs(s["fit"].gamma - TRUE_GAMMA) > 0.4
+
+    # Central predictions remain trustworthy...
+    assert s["mean_rel_err"] < 0.02  # mean within 2%
+    assert s["median_rel_err"] < 0.02  # median within 2%
+
+    # ...but the distribution is genuinely off in its spread: this is the
+    # "modest, not negligible" caveat made concrete.
+    assert s["std_rel_err"] > 0.10  # std off by more than 10%
+    assert 0.02 < s["kl_nats"] < 0.15  # small, but not zero
+
+
+def test_mle_offset_is_the_accurate_baseline():
+    """For contrast: MLE recovers both the parameters and the
+    distribution to high accuracy, so the divergences above are a
+    property of the MOM/MPP initialisers, not of offsetting itself."""
+    for dist, params in [(Rayleigh, (3.0,)), (Gamma, (3.0, 2.0))]:
+        s = _summary(dist, params, how="MLE")
+        assert s["max_param_rel_err"] < 0.05  # parameters within 5%
+        assert s["kl_nats"] < 0.01  # distribution essentially identical
+        assert s["wasserstein_frac_std"] < 0.05

--- a/surpyval/univariate/parametric/__init__.py
+++ b/surpyval/univariate/parametric/__init__.py
@@ -16,6 +16,7 @@ import numpy as np
 from .distributions import (
     Bernoulli,
     Beta,
+    Beta4,
     CustomDistribution,
     ExactEventTime,
     ExpoWeibull,

--- a/surpyval/univariate/parametric/distributions/__init__.py
+++ b/surpyval/univariate/parametric/distributions/__init__.py
@@ -1,5 +1,6 @@
 from .bernoulli import Bernoulli, FixedEventProbability
 from .beta import Beta
+from .beta4 import Beta4
 from .custom_distribution import CustomDistribution
 from .exact_event_time import ExactEventTime
 from .expo_weibull import ExpoWeibull

--- a/surpyval/univariate/parametric/distributions/beta4.py
+++ b/surpyval/univariate/parametric/distributions/beta4.py
@@ -1,0 +1,471 @@
+from autograd.scipy.special import beta as abeta
+from autograd.scipy.special import betaln as abetaln
+from scipy.special import betaincinv, comb, digamma
+
+from surpyval import np
+from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
+from surpyval.utils.autograd_gamma_compat import betainc as abetainc
+from surpyval.utils.autograd_gamma_compat import betaincln as abetaincln
+
+
+class Beta4_(ParametricFitter):
+    r"""
+    The four-parameter (generalised) Beta distribution.
+
+    The standard :class:`Beta` distribution is supported on ``[0, 1]``.
+    The four-parameter Beta generalises it to an arbitrary finite
+    interval ``[a, b]`` by introducing a location parameter ``a`` (the
+    lower bound) and a scale that stretches the unit interval out to an
+    upper bound ``b``. If ``Y`` is a standard Beta random variable then
+    ``X = a + (b - a) Y`` is four-parameter Beta distributed.
+
+    Because the support ``[a, b]`` is itself estimated, this is the
+    distribution to reach for when data are bounded on *both* sides but
+    neither bound is zero — the case where ``Beta(..., offset=True)``
+    would (deliberately) refuse, since a one-sided offset cannot move the
+    lower bound while keeping the upper bound pinned at 1.
+    """
+
+    def __init__(self, name):
+        super().__init__(
+            name=name,
+            k=4,
+            bounds=((0, None), (0, None), (None, None), (None, None)),
+            # The support [a, b] is data-dependent and resolved from the
+            # fitted ``a`` (param 2) and ``b`` (param 3) parameters.
+            support=(np.nan, np.nan),
+            param_names=["alpha", "beta", "a", "b"],
+            param_map={"alpha": 0, "beta": 1, "a": 2, "b": 3},
+            plot_x_scale="linear",
+        )
+        # The four-parameter Beta has no linearising probability plot.
+        self.supports_mpp = False
+        # ``a`` and ``b`` supply the left and right support bounds.
+        self.support_param_index = (2, 3)
+
+    def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
+        x = np.asarray(x, dtype=float)
+        if (n is not None) and (c is not None) and (c == 0).all():
+            x = np.repeat(x, n)
+
+        span = x.max() - x.min()
+        if span <= 0:
+            span = 1.0
+
+        # Place the initial bounds just outside the observed range so that
+        # every observed point sits strictly inside (a, b).
+        a = x.min() - 0.05 * span
+        b = x.max() + 0.05 * span
+
+        u = (x - a) / (b - a)
+        mean = u.mean()
+        var = u.var()
+        if var <= 0:
+            var = 1e-3
+        term1 = (mean * (1 - mean) / var) - 1
+        alpha = max(term1 * mean, 0.5)
+        beta = max(term1 * (1 - mean), 0.5)
+
+        return alpha, beta, a, b
+
+    def _z(self, x, a, b):
+        """Standardise ``x`` onto the unit interval."""
+        return (x - a) / (b - a)
+
+    def sf(self, x, alpha, beta, a, b):
+        r"""
+
+        Survival (or reliability) function for the four-parameter Beta
+        distribution:
+
+        .. math::
+            R(x) = 1 - I_{z}\left(\alpha, \beta\right), \quad
+            z = \frac{x - a}{b - a}
+
+        Parameters
+        ----------
+
+        x : numpy array or scalar
+            The values at which the function will be calculated
+        alpha : numpy array or scalar
+            The first shape parameter for the Beta distribution
+        beta : numpy array or scalar
+            The second shape parameter for the Beta distribution
+        a : numpy array or scalar
+            The lower bound of the support
+        b : numpy array or scalar
+            The upper bound of the support
+
+        Returns
+        -------
+
+        sf : scalar or numpy array
+            The value(s) of the reliability function at x.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from surpyval import Beta4
+        >>> x = np.array([2.1, 2.2, 2.3, 2.4, 2.5])
+        >>> Beta4.sf(x, 3, 4, 2, 3)
+        array([0.98415, 0.90112, 0.74431, 0.54432, 0.34375])
+        """
+        return 1 - self.ff(x, alpha, beta, a, b)
+
+    def cs(self, x, X, alpha, beta, a, b):
+        r"""
+
+        Conditional survival (or reliability) function for the
+        four-parameter Beta distribution:
+
+        .. math::
+            R(x, X) = \frac{R(x + X)}{R(X)}
+
+        Parameters
+        ----------
+
+        x : numpy array or scalar
+            The values at which the function will be calculated
+        X : numpy array or scalar
+            The value(s) at which each value(s) in x was known to have survived
+        alpha : numpy array or scalar
+            The first shape parameter for the Beta distribution
+        beta : numpy array or scalar
+            The second shape parameter for the Beta distribution
+        a : numpy array or scalar
+            The lower bound of the support
+        b : numpy array or scalar
+            The upper bound of the support
+
+        Returns
+        -------
+
+        cs : scalar or numpy array
+            The value(s) of the conditional survival function at x.
+        """
+        return self.sf(x + X, alpha, beta, a, b) / self.sf(
+            X, alpha, beta, a, b
+        )
+
+    def ff(self, x, alpha, beta, a, b):
+        r"""
+
+        Failure (CDF or unreliability) function for the four-parameter
+        Beta distribution:
+
+        .. math::
+            F(x) = I_{z}\left(\alpha, \beta\right), \quad
+            z = \frac{x - a}{b - a}
+
+        Parameters
+        ----------
+
+        x : numpy array or scalar
+            The values at which the function will be calculated
+        alpha : numpy array or scalar
+            The first shape parameter for the Beta distribution
+        beta : numpy array or scalar
+            The second shape parameter for the Beta distribution
+        a : numpy array or scalar
+            The lower bound of the support
+        b : numpy array or scalar
+            The upper bound of the support
+
+        Returns
+        -------
+
+        ff : scalar or numpy array
+            The value(s) of the failure function at x.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from surpyval import Beta4
+        >>> x = np.array([2.1, 2.2, 2.3, 2.4, 2.5])
+        >>> Beta4.ff(x, 3, 4, 2, 3)
+        array([0.01585, 0.09888, 0.25569, 0.45568, 0.65625])
+        """
+        z = np.clip(self._z(x, a, b), 0.0, 1.0)
+        return abetainc(alpha, beta, z)
+
+    def df(self, x, alpha, beta, a, b):
+        r"""
+
+        Density function for the four-parameter Beta distribution:
+
+        .. math::
+            f(x) = \frac{\left(x - a\right)^{\alpha - 1}
+            \left(b - x\right)^{\beta - 1}}{B\left(\alpha, \beta\right)
+            \left(b - a\right)^{\alpha + \beta - 1}}
+
+        Parameters
+        ----------
+
+        x : numpy array or scalar
+            The values at which the function will be calculated
+        alpha : numpy array or scalar
+            The first shape parameter for the Beta distribution
+        beta : numpy array or scalar
+            The second shape parameter for the Beta distribution
+        a : numpy array or scalar
+            The lower bound of the support
+        b : numpy array or scalar
+            The upper bound of the support
+
+        Returns
+        -------
+
+        df : scalar or numpy array
+            The value(s) of the density function at x.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from surpyval import Beta4
+        >>> x = np.array([2.1, 2.2, 2.3, 2.4, 2.5])
+        >>> Beta4.df(x, 3, 4, 2, 3)
+        array([0.4374, 1.2288, 1.8522, 2.0736, 1.875 ])
+        """
+        num = (x - a) ** (alpha - 1) * (b - x) ** (beta - 1)
+        den = abeta(alpha, beta) * (b - a) ** (alpha + beta - 1)
+        return num / den
+
+    def hf(self, x, alpha, beta, a, b):
+        r"""
+
+        Instantaneous hazard rate for the four-parameter Beta
+        distribution.
+
+        .. math::
+            h(x) = \frac{f(x)}{R(x)}
+
+        Parameters
+        ----------
+
+        x : numpy array or scalar
+            The values at which the function will be calculated
+        alpha : numpy array or scalar
+            The first shape parameter for the Beta distribution
+        beta : numpy array or scalar
+            The second shape parameter for the Beta distribution
+        a : numpy array or scalar
+            The lower bound of the support
+        b : numpy array or scalar
+            The upper bound of the support
+
+        Returns
+        -------
+
+        hf : scalar or numpy array
+            The value(s) of the instantaneous hazard rate at x.
+        """
+        return self.df(x, alpha, beta, a, b) / self.sf(x, alpha, beta, a, b)
+
+    def Hf(self, x, alpha, beta, a, b):
+        r"""
+
+        Cumulative hazard rate for the four-parameter Beta distribution.
+
+        .. math::
+            H(x) = -\ln\left(R(x)\right)
+
+        Parameters
+        ----------
+
+        x : numpy array or scalar
+            The values at which the function will be calculated
+        alpha : numpy array or scalar
+            The first shape parameter for the Beta distribution
+        beta : numpy array or scalar
+            The second shape parameter for the Beta distribution
+        a : numpy array or scalar
+            The lower bound of the support
+        b : numpy array or scalar
+            The upper bound of the support
+
+        Returns
+        -------
+
+        Hf : scalar or numpy array
+            The value(s) of the cumulative hazard rate at x.
+        """
+        return -np.log(self.sf(x, alpha, beta, a, b))
+
+    def qf(self, p, alpha, beta, a, b):
+        r"""
+
+        Quantile function for the four-parameter Beta distribution:
+
+        .. math::
+            q(p) = a + \left(b - a\right) I^{-1}_{p}\left(\alpha, \beta\right)
+
+        Parameters
+        ----------
+
+        p : numpy array or scalar
+            The percentiles at which the quantile will be calculated
+        alpha : numpy array or scalar
+            The first shape parameter for the Beta distribution
+        beta : numpy array or scalar
+            The second shape parameter for the Beta distribution
+        a : numpy array or scalar
+            The lower bound of the support
+        b : numpy array or scalar
+            The upper bound of the support
+
+        Returns
+        -------
+
+        q : scalar or numpy array
+            The quantiles for the Beta distribution at each value p.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from surpyval import Beta4
+        >>> p = np.array([.1, .2, .3, .4, .5])
+        >>> Beta4.qf(p, 3, 4, 2, 3)
+        array([2.20090888, 2.26864915, 2.32332388, 2.37307973, 2.42140719])
+        """
+        return a + (b - a) * betaincinv(alpha, beta, p)
+
+    def mean(self, alpha, beta, a, b):
+        r"""
+
+        Mean of the four-parameter Beta distribution
+
+        .. math::
+            E = a + \left(b - a\right)\frac{\alpha}{\alpha + \beta}
+
+        Parameters
+        ----------
+
+        alpha : numpy array or scalar
+            The first shape parameter for the Beta distribution
+        beta : numpy array or scalar
+            The second shape parameter for the Beta distribution
+        a : numpy array or scalar
+            The lower bound of the support
+        b : numpy array or scalar
+            The upper bound of the support
+
+        Returns
+        -------
+
+        mean : scalar or numpy array
+            The mean(s) of the Beta distribution
+
+        Examples
+        --------
+        >>> from surpyval import Beta4
+        >>> Beta4.mean(3, 4, 2, 3)
+        2.4285714285714284
+        """
+        return a + (b - a) * alpha / (alpha + beta)
+
+    def moment(self, m, alpha, beta, a, b):
+        r"""
+
+        m-th (non central) moment of the four-parameter Beta distribution.
+
+        Computed from the standard Beta moments via the binomial
+        expansion of :math:`\left(a + (b - a) U\right)^m`.
+
+        Parameters
+        ----------
+
+        m : integer
+            The ordinal of the moment to calculate
+        alpha : numpy array or scalar
+            The first shape parameter for the Beta distribution
+        beta : numpy array or scalar
+            The second shape parameter for the Beta distribution
+        a : numpy array or scalar
+            The lower bound of the support
+        b : numpy array or scalar
+            The upper bound of the support
+
+        Returns
+        -------
+
+        moment : scalar or numpy array
+            The moment(s) of the Beta distribution
+
+        Examples
+        --------
+        >>> from surpyval import Beta4
+        >>> Beta4.moment(1, 3, 4, 2, 3)
+        2.4285714285714284
+        """
+        scale = b - a
+        total = 0.0
+        for k in range(m + 1):
+            # k-th raw moment of the standard Beta(alpha, beta)
+            u_moment = np.exp(abetaln(k + alpha, beta) - abetaln(alpha, beta))
+            total = total + comb(m, k) * a ** (m - k) * scale**k * u_moment
+        return total
+
+    def entropy(self, alpha, beta, a, b):
+        r"""
+
+        Differential entropy of the four-parameter Beta distribution.
+
+        Equal to the standard Beta entropy plus :math:`\ln(b - a)` for the
+        change of scale.
+
+        Parameters
+        ----------
+
+        alpha : numpy array or scalar
+            The first shape parameter for the Beta distribution
+        beta : numpy array or scalar
+            The second shape parameter for the Beta distribution
+        a : numpy array or scalar
+            The lower bound of the support
+        b : numpy array or scalar
+            The upper bound of the support
+
+        Returns
+        -------
+
+        entropy : scalar or numpy array
+            The entropy(ies) of the Beta distribution
+        """
+        standard = (
+            abetaln(alpha, beta)
+            - (alpha - 1) * digamma(alpha)
+            - (beta - 1) * digamma(beta)
+            + (alpha + beta - 2) * digamma(alpha + beta)
+        )
+        return standard + np.log(b - a)
+
+    def log_df(self, x, alpha, beta, a, b):
+        return (
+            (alpha - 1) * np.log(x - a)
+            + (beta - 1) * np.log(b - x)
+            - abetaln(alpha, beta)
+            - (alpha + beta - 1) * np.log(b - a)
+        )
+
+    def log_ff(self, x, alpha, beta, a, b):
+        z = np.clip(self._z(x, a, b), 0.0, 1.0)
+        return abetaincln(alpha, beta, z)
+
+    def mpp_x_transform(self, x, gamma=0):
+        return x - gamma
+
+    def mpp_y_transform(self, y, *params):
+        return self.qf(y, *params)
+
+    def mpp_inv_y_transform(self, y, *params):
+        return self.ff(y, *params)
+
+    def mpp(self, *args, **kwargs):
+        msg = "Probability Plotting Method for Beta4 distribution"
+        raise NotImplementedError(msg)
+
+    def _plot_x_bounds(self, x, params):
+        return float(params[2]), float(params[3])
+
+
+Beta4: ParametricFitter = Beta4_("Beta4")

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -92,6 +92,12 @@ class ParametricFitter:
         self.plot_x_scale = plot_x_scale
         self.y_ticks = DEFAULT_Y_TICKS if y_ticks is None else y_ticks
         self.supports_mpp = True
+        # For distributions whose support is data-dependent (declared as
+        # NaN, e.g. the 4-parameter Beta), these give the indices of the
+        # parameters that supply the left and right support bounds once
+        # the model is fitted. The default ``(0, 1)`` matches the legacy
+        # behaviour used by ``Uniform``.
+        self.support_param_index = (0, 1)
 
     def random(self, size, *params):
         r"""
@@ -301,7 +307,15 @@ class ParametricFitter:
         heuristic,
         turnbull_estimator,
     ):
-        if offset and (self.support[0] != 0):
+        # Offsetting (a free location/threshold ``gamma``) only makes sense
+        # for distributions supported on a half-line ``[0, inf)``. A
+        # distribution with a finite upper bound (e.g. Beta on ``[0, 1]``)
+        # or a data-dependent support cannot be offset: shifting the lower
+        # bound while pinning the upper one is not a member of the family.
+        # Use the 4-parameter Beta instead if you need a shifted/scaled
+        # Beta on an arbitrary ``[a, b]`` interval.
+        offsettable = (self.support[0] == 0) and np.isinf(self.support[1])
+        if offset and not offsettable:
             detail = f"{self.name} distribution cannot be offset"
             raise ValueError(detail)
 
@@ -867,8 +881,10 @@ class ParametricFitter:
                 # finite. If it isn't, then the distribution cannot be offset.
                 # i.e if both finite or both infinite, then cannot be offset,
                 # zero-inflated, or limited failure.
-                if np.all(np.isinf(self.support)) or np.all(
-                    np.isfinite(self.support)
+                if (
+                    np.all(np.isinf(self.support))
+                    or np.all(np.isfinite(self.support))
+                    or np.all(np.isnan(self.support))
                 ):
                     with np.errstate(all="ignore"):
                         init = np.array(
@@ -965,16 +981,18 @@ class ParametricFitter:
         elif self.support[0] == -np.inf:
             left = -np.inf
         elif np.isnan(self.support[0]):
-            # This only works for the uniform dist
-            # TODO: More general support setting. i.e. 4 parameter Beta
-            left = model.params[0]
+            # Data-dependent left support: read it from the fitted
+            # parameter the distribution nominates (``a`` for the uniform
+            # and the 4-parameter Beta).
+            left = model.params[self.support_param_index[0]]
 
         if np.isfinite(self.support[1]):
             right = self.support[1]
         elif self.support[1] == np.inf:
             right = np.inf
         elif np.isnan(self.support[1]):
-            right = model.params[1]
+            # Data-dependent right support (``b``).
+            right = model.params[self.support_param_index[1]]
 
         model.support = np.array([left, right])
 
@@ -1071,7 +1089,12 @@ class ParametricFitter:
         if offset:
             model.support = (gamma, model.support[1])
         elif np.isnan(self.support).any():
-            model.support = np.array(model.params)
+            left, right = self.support
+            if np.isnan(left):
+                left = model.params[self.support_param_index[0]]
+            if np.isnan(right):
+                right = model.params[self.support_param_index[1]]
+            model.support = np.array([left, right])
 
         for i, (low, upp) in enumerate(self.bounds):
             if low is None:


### PR DESCRIPTION
Offsetting only makes sense for distributions supported on the half
line [0, inf): the gamma offset slides the lower support bound. The
validation previously allowed offset whenever support[0] == 0, which let
Beta (support [0, 1]) through to an opaque zip() failure because it has
no offset initialiser. The check now requires an infinite upper bound,
so Beta and any other finite-upper-bound distribution raise a clear
'cannot be offset' ValueError.

The use case offsetting was reaching for - a Beta on an arbitrary
[a, b] interval - is now served by a new four-parameter Beta (Beta4),
which estimates the lower bound a and upper bound b alongside the two
shape parameters. Generalises the data-dependent support machinery via
a support_param_index hook (used in fit and from_params) so the bounds
can be read from any parameter positions, not just (0, 1).

Also notes in DEVELOPMENT.md that the remaining offset parameter-bias
issues are minor in distribution terms (small KL / earth-mover distance
between the true and inferred distributions) even when the individual
parameters are off.

Adds Beta4 to the math, fit, and censoring tests and to fit_best.