### PR TITLE
Recurrent: RenewalModel fitter/model split, ARI fold-in, raw-xicn data simulators

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,6 +16,88 @@ This document tracks known issues, technical debt, and improvement priorities fo
 
 ## 4. Recurrent Module — Bugs and Gaps
 
+### Fresh deep-dive — 2026-06-14 (full-package audit)
+
+A current-state audit of the whole `recurrent/` package (parametric intensity,
+renewal, regression, nonparametric, competing risks). Findings are grouped by
+theme; items already resolved are marked **[done]**.
+
+**A. Correctness bugs**
+- `ProportionalIntensityHPP` crashes on left- or interval-censored data:
+  `Z_left`/`Z_i` are assigned only in the no-censoring `else` branches
+  (`hpp_proportional_intensity.py:130,147`) but used in the likelihood
+  (`:165,174`) → `NameError`. The NHPP sibling is fine (it uses ternaries).
+- Left-truncated MCF is wrong: `RecurrentEventData.to_xrd()` builds the
+  at-risk set assuming every item enters at `t=0`, ignoring `tl`; inflates the
+  MCF and propagates to `CauseSpecificMCF`. (Left truncation *is* handled for
+  the parametric NHPP likelihood via `get_previous_x`; only the nonparametric
+  risk set is wrong.)
+- `nhpp_proportional_intensity.py:131` calls `dist.log_iif(...)`
+  unconditionally under a `# TODO`; crashes for any baseline lacking it, with
+  no log-path fallback (underflow risk).
+- Lower: NHPP/HPP likelihoods take `np.log(delta_cif)` with no guard against a
+  non-positive delta (pathological params mid-optimisation); `CoxLewis.inv_cif`
+  can return negative times → invalid interarrivals in simulation, unguarded.
+
+**B. Dead code / stubs / docs**
+- `ParametricRecurrenceRegressionModel` (`parametric_regression.py`) — `# TODO`
+  stub simulation, never imported/exported. Remove or finish.
+- `_validate_memory` duplicated verbatim in `renewal/ara.py` and
+  `parametric/ari.py`.
+- 16 copy-pasted docstrings read "Parameters of the Duane model" inside
+  `Crow`/`CrowAMSAA`/`CoxLewis`.
+- `has_left_censoing` typo (`nhpp_fitter.py`, NHPP regression file).
+- Doubled `to_xrd()` call in `nonparametric/mcf.py:106-107`.
+
+**C. Simplification**
+- The multi-start MLE fit scaffolding is copy-pasted across the four repair
+  fitters (`GeneralizedRenewal`, `GeneralizedOneRenewal`, `ARA`, `ARI`): the
+  `for X_init in [...]` loop, `bounds_convert`, the identical "Could not find a
+  good solution" raise, and the `_neg_ll`/`_mle`/`_n_obs` storage → a
+  `RenewalFitMixin._fit_repair_model(...)`.
+- Regression simulation is the stale pre-mixin copy (`tol=1e-5`, no `seed`/
+  `max_events`) in `ProportionalIntensityModel` → should inherit
+  `RecurrenceSimulationMixin`.
+- The parametric (`HPP`/`Crow`/`Duane`/`CoxLewis`) and regression fitters never
+  set `_neg_ll`/`_mle`/`_n_obs`, so they get no AIC/BIC/SE even though
+  `LikelihoodInferenceMixin` exists and the repair models use it (~3 lines per
+  fit).
+- `Crow`/`Duane`/`CrowAMSAA`/`CoxLewis` each redefine `iif`/`log_iif`/`cif`/
+  `inv_cif` with identical docstring boilerplate (the models are mathematically
+  distinct — do not merge the math) → an `IntensityModel` ABC for the contract.
+  `HPP` could subclass `NHPPFitter` (overriding `create_negll_func`).
+
+**D. Missing capabilities**
+- No goodness-of-fit / trend tests anywhere (Laplace, MIL-HDBK-189C).
+- Truncation half-wired: `tr` not in the NHPP integral (right window-close
+  relies on a `c=1` row); MCF risk set ignores `tl` (see A); not exposed on
+  nonparametric `fit()`, regression `fit()`, or `CauseSpecificMCF.fit()`.
+- `handle_xicn` has no `e` (event-mark) parameter, so `CauseSpecificMCF.fit`
+  bypasses it and can't take truncation; no `fit_from_df` for marks.
+- The regression submodule and the nonparametric MCF have **zero tests**.
+- No residual diagnostics; no parametric CI band on `plot()`.
+
+**E. API inconsistencies**
+- `ProportionalIntensityModel.cif(x, Z)` / `time_terminated_simulation(T, Z,
+  ...)` require `Z` at call time vs `ParametricRecurrenceModel.cif(x)`.
+- `HPP` is not an `NHPPFitter`; `how=` only on `NHPPFitter`; `__repr__`
+  hardcodes "Fitted by: MLE"; string dispatch `dist.name == "CoxLewis"`;
+  `@classmethod` on `iif`/`cif` that take `self`.
+
+**F. Resolved since this review began** *(this branch)*
+- Renewal fitters now return a generic `RenewalModel` (fitter/model split
+  matching univariate `Weibull_ → Parametric`); `ARI` folded into the same
+  `RenewalModel` (its "distribution" is an intensity model). **[done]**
+- AIC/BIC/standard errors for the repair models via `LikelihoodInferenceMixin`.
+  **[done]**
+- Left-truncation support for the NHPP family; interval-censoring validation
+  fix in `handle_xicn`; shared `coerce_xcnt_x`/`format_truncation` helpers.
+  **[done]**
+- `kijima_type` validation; `q` bounded `≥ 0`; dead `q = q` removed;
+  `RecurrenceSimulationMixin` de-duplication. **[done]**
+
+---
+
 ### Confirmed bugs
 
 **Typo `has_left_censoing` (missing 'r')**
