### PR TITLE
Add DataFrame fit/predict with named covariates and formulas to univariate regression

### DIFF
--- a/surpyval/tests/univariate/regression/test_dataframe_fit.py
+++ b/surpyval/tests/univariate/regression/test_dataframe_fit.py
@@ -1,0 +1,159 @@
+"""
+Tests for fitting and predicting parametric regression models directly from
+pandas DataFrames, retaining covariate names and supporting formulas.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from surpyval import AFT, PO, AcceleratedLife, Power, Weibull, WeibullPH
+from surpyval.univariate.regression import CoxPH
+
+
+def _make_df(seed=0, n=200):
+    rng = np.random.default_rng(seed)
+    age = rng.normal(50, 10, n)
+    sex = rng.choice(["M", "F"], n)
+    beta = 0.03 * (age - 50) + np.where(sex == "M", 0.4, 0.0)
+    x = Weibull.random(n, 10, 2) * np.exp(-beta / 2)
+    c = np.zeros(n)
+    return pd.DataFrame(
+        {"time": x, "age": age, "sex": sex, "censored": c}
+    )
+
+
+PARAMETRIC_FITTERS = [
+    WeibullPH,
+    AFT(Weibull),
+    PO(Weibull),
+]
+
+
+@pytest.mark.parametrize("fitter", PARAMETRIC_FITTERS)
+def test_fit_from_df_keeps_feature_names(fitter):
+    df = _make_df()
+    model = fitter.fit_from_df(
+        df, x_col="time", Z_cols=["age"], c_col="censored"
+    )
+    assert model.feature_names == ["age"]
+    assert model.formula is None
+
+
+@pytest.mark.parametrize("fitter", PARAMETRIC_FITTERS)
+def test_predict_from_df_matches_array(fitter):
+    df = _make_df()
+    model = fitter.fit_from_df(
+        df, x_col="time", Z_cols=["age"], c_col="censored"
+    )
+    sub = df[["age"]].head(3)
+    from_df = model.sf([5, 10, 15], sub)
+    from_arr = model.sf([5, 10, 15], sub.values)
+    assert np.allclose(from_df, from_arr)
+
+
+@pytest.mark.parametrize("fitter", PARAMETRIC_FITTERS)
+def test_predict_from_df_selects_correct_columns(fitter):
+    # The predict DataFrame has extra columns and a different order: the
+    # model must still select the column it was trained on.
+    df = _make_df()
+    model = fitter.fit_from_df(
+        df, x_col="time", Z_cols=["age"], c_col="censored"
+    )
+    reordered = df[["age"]].head(3)
+    scrambled = pd.DataFrame(
+        {
+            "junk": [1, 2, 3],
+            "age": reordered["age"].values,
+            "sex": ["M", "F", "M"],
+        }
+    )
+    assert np.allclose(
+        model.sf([7], reordered), model.sf([7], scrambled)
+    )
+
+
+def test_formula_with_categorical():
+    df = _make_df()
+    model = WeibullPH.fit_from_df(
+        df, x_col="time", formula="age + sex", c_col="censored"
+    )
+    assert model.formula == "age + sex"
+    # Categorical 'sex' should be expanded into dummy columns.
+    assert "age" in model.feature_names
+    assert any(name.startswith("sex") for name in model.feature_names)
+
+    # Prediction on a fresh DataFrame uses the same encoding.
+    new_df = pd.DataFrame({"age": [60.0, 40.0], "sex": ["M", "F"]})
+    sf = model.sf([5, 10], new_df)
+    assert sf.shape == (2,)
+    assert np.all((sf >= 0) & (sf <= 1))
+
+
+def test_formula_and_z_cols_are_mutually_exclusive():
+    df = _make_df()
+    with pytest.raises(ValueError):
+        WeibullPH.fit_from_df(
+            df, x_col="time", Z_cols=["age"], formula="age"
+        )
+
+
+def test_requires_z_cols_or_formula():
+    df = _make_df()
+    with pytest.raises(ValueError):
+        WeibullPH.fit_from_df(df, x_col="time")
+
+
+def test_unknown_column_raises():
+    df = _make_df()
+    with pytest.raises(ValueError):
+        WeibullPH.fit_from_df(
+            df, x_col="time", Z_cols=["not_a_column"], c_col="censored"
+        )
+
+
+def test_predicting_df_on_array_fit_model_raises():
+    df = _make_df()
+    model = WeibullPH.fit(
+        x=df["time"].values,
+        Z=df[["age"]].values,
+        c=df["censored"].values,
+    )
+    with pytest.raises(ValueError):
+        model.sf([5], df[["age"]].head(2))
+
+
+def test_single_string_z_col():
+    df = _make_df()
+    model = WeibullPH.fit_from_df(
+        df, x_col="time", Z_cols="age", c_col="censored"
+    )
+    assert model.feature_names == ["age"]
+    assert np.isfinite(model.sf([5], df[["age"]].head(1))).all()
+
+
+def test_accelerated_life_fit_from_df():
+    rng = np.random.default_rng(3)
+    stresses = np.repeat([1.0, 2.0, 3.0, 4.0], 40)
+    x = Weibull.random(len(stresses), 100 / stresses, 3)
+    df = pd.DataFrame(
+        {"time": x, "stress": stresses, "censored": np.zeros_like(x)}
+    )
+    model = AcceleratedLife(Weibull, Power).fit_from_df(
+        df, x_col="time", Z_cols=["stress"], c_col="censored"
+    )
+    assert model.feature_names == ["stress"]
+    sub = df[["stress"]].head(2)
+    assert np.allclose(model.sf([50], sub), model.sf([50], sub.values))
+
+
+def test_coxph_formula_predict_from_df():
+    df = _make_df()
+    model = CoxPH.fit_from_df(
+        df, x_col="time", formula="age + sex", c_col="censored"
+    )
+    assert "age" in model.feature_names
+    new_df = pd.DataFrame({"age": [60.0, 40.0], "sex": ["M", "F"]})
+    sf = model.sf([5, 10], new_df)
+    assert sf.shape == (2,)
+    assert np.all((sf >= 0) & (sf <= 1))

--- a/surpyval/univariate/regression/accelerated_failure_time/aft_fitter.py
+++ b/surpyval/univariate/regression/accelerated_failure_time/aft_fitter.py
@@ -6,6 +6,7 @@ from surpyval.utils.surpyval_data import SurpyvalData
 
 from .._likelihood import regression_neg_ll
 from ..parametric_regression_model import ParametricRegressionModel
+from ..regression_data import DataFrameRegressionMixin
 
 
 class _LogLinearPhiModel:
@@ -23,7 +24,7 @@ class _LogLinearPhiModel:
         return {"beta_" + str(i): i for i in range(Z.shape[1])}
 
 
-class AFTFitter:
+class AFTFitter(DataFrameRegressionMixin):
     """
     Accelerated Failure Time fitter using exp(beta'Z) as the acceleration
     factor.

--- a/surpyval/univariate/regression/accelerated_life/parameter_substitution.py
+++ b/surpyval/univariate/regression/accelerated_life/parameter_substitution.py
@@ -9,9 +9,10 @@ from surpyval.utils.surpyval_data import SurpyvalData
 
 from .._likelihood import regression_neg_ll
 from ..parametric_regression_model import ParametricRegressionModel
+from ..regression_data import DataFrameRegressionMixin
 
 
-class ParameterSubstitutionFitter:
+class ParameterSubstitutionFitter(DataFrameRegressionMixin):
     def __init__(
         self,
         kind,

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -4,6 +4,8 @@ from scipy.stats import uniform
 
 from surpyval.utils import fsli_to_xcnt
 
+from .regression_data import prepare_Z
+
 
 class ParametricRegressionModel:
     """
@@ -15,6 +17,24 @@ class ParametricRegressionModel:
     analysis and numeric integration.
 
     """
+
+    # Covariate metadata populated when the model is fit from a pandas
+    # DataFrame (see ``DataFrameRegressionMixin.fit_from_df``). These defaults
+    # keep the array based interface working unchanged.
+    feature_names = None
+    formula = None
+    _model_spec = None
+
+    def _prepare_Z(self, Z):
+        """
+        Convert ``Z`` to a numeric design matrix.
+
+        If a pandas DataFrame is passed and the model was fit from a DataFrame,
+        the covariate columns (or formula) recorded at fit time are used to
+        select and encode the correct columns. Otherwise ``Z`` is returned
+        unchanged.
+        """
+        return prepare_Z(Z, self.feature_names, self._model_spec)
 
     def __repr__(self):
         dist_params = self.params[0 : self.k_dist]
@@ -67,6 +87,7 @@ class ParametricRegressionModel:
             return "Unable to fit values"
 
     def phi(self, Z):
+        Z = self._prepare_Z(Z)
         return self.reg_model.phi(Z, *self.phi_params)
 
     def sf(self, x, Z):
@@ -102,6 +123,7 @@ class ParametricRegressionModel:
         """
         if isinstance(x, list):
             x = np.array(x)
+        Z = self._prepare_Z(Z)
         return self.model.sf(x, Z, *self.params)
 
     def ff(self, x, Z):
@@ -138,7 +160,7 @@ class ParametricRegressionModel:
         """
         if isinstance(x, list):
             x = np.array(x)
-
+        Z = self._prepare_Z(Z)
         return self.model.ff(x, Z, *self.params)
 
     def df(self, x, Z):
@@ -175,6 +197,7 @@ class ParametricRegressionModel:
         """
         if isinstance(x, list):
             x = np.array(x)
+        Z = self._prepare_Z(Z)
         return self.model.df(x, Z, *self.params)
 
     def hf(self, x, Z):
@@ -212,6 +235,7 @@ class ParametricRegressionModel:
         """
         if isinstance(x, list):
             x = np.array(x)
+        Z = self._prepare_Z(Z)
         return self.model.hf(x, Z, *self.params)
 
     def Hf(self, x, Z):
@@ -250,6 +274,7 @@ class ParametricRegressionModel:
         """
         if isinstance(x, list):
             x = np.array(x)
+        Z = self._prepare_Z(Z)
         return self.model.Hf(x, Z, *self.params)
 
     def random(self, size, Z):

--- a/surpyval/univariate/regression/proportional_hazards/cox_ph.py
+++ b/surpyval/univariate/regression/proportional_hazards/cox_ph.py
@@ -525,12 +525,14 @@ class CoxPH_:
         model: SemiParametricProportionalHazardsModel
             The fitted model.
         """
-        x, c, n, Z, form = validate_coxph_df_inputs(
+        x, c, n, Z, form, feature_names, model_spec = validate_coxph_df_inputs(
             df, x_col, c_col, n_col, Z_cols, formula
         )
 
         model = self.fit(x, Z, c, n, method=method)
         model.formula = form
+        model.feature_names = feature_names
+        model._model_spec = model_spec
 
         return model
 

--- a/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
+++ b/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
@@ -8,13 +8,14 @@ from surpyval.utils.surpyval_data import SurpyvalData
 
 from .._likelihood import regression_neg_ll
 from ..parametric_regression_model import ParametricRegressionModel
+from ..regression_data import DataFrameRegressionMixin
 
 
 class Phi:
     pass
 
 
-class ProportionalHazardsFitter:
+class ProportionalHazardsFitter(DataFrameRegressionMixin):
     def __init__(
         self,
         name,

--- a/surpyval/univariate/regression/proportional_odds/proportional_odds_fitter.py
+++ b/surpyval/univariate/regression/proportional_odds/proportional_odds_fitter.py
@@ -6,9 +6,10 @@ from surpyval.utils.surpyval_data import SurpyvalData
 
 from .._likelihood import regression_neg_ll
 from ..parametric_regression_model import ParametricRegressionModel
+from ..regression_data import DataFrameRegressionMixin
 
 
-class ProportionalOddsFitter:
+class ProportionalOddsFitter(DataFrameRegressionMixin):
     """
     Proportional Odds model fitter using exp(beta'Z) as the odds multiplier.
 

--- a/surpyval/univariate/regression/regression_data.py
+++ b/surpyval/univariate/regression/regression_data.py
@@ -1,0 +1,219 @@
+"""
+Helpers for fitting and predicting parametric regression models directly
+from pandas DataFrames.
+
+These utilities let a user fit a regression model by naming the columns of a
+DataFrame (or by providing a ``formula``) so that the names of the covariates
+are retained on the fitted model. The same metadata is then used at prediction
+time so that a DataFrame can be passed to ``sf``, ``ff``, ``df``, ``hf``,
+``Hf`` and ``random`` and the correct columns will be selected automatically.
+"""
+
+import numpy as np
+import pandas as pd
+from formulaic import Formula
+
+
+def design_matrix_from_df(df, Z_cols=None, formula=None):
+    """
+    Build a covariate design matrix ``Z`` from a pandas DataFrame.
+
+    Exactly one of ``Z_cols`` or ``formula`` must be provided.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        The dataframe containing the covariate columns.
+    Z_cols : str or list of str, optional
+        The column name(s) of the covariates to use.
+    formula : str, optional
+        A ``formulaic`` formula describing the design matrix, e.g.
+        ``"age + sex + age:sex"``. An intercept is never added (the baseline
+        distribution provides the intercept), so the formula is parsed as
+        ``"0 + " + formula``.
+
+    Returns
+    -------
+    Z : numpy.ndarray
+        The two dimensional design matrix.
+    feature_names : list of str
+        The names of the columns of ``Z``.
+    model_spec : formulaic.ModelSpec or None
+        The fitted ``formulaic`` model specification when a ``formula`` was
+        used. This is retained so that the exact same encoding (including
+        categorical factor levels) can be reproduced at prediction time.
+        ``None`` when ``Z_cols`` was used.
+    """
+    if (Z_cols is None) and (formula is None):
+        raise ValueError("One of 'Z_cols' or 'formula' must be provided")
+
+    if (Z_cols is not None) and (formula is not None):
+        raise ValueError(
+            "Either 'Z_cols' or 'formula' must be provided; not both"
+        )
+
+    if formula is not None:
+        model_matrix = Formula("0 + " + formula).get_model_matrix(df)
+        feature_names = list(model_matrix.columns)
+        model_spec = model_matrix.model_spec
+        Z = np.asarray(model_matrix, dtype=float)
+        return Z, feature_names, model_spec
+
+    if isinstance(Z_cols, str):
+        Z_cols = [Z_cols]
+    else:
+        Z_cols = list(Z_cols)
+
+    unknown = [c for c in Z_cols if c not in df.columns]
+    if len(unknown) > 0:
+        raise ValueError("{} not in dataframe columns".format(unknown))
+
+    Z = df[Z_cols].values.astype(float)
+    return Z, Z_cols, None
+
+
+def prepare_Z(Z, feature_names=None, model_spec=None):
+    """
+    Convert a covariate input ``Z`` into a numeric design matrix.
+
+    If ``Z`` is a pandas DataFrame, the columns are selected using the
+    ``feature_names`` and/or ``model_spec`` that were stored when the model was
+    fit from a DataFrame, ensuring the same covariates (and encoding) are used
+    for prediction. Any other input is returned unchanged so that the existing
+    array based interface keeps working.
+
+    Parameters
+    ----------
+    Z : array_like or pandas.DataFrame
+        The covariates to prepare.
+    feature_names : list of str, optional
+        The covariate column names recorded at fit time.
+    model_spec : formulaic.ModelSpec, optional
+        The formula model specification recorded at fit time.
+
+    Returns
+    -------
+    Z : numpy.ndarray or array_like
+        A numeric design matrix when ``Z`` was a DataFrame, otherwise ``Z``
+        unchanged.
+    """
+    if not isinstance(Z, pd.DataFrame):
+        return Z
+
+    if model_spec is not None:
+        return np.asarray(model_spec.get_model_matrix(Z), dtype=float)
+
+    if feature_names is not None:
+        unknown = [c for c in feature_names if c not in Z.columns]
+        if len(unknown) > 0:
+            raise ValueError(
+                "{} not in dataframe columns".format(unknown)
+            )
+        return Z[feature_names].values.astype(float)
+
+    raise ValueError(
+        "A pandas DataFrame was passed as Z but the model was not fit with "
+        "named covariates. Fit the model with 'fit_from_df' (or pass a numpy "
+        "array) to predict from a DataFrame."
+    )
+
+
+class DataFrameRegressionMixin:
+    """
+    Mixin adding a ``fit_from_df`` method to a parametric regression fitter.
+
+    The fitter must expose a ``fit(x, Z, c=None, n=None, t=None, init=None,
+    fixed=None)`` method returning a ``ParametricRegressionModel``.
+    """
+
+    def fit_from_df(
+        self,
+        df,
+        x_col,
+        Z_cols=None,
+        c_col=None,
+        n_col=None,
+        tl_col=None,
+        tr_col=None,
+        formula=None,
+        init=None,
+        fixed=None,
+    ):
+        """
+        Fit the regression model using a pandas DataFrame as the input.
+
+        The names of the covariates are retained on the fitted model so that a
+        DataFrame can later be passed to the prediction methods (``sf``,
+        ``ff``, ``df``, ``hf``, ``Hf``, ``random``) and the correct columns
+        will be selected automatically.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            The dataframe containing the data.
+        x_col : str
+            The column name of the observed times.
+        Z_cols : str or list of str, optional
+            The column name(s) of the covariates. Mutually exclusive with
+            ``formula``.
+        c_col : str, optional
+            The column name of the censoring indicator.
+        n_col : str, optional
+            The column name of the number of observations at each time.
+        tl_col : str, optional
+            The column name of the left truncation values.
+        tr_col : str, optional
+            The column name of the right truncation values.
+        formula : str, optional
+            A ``formulaic`` formula describing the covariates, e.g.
+            ``"age + sex"``. Mutually exclusive with ``Z_cols``.
+        init : array_like, optional
+            The initial values for the parameters.
+        fixed : dict, optional
+            A dictionary of parameters to fix to a specific value.
+
+        Returns
+        -------
+        ParametricRegressionModel
+            The fitted model, with ``feature_names`` (and ``formula``) set.
+
+        Examples
+        --------
+        >>> from surpyval import WeibullPH
+        >>> model = WeibullPH.fit_from_df(
+        ...     df, x_col="time", Z_cols=["age", "weight"], c_col="censored"
+        ... )
+        >>> model.sf([10, 20], df[["age", "weight"]])
+        """
+        Z, feature_names, model_spec = design_matrix_from_df(
+            df, Z_cols, formula
+        )
+
+        x = df[x_col].values
+
+        c = None if c_col is None else df[c_col].values
+        n = None if n_col is None else df[n_col].values
+
+        if (tl_col is None) and (tr_col is None):
+            t = None
+        else:
+            n_rows = len(df)
+            tl = (
+                np.full(n_rows, -np.inf)
+                if tl_col is None
+                else df[tl_col].values.astype(float)
+            )
+            tr = (
+                np.full(n_rows, np.inf)
+                if tr_col is None
+                else df[tr_col].values.astype(float)
+            )
+            t = np.column_stack([tl, tr])
+
+        model = self.fit(x, Z, c=c, n=n, t=t, init=init, fixed=fixed)
+
+        model.feature_names = feature_names
+        model.formula = formula
+        model._model_spec = model_spec
+
+        return model

--- a/surpyval/univariate/regression/semi_parametric_regression_model.py
+++ b/surpyval/univariate/regression/semi_parametric_regression_model.py
@@ -2,11 +2,26 @@ import autograd.numpy as np
 
 from surpyval.utils import _get_idx
 
+from .regression_data import prepare_Z
+
 
 class SemiParametricRegressionModel:
+    # Covariate metadata populated when the model is fit from a pandas
+    # DataFrame via ``CoxPH.fit_from_df``.
+    feature_names = None
+    formula = None
+    _model_spec = None
+
     def __init__(self, kind, parameterization):
         self.kind = kind
         self.parameterization = parameterization
+
+    def _prepare_Z(self, Z):
+        """
+        Convert ``Z`` to a numeric design matrix, selecting the covariate
+        columns recorded at fit time when a pandas DataFrame is passed.
+        """
+        return prepare_Z(Z, self.feature_names, self._model_spec)
 
     def __repr__(self):
         out = (
@@ -23,10 +38,12 @@ class SemiParametricRegressionModel:
         return out
 
     def hf(self, x, Z):
+        Z = self._prepare_Z(Z)
         idx, rev = _get_idx(self.x, x)
         return (self.h0[idx] * self.phi(Z))[rev]
 
     def Hf(self, x, Z):
+        Z = self._prepare_Z(Z)
         idx, rev = _get_idx(self.x, x)
         return (self.H0[idx] * self.phi(Z))[rev]
 

--- a/surpyval/utils/__init__.py
+++ b/surpyval/utils/__init__.py
@@ -1042,6 +1042,8 @@ def wrangle_and_check_form_and_Z_cols(Z_cols, formula, df):
         )
 
     if Z_cols is not None:
+        if isinstance(Z_cols, str):
+            Z_cols = [Z_cols]
         unknown = [x for x in Z_cols if x not in df.columns]
         if len(unknown) > 0:
             raise ValueError("{} not in dataframe columns".format(unknown))
@@ -1049,12 +1051,17 @@ def wrangle_and_check_form_and_Z_cols(Z_cols, formula, df):
         mask = ~df[Z_cols].isna().any(axis=1).values
         Z = Z[mask]
         form = None
+        feature_names = list(Z_cols)
+        model_spec = None
     else:
         form = Formula("0 + " + formula)
-        Z = form.get_model_matrix(df, na_action="ignore").values.astype(float)
+        model_matrix = form.get_model_matrix(df, na_action="ignore")
+        feature_names = list(model_matrix.columns)
+        model_spec = model_matrix.model_spec
+        Z = model_matrix.values.astype(float)
         mask = ~np.any(np.isnan(Z), axis=1)
 
-    return Z, mask, form
+    return Z, mask, form, feature_names, model_spec
 
 
 def wrangle_Z(Z):
@@ -1225,7 +1232,9 @@ def validate_tv_coxph_df_inputs(
             x = s[x_col].values
             _check_an_ids_tl_and_x(i, tl, x)
 
-    Z, mask, form = wrangle_and_check_form_and_Z_cols(Z_cols, formula, df)
+    Z, mask, form, _, _ = wrangle_and_check_form_and_Z_cols(
+        Z_cols, formula, df
+    )
 
     x = df.loc[mask, x_col].values
     tl = df.loc[mask, tl_col].values
@@ -1248,7 +1257,9 @@ def validate_tv_coxph_df_inputs(
 def validate_coxph_df_inputs(df, x_col, c_col, n_col, Z_cols, formula):
     # TODO: Return the count of dropped rows?
 
-    Z, mask, form = wrangle_and_check_form_and_Z_cols(Z_cols, formula, df)
+    Z, mask, form, feature_names, model_spec = (
+        wrangle_and_check_form_and_Z_cols(Z_cols, formula, df)
+    )
 
     x = df.loc[mask, x_col].values
 
@@ -1264,7 +1275,7 @@ def validate_coxph_df_inputs(df, x_col, c_col, n_col, Z_cols, formula):
 
     x, c, n, _ = xcnt_handler(x, c, n, group_and_sort=False)
 
-    return x, c, n, Z, form
+    return x, c, n, Z, form, feature_names, model_spec
 
 
 def validate_coxph(x, c, n, Z, tl, method):


### PR DESCRIPTION
Univariate parametric regression fitters (AFT, PH, PO, Accelerated Life)
now expose a fit_from_df method that retains covariate names from a pandas
DataFrame and optionally accepts a formulaic formula. The fitted model
records the feature names (and formula model spec), so a DataFrame can be
passed directly to the prediction methods (sf, ff, df, hf, Hf, phi) and the
correct columns are selected and encoded automatically.

CoxPH fit_from_df now records the same metadata so its predictions accept a
DataFrame too.