### PR TITLE
Fix Turnbull heuristic downgrade in parametric fitter

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -174,16 +174,24 @@ Only one test file with one test covers the entire recurrent module (`tests/recu
 
 ## 5. Code Quality
 
-### Turnbull heuristic downgrade never takes effect
-**File:** `surpyval/univariate/parametric/parametric_fitter.py` (`_validate_fit_inputs`, ~line 344)
+### Turnbull heuristic downgrade never takes effect — FIXED
+**File:** `surpyval/univariate/parametric/parametric_fitter.py` (`_validate_fit_inputs`)
 
 The block that swaps the memory-hungry Turnbull heuristic for the
 plain estimator when there is no left/interval censoring or
-right-truncation assigns to a local variable and returns `True`, so the
-caller never sees the downgrade — the optimization has never applied.
-Fix by returning the adjusted heuristic and using it in
-`fit_from_surpyval_data`. Results should be equivalent, but plotting
-points and performance change, so verify against a Turnbull fixture.
+right-truncation assigned to a local variable and returned `True`, so the
+caller never saw the downgrade — the optimization had never applied.
+`_validate_fit_inputs` now returns the (possibly adjusted) heuristic and
+`fit_from_surpyval_data` captures it. Verified equivalent against a
+Turnbull fixture (right-censored-only data fits identically to the
+Fleming-Harrington downgrade).
+
+Activating the path also exposed a latent bug in the guard itself: the
+"no right-truncation" check used `(~np.isfinite(tr)).any()` (true when
+*any* point is untruncated), which wrongly downgraded partially
+right-truncated data and then crashed in `plotting_positions` because the
+truncated points still require Turnbull. Changed to `.all()` so the
+downgrade only fires when every observation is untruncated.
 
 ### Structural refactors in the univariate parametric module
 Deferred from the June 2026 clean-up (sections 1–5 of that review are

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -174,25 +174,6 @@ Only one test file with one test covers the entire recurrent module (`tests/recu
 
 ## 5. Code Quality
 
-### Turnbull heuristic downgrade never takes effect — FIXED
-**File:** `surpyval/univariate/parametric/parametric_fitter.py` (`_validate_fit_inputs`)
-
-The block that swaps the memory-hungry Turnbull heuristic for the
-plain estimator when there is no left/interval censoring or
-right-truncation assigned to a local variable and returned `True`, so the
-caller never saw the downgrade — the optimization had never applied.
-`_validate_fit_inputs` now returns the (possibly adjusted) heuristic and
-`fit_from_surpyval_data` captures it. Verified equivalent against a
-Turnbull fixture (right-censored-only data fits identically to the
-Fleming-Harrington downgrade).
-
-Activating the path also exposed a latent bug in the guard itself: the
-"no right-truncation" check used `(~np.isfinite(tr)).any()` (true when
-*any* point is untruncated), which wrongly downgraded partially
-right-truncated data and then crashed in `plotting_positions` because the
-truncated points still require Turnbull. Changed to `.all()` so the
-downgrade only fires when every observation is untruncated.
-
 ### Structural refactors in the univariate parametric module
 Deferred from the June 2026 clean-up (sections 1–5 of that review are
 done):

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -380,7 +380,7 @@ class ParametricFitter:
         if (
             (heuristic == "Turnbull")
             and (not ((-1 in surv_data.c) or (2 in surv_data.c)))
-            and ((~np.isfinite(surv_data.tr)).any())
+            and ((~np.isfinite(surv_data.tr)).all())
         ):
             # The Turnbull method is extremely memory intensive.
             # So if no left or interval censoring and no right-truncation
@@ -434,7 +434,7 @@ class ParametricFitter:
             raise ValueError("Right truncated value can only be single number \
                               when using MPS")
 
-        return True
+        return heuristic
 
     def fit(
         self,
@@ -820,7 +820,7 @@ class ParametricFitter:
             tr = np.where(tr > self.support[1], self.support[1], tr)
 
         # Validate inputs
-        self._validate_fit_inputs(
+        heuristic = self._validate_fit_inputs(
             surv_data,
             how,
             offset,


### PR DESCRIPTION
_validate_fit_inputs computed the swap from the memory-hungry Turnbull
heuristic to the plain estimator (when there is no left/interval
censoring or right-truncation) on a local variable and returned True, so
the caller never saw the downgrade and it never applied. Return the
adjusted heuristic and capture it in fit_from_surpyval_data.

Also fix the guard's right-truncation test: it used .any() (true when
any point is untruncated), which downgraded partially right-truncated
data and then crashed in plotting_positions. Use .all() so the downgrade
only fires when every observation is untruncated.