### PR TITLE
Add CountingProcess base class for proportional intensity type check

### DIFF
--- a/surpyval/recurrent/__init__.py
+++ b/surpyval/recurrent/__init__.py
@@ -1,5 +1,5 @@
 from .nonparametric import NonParametricCounting
-from .parametric import HPP, CoxLewis, CrowAMSAA, Duane
+from .parametric import HPP, CountingProcess, CoxLewis, CrowAMSAA, Duane
 from .regression import ProportionalIntensityHPP, ProportionalIntensityNHPP
 from .renewal import (
     ARA,

--- a/surpyval/recurrent/parametric/__init__.py
+++ b/surpyval/recurrent/parametric/__init__.py
@@ -1,3 +1,4 @@
+from .counting_process import CountingProcess
 from .cox_lewis import CoxLewis
 from .crow_amsaa import CrowAMSAA
 from .duane import Duane

--- a/surpyval/recurrent/parametric/counting_process.py
+++ b/surpyval/recurrent/parametric/counting_process.py
@@ -1,0 +1,40 @@
+from abc import ABC, abstractmethod
+
+from numpy.typing import ArrayLike
+
+
+class CountingProcess(ABC):
+    """
+    Abstract base class for parametric counting-process intensity models.
+
+    A counting process ``N(t)`` counts the number of events observed up to
+    time ``t``. Every parametric counting process in surpyval is described
+    by functions of time and its parameters:
+
+    - ``iif`` the instantaneous intensity function (the rate of events),
+    - ``cif`` the cumulative intensity function (the expected number of
+      events by ``t``, i.e. the integral of ``iif`` from the origin), and
+    - ``log_iif`` the natural logarithm of the instantaneous intensity,
+      used directly in the log-likelihood.
+
+    Concrete subclasses also expose a ``param_names`` attribute listing the
+    names of the model's parameters. This shared base lets fitters such as
+    :class:`ProportionalIntensityNHPP` verify, with a simple ``isinstance``
+    check, that the intensity model handed to them really is a counting
+    process.
+    """
+
+    @abstractmethod
+    def iif(self, x: ArrayLike, *params) -> ArrayLike:
+        """Instantaneous intensity function (event rate) at ``x``."""
+        ...
+
+    @abstractmethod
+    def cif(self, x: ArrayLike, *params) -> ArrayLike:
+        """Cumulative intensity (expected event count) by ``x``."""
+        ...
+
+    @abstractmethod
+    def log_iif(self, x: ArrayLike, *params) -> ArrayLike:
+        """Natural logarithm of the instantaneous intensity at ``x``."""
+        ...

--- a/surpyval/recurrent/parametric/hpp.py
+++ b/surpyval/recurrent/parametric/hpp.py
@@ -4,13 +4,14 @@ from autograd import numpy as anp
 from scipy.optimize import root
 from scipy.special import gammaln
 
+from surpyval.recurrent.parametric.counting_process import CountingProcess
 from surpyval.recurrent.parametric.parametric_recurrence import (
     ParametricRecurrenceModel,
 )
 from surpyval.utils.recurrent_utils import handle_xicn
 
 
-class HPP:
+class HPP(CountingProcess):
     """
     Represents the Homogeneous Poisson Process (HPP) model.
     This class includes methods to evaluate various statistical functions of

--- a/surpyval/recurrent/parametric/nhpp_fitter.py
+++ b/surpyval/recurrent/parametric/nhpp_fitter.py
@@ -2,13 +2,14 @@ from autograd import numpy as np
 from scipy.optimize import minimize
 from scipy.special import gammaln
 
+from surpyval.recurrent.parametric.counting_process import CountingProcess
 from surpyval.recurrent.parametric.parametric_recurrence import (
     ParametricRecurrenceModel,
 )
 from surpyval.utils.recurrent_utils import handle_xicn
 
 
-class NHPPFitter:
+class NHPPFitter(CountingProcess):
     def create_negll_func(self, data):
         x, c, n = data.x, data.c, data.n
         x_prev = data.get_previous_x()

--- a/surpyval/recurrent/regression/nhpp_proportional_intensity.py
+++ b/surpyval/recurrent/regression/nhpp_proportional_intensity.py
@@ -3,6 +3,7 @@ from scipy.optimize import minimize
 from scipy.special import gammaln
 
 from surpyval.recurrent.parametric import Duane
+from surpyval.recurrent.parametric.counting_process import CountingProcess
 from surpyval.utils.recurrent_utils import handle_xicn
 
 from .proportional_intensity import ProportionalIntensityModel
@@ -171,6 +172,11 @@ class ProportionalIntensityNHPP:
 
     @classmethod
     def fit_from_recurrent_data(cls, data, dist, init=None):
+        if not isinstance(dist, CountingProcess):
+            raise TypeError(
+                "`dist` must be a CountingProcess instance "
+                "(e.g. Duane, CrowAMSAA, CoxLewis); got {!r}".format(dist)
+            )
         out = ProportionalIntensityModel()
         out.dist = dist
         out.data = data

--- a/surpyval/tests/recurrent/test_counting_process.py
+++ b/surpyval/tests/recurrent/test_counting_process.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pytest
+
+from surpyval.recurrent import (
+    HPP,
+    CountingProcess,
+    CoxLewis,
+    CrowAMSAA,
+    Duane,
+    ProportionalIntensityNHPP,
+)
+from surpyval.recurrent.parametric import CountingProcess as ParametricCP
+from surpyval.utils.recurrent_utils import handle_xicn
+
+
+def test_countingprocess_exported_consistently():
+    # The same class should be reachable from both export points.
+    assert CountingProcess is ParametricCP
+
+
+@pytest.mark.parametrize("dist", [Duane, CrowAMSAA, CoxLewis])
+def test_nhpp_intensity_models_are_counting_processes(dist):
+    assert isinstance(dist, CountingProcess)
+
+
+def test_hpp_is_a_counting_process():
+    assert isinstance(HPP(), CountingProcess)
+
+
+def test_counting_process_cannot_be_instantiated():
+    # It is abstract: the intensity functions must be supplied by subclasses.
+    with pytest.raises(TypeError):
+        CountingProcess()
+
+
+def _toy_recurrent_data():
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    Z = np.array([[0.0], [1.0], [0.0], [1.0], [0.0]])
+    return handle_xicn(x, Z=Z, as_recurrent_data=True)
+
+
+@pytest.mark.parametrize("bad_dist", [object(), "Duane", Duane.__class__, 42])
+def test_proportional_intensity_rejects_non_counting_process(bad_dist):
+    data = _toy_recurrent_data()
+    with pytest.raises(TypeError):
+        ProportionalIntensityNHPP.fit_from_recurrent_data(data, dist=bad_dist)
+
+
+def test_proportional_intensity_accepts_counting_process():
+    # A genuine counting process must pass the type guard. The guard runs
+    # before any optimisation, so it is enough to confirm that no TypeError
+    # about ``dist`` is raised (any downstream numerical error is unrelated).
+    data = _toy_recurrent_data()
+    try:
+        ProportionalIntensityNHPP.fit_from_recurrent_data(data, dist=Duane)
+    except TypeError as e:  # pragma: no cover - guard must not trigger
+        pytest.fail("valid CountingProcess was rejected: {}".format(e))
+    except Exception:
+        pass


### PR DESCRIPTION
Introduce an abstract CountingProcess base class declaring the
counting-process intensity contract (iif, cif, log_iif). NHPPFitter
(Duane, CrowAMSAA, CoxLewis) and HPP now inherit from it, so
ProportionalIntensityNHPP can validate its dist argument with an
isinstance check and raise a clear TypeError on an invalid model.

https://claude.ai/code/session_01RzpUK3u4opkKriQ1RCvdJb