### PR TITLE
Deduplicate xcnt/xicn handlers via shared coerce/format helpers

### DIFF
--- a/surpyval/tests/recurrent/test_nhpp_censoring.py
+++ b/surpyval/tests/recurrent/test_nhpp_censoring.py
@@ -26,10 +26,11 @@ def test_crow_interval_censoring_fits():
 
 
 def test_interval_left_must_not_exceed_right():
-    # A reversed interval [5, 1] is invalid regardless of input type.
-    with pytest.raises(ValueError, match="left bound <= right bound"):
+    # A reversed interval [5, 1] is invalid regardless of input type. The
+    # check is shared with the univariate handler via coerce_xcnt_x.
+    with pytest.raises(ValueError, match="less than or equal to right"):
         handle_xicn(np.array([[5.0, 1.0]]), np.array([1]), c=np.array([2]))
-    with pytest.raises(ValueError, match="left bound <= right bound"):
+    with pytest.raises(ValueError, match="less than or equal to right"):
         handle_xicn([[5.0, 1.0]], [1], c=[2])
 
 

--- a/surpyval/utils/__init__.py
+++ b/surpyval/utils/__init__.py
@@ -297,6 +297,111 @@ def xrd_handler(x, r, d):
     return x, r, d
 
 
+def coerce_xcnt_x(x):
+    """
+    Coerce the ``x`` variable of xcnt-format data into a numpy array.
+
+    Accepts a 1D array of event values, or a 2D array / list-of-pairs of
+    ``[left, right]`` interval bounds. Validates dimensionality, the interval
+    ordering (``left <= right``) and the absence of NaNs. Shared by the
+    univariate (``xcnt_handler``) and recurrent (``handle_xicn``) handlers.
+    """
+    if isinstance(x, list):
+        if any(isinstance(v, list) for v in x):
+            x_ndarray = np.empty(shape=(len(x), 2))
+            for idx, val in enumerate(x):
+                val_arr = np.atleast_1d(val)
+                if len(val_arr) > 2:
+                    raise ValueError(
+                        "Each element of 'x' must be either scalar or"
+                        " array-like of no more than length 2"
+                    )
+                x_ndarray[idx, :] = val_arr
+            x = x_ndarray
+        else:
+            x = np.array(x)
+    elif isinstance(x, Series):
+        x = np.array(x)
+    else:
+        x = np.asarray(x)
+
+    if x.ndim > 2:
+        raise ValueError("Variable 'x' array must be one or two dimensional")
+    if x.ndim == 2:
+        if x.shape[1] != 2:
+            raise ValueError(
+                "Dimension 1 must be equal to 2, try transposing data, or do"
+                " you have a 1d array in a 2d array?"
+            )
+        if not (x[:, 0] <= x[:, 1]).all():
+            raise ValueError(
+                "All left intervals must be less than or equal to right"
+                " intervals"
+            )
+    if np.isnan(x).any():
+        raise ValueError("Variable 'x' cannot contain NaN values")
+    return x
+
+
+def format_truncation(t, tl, tr, n_rows):
+    """
+    Build the ``(n_rows, 2)`` truncation array from either a ``t`` matrix or
+    separate ``tl``/``tr`` bounds (scalars broadcast to all rows). The default
+    window is the whole real line ``[-inf, inf]``. Shared by ``xcnt_handler``
+    and ``handle_xicn``.
+    """
+    if t is not None and ((tl is not None) or (tr is not None)):
+        raise ValueError(
+            "Cannot use 't' with 'tl' or 'tr'. Use either 't' or any"
+            " combination of 'tl' and 'tr'"
+        )
+
+    if (t is None) and (tl is None) and (tr is None):
+        tl_arr = np.ones(n_rows) * -np.inf
+        tr_arr = np.ones(n_rows) * np.inf
+        return np.vstack([tl_arr, tr_arr]).T
+
+    if (tl is not None) or (tr is not None):
+        if tl is None:
+            tl_arr = np.ones(n_rows) * -np.inf
+        elif np.isscalar(tl):
+            tl_arr = np.ones(n_rows) * tl
+        else:
+            tl_arr = np.array(tl, dtype=float)
+
+        if tr is None:
+            tr_arr = np.ones(n_rows) * np.inf
+        elif np.isscalar(tr):
+            tr_arr = np.ones(n_rows) * tr
+        else:
+            tr_arr = np.array(tr, dtype=float)
+
+        if tl_arr.ndim > 1 or tr_arr.ndim > 1:
+            raise ValueError(
+                "Truncation arrays must be one dimensional, did you mean to"
+                " use 't'"
+            )
+        if tl_arr.shape[0] != n_rows or tr_arr.shape[0] != n_rows:
+            raise ValueError(
+                "Truncation array must be same length as variable array"
+            )
+        return np.vstack([tl_arr, tr_arr]).T
+
+    t = np.array(t, dtype=float)
+    if t.ndim != 2:
+        raise ValueError("Truncation ndarray must be 2 dimensional")
+    if t.shape[0] != n_rows:
+        raise ValueError(
+            "Truncation ndarray must be same shape as variable array"
+        )
+    if t.shape[1] != 2:
+        raise ValueError(
+            "Truncation array must have shape (n, 2) with left and right"
+            " bounds"
+        )
+    return t
+
+
 def xcnt_handler(
     x=None,
     c=None,
@@ -430,41 +535,7 @@ def xcnt_handler(
         except Exception:
             raise ValueError("'xl' and 'xr' must be the same length")
 
-    if isinstance(x, list):
-        if any(isinstance(v, list) for v in x):
-            x_ndarray = np.empty(shape=(len(x), 2))
-            for idx, val in enumerate(x):
-                val_arr = np.atleast_1d(val)
-                if len(val_arr) > 2:
-                    raise ValueError(
-                        "Each element of 'x' must be either scalar or"
-                        + " array-like of no more than length 2"
-                    )
-                x_ndarray[idx, :] = val_arr
-            x = x_ndarray
-        else:
-            x = np.array(x)
-    elif isinstance(x, Series):
-        x = np.array(x)
-
-    if x.ndim > 2:
-        raise ValueError("Variable 'x' array must be one or two dimensional")
-
-    if x.ndim == 2:
-        if x.shape[1] != 2:
-            raise ValueError(
-                "Dimension 1 must be equal to 2, try transposing data, or do"
-                + " you have a 1d array in a 2d array?"
-            )
-
-        if not (x[:, 0] <= x[:, 1]).all():
-            raise ValueError(
-                "All left intervals must be less than or equal to right"
-                + " intervals"
-            )
-
-    if np.isnan(x).any():
-        raise ValueError("Variable 'x' cannot contain NaN values")
+    x = coerce_xcnt_x(x)
 
     # logic for censoring flag
     if c is not None:
@@ -535,69 +606,7 @@ def xcnt_handler(
         # Do check here for groupby and binning
         n = np.ones(x.shape[0])
 
-    if t is not None and ((tl is not None) or (tr is not None)):
-        raise ValueError(
-            "Cannot use 't' with 'tl' or 'tr'. Use either 't' or any"
-            + " combination of 'tl' and 'tr'"
-        )
-
-    elif (t is None) and (tl is None) and (tr is None):
-        tl = np.ones(x.shape[0]) * -np.inf
-        tr = np.ones(x.shape[0]) * np.inf
-        t = np.vstack([tl, tr]).T
-    elif (tl is not None) or (tr is not None):
-        if tl is None:
-            tl = np.ones(x.shape[0]) * -np.inf
-        elif np.isscalar(tl):
-            tl = np.ones(x.shape[0]) * tl
-        else:
-            tl = np.array(tl)
-
-        if tr is None:
-            tr = np.ones(x.shape[0]) * np.inf
-        elif np.isscalar(tr):
-            tr = np.ones(x.shape[0]) * tr
-        else:
-            tr = np.array(tr)
-
-        if tl.ndim > 1:
-            raise ValueError(
-                "Left truncation array must be one dimensional, did you mean"
-                + " to use 't'"
-            )
-        if tr.ndim > 1:
-            raise ValueError(
-                "Left truncation array must be one dimensional, did you mean"
-                + " to use 't'"
-            )
-        if tl.shape[0] != x.shape[0]:
-            raise ValueError(
-                "Left truncation array must be same length as variable array"
-            )
-        if tr.shape[0] != x.shape[0]:
-            raise ValueError(
-                "Right truncation array must be same length as variable array"
-            )
-        if tl.shape != tr.shape:
-            raise ValueError(
-                "Left truncation array and right truncation array must be the"
-                + " same length"
-            )
-        t = np.vstack([tl, tr]).T
-
-    else:
-        t = np.array(t)
-        if t.ndim != 2:
-            raise ValueError("Truncation ndarray must be 2 dimensional")
-        if t.shape[0] != x.shape[0]:
-            raise ValueError(
-                "Truncation ndarray must be same shape as variable array"
-            )
-        if t.shape[1] != 2:
-            raise ValueError(
-                "Truncation array must have shape (n, 2) with left and"
-                + " right bounds"
-            )
+    t = format_truncation(t, tl, tr, x.shape[0])
 
     if (t[:, 1] <= t[:, 0]).any():
         raise ValueError(

--- a/surpyval/utils/recurrent_utils.py
+++ b/surpyval/utils/recurrent_utils.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from surpyval.utils import coerce_xcnt_x, format_truncation
+
 from .recurrent_event_data import RecurrentEventData
 
 
@@ -40,23 +42,7 @@ def handle_xicn(
     x, i=None, c=None, n=None, t=None, tl=None, tr=None, Z=None,
     as_recurrent_data=True,
 ):
-    if isinstance(x, list):
-        if any(isinstance(v, list) for v in x):
-            x_ndarray = np.empty(shape=(len(x), 2))
-            for idx, val in enumerate(x):
-                x_ndarray[idx, :] = np.array(val)
-            x = x_ndarray
-        else:
-            x = np.array(x)
-    else:
-        x = np.asarray(x)
-
-    # Interval-censored events are 2D rows [left, right]; the left bound of
-    # each interval must not exceed its right bound.
-    if x.ndim == 2 and (x[:, 0] > x[:, 1]).any():
-        raise ValueError(
-            "interval-censored x must have left bound <= right bound"
-        )
+    x = coerce_xcnt_x(x)
 
     if i is None:
         i = np.ones(x.shape[0])
@@ -73,37 +59,14 @@ def handle_xicn(
     else:
         c = np.array(c)
 
-    # Truncation, following surpyval's xcnt convention: ``t`` is an (N, 2)
-    # array of [left, right] truncation bounds, or ``tl``/``tr`` give the
-    # bounds separately (scalar broadcasts to all rows). The default window is
-    # the whole real line, so no assumption is made about the sign of ``x``
-    # (e.g. a log-intensity model can take negative values); the integration
-    # origin for untruncated NHPP data falls back to 0 in ``get_previous_x``.
-    nrows = x.shape[0]
-    if t is not None:
-        if tl is not None or tr is not None:
-            raise ValueError("Cannot use `t` together with `tl`/`tr`.")
-        t = np.array(t, dtype=float)
-        if t.ndim == 1:
-            t = np.broadcast_to(t, (nrows, 2)).copy()
-        tl_arr = t[:, 0]
-        tr_arr = t[:, 1]
-    else:
-        if tl is None:
-            tl_arr = np.full(nrows, -np.inf)
-        elif np.isscalar(tl):
-            tl_arr = np.full(nrows, float(tl))
-        else:
-            tl_arr = np.array(tl, dtype=float)
-        if tr is None:
-            tr_arr = np.full(nrows, np.inf)
-        elif np.isscalar(tr):
-            tr_arr = np.full(nrows, float(tr))
-        else:
-            tr_arr = np.array(tr, dtype=float)
-
-    if tl_arr.shape[0] != nrows or tr_arr.shape[0] != nrows:
-        raise ValueError("truncation must have the same length as x")
+    # Truncation follows surpyval's xcnt convention (shared with the univariate
+    # handler): the default window is the whole real line, so no assumption is
+    # made about the sign of ``x`` (e.g. a log-intensity model can take
+    # negative values); the integration origin for untruncated NHPP data falls
+    # back to 0 in ``get_previous_x``.
+    truncation = format_truncation(t, tl, tr, x.shape[0])
+    tl_arr = truncation[:, 0]
+    tr_arr = truncation[:, 1]
 
     if Z is not None:
         if isinstance(Z, dict):


### PR DESCRIPTION
Follow-up to #83 (merged). That PR brought in everything through the interval-censoring fix (`5b020cb`); this is the one remaining commit on the branch that landed after the merge.

## What this does

The univariate (`xcnt_handler`) and recurrent (`handle_xicn`) data handlers carried near-identical copies of two normalization steps. This extracts them into shared helpers in `surpyval.utils` and routes both handlers through them:

- **`coerce_xcnt_x(x)`** — the canonical `x` parser/validator (1-D values or 2-D `[left, right]` intervals, with dimensionality, `left <= right`, and NaN checks).
- **`format_truncation(t, tl, tr, n_rows)`** — the canonical `(N, 2)` truncation builder (`t`-XOR-`tl`/`tr`, `[-inf, inf]` default, scalar broadcast, length checks).

`xcnt_handler` keeps its univariate-only censoring/`n` and within-window validation; `handle_xicn` keeps its recurrent-only item dimension, `(i, x)` sorting, and per-item validation. Net ~110 lines of duplicated parsing removed.

## Behaviour

No change beyond `handle_xicn` now sharing `xcnt_handler`'s stricter input checks and unified error messages (one recurrent test's regex updated to the shared message). Full test suite: 569 passed, 1 skipped.

https://claude.ai/code/session_016iTenPQBeictHbgBzwpyoi

---
_Generated by [Claude Code](https://claude.ai/code/session_016iTenPQBeictHbgBzwpyoi)_