@@ -31,13 +113,6 @@ The MLE likelihood falls back to the non-log path; for small intensities this ca
 
 **`CoxLewis.inv_cif()` can return negative times**
 When `ln(N) < alpha`, the expression `(ln(N) - alpha) / beta` is negative. No guard or error is raised; simulation silently produces invalid (negative) event times.
-
-**Renewal model restoration factor `q` is unbounded**
-**File:** `surpyval/recurrent/renewal/generalized_renewal.py`
-Multi-start search covers `q ∈ {0.0001, 1.0, 2.0}` but the optimizer is unconstrained, so `q` can go negative, violating the virtual-age assumption. Add a bound `q ≥ 0`.
-
-**Redundant `q = q` assignment**
-**File:** `surpyval/recurrent/renewal/generalized_renewal.py:409` — dead assignment, remove.
 
 ---
 

--- a/surpyval/recurrent/__init__.py
+++ b/surpyval/recurrent/__init__.py
@@ -1,4 +1,9 @@
 from .nonparametric import NonParametricCounting
 from .parametric import ARI, HPP, CoxLewis, Crow, CrowAMSAA, Duane
 from .regression import ProportionalIntensityHPP, ProportionalIntensityNHPP
-from .renewal import ARA, GeneralizedOneRenewal, GeneralizedRenewal
+from .renewal import (
+    ARA,
+    GeneralizedOneRenewal,
+    GeneralizedRenewal,
+    RenewalModel,
+)

--- a/surpyval/recurrent/parametric/ari.py
+++ b/surpyval/recurrent/parametric/ari.py
@@ -1,9 +1,7 @@
 import numpy as np
 from scipy.optimize import brentq, minimize
 
-from surpyval.recurrent.inference import LikelihoodInferenceMixin
 from surpyval.recurrent.parametric.crow import Crow
-from surpyval.recurrent.simulation import RecurrenceSimulationMixin
 from surpyval.univariate.parametric.fitters import bounds_convert
 from surpyval.utils.recurrent_utils import (
     handle_xicn,
@@ -36,7 +34,7 @@ def ari_reduction(failure_intensities, rho, m):
     return rho * np.sum(weights * recent)
 
 
-class ARI(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
+class ARI:
     """
     Arithmetic Reduction of Intensity (ARI) imperfect-repair model of Doyen and
     Gaudoin (2004).
@@ -69,42 +67,6 @@ class ARI(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
     >>> model = ARI.fit(x, i, m=1, dist=Crow)
     """
 
-    _restoration_param_name = "rho"
-
-    def __init__(self, dist, dist_params, rho, m=1):
-        self.dist = dist
-        self.dist_params = np.asarray(dist_params, dtype=float)
-        self.rho = rho
-        self.m = m
-
-    def __repr__(self):
-        out = (
-            "ARI Recurrence SurPyval Model"
-            + "\n============================="
-            + f"\nBaseline Intensity  : {self.dist.name}"
-            + "\nFitted by           : MLE"
-            + f"\nMemory (m)          : {self.m}"
-            + f"\nRepair Efficiency   : {self.rho}"
-        )
-
-        param_string = "\n".join(
-            [
-                "{:>10}".format(name) + ": " + str(p)
-                for p, name in zip(self.dist.param_names, self.dist_params)
-            ]
-        )
-
-        return (
-            out
-            + "\nParameters          :\n"
-            + "{params}".format(params=param_string)
-        )
-
-    @property
-    def parameter_names(self):
-        self._check_fitted()
-        return [self._restoration_param_name, *self.dist.param_names]
-
     @staticmethod
     def _validate_memory(m):
         if m == np.inf:
@@ -114,11 +76,12 @@ class ARI(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
                 "m must be a positive integer or numpy.inf; got {!r}".format(m)
             )
 
-    def _new_sequence_sampler(self):
-        dist = self.dist
-        dp = self.dist_params
-        rho = self.rho
-        m = self.m
+    @staticmethod
+    def _build_sampler(model):
+        dist = model.model.dist
+        dp = model.model.params
+        rho = model.rho
+        m = model.m
         history_iif = []
         running = [0.0]
         reduction = [0.0]
@@ -145,6 +108,23 @@ class ARI(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
             return xi
 
         return sample
+
+    @classmethod
+    def _make_model(cls, baseline_dist, dist_params, rho, m):
+        from surpyval.recurrent.renewal.renewal_model import RenewalModel
+
+        model = baseline_dist.from_params(list(dist_params))
+        out = RenewalModel(
+            model,
+            rho,
+            "rho",
+            "Repair Efficiency",
+            "ARI Recurrence",
+            cls._build_sampler,
+            dist_label="Baseline Intensity",
+        )
+        out.m = m
+        return out
 
     @classmethod
     def create_negll_func(cls, data, dist, m):
@@ -253,7 +233,7 @@ class ARI(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
                 )
 
         rho, *dist_params = inv_trans(res.x)
-        out = cls(dist, dist_params, rho, m)
+        out = cls._make_model(dist, dist_params, rho, m)
         out.res = res
         out.data = data
         out._neg_ll = neg_ll
@@ -319,4 +299,4 @@ class ARI(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
             An ARI object built from the supplied parameters.
         """
         cls._validate_memory(m)
-        return cls(dist, dist_params, rho, m)
+        return cls._make_model(dist, dist_params, rho, m)

--- a/surpyval/recurrent/renewal/__init__.py
+++ b/surpyval/recurrent/renewal/__init__.py
@@ -1,3 +1,4 @@
 from .ara import ARA
 from .generalized_one_renewal import GeneralizedOneRenewal
 from .generalized_renewal import GeneralizedRenewal
+from .renewal_model import RenewalModel

--- a/surpyval/recurrent/renewal/ara.py
+++ b/surpyval/recurrent/renewal/ara.py
@@ -2,8 +2,7 @@ import numpy as np
 from scipy.optimize import minimize
 
 from surpyval import Weibull
-from surpyval.recurrent.inference import LikelihoodInferenceMixin
-from surpyval.recurrent.simulation import RecurrenceSimulationMixin
+from surpyval.recurrent.renewal.renewal_model import RenewalModel
 from surpyval.univariate.parametric.fitters import bounds_convert
 from surpyval.utils.recurrent_utils import (
     handle_xicn,
@@ -52,7 +51,7 @@ def ara_virtual_ages(arrival_times, rho, m):
     return v
 
 
-class ARA(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
+class ARA:
     """
     Arithmetic Reduction of Age (ARA) imperfect-repair model of Doyen and
     Gaudoin (2004).
@@ -80,38 +79,6 @@ class ARA(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
     >>> model = ARA.fit(x, i, c=c, m=2)
     """
 
-    _restoration_param_name = "rho"
-
-    def __init__(self, model, rho, m=1):
-        self.model = model
-        self.rho = rho
-        self.m = m
-
-    def __repr__(self):
-        out = (
-            "ARA Renewal SurPyval Model"
-            + "\n=========================="
-            + f"\nDistribution        : {self.model.dist.name}"
-            + "\nFitted by           : MLE"
-            + f"\nMemory (m)          : {self.m}"
-            + f"\nRepair Efficiency   : {self.rho}"
-        )
-
-        param_string = "\n".join(
-            [
-                "{:>10}".format(name) + ": " + str(p)
-                for p, name in zip(
-                    self.model.params, self.model.dist.param_names
-                )
-            ]
-        )
-
-        return (
-            out
-            + "\nParameters          :\n"
-            + "{params}".format(params=param_string)
-        )
-
     @staticmethod
     def _validate_memory(m):
         if m == np.inf:
@@ -121,9 +88,10 @@ class ARA(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
                 "m must be a positive integer or numpy.inf; got {!r}".format(m)
             )
 
-    def _new_sequence_sampler(self):
-        rho = self.rho
-        m = self.m
+    @staticmethod
+    def _build_sampler(model):
+        rho = model.rho
+        m = model.m
         arrivals = []
         running = 0.0
 
@@ -137,13 +105,26 @@ class ARA(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
                 upper = n if np.isinf(m) else min(int(m), n)
                 j = np.arange(upper)
                 v = T[-1] - rho * np.sum(((1.0 - rho) ** j) * T[n - 1 - j])
-            u_adj = ui * self.model.sf(v)
-            xi = self.model.qf(1 - u_adj) - v
+            u_adj = ui * model.model.sf(v)
+            xi = model.model.qf(1 - u_adj) - v
             running += xi
             arrivals.append(running)
             return xi
 
         return sample
+
+    @classmethod
+    def _make_model(cls, underlying_model, rho, m):
+        out = RenewalModel(
+            underlying_model,
+            rho,
+            "rho",
+            "Repair Efficiency",
+            "ARA Renewal",
+            cls._build_sampler,
+        )
+        out.m = m
+        return out
 
     @classmethod
     def create_negll_func(cls, data, dist, m):
@@ -196,8 +177,8 @@ class ARA(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
         Returns
         -------
 
-        ARA
-            A fitted ARA object.
+        RenewalModel
+            A fitted renewal model.
         """
         cls._validate_memory(m)
         validate_renewal_censoring(data.c, cls.__name__)
@@ -250,7 +231,7 @@ class ARA(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
 
         rho, *dist_params = inv_trans(res.x)
         model = dist.from_params(list(dist_params))
-        out = cls(model, rho, m)
+        out = cls._make_model(model, rho, m)
         out.res = res
         out.data = data
         out._neg_ll = neg_ll
@@ -285,8 +266,8 @@ class ARA(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
         Returns
         -------
 
-        ARA
-            A fitted ARA object.
+        RenewalModel
+            A fitted renewal model.
         """
         data = handle_xicn(x, i, c, n, as_recurrent_data=True)
         return cls.fit_from_recurrent_data(data, dist, m, init=init)
@@ -317,4 +298,4 @@ class ARA(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
         """
         cls._validate_memory(m)
         model = dist.from_params(params)
-        return cls(model, rho, m)
+        return cls._make_model(model, rho, m)

--- a/surpyval/recurrent/renewal/generalized_one_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_one_renewal.py
@@ -2,8 +2,7 @@ import numpy as np
 from scipy.optimize import minimize
 
 from surpyval import Weibull
-from surpyval.recurrent.inference import LikelihoodInferenceMixin
-from surpyval.recurrent.simulation import RecurrenceSimulationMixin
+from surpyval.recurrent.renewal.renewal_model import RenewalModel
 from surpyval.utils.recurrent_utils import (
     handle_xicn,
     reject_left_truncation,
@@ -11,9 +10,7 @@ from surpyval.utils.recurrent_utils import (
 )
 
 
-class GeneralizedOneRenewal(
-    RecurrenceSimulationMixin, LikelihoodInferenceMixin
-):
+class GeneralizedOneRenewal:
     """
     A class to handle the G1 renewal process of Kaminskiy and Krivtsov, in
     which the jth interarrival time is the underlying lifetime distribution
@@ -60,39 +57,10 @@ class GeneralizedOneRenewal(
            8.54474531])
     """
 
-    def __init__(self, model, q):
-        self.model = model
-        self.q = q
-
-    def __repr__(self):
-        out = (
-            "G1 Renewal SurPyval Model"
-            + "\n========================="
-            + f"\nDistribution        : {self.model.dist.name}"
-            + "\nFitted by           : MLE"
-            + f"\nRestoration Factor  : {self.q}"
-        )
-
-        param_string = "\n".join(
-            [
-                "{:>10}".format(name) + ": " + str(p)
-                for p, name in zip(
-                    self.model.params, self.model.dist.param_names
-                )
-            ]
-        )
-
-        out = (
-            out
-            + "\nParameters          :\n"
-            + "{params}".format(params=param_string)
-        )
-
-        return out
-
-    def _new_sequence_sampler(self):
-        base_params = self.model.params
-        q = self.q
+    @staticmethod
+    def _build_sampler(model):
+        base_params = model.model.params
+        q = model.q
         j = 0
 
         def sample(ui):
@@ -102,9 +70,20 @@ class GeneralizedOneRenewal(
             # factor.
             cj = (1.0 + q) ** j
             j += 1
-            return cj * self.model.dist.qf(ui, *base_params)
+            return cj * model.model.dist.qf(ui, *base_params)
 
         return sample
+
+    @classmethod
+    def _make_model(cls, underlying_model, q):
+        return RenewalModel(
+            underlying_model,
+            q,
+            "q",
+            "Restoration Factor",
+            "G1 Renewal",
+            cls._build_sampler,
+        )
 
     @classmethod
     def create_negll_func(cls, x, i, c, n, dist):
@@ -170,8 +149,8 @@ class GeneralizedOneRenewal(
         Returns
         -------
 
-        GeneralizedOneRenewal
-            A fitted GeneralizedOneRenewal object.
+        RenewalModel
+            A fitted renewal model.
 
         Example
         -------
@@ -246,7 +225,7 @@ class GeneralizedOneRenewal(
 
         underlying_model = dist.from_params(list(res.x[1:]))
         q = res.x[0]
-        out = cls(underlying_model, q)
+        out = cls._make_model(underlying_model, q)
         out.res = res
         out.data = data
         out._neg_ll = neg_ll
@@ -278,8 +257,8 @@ class GeneralizedOneRenewal(
         Returns
         -------
 
-        GeneralizedOneRenewal
-            A fitted GeneralizedOneRenewal object.
+        RenewalModel
+            A fitted renewal model.
 
         Example
         -------
@@ -323,8 +302,8 @@ class GeneralizedOneRenewal(
         Returns
         -------
 
-        GeneralizedOneRenewal
-            A fitted GeneralizedOneRenewal object.
+        RenewalModel
+            A fitted renewal model.
 
         Example
         -------
@@ -349,4 +328,4 @@ class GeneralizedOneRenewal(
         """
         cls._check_dist_eligible(dist)
         model = dist.from_params(params)
-        return cls(model, q)
+        return cls._make_model(model, q)

--- a/surpyval/recurrent/renewal/generalized_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_renewal.py
@@ -2,8 +2,7 @@ import numpy as np
 from scipy.optimize import minimize
 
 from surpyval import Weibull
-from surpyval.recurrent.inference import LikelihoodInferenceMixin
-from surpyval.recurrent.simulation import RecurrenceSimulationMixin
+from surpyval.recurrent.renewal.renewal_model import RenewalModel
 from surpyval.univariate.parametric.fitters import bounds_convert
 from surpyval.utils.recurrent_utils import (
     handle_xicn,
@@ -31,7 +30,7 @@ def kijima_ii_from_prev_interarrival(previous_interarrival_times, q):
     )
 
 
-class GeneralizedRenewal(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
+class GeneralizedRenewal:
     """
     A class to handle the generalized renewal process with different Kijima
     models.
@@ -69,48 +68,6 @@ class GeneralizedRenewal(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
     array([0.1214   , 1.1772   , 2.406    , 3.919    , 5.804    , 8.6088822])
     """
 
-    def __init__(self, model, q, kijima_type="i"):
-        self.model = model
-        self.q = q
-        self.kijima_type = kijima_type
-        if kijima_type == "i":
-            self.virtual_age_function = self.kijima_i
-        elif kijima_type == "ii":
-            self.virtual_age_function = self.kijima_ii
-        else:
-            raise ValueError(
-                "Unknown kijima_type {!r}; must be 'i' or 'ii'".format(
-                    kijima_type
-                )
-            )
-
-    def __repr__(self):
-        out = (
-            "Generalized Renewal SurPyval Model"
-            + "\n=================================="
-            + f"\nDistribution        : {self.model.dist.name}"
-            + "\nFitted by           : MLE"
-            + f"\nKijima Type         : {self.kijima_type}"
-            + f"\nRestoration Factor  : {self.q}"
-        )
-
-        param_string = "\n".join(
-            [
-                "{:>10}".format(name) + ": " + str(p)
-                for p, name in zip(
-                    self.model.params, self.model.dist.param_names
-                )
-            ]
-        )
-
-        out = (
-            out
-            + "\nParameters          :\n"
-            + "{params}".format(params=param_string)
-        )
-
-        return out
-
     @classmethod
     def kijima_i(self, v, x, q):
         return v + q * x
@@ -119,18 +76,46 @@ class GeneralizedRenewal(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
     def kijima_ii(self, v, x, q):
         return q * (v + x)
 
-    def _new_sequence_sampler(self):
-        q = self.q
+    @classmethod
+    def _resolve_virtual_age_function(cls, kijima_type):
+        if kijima_type == "i":
+            return cls.kijima_i
+        if kijima_type == "ii":
+            return cls.kijima_ii
+        raise ValueError(
+            "Unknown kijima_type {!r}; must be 'i' or 'ii'".format(kijima_type)
+        )
+
+    @staticmethod
+    def _build_sampler(model):
+        q = model.q
+        virtual_age_function = model._virtual_age_function
         virtual_age = 0.0
 
         def sample(ui):
             nonlocal virtual_age
-            u_adj = ui * self.model.sf(virtual_age)
-            xi = self.model.qf(1 - u_adj) - virtual_age
-            virtual_age = self.virtual_age_function(virtual_age, xi, q)
+            u_adj = ui * model.model.sf(virtual_age)
+            xi = model.model.qf(1 - u_adj) - virtual_age
+            virtual_age = virtual_age_function(virtual_age, xi, q)
             return xi
 
         return sample
+
+    @classmethod
+    def _make_model(cls, underlying_model, q, kijima_type):
+        out = RenewalModel(
+            underlying_model,
+            q,
+            "q",
+            "Restoration Factor",
+            "Generalized Renewal",
+            cls._build_sampler,
+        )
+        out.kijima_type = kijima_type
+        out._virtual_age_function = cls._resolve_virtual_age_function(
+            kijima_type
+        )
+        return out
 
     @classmethod
     def create_negll_func(cls, data, dist, kijima="i"):
@@ -210,8 +195,8 @@ class GeneralizedRenewal(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
         Returns
         -------
 
-        GeneralizedRenewal
-            A fitted GeneralizedRenewal object.
+        RenewalModel
+            A fitted renewal model.
 
         Example
         -------
@@ -306,7 +291,7 @@ class GeneralizedRenewal(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
 
         q, *dist_params = inv_trans(res.x)
         model = dist.from_params(list(dist_params))
-        out = cls(model, q, kijima)
+        out = cls._make_model(model, q, kijima)
         out.res = res
         out.data = data
         out._neg_ll = neg_ll_bounded
@@ -343,8 +328,8 @@ class GeneralizedRenewal(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
         Returns
         -------
 
-        GeneralizedRenewal
-            A fitted GeneralizedRenewal object.
+        RenewalModel
+            A fitted renewal model.
 
         Example
         -------
@@ -392,8 +377,8 @@ class GeneralizedRenewal(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
         Returns
         -------
 
-        GeneralizedRenewal
-            A fitted GeneralizedRenewal object.
+        RenewalModel
+            A fitted renewal model.
 
         Example
         -------
@@ -418,4 +403,4 @@ class GeneralizedRenewal(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
             sigma: 2
         """
         model = dist.from_params(params)
-        return cls(model, q, kijima)
+        return cls._make_model(model, q, kijima)

--- a/surpyval/recurrent/renewal/renewal_model.py
+++ b/surpyval/recurrent/renewal/renewal_model.py
@@ -47,11 +47,13 @@ class RenewalModel(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
         restoration_label,
         kind,
         sampler_factory,
+        dist_label="Distribution",
     ):
         self.model = model
         self.restoration = restoration
         self._restoration_param_name = restoration_name
         self._restoration_label = restoration_label
+        self._dist_label = dist_label
         self.kind = kind
         self._sampler_factory = sampler_factory
         # Expose the restoration parameter under its conventional name
@@ -66,7 +68,7 @@ class RenewalModel(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
         lines = [
             title,
             "=" * len(title),
-            f"Distribution        : {self.model.dist.name}",
+            "{:<20}: {}".format(self._dist_label, self.model.dist.name),
             "Fitted by           : MLE",
         ]
         if getattr(self, "kijima_type", None) is not None:

--- a/surpyval/recurrent/renewal/renewal_model.py
+++ b/surpyval/recurrent/renewal/renewal_model.py
@@ -1,0 +1,84 @@
+from surpyval.recurrent.inference import LikelihoodInferenceMixin
+from surpyval.recurrent.simulation import RecurrenceSimulationMixin
+
+
+class RenewalModel(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
+    """
+    A fitted renewal / imperfect-repair recurrence model.
+
+    This is the model object returned by the renewal-family fitters
+    (``GeneralizedRenewal``, ``GeneralizedOneRenewal``, ``ARA``), in the same
+    way that the intensity fitters (``Crow``, ``Duane``, ...) return a
+    ``ParametricRecurrenceModel``. It holds the fitted underlying lifetime
+    distribution and the restoration parameter, and provides the simulation
+    (``mcf``, ``plot``, ``count_terminated_simulation``,
+    ``time_terminated_simulation``) and likelihood-inference
+    (``log_likelihood``, ``aic``, ``bic``, ``standard_errors``) behaviour via
+    the shared mixins.
+
+    These processes have no closed-form intensity, so the mean cumulative
+    function is obtained by simulation.
+
+    Parameters
+    ----------
+    model : Parametric
+        The fitted underlying lifetime distribution.
+    restoration : float
+        The fitted restoration / repair parameter (``q`` for the generalized
+        and G1 renewal processes, ``rho`` for ARA).
+    restoration_name : str
+        The attribute/label name of the restoration parameter (e.g. ``"q"`` or
+        ``"rho"``); it is also exposed as an attribute of that name.
+    restoration_label : str
+        Human-readable label used in ``__repr__`` (e.g. ``"Restoration
+        Factor"`` or ``"Repair Efficiency"``).
+    kind : str
+        Display name of the process (e.g. ``"Generalized Renewal"``).
+    sampler_factory : callable
+        ``sampler_factory(model) -> sample`` returning a fresh per-sequence
+        sampler ``sample(ui) -> interarrival`` for simulation.
+    """
+
+    def __init__(
+        self,
+        model,
+        restoration,
+        restoration_name,
+        restoration_label,
+        kind,
+        sampler_factory,
+    ):
+        self.model = model
+        self.restoration = restoration
+        self._restoration_param_name = restoration_name
+        self._restoration_label = restoration_label
+        self.kind = kind
+        self._sampler_factory = sampler_factory
+        # Expose the restoration parameter under its conventional name
+        # (``q``/``rho``) so existing usage keeps working.
+        setattr(self, restoration_name, restoration)
+
+    def _new_sequence_sampler(self):
+        return self._sampler_factory(self)
+
+    def __repr__(self):
+        title = f"{self.kind} SurPyval Model"
+        lines = [
+            title,
+            "=" * len(title),
+            f"Distribution        : {self.model.dist.name}",
+            "Fitted by           : MLE",
+        ]
+        if getattr(self, "kijima_type", None) is not None:
+            lines.append(f"Kijima Type         : {self.kijima_type}")
+        if getattr(self, "m", None) is not None:
+            lines.append(f"Memory (m)          : {self.m}")
+        lines.append(
+            "{:<20}: {}".format(self._restoration_label, self.restoration)
+        )
+
+        param_string = "\n".join(
+            "{:>10}".format(name) + ": " + str(p)
+            for p, name in zip(self.model.params, self.model.dist.param_names)
+        )
+        return "\n".join(lines) + "\nParameters          :\n" + param_string

--- a/surpyval/recurrent/simulation.py
+++ b/surpyval/recurrent/simulation.py
@@ -169,6 +169,22 @@ class RecurrenceSimulationMixin:
 
         RecurrentEventData
             The simulated recurrence data in xicn format.
+
+        Notes
+        -----
+
+        Count termination is a failure-terminated (Type II) scheme: each item
+        is observed until its ``events + 1``-th event, so its observation
+        window is the random time of that last event and every event is exact
+        (``c = 0``). Parametric fits handle this correctly -- the
+        interarrival/intensity likelihood ends at the last observed event and
+        the MLE is consistent. The nonparametric MCF, however, is only reliable
+        up to roughly ``events`` recurrences: beyond that the at-risk set is
+        depleted and the curve is biased (which is why
+        :meth:`count_terminated_simulation` trims to ``mcf_hat < events``). For
+        a fixed-window observation scheme, use
+        :meth:`time_terminated_simulation_data`, which right-censors each item
+        at ``T``.
         """
         from surpyval.utils.recurrent_utils import handle_xicn
 

--- a/surpyval/recurrent/simulation.py
+++ b/surpyval/recurrent/simulation.py
@@ -69,6 +69,150 @@ class RecurrenceSimulationMixin:
         """
         return model
 
+    def _simulate_count_xicn(self, events, items, seed):
+        """
+        Simulate ``items`` count-terminated sequences and return the raw event
+        data as an ``xicn`` dict (``events + 1`` exact events per sequence).
+        """
+        self._set_simulation_seed(seed)
+        self.initialize_simulation()
+
+        xicn = {"x": [], "i": [], "c": [], "n": []}
+
+        for i in range(0, items):
+            running = 0
+            sample = self._new_sequence_sampler()
+            for j in range(0, events + 1):
+                ui = self.get_uniform_random_number()
+                running += sample(ui)
+                xicn["x"].append(running)
+                xicn["i"].append(i + 1)
+                xicn["c"].append(0)
+                xicn["n"].append(1)
+
+        self.clear_simulation()
+        return xicn
+
+    def _simulate_time_xicn(self, T, items, tol, max_events, seed):
+        """
+        Simulate ``items`` time-terminated sequences and return the raw event
+        data as an ``xicn`` dict. Each sequence ends in a right-censored (c=1)
+        row at ``T``, or an observed (c=0) row at its last event if it stalls
+        or hits ``max_events``. Warns in the latter cases.
+        """
+        self._set_simulation_seed(seed)
+        self.initialize_simulation()
+        stalled = False
+        hit_max_events = False
+
+        xicn = {"x": [], "i": [], "c": [], "n": []}
+
+        for i in range(0, items):
+            running = 0
+            n_events = 0
+            sample = self._new_sequence_sampler()
+            while True:
+                ui = self.get_uniform_random_number()
+                xi = sample(ui)
+                running += xi
+                n_events += 1
+                xicn["i"].append(i + 1)
+                xicn["n"].append(1)
+                if running > T:
+                    xicn["x"].append(T)
+                    xicn["c"].append(1)
+                    break
+                elif xi < tol:
+                    stalled = True
+                    xicn["x"].append(running)
+                    xicn["c"].append(0)
+                    break
+                elif n_events >= max_events:
+                    hit_max_events = True
+                    xicn["x"].append(running)
+                    xicn["c"].append(0)
+                    break
+                else:
+                    xicn["x"].append(running)
+                    xicn["c"].append(0)
+
+        self.clear_simulation()
+
+        if stalled:
+            warnings.warn(STALLED_WARNING)
+        if hit_max_events:
+            warnings.warn(MAX_EVENTS_WARNING.format(max_events))
+
+        return xicn
+
+    def count_terminated_simulation_data(self, events, items=1, seed=None):
+        """
+        Simulate count-terminated recurrence data and return the raw events.
+
+        Unlike :meth:`count_terminated_simulation` (which returns the fitted
+        ``NonParametricCounting`` MCF), this returns the simulated event data
+        itself, ready to be refitted or inspected via ``.x``/``.i``/``.c``/
+        ``.n``.
+
+        Parameters
+        ----------
+
+        events: int
+            Number of events to simulate per sequence.
+        items: int, optional
+            Number of items (or sequences) to simulate. Default is 1.
+        seed: int or numpy.random.Generator, optional
+            Seed for a reproducible simulation.
+
+        Returns
+        -------
+
+        RecurrentEventData
+            The simulated recurrence data in xicn format.
+        """
+        from surpyval.utils.recurrent_utils import handle_xicn
+
+        xicn = self._simulate_count_xicn(events, items, seed)
+        return handle_xicn(as_recurrent_data=True, **xicn)
+
+    def time_terminated_simulation_data(
+        self, T, items=1, tol=1e-8, max_events=10_000, seed=None
+    ):
+        """
+        Simulate time-terminated recurrence data and return the raw events.
+
+        Unlike :meth:`time_terminated_simulation` (which returns the fitted
+        ``NonParametricCounting`` MCF), this returns the simulated event data
+        itself, ready to be refitted or inspected via ``.x``/``.i``/``.c``/
+        ``.n``. Each sequence is right-censored at ``T``.
+
+        Parameters
+        ----------
+
+        T: float
+            Time termination value.
+        items: int, optional
+            Number of items (or sequences) to simulate. Default is 1.
+        tol: float, optional
+            Interarrival times below this value end the sequence early.
+            Default is 1e-8.
+        max_events: int, optional
+            Hard per-sequence event cap that guarantees termination.
+            Default is 10000.
+        seed: int or numpy.random.Generator, optional
+            Seed for a reproducible simulation.
+
+        Returns
+        -------
+
+        RecurrentEventData
+            The simulated recurrence data in xicn format.
+        """
+        from surpyval.utils.recurrent_utils import handle_xicn
+
+        xicn = self._simulate_time_xicn(T, items, tol, max_events, seed)
+        return handle_xicn(as_recurrent_data=True, **xicn)
+
     def count_terminated_simulation(self, events, items=1, seed=None):
         """
         Simulate count-terminated recurrence data based on the fitted model.
@@ -90,23 +234,7 @@ class RecurrenceSimulationMixin:
         NonParametricCounting
             An NonParametricCounting model built from the simulated data.
         """
-        self._set_simulation_seed(seed)
-        self.initialize_simulation()
-
-        xicn = {"x": [], "i": [], "c": [], "n": []}
-
-        for i in range(0, items):
-            running = 0
-            sample = self._new_sequence_sampler()
-            for j in range(0, events + 1):
-                ui = self.get_uniform_random_number()
-                running += sample(ui)
-                xicn["x"].append(running)
-                xicn["i"].append(i + 1)
-                xicn["c"].append(0)
-                xicn["n"].append(1)
-
-        self.clear_simulation()
+        xicn = self._simulate_count_xicn(events, items, seed)
 
         model = NonParametricCounting.fit(**xicn)
         self._postprocess_simulated_model(model)
@@ -154,48 +282,7 @@ class RecurrenceSimulationMixin:
         an interarrival time falls below ``tol`` or it reaches ``max_events``
         before T. A warning is raised in either case.
         """
-        self._set_simulation_seed(seed)
-        self.initialize_simulation()
-        stalled = False
-        hit_max_events = False
-
-        xicn = {"x": [], "i": [], "c": [], "n": []}
-
-        for i in range(0, items):
-            running = 0
-            n_events = 0
-            sample = self._new_sequence_sampler()
-            while True:
-                ui = self.get_uniform_random_number()
-                xi = sample(ui)
-                running += xi
-                n_events += 1
-                xicn["i"].append(i + 1)
-                xicn["n"].append(1)
-                if running > T:
-                    xicn["x"].append(T)
-                    xicn["c"].append(1)
-                    break
-                elif xi < tol:
-                    stalled = True
-                    xicn["x"].append(running)
-                    xicn["c"].append(0)
-                    break
-                elif n_events >= max_events:
-                    hit_max_events = True
-                    xicn["x"].append(running)
-                    xicn["c"].append(0)
-                    break
-                else:
-                    xicn["x"].append(running)
-                    xicn["c"].append(0)
-
-        self.clear_simulation()
-
-        if stalled:
-            warnings.warn(STALLED_WARNING)
-        if hit_max_events:
-            warnings.warn(MAX_EVENTS_WARNING.format(max_events))
+        xicn = self._simulate_time_xicn(T, items, tol, max_events, seed)
 
         model = NonParametricCounting.fit(**xicn)
         self._postprocess_simulated_model(model)

--- a/surpyval/tests/recurrent/test_counting.py
+++ b/surpyval/tests/recurrent/test_counting.py
@@ -9,6 +9,7 @@ matplotlib.use("Agg")
 from surpyval import Exponential, Gamma, Normal, Weibull  # noqa: E402
 from surpyval.recurrent import HPP  # noqa: E402
 from surpyval.recurrent.renewal import (  # noqa: E402
+    ARA,
     GeneralizedOneRenewal,
     GeneralizedRenewal,
 )
@@ -162,6 +163,56 @@ def test_count_terminated_simulation_via_mixin():
         [0.1696, 1.181, 2.287, 3.6694, 5.58237925, 8.54474531]
     )
     assert np.allclose(np_model.mcf(np.array([1, 2, 3, 4, 5, 6])), expected)
+
+
+def test_count_terminated_simulation_data_is_recurrent_data():
+    # The data simulator returns raw xicn events (RecurrentEventData), not the
+    # aggregated MCF, with events+1 exact events per item.
+    from surpyval.utils.recurrent_event_data import RecurrentEventData
+
+    model = GeneralizedOneRenewal.fit_from_parameters(
+        [5.0, 1.5], q=0.2, dist=Weibull
+    )
+    data = model.count_terminated_simulation_data(8, items=20, seed=0)
+    assert isinstance(data, RecurrentEventData)
+    assert len(data.x) == 20 * (8 + 1)
+    assert len(set(data.i.tolist())) == 20
+    assert set(data.c.tolist()) == {0}
+
+
+def test_simulated_data_round_trips_through_fit():
+    # Simulating from a known model and refitting recovers it in the right
+    # neighbourhood (this is now possible because the simulator yields events).
+    truth = ARA.fit_from_parameters([10.0, 2.0], rho=0.5, m=2, dist=Weibull)
+    data = truth.count_terminated_simulation_data(events=8, items=400, seed=0)
+    refit = ARA.fit(data.x, data.i, c=data.c, m=2)
+    assert 0.0 < refit.rho < 1.0
+    assert np.all(refit.model.params > 0)
+
+
+def test_time_terminated_simulation_data_is_censored_at_T():
+    from surpyval.utils.recurrent_event_data import RecurrentEventData
+
+    model = GeneralizedOneRenewal.fit_from_parameters(
+        [5.0, 1.5], q=0.2, dist=Weibull
+    )
+    data = model.time_terminated_simulation_data(T=60, items=20, seed=2)
+    assert isinstance(data, RecurrentEventData)
+    # Each reaching sequence ends in a right-censored row at T.
+    assert (data.c == 1).any()
+    assert data.x[data.c == 1].max() <= 60.0 + 1e-9
+
+
+def test_parametric_recurrence_model_has_data_simulators():
+    # The data simulators come from the shared mixin, so the intensity models
+    # (HPP, Crow, ...) get them too.
+    from surpyval.utils.recurrent_event_data import RecurrentEventData
+
+    x = Exponential.random(20, 1.0).cumsum()
+    hpp = HPP.fit(x)
+    data = hpp.count_terminated_simulation_data(10, items=15, seed=0)
+    assert isinstance(data, RecurrentEventData)
+    assert len(data.x) == 15 * (10 + 1)
 
 
 def test_time_terminated_tol_stops_decaying_sequence():


### PR DESCRIPTION
Continues the recurrent-module work after #84 (merged). #84 carried only the handler dedup; these are the commits pushed to the branch afterward.

## Fitter/model split — `RenewalModel`
The renewal fitters previously returned an instance of themselves (fitter and model conflated). They now return a generic **`RenewalModel`**, matching the univariate `Weibull_ → Parametric` pattern and the recurrent `Crow_ → ParametricRecurrenceModel` one. `GeneralizedRenewal`, `GeneralizedOneRenewal` and `ARA` become pure fitters; `RenewalModel` (simulation + inference mixins) holds the fitted distribution, restoration parameter and sampler. Public attributes (`.q`/`.rho`/`.m`/`.kijima_type`/`.model`) and the repr are preserved, so only the return *type* changes.

## ARI folded into `RenewalModel`
ARI is a repair model whose underlying "distribution" is an intensity model (`iif`/`cif`) rather than a lifetime distribution (`sf`/`qf`) — `RenewalModel` is agnostic to that (the sampler captures the difference), so ARI now returns a `RenewalModel` too. The recurrent module now has exactly two model classes: `RenewalModel` (repair models, MCF by simulation) and `ParametricRecurrenceModel` (closed-form-CIF intensity models).

## Raw-`xicn` data simulators
`count_terminated_simulation_data` / `time_terminated_simulation_data` on the shared mixin return the raw simulated events as `RecurrentEventData` (not the aggregated MCF), so simulated data can be refit or inspected. Every recurrence model gets them. The simulation loops are factored into shared helpers, so the existing model-returning simulators are behaviour-preserving. Documents the Type-II truncation caveat on the count-terminated variant.

## Docs
`DEVELOPMENT.md` gains a dated full-package recurrent audit (A–F), with resolved items marked.

Full test suite: 573 passed, 1 skipped.

https://claude.ai/code/session_016iTenPQBeictHbgBzwpyoi

---
_Generated by [Claude Code](https://claude.ai/code/session_016iTenPQBeictHbgBzwpyoi)_