### PR TITLE
Remove dead MixtureModel.R_cb and tidy attribute hygiene

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -174,18 +174,6 @@ Only one test file with one test covers the entire recurrent module (`tests/recu
 
 ## 5. Code Quality
 
-### Structural refactors in the univariate parametric module
-Deferred from the June 2026 clean-up (sections 1–5 of that review are
-done):
-
-- `MixtureModel` composes rather than inherits: it now shares the
-  probability-plot code but still reimplements `sf/ff/df/mean/random`
-  aggregation and its own `R_cb`, and sets most attributes outside
-  `__init__`. Its `R_cb` is unreachable: it reads `self.res` and
-  `self.hess_inv`, which `_em()` never sets, so it raises
-  `AttributeError` on any fitted model. Either compute a Hessian after
-  EM or remove the method.
-
 ### Type hints are vestigial
 The package ships `py.typed`, but only `ParametricFitter.__init__` is
 annotated. Either grow annotations outward (fitter signatures and

--- a/surpyval/tests/univariate/parametric/test_mixture_model.py
+++ b/surpyval/tests/univariate/parametric/test_mixture_model.py
@@ -1,0 +1,73 @@
+"""
+Tests for the ``MixtureModel`` fitter.
+"""
+
+import numpy as np
+import pytest
+
+import surpyval as sp
+
+
+def _fitted_model(m=2, seed=0):
+    np.random.seed(seed)
+    x = np.concatenate(
+        [sp.Weibull.random(100, 10, 3), sp.Weibull.random(100, 50, 4)]
+    )
+    mm = sp.MixtureModel(dist=sp.Weibull, m=m)
+    mm.fit(x=x)
+    return mm
+
+
+def test_unfitted_attributes_are_none():
+    mm = sp.MixtureModel(dist=sp.Weibull, m=2)
+    assert mm.params is None
+    assert mm.w is None
+    assert mm.data is None
+    assert repr(mm) == "Unable to fit values"
+
+
+def test_fit_populates_params_and_weights():
+    mm = _fitted_model()
+    assert mm.params is not None
+    assert mm.params.shape == (2, sp.Weibull.k)
+    # Weights are a valid probability vector.
+    assert np.isclose(mm.w.sum(), 1.0)
+    assert np.all(mm.w >= 0)
+
+
+def test_distribution_functions_are_consistent():
+    mm = _fitted_model()
+    grid = np.array([1.0, 5.0, 10.0, 25.0, 50.0])
+    # sf and ff are complements.
+    assert np.allclose(mm.sf(grid), 1 - mm.ff(grid))
+    # ff is a valid CDF: non-decreasing and within [0, 1].
+    ff = mm.ff(grid)
+    assert np.all(np.diff(ff) >= 0)
+    assert np.all(ff >= 0) and np.all(ff <= 1)
+    # df is non-negative.
+    assert np.all(mm.df(grid) >= 0)
+
+
+def test_random_returns_requested_size_for_m_gt_2():
+    # Regression test for the slice-accumulation bug in random(): for
+    # m > 2 the per-component samples must be laid down contiguously
+    # without overwriting earlier components.
+    mm = _fitted_model(m=3)
+    rvs = mm.random(500)
+    assert rvs.shape == (500,)
+    # All draws should be populated (Weibull draws are strictly positive),
+    # i.e. no slot was left as the initial zero from an overwritten slice.
+    assert np.all(rvs > 0)
+
+
+def test_r_cb_is_removed():
+    # R_cb was dead code that raised AttributeError on every fitted model;
+    # it has been removed rather than silently shipped.
+    mm = _fitted_model()
+    assert not hasattr(mm, "R_cb")
+
+
+def test_too_few_data_points_raises():
+    mm = sp.MixtureModel(dist=sp.Weibull, m=2)
+    with pytest.raises(ValueError):
+        mm.fit(x=[1.0, 2.0])

--- a/surpyval/univariate/parametric/mixture_model.py
+++ b/surpyval/univariate/parametric/mixture_model.py
@@ -1,9 +1,7 @@
 import warnings
 
-from autograd import jacobian
 from matplotlib import pyplot as plt
 from scipy.optimize import minimize
-from scipy.special import ndtri as z
 
 from surpyval import Distribution, np
 from surpyval.utils.surpyval_data import SurpyvalData
@@ -41,9 +39,14 @@ class MixtureModel(Distribution):
     def __init__(self, dist, m=2):
         self.m = m
         self.dist = dist
+        self.data = None
+        self.params = None
+        self.w = None
+        self.p = None
+        self.loglike = None
 
     def __repr__(self):
-        if hasattr(self, "params"):
+        if self.params is not None:
             param_string = "\n".join(
                 [
                     f"{name:>10}: {p}"
@@ -223,25 +226,6 @@ class MixtureModel(Distribution):
 
         self._em()
 
-    def R_cb(self, t, cb=0.05):
-        def ssf(params):
-            params = np.reshape(params, (self.m, self.dist.k + 1))
-            F = np.zeros_like(t)
-            for i in range(self.m):
-                F = F + params[i, 0] * self.dist.ff(t, *params[i, 1::])
-            return 1 - F
-
-        with np.errstate(all="ignore"):
-            jac = np.atleast_2d(jacobian(ssf)(self.res.x))
-
-        # First-order delta method: Var(R) = J Sigma J^T
-        var_u = np.einsum("ij,jk,ik->i", jac, self.hess_inv, jac)
-        diff = z(cb / 2) * np.sqrt(var_u) * np.array([1.0, -1.0]).reshape(2, 1)
-        R_hat = self.sf(t)
-        exponent = diff / (R_hat * (1 - R_hat))
-        R_cb = R_hat / (R_hat + (1 - R_hat) * np.exp(exponent))
-        return R_cb.T
-
     def mean(self):
         mean = 0
         for i in range(self.m):
@@ -254,7 +238,7 @@ class MixtureModel(Distribution):
         s_last = 0
         for i, s in enumerate(sizes):
             rvs[s_last : s + s_last] = self.dist.random(s, *self.params[i, :])
-            s_last = s
+            s_last += s
         # Shuffles the data (inplace) so that the data is random
         np.random.shuffle(rvs)
         return rvs
@@ -385,7 +369,7 @@ class MixtureModel(Distribution):
         if ax is None:
             ax = plt.gcf().gca()
 
-        if not hasattr(self, "params"):
+        if self.params is None:
             raise ValueError("Can't plot model that failed to fit")
 
         heuristic = adjust_heuristic(self.data.c, self.data.t, heuristic)


### PR DESCRIPTION
R_cb read self.res/self.hess_inv, which the EM fit path never sets, so
it raised AttributeError on every fitted model. Remove it (and the now
unused autograd/ndtri imports) rather than ship a broken bound.

Also initialise data/params/w/p/loglike in __init__ so an unfitted
instance is well-defined (replacing hasattr checks with is-not-None),
and fix the random() slice accumulation so component samples are laid
down contiguously for m > 2. Add mixture-model tests and drop the
resolved item from DEVELOPMENT.md section 5.