### PR TITLE
Adopt Distribution ABC across all model types

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -147,9 +147,6 @@ They support a nice composition API (`model_a | model_b`,
 only `sf/ff/df/hf/Hf` (no `params`, `fit`, serialization or bounds).
 Either make them public properly or mark them experimental.
 
-### `Distribution` ABC adoption is incomplete
-`Parametric` now inherits from the `Distribution` ABC (`distribution.py`), but `NonParametric`, `MixtureModel`, `SeriesModel`, `ParallelModel`, `NeverOccurs`, and `InstantlyOccurs` expose the same interface without inheriting it. Users still cannot write polymorphic code using `isinstance(model, Distribution)` across model types.
-
 ### Parameter naming inconsistency (`alpha`/`beta`)
 Weibull, LogLogistic, Gamma, Beta, and ExpoWeibull all use `param_names=['alpha', 'beta']` but the roles differ across distributions. Positional use will produce silently incorrect results.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -147,9 +147,6 @@ They support a nice composition API (`model_a | model_b`,
 only `sf/ff/df/hf/Hf` (no `params`, `fit`, serialization or bounds).
 Either make them public properly or mark them experimental.
 
-### `cb()` default `on` parameter differs between `Parametric` and `NonParametric`
-`Parametric.cb()` (`parametric.py`) defaults to `on='R'`; `NonParametric.cb()` (`nonparametric.py`) defaults to `on='sf'`. Both strings refer to the survival function in the same conditional.
-
 ### `Distribution` ABC adoption is incomplete
 `Parametric` now inherits from the `Distribution` ABC (`distribution.py`), but `NonParametric`, `MixtureModel`, `SeriesModel`, `ParallelModel`, `NeverOccurs`, and `InstantlyOccurs` expose the same interface without inheriting it. Users still cannot write polymorphic code using `isinstance(model, Distribution)` across model types.
 

--- a/surpyval/__init__.py
+++ b/surpyval/__init__.py
@@ -2,7 +2,11 @@ __version__ = "0.11.1"
 
 from autograd import numpy as np
 
-from surpyval.distribution import Distribution
+from surpyval.distribution import (
+    Distribution,
+    NonParametricDistribution,
+    ParametricDistribution,
+)
 from surpyval.univariate.nonparametric import (
     FlemingHarrington,
     KaplanMeier,

--- a/surpyval/distribution.py
+++ b/surpyval/distribution.py
@@ -1,18 +1,27 @@
 from abc import ABC, abstractmethod
 
+import numpy as np
 from numpy.typing import ArrayLike
 
 
 class Distribution(ABC):
     """
-    An abstract base class that all surpyval distributions inherit from,
-    implementing the following methods:
-    - .sf()
-    - .ff()
-    """
+    Root abstract base class that every surpyval model inherits from.
 
-    def __init__(self, name: str):
-        self.name = name
+    The contract shared by all models -- parametric, nonparametric,
+    mixtures, compositions and degenerate models -- is the survival
+    interface:
+
+    - ``sf()`` the survival (reliability) function
+    - ``ff()`` the cumulative distribution (failure) function
+
+    ``Hf()`` is provided as a default derived from ``sf()`` and may be
+    overridden by models with a closed form. Statistical summaries such
+    as ``moment``, ``entropy``, ``random`` and ``to_dict`` are not part
+    of this minimal contract; the ``ParametricDistribution`` and
+    ``NonParametricDistribution`` subclasses add the ones appropriate to
+    their model family.
+    """
 
     @abstractmethod
     def sf(self, x: ArrayLike, *args, **kwargs) -> ArrayLike: ...
@@ -20,14 +29,38 @@ class Distribution(ABC):
     @abstractmethod
     def ff(self, x: ArrayLike, *args, **kwargs) -> ArrayLike: ...
 
-    @abstractmethod
-    def entropy(self, *args, **kwargs) -> ArrayLike: ...
+    def Hf(self, x: ArrayLike, *args, **kwargs) -> ArrayLike:
+        # Cumulative hazard derived from the survival function. Models
+        # with a closed-form cumulative hazard override this.
+        return -np.log(self.sf(x, *args, **kwargs))
 
-    @abstractmethod
-    def moment(self, n: ArrayLike, *args, **kwargs) -> ArrayLike: ...
+
+class ParametricDistribution(Distribution):
+    """
+    A fully specified parametric model. In addition to the survival
+    interface it supports random sampling and the standard statistical
+    summaries (moments, entropy) and can be serialised with ``to_dict``.
+    """
 
     @abstractmethod
     def random(self, size: ArrayLike, *args, **kwargs) -> ArrayLike: ...
 
     @abstractmethod
+    def moment(self, n: ArrayLike, *args, **kwargs) -> ArrayLike: ...
+
+    @abstractmethod
+    def entropy(self, *args, **kwargs) -> ArrayLike: ...
+
+    @abstractmethod
     def to_dict(self) -> dict: ...
+
+
+class NonParametricDistribution(Distribution):
+    """
+    An empirical model produced by a nonparametric estimator
+    (Kaplan-Meier, Nelson-Aalen, Fleming-Harrington or Turnbull). Adds
+    random sampling from the fitted estimate to the survival interface.
+    """
+
+    @abstractmethod
+    def random(self, size: ArrayLike, *args, **kwargs) -> ArrayLike: ...

--- a/surpyval/experimental/parallel.py
+++ b/surpyval/experimental/parallel.py
@@ -1,11 +1,11 @@
 from autograd import elementwise_grad
 
 import surpyval as surv
-from surpyval import np
+from surpyval import Distribution, np
 from surpyval.experimental.series import SeriesModel
 
 
-class ParallelModel:
+class ParallelModel(Distribution):
     def __or__(self, other):
         if isinstance(other, surv.Parametric):
             return SeriesModel([*self.models, other])

--- a/surpyval/experimental/parallel.py
+++ b/surpyval/experimental/parallel.py
@@ -1,26 +1,23 @@
 from autograd import elementwise_grad
 
-import surpyval as surv
 from surpyval import Distribution, np
 from surpyval.experimental.series import SeriesModel
 
 
 class ParallelModel(Distribution):
     def __or__(self, other):
-        if isinstance(other, surv.Parametric):
-            return SeriesModel([*self.models, other])
-        elif isinstance(other, ParallelModel):
-            return ParallelModel([*self.models, other])
-        else:
-            return SeriesModel([*self.models, *other.models])
-
-    def __and__(self, other):
-        if isinstance(other, surv.Parametric):
+        if isinstance(other, ParallelModel):
             return ParallelModel([*self.models, other])
         elif isinstance(other, SeriesModel):
-            return ParallelModel([*self.models, other])
-        else:
+            return SeriesModel([*self.models, *other.models])
+        # Leaf model (Parametric, NonParametric, MixtureModel, ...)
+        return SeriesModel([*self.models, other])
+
+    def __and__(self, other):
+        if isinstance(other, ParallelModel):
             return ParallelModel([*self.models, *other.models])
+        # SeriesModel and leaf models alike nest as a single component.
+        return ParallelModel([*self.models, other])
 
     def __init__(self, models):
         self.models = models

--- a/surpyval/experimental/series.py
+++ b/surpyval/experimental/series.py
@@ -1,10 +1,10 @@
 from autograd import elementwise_grad
 
 import surpyval as surv
-from surpyval import np
+from surpyval import Distribution, np
 
 
-class SeriesModel:
+class SeriesModel(Distribution):
     def __or__(self, other):
         if isinstance(other, surv.Parametric):
             return SeriesModel([*self.models, other])

--- a/surpyval/experimental/series.py
+++ b/surpyval/experimental/series.py
@@ -1,23 +1,25 @@
 from autograd import elementwise_grad
 
-import surpyval as surv
 from surpyval import Distribution, np
 
 
 class SeriesModel(Distribution):
     def __or__(self, other):
-        if isinstance(other, surv.Parametric):
-            return SeriesModel([*self.models, other])
-        else:
+        from surpyval.experimental.parallel import ParallelModel
+
+        # Composite operands contribute their components; any other
+        # Distribution (Parametric, NonParametric, MixtureModel, ...) is
+        # a leaf and is appended whole.
+        if isinstance(other, (SeriesModel, ParallelModel)):
             return SeriesModel([*self.models, *other.models])
+        return SeriesModel([*self.models, other])
 
     def __and__(self, other):
         from surpyval.experimental.parallel import ParallelModel
 
-        if isinstance(other, surv.Parametric):
-            return ParallelModel([*self.models, other])
-        else:
+        if isinstance(other, (SeriesModel, ParallelModel)):
             return ParallelModel([*self.models, *other.models])
+        return ParallelModel([*self.models, other])
 
     def __init__(self, models):
         self.models = models

--- a/surpyval/tests/test_distribution_abc.py
+++ b/surpyval/tests/test_distribution_abc.py
@@ -55,6 +55,24 @@ def test_composed_models_are_distributions():
     assert isinstance(ParallelModel([model, model]), Distribution)
 
 
+def test_composition_accepts_any_distribution_leaf():
+    # The | and & operators previously only recognised Parametric leaves.
+    # They now accept any non-composite Distribution (here NonParametric).
+    weibull, _ = _parametric_model()
+    npm = sp.NelsonAalen.fit([1.0, 2.0, 3.0, 4.0, 5.0])
+    grid = np.array([1.0, 2.0, 3.0])
+
+    series = SeriesModel([weibull]) | npm
+    assert len(series.models) == 2
+    # Series survival is the product of component survival functions.
+    assert np.allclose(series.sf(grid), weibull.sf(grid) * npm.sf(grid))
+
+    parallel = ParallelModel([weibull]) & npm
+    assert len(parallel.models) == 2
+    # Parallel failure is the product of component failure functions.
+    assert np.allclose(parallel.ff(grid), weibull.ff(grid) * npm.ff(grid))
+
+
 def test_hf_default_derives_from_sf():
     # MixtureModel has no closed-form Hf, so it falls back to the
     # Distribution default Hf = -log(sf).

--- a/surpyval/tests/test_distribution_abc.py
+++ b/surpyval/tests/test_distribution_abc.py
@@ -1,0 +1,65 @@
+"""
+Every surpyval model should participate in the ``Distribution`` ABC
+hierarchy so that user code can dispatch on ``isinstance(model,
+Distribution)``. These tests pin the adoption down across the model
+families.
+"""
+
+import numpy as np
+
+import surpyval as sp
+from surpyval import (
+    Distribution,
+    NonParametricDistribution,
+    ParametricDistribution,
+)
+from surpyval.experimental.parallel import ParallelModel
+from surpyval.experimental.series import SeriesModel
+
+
+def _parametric_model():
+    np.random.seed(0)
+    x = np.concatenate(
+        [sp.Weibull.random(50, 10, 3), sp.Weibull.random(50, 50, 4)]
+    )
+    return sp.Weibull.fit(x), x
+
+
+def test_parametric_is_parametric_distribution():
+    model, _ = _parametric_model()
+    assert isinstance(model, Distribution)
+    assert isinstance(model, ParametricDistribution)
+
+
+def test_nonparametric_is_nonparametric_distribution():
+    model = sp.NelsonAalen.fit([1.0, 2.0, 3.0, 4.0, 5.0])
+    assert isinstance(model, Distribution)
+    assert isinstance(model, NonParametricDistribution)
+
+
+def test_mixture_model_is_distribution():
+    _, x = _parametric_model()
+    mm = sp.MixtureModel(dist=sp.Weibull, m=2)
+    mm.fit(x=x)
+    assert isinstance(mm, Distribution)
+
+
+def test_degenerate_models_are_distributions():
+    assert issubclass(sp.NeverOccurs, Distribution)
+    assert issubclass(sp.InstantlyOccurs, Distribution)
+
+
+def test_composed_models_are_distributions():
+    model, _ = _parametric_model()
+    assert isinstance(SeriesModel([model, model]), Distribution)
+    assert isinstance(ParallelModel([model, model]), Distribution)
+
+
+def test_hf_default_derives_from_sf():
+    # MixtureModel has no closed-form Hf, so it falls back to the
+    # Distribution default Hf = -log(sf).
+    _, x = _parametric_model()
+    mm = sp.MixtureModel(dist=sp.Weibull, m=2)
+    mm.fit(x=x)
+    grid = np.array([1.0, 5.0, 10.0, 25.0])
+    assert np.allclose(mm.Hf(grid), -np.log(mm.sf(grid)))

--- a/surpyval/univariate/nonparametric/nonparametric.py
+++ b/surpyval/univariate/nonparametric/nonparametric.py
@@ -231,7 +231,7 @@ class NonParametric:
     def cb(
         self,
         x,
-        on="R",
+        on="sf",
         bound="two-sided",
         interp="step",
         alpha_ci=0.05,

--- a/surpyval/univariate/nonparametric/nonparametric.py
+++ b/surpyval/univariate/nonparametric/nonparametric.py
@@ -231,7 +231,7 @@ class NonParametric:
     def cb(
         self,
         x,
-        on="sf",
+        on="R",
         bound="two-sided",
         interp="step",
         alpha_ci=0.05,

--- a/surpyval/univariate/nonparametric/nonparametric.py
+++ b/surpyval/univariate/nonparametric/nonparametric.py
@@ -4,12 +4,14 @@ import pandas as pd
 from scipy.interpolate import interp1d
 from scipy.stats import norm, t
 
+from surpyval.distribution import NonParametricDistribution
+
 
 def interp_function(x, y, kind):
     return interp1d(x, y, kind=kind, bounds_error=False, fill_value=np.nan)
 
 
-class NonParametric:
+class NonParametric(NonParametricDistribution):
     """
     Result of ``.fit()`` method for every non-parametric
     surpyval distribution. This means that each of the

--- a/surpyval/univariate/parametric/__init__.py
+++ b/surpyval/univariate/parametric/__init__.py
@@ -13,6 +13,8 @@ Parametric Analysis
 
 import numpy as np
 
+from surpyval.distribution import Distribution
+
 from .distributions import (
     Bernoulli,
     Beta,
@@ -40,7 +42,7 @@ from .parametric import Parametric
 from .parametric_fitter import ParametricFitter
 
 
-class NeverOccurs:
+class NeverOccurs(Distribution):
     @classmethod
     def sf(cls, x):
         return np.ones_like(x).astype(float)
@@ -58,7 +60,7 @@ class NeverOccurs:
         return np.ones(size) * np.inf
 
 
-class InstantlyOccurs:
+class InstantlyOccurs(Distribution):
     @classmethod
     def sf(cls, x):
         return np.zeros_like(x).astype(float)

--- a/surpyval/univariate/parametric/mixture_model.py
+++ b/surpyval/univariate/parametric/mixture_model.py
@@ -5,7 +5,7 @@ from matplotlib import pyplot as plt
 from scipy.optimize import minimize
 from scipy.special import ndtri as z
 
-from surpyval import np
+from surpyval import Distribution, np
 from surpyval.utils.surpyval_data import SurpyvalData
 
 from .probability_plotting import (
@@ -15,7 +15,7 @@ from .probability_plotting import (
 )
 
 
-class MixtureModel:
+class MixtureModel(Distribution):
     """
     A class for creating a Mixture Model fitter.
 

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -7,7 +7,7 @@ from scipy.special import ndtri as z
 from scipy.stats import uniform
 
 import surpyval as surv
-from surpyval import Distribution, np
+from surpyval import ParametricDistribution, np
 from surpyval.utils import fsli_to_xcnt
 
 from .probability_plotting import (
@@ -17,7 +17,7 @@ from .probability_plotting import (
 )
 
 
-class Parametric(Distribution):
+class Parametric(ParametricDistribution):
     """
     Result of ``.fit()`` or ``.from_params()`` method for every parametric
     surpyval distribution.

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -747,7 +747,7 @@ class Parametric(Distribution):
             msg = "Entropy not available for LFP distribution"
             raise NotImplementedError(msg)
 
-    def cb(self, t, on="R", alpha_ci=0.05, bound="two-sided"):
+    def cb(self, t, on="sf", alpha_ci=0.05, bound="two-sided"):
         r"""
         Confidence bounds of the ``on`` function at the ``alpa_ci`` level of
         significance. Can be the upper, lower, or two-sided confidence by


### PR DESCRIPTION
## Summary
Complete the adoption of the `Distribution` abstract base class across all surpyval model types, enabling polymorphic code using `isinstance()` checks. Previously only `Parametric` models inherited from `Distribution`, while `NonParametric`, `MixtureModel`, `SeriesModel`, `ParallelModel`, and degenerate models exposed the same interface without inheriting it.

## Key Changes

- **Refactored `Distribution` ABC hierarchy** into three levels:
  - `Distribution`: Root ABC with minimal contract (`sf()`, `ff()`, and default `Hf()`)
  - `ParametricDistribution`: Adds `random()`, `moment()`, `entropy()`, `to_dict()`
  - `NonParametricDistribution`: Adds `random()` for empirical sampling

- **Updated all model classes to inherit from appropriate ABC**:
  - `Parametric` now inherits from `ParametricDistribution`
  - `NonParametric` now inherits from `NonParametricDistribution`
  - `MixtureModel`, `SeriesModel`, `ParallelModel` now inherit from `Distribution`
  - `NeverOccurs` and `InstantlyOccurs` now inherit from `Distribution`

- **Simplified composition operators** (`|` and `&` in `SeriesModel`/`ParallelModel`):
  - Now accept any `Distribution` leaf, not just `Parametric` models
  - Enables mixing parametric and nonparametric models in compositions
  - Cleaner dispatch logic based on composite vs. leaf distinction

- **Added default `Hf()` implementation** to `Distribution` base class:
  - Derived from `sf()` as `-log(sf(x))`
  - Can be overridden by models with closed-form cumulative hazard

- **Standardized `cb()` default parameter** in `Parametric`:
  - Changed default `on` parameter from `"R"` to `"sf"` for consistency with `NonParametric`

- **Exported new ABC classes** from main `__init__.py`:
  - `ParametricDistribution` and `NonParametricDistribution` now public

- **Added comprehensive test suite** (`test_distribution_abc.py`):
  - Verifies all model types properly inherit from `Distribution`
  - Tests composition with mixed model types
  - Validates default `Hf()` behavior

## Implementation Details

The refactoring maintains backward compatibility while establishing a clear contract hierarchy. The `Distribution` base class now defines only the essential survival interface (`sf`, `ff`, `Hf`), with statistical methods pushed to appropriate subclasses. This allows compositions and degenerate models to participate in the ABC hierarchy without requiring unrelated methods.

https://claude.ai/code/session_01A1C2qwCwJUjFL81hEvJxxK