### PR TITLE
Fix Cox-Lewis CIF/IIF mix-up and add MCF plot start point

### DIFF
--- a/surpyval/recurrent/nonparametric/mcf.py
+++ b/surpyval/recurrent/nonparametric/mcf.py
@@ -81,18 +81,30 @@ class NonParametricCounting:
             mcf_cb[np.where(x > self.x.max())] = np.nan
         return mcf_cb
 
-    def plot(self, confidence=0.95, plot_bounds=True, ax=None):
+    def plot(self, confidence=0.95, plot_bounds=True, ax=None, start=0.0):
         if ax is None:
             ax = plt.gcf().gca()
 
-        ax.step(self.x, self.mcf_hat, where="post", label="MCF")
+        # Prepend the start point so the step plot always begins from it
+        # (the MCF is 0 before the first observed event).
+        if start is not None and start < self.x.min():
+            x = np.hstack([[start], self.x])
+            mcf_hat = np.hstack([[0.0], self.mcf_hat])
+        else:
+            x = self.x
+            mcf_hat = self.mcf_hat
+
+        ax.step(x, mcf_hat, where="post", label="MCF")
         if plot_bounds:
             if self.var is not None:
+                cb = self.mcf_cb(
+                    self.x, bound="two-sided", confidence=confidence
+                )
+                if start is not None and start < self.x.min():
+                    cb = np.vstack([[0.0, 0.0], cb])
                 ax.step(
-                    self.x,
-                    self.mcf_cb(
-                        self.x, bound="two-sided", confidence=confidence
-                    ),
+                    x,
+                    cb,
                     where="post",
                     label=f"{confidence * 100}% Confidence Bounds",
                     color="red",

--- a/surpyval/recurrent/parametric/cox_lewis.py
+++ b/surpyval/recurrent/parametric/cox_lewis.py
@@ -24,19 +24,19 @@ class CoxLewis_(NHPPFitter):
     Process             : Cox-Lewis
     Fitted by           : MLE
     Parameters          :
-        alpha: 0.7177727527489457
-        beta: 0.08828975097259131
+        alpha: 0.3848528712360503
+        beta: 0.1939447728437042
     >>> model.cif([1, 2, 3, 4, 5, 6])
-    array([2.23907426, 2.44575105, 2.67150506, 2.91809719, 3.1874509 ,
-           3.4816672 ])
+    array([ 1.6215655 ,  3.59019342,  5.98016527,  8.88166096, 12.40416155,
+           16.68058024])
     >>>
     >>> model.iif([1, 2, 3, 4, 5, 6])
-    array([0.19768731, 0.21593475, 0.23586652, 0.25763807, 0.28141925,
-           0.30739553])
+    array([1.78389227, 2.16569736, 2.62921991, 3.19194983, 3.87512041,
+           4.70450946])
     >>>
     >>> model.inv_cif([1, 2, 3, 4, 5, 6])
-    array([-8.12974037, -0.27891768,  4.3135192 ,  7.57190502, 10.09930541,
-           12.16434189])
+    array([0.63923607, 1.20789182, 1.72001505, 2.18583659, 2.61303902,
+           3.00753845])
     """
 
     def __init__(self):
@@ -52,13 +52,17 @@ class CoxLewis_(NHPPFitter):
         """
         Cumulative intensity function (CIF) of the Cox-Lewis model.
 
+        This is the integral of the instantaneous intensity from 0 to ``x``,
+        i.e. the expected number of events by ``x``. It satisfies
+        ``cif(0) == 0``.
+
         Parameters
         ----------
 
         x : float
             The value at which CIF is evaluated.
         params : tuple
-            Parameters of the Duane model.
+            Parameters of the Cox-Lewis model.
 
         Returns
         -------
@@ -68,11 +72,12 @@ class CoxLewis_(NHPPFitter):
         """
         alpha = params[0]
         beta = params[1]
-        return np.exp(alpha + beta * x)
+        return np.exp(alpha) / beta * (np.exp(beta * x) - 1.0)
 
     def iif(self, x, *params):
         """
         Instantaneous intensity function (IIF) or the failure rate of the
+        Cox-Lewis model. This is the log-linear intensity that defines the
         Cox-Lewis model.
 
         Parameters
@@ -81,7 +86,7 @@ class CoxLewis_(NHPPFitter):
         x : float
             The value at which IIF is evaluated.
         params : tuple
-            Parameters of the Duane model.
+            Parameters of the Cox-Lewis model.
 
         Returns
         -------
@@ -91,7 +96,7 @@ class CoxLewis_(NHPPFitter):
         """
         alpha = params[0]
         beta = params[1]
-        return beta * np.exp(alpha + beta * x)
+        return np.exp(alpha + beta * x)
 
     def log_iif(self, x, *params):
         """
@@ -104,7 +109,7 @@ class CoxLewis_(NHPPFitter):
         x : float
             The value at which log(IIF) is evaluated.
         params : tuple
-            Parameters of the Duane model.
+            Parameters of the Cox-Lewis model.
 
         Returns
         -------
@@ -114,7 +119,7 @@ class CoxLewis_(NHPPFitter):
         """
         alpha = params[0]
         beta = params[1]
-        return np.log(beta) + alpha + beta * x
+        return alpha + beta * x
 
     def inv_cif(self, N, *params):
         """
@@ -127,7 +132,7 @@ class CoxLewis_(NHPPFitter):
         N : float
             The number of events expected to have occured.
         params : tuple
-            Parameters of the Duane model.
+            Parameters of the Cox-Lewis model.
 
         Returns
         -------
@@ -137,7 +142,7 @@ class CoxLewis_(NHPPFitter):
         """
         alpha = params[0]
         beta = params[1]
-        return (np.log(N) - alpha) / beta
+        return np.log(1.0 + N * beta * np.exp(-alpha)) / beta
 
 
 CoxLewis = CoxLewis_()

--- a/surpyval/tests/recurrent/test_cox_lewis.py
+++ b/surpyval/tests/recurrent/test_cox_lewis.py
@@ -1,0 +1,57 @@
+import numpy as np
+import pytest
+from scipy.integrate import quad
+
+from surpyval.recurrent import CoxLewis
+
+
+@pytest.mark.parametrize(
+    "alpha,beta", [(0.5, 0.2), (-1.0, 0.5), (1.0, -0.1), (0.0, 1.0)]
+)
+def test_cif_is_integral_of_iif(alpha, beta):
+    # The cumulative intensity must be the integral of the instantaneous
+    # intensity from 0 to x, i.e. cif(x) == \int_0^x iif(s) ds.
+    for x in [0.5, 1.0, 3.0, 7.0]:
+        expected, _ = quad(lambda s: CoxLewis.iif(s, alpha, beta), 0.0, x)
+        assert np.isclose(CoxLewis.cif(x, alpha, beta), expected)
+
+
+@pytest.mark.parametrize("alpha,beta", [(0.5, 0.2), (-1.0, 0.5), (0.0, 1.0)])
+def test_cif_is_zero_at_origin(alpha, beta):
+    # A cumulative intensity (expected count) must start at zero.
+    assert np.isclose(CoxLewis.cif(0.0, alpha, beta), 0.0)
+
+
+@pytest.mark.parametrize("alpha,beta", [(0.5, 0.2), (-1.0, 0.5), (0.0, 1.0)])
+def test_iif_is_log_linear_intensity(alpha, beta):
+    # The Cox-Lewis model is defined by a log-linear intensity.
+    x = np.array([0.0, 1.0, 2.5, 5.0])
+    assert np.allclose(CoxLewis.iif(x, alpha, beta), np.exp(alpha + beta * x))
+    assert np.allclose(CoxLewis.log_iif(x, alpha, beta), alpha + beta * x)
+
+
+@pytest.mark.parametrize("alpha,beta", [(0.5, 0.2), (-1.0, 0.5), (0.0, 1.0)])
+def test_inv_cif_inverts_cif(alpha, beta):
+    N = np.array([0.5, 1.0, 4.0, 10.0])
+    x = CoxLewis.inv_cif(N, alpha, beta)
+    assert np.allclose(CoxLewis.cif(x, alpha, beta), N)
+
+
+def test_fit_recovers_log_linear_intensity():
+    # Events simulated from a known log-linear intensity should recover the
+    # generating parameters (alpha, beta) via the intensity, not an offset
+    # reparameterisation.
+    rng = np.random.default_rng(0)
+    alpha, beta = 0.0, 0.3
+    # Thinning on [0, T]: homogeneous candidates at the max rate, kept w.p.
+    # iif(t)/iif(T).
+    T = 20.0
+    lam_max = np.exp(alpha + beta * T)
+    n_cand = rng.poisson(lam_max * T)
+    cand = np.sort(rng.uniform(0, T, n_cand))
+    keep = rng.uniform(0, 1, n_cand) < np.exp(alpha + beta * cand) / lam_max
+    events = cand[keep]
+
+    model = CoxLewis.fit(events, tl=0.0, tr=T)
+    assert np.isclose(model.params[0], alpha, atol=0.5)
+    assert np.isclose(model.params[1], beta, atol=0.1)


### PR DESCRIPTION
The Cox-Lewis model had its intensity functions swapped. The log-linear
expression exp(alpha + beta*x) that defines the model is the instantaneous
intensity (IIF), but it was assigned to cif(), while iif() returned its
derivative beta*exp(...). This also left cif(0) = exp(alpha) != 0, biasing
the MSE objective and the left/interval-censored likelihood terms.

Corrected so that:
- iif(x)     = exp(alpha + beta*x)            (log-linear intensity)
- log_iif(x) = alpha + beta*x
- cif(x)     = (exp(alpha)/beta)*(exp(beta*x) - 1)   (integral, cif(0)=0)
- inv_cif(N) = log(1 + N*beta*exp(-alpha)) / beta

Added tests asserting cif is the integral of iif, cif(0)=0, the log-linear
intensity, inv_cif inverts cif, and that fitting recovers the generating
parameters.

Also added an optional `start` argument (default 0.0) to the nonparametric
MCF plot so the step curve always begins from that point, since the MCF is
zero before the first observed event.