### PR TITLE
Add type hints to univariate parametric public API

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,6 +14,47 @@ This document tracks known issues, technical debt, and improvement priorities fo
 
 ---
 
+## 1. Type Hints — Finish the Package
+
+The package ships `py.typed` and `mypy` runs in CI, so the typing
+contract is live and must be honoured across the whole package, not
+just the parts done so far.
+
+**Done (public APIs, all mypy-clean, no new errors over baseline):**
+- Univariate **parametric**: `ParametricFitter.fit`/`fit_from_df`/
+  `fit_from_surpyval_data`/`fit_from_ecdf` and the `Parametric` model
+  (sf/ff/df/hf/Hf/qf/cs/random/mean/var/moment/entropy/cb/param_cb,
+  the AIC/BIC family, serialization, plotting).
+- Univariate **nonparametric**: `NonParametricFitter.fit`/`from_xrd`
+  and the `NonParametric` model methods, plus the `FIT_FUNCS`/
+  `VAR_FUNCS` dispatch dicts.
+- Univariate **regression**: `fit`/`fit_from_df` on the AFT/PH/PO/
+  parameter-substitution fitters and `CoxPH`, the `DataFrameRegression
+  Mixin`, and the `ParametricRegressionModel`/`SemiParametricRegression
+  Model` prediction methods.
+- Top-level helpers: `fit_best`, `handle_xicn` (and the recurrent
+  validators), `SurpyvalData`, `RecurrentEventData`.
+
+**Still to do (in suggested order):**
+- Public APIs of the remaining modules: univariate **competing risks**
+  (Fine-Gray, cause-specific PH), the **recurrent** package
+  (parametric intensity, renewal, regression, nonparametric MCF,
+  competing risks), and the **experimental** forest.
+- A second pass to annotate the *internal* helpers in every module
+  (the `_cb_*` confidence-bound helpers, the `mle`/`mpp`/`mps`/`mse`/
+  `mom` fitters, etc.) — public-API typing only annotates the surface.
+- Once a module is fully typed (public **and** internal defs), turn on
+  `disallow_untyped_defs` for it in `[tool.mypy]` so coverage ratchets
+  and cannot regress. This cannot be enabled per-module until that
+  module has zero unannotated defs.
+
+Convention used so far: annotate array-like inputs as `npt.ArrayLike`
+and array returns as `npt.NDArray`; declare dynamically-set instance
+attributes as class-level annotations; leave the autograd-`numpy`
+numeric kernels loosely typed (they buy little from precise typing).
+
+---
+
 ## 4. Recurrent Module — Bugs and Gaps
 
 ### Fresh deep-dive — 2026-06-14 (full-package audit)
@@ -174,12 +215,6 @@ Only one test file with one test covers the entire recurrent module (`tests/recu
 
 ## 5. Code Quality
 
-### Type hints are vestigial
-The package ships `py.typed`, but only `ParametricFitter.__init__` is
-annotated. Either grow annotations outward (fitter signatures and
-`fit()` are the highest-value targets) or remove the `py.typed`
-marker; the current state advertises typing that doesn't exist.
-
 ### Docstring examples are not doctested
 Most distribution docstring examples now execute correctly (Rayleigh's
 and GumbelLEV's were rewritten with verified outputs in June 2026),
@@ -260,12 +295,10 @@ last point). It is retained only for backward compatibility; decide
 whether to formally deprecate and remove it, or keep it and accept the
 maintenance of a statistically unjustified path.
 
-### Type hints and residual test gaps
-The module is untyped despite the package shipping `py.typed` (see also
-section 4). The new behaviour is well covered, but `plot()` with
-non-step `interp`, the `set_lower_limit` path in
-`NonParametricFitter.fit`, and the `from_xrd` entry point still have no
-direct tests.
+### Residual test gaps
+The new behaviour is well covered, but `plot()` with non-step
+`interp`, the `set_lower_limit` path in `NonParametricFitter.fit`, and
+the `from_xrd` entry point still have no direct tests.
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,16 +4,6 @@ This document tracks known issues, technical debt, and improvement priorities fo
 
 ---
 
-## Priority Order
-
-1. Correctness (silent wrong results)
-2. Stability (features that crash)
-3. Test infrastructure
-4. API consistency
-5. Code quality / tooling
-
----
-
 ## 1. Type Hints — Finish the Package
 
 The package ships `py.typed` and `mypy` runs in CI, so the typing

--- a/surpyval/fit_best.py
+++ b/surpyval/fit_best.py
@@ -1,6 +1,8 @@
 import warnings
+from collections.abc import Iterable
 
 import numpy as np
+import numpy.typing as npt
 
 from surpyval.univariate.parametric import (
     Beta,
@@ -13,6 +15,7 @@ from surpyval.univariate.parametric import (
     LogLogistic,
     LogNormal,
     Normal,
+    Parametric,
     ParametricFitter,
     Rayleigh,
     Uniform,
@@ -39,29 +42,39 @@ METRICS = ["aic", "aic_c", "bic", "neg_ll"]
 
 
 def fit_best(
-    x, c=None, n=None, t=None, metric="aic", include=None, exclude=None
-):
-    include = set(include) if include is not None else set()
-    exclude = set(exclude) if exclude is not None else set()
+    x: npt.ArrayLike,
+    c: npt.ArrayLike | None = None,
+    n: npt.ArrayLike | None = None,
+    t: npt.ArrayLike | None = None,
+    metric: str = "aic",
+    include: Iterable[str] | None = None,
+    exclude: Iterable[str] | None = None,
+) -> Parametric | None:
+    include_set = set(include) if include is not None else set()
+    exclude_set = set(exclude) if exclude is not None else set()
 
     if metric not in METRICS:
         raise ValueError(
             '`metric` must be on of "{}"'.format('", "'.join(METRICS))
         )
 
-    if (len(include) > 0) and (len(exclude) > 0):
+    if (len(include_set) > 0) and (len(exclude_set) > 0):
         raise ValueError("Provide either an include or an exclude, not both.")
 
-    if len(exclude) > 0:
-        include = [dist for dist in distributions if dist.name not in exclude]
-    elif len(include) > 0:
-        include = [dist for dist in distributions if dist.name in include]
+    if len(exclude_set) > 0:
+        candidates = [
+            dist for dist in distributions if dist.name not in exclude_set
+        ]
+    elif len(include_set) > 0:
+        candidates = [
+            dist for dist in distributions if dist.name in include_set
+        ]
     else:
-        include = distributions
+        candidates = distributions
 
     measure = np.inf
-    model = None
-    for dist in include:
+    model: Parametric | None = None
+    for dist in candidates:
         try:
             temp_model = dist.fit(x, c, n, t)
             tmp_measure = getattr(temp_model, metric)()

--- a/surpyval/univariate/nonparametric/__init__.py
+++ b/surpyval/univariate/nonparametric/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any, Callable
+
 from .filliben import filliben
 from .fleming_harrington import (
     FlemingHarrington,
@@ -13,14 +15,14 @@ from .rank_adjust import rank_adjust
 from .success_run import success_run
 from .turnbull import Turnbull, turnbull
 
-FIT_FUNCS = {
+FIT_FUNCS: dict[str, Callable[..., Any]] = {
     "Nelson-Aalen": nelson_aalen,
     "Kaplan-Meier": kaplan_meier,
     "Fleming-Harrington": fleming_harrington,
     "Turnbull": turnbull,
 }
 
-VAR_FUNCS = {
+VAR_FUNCS: dict[str, Callable[..., Any]] = {
     "Nelson-Aalen": nelson_aalen_variance,
     "Kaplan-Meier": greenwood_variance,
     "Fleming-Harrington": fleming_harrington_variance,

--- a/surpyval/univariate/nonparametric/nonparametric.py
+++ b/surpyval/univariate/nonparametric/nonparametric.py
@@ -1,13 +1,21 @@
+from typing import TYPE_CHECKING, Any, Callable
+
 import matplotlib.pyplot as plt
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 from scipy.interpolate import interp1d
 from scipy.stats import norm, t
 
 from surpyval.distribution import NonParametricDistribution
 
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
 
-def interp_function(x, y, kind):
+
+def interp_function(
+    x: npt.ArrayLike, y: npt.ArrayLike, kind: str
+) -> Callable[[npt.ArrayLike], npt.NDArray]:
     return interp1d(x, y, kind=kind, bounds_error=False, fill_value=np.nan)
 
 
@@ -20,7 +28,20 @@ class NonParametric(NonParametricDistribution):
     ``FlemingHarrington``, or ``Turnbull`` estimators.
     """
 
-    def __repr__(self):
+    # Attributes populated by the fitter (``NonParametricFitter.fit`` /
+    # ``from_xrd`` / ``fit_from_ecdf``). Declared here so static type
+    # checkers know their types.
+    x: npt.NDArray
+    r: npt.NDArray
+    d: npt.NDArray
+    R: npt.NDArray
+    F: npt.NDArray
+    H: npt.NDArray
+    model: str
+    greenwood: npt.NDArray
+    data: dict[str, Any]
+
+    def __repr__(self) -> str:
         out = (
             "Non-Parametric SurPyval Model"
             + "\n============================="
@@ -35,7 +56,7 @@ class NonParametric(NonParametricDistribution):
 
         return out
 
-    def sf(self, x, interp="step"):
+    def sf(self, x: npt.ArrayLike, interp: str = "step") -> npt.NDArray:
         r"""
 
         Surival (or Reliability) function with the
@@ -84,7 +105,7 @@ class NonParametric(NonParametricDistribution):
         # R = np.where(x > self.x.max(), np.nan, R)
         return R
 
-    def ff(self, x, interp="step"):
+    def ff(self, x: npt.ArrayLike, interp: str = "step") -> npt.NDArray:
         r"""
 
         CDF (failure or unreliability) function with the
@@ -116,7 +137,7 @@ class NonParametric(NonParametricDistribution):
         """
         return 1 - self.sf(x, interp=interp)
 
-    def hf(self, x, interp="step"):
+    def hf(self, x: npt.ArrayLike, interp: str = "step") -> npt.NDArray:
         r"""
 
         Instantaneous hazard function with the non-parametric
@@ -161,7 +182,7 @@ class NonParametric(NonParametricDistribution):
         hf = hf.ffill().values
         return hf[rev]
 
-    def df(self, x, interp="step"):
+    def df(self, x: npt.ArrayLike, interp: str = "step") -> npt.NDArray:
         r"""
 
         Density function with the non-parametric estimates
@@ -195,7 +216,7 @@ class NonParametric(NonParametricDistribution):
         """
         return self.hf(x, interp=interp) * np.exp(-self.Hf(x, interp=interp))
 
-    def Hf(self, x, interp="step"):
+    def Hf(self, x: npt.ArrayLike, interp: str = "step") -> npt.NDArray:
         r"""
 
         Cumulative hazard rate with the non-parametric estimates
@@ -232,14 +253,14 @@ class NonParametric(NonParametricDistribution):
 
     def cb(
         self,
-        x,
-        on="sf",
-        bound="two-sided",
-        interp="step",
-        alpha_ci=0.05,
-        bound_type="exp",
-        dist="z",
-    ):
+        x: npt.ArrayLike,
+        on: str = "sf",
+        bound: str = "two-sided",
+        interp: str = "step",
+        alpha_ci: float = 0.05,
+        bound_type: str = "exp",
+        dist: str = "z",
+    ) -> npt.NDArray:
         r"""
 
         Confidence bounds of the ``on`` function at the
@@ -363,13 +384,13 @@ class NonParametric(NonParametricDistribution):
 
     def R_cb(
         self,
-        x,
-        bound="two-sided",
-        interp="step",
-        alpha_ci=0.05,
-        bound_type="exp",
-        dist="z",
-    ):
+        x: npt.ArrayLike,
+        bound: str = "two-sided",
+        interp: str = "step",
+        alpha_ci: float = 0.05,
+        bound_type: str = "exp",
+        dist: str = "z",
+    ) -> npt.NDArray:
         if bound_type not in ["exp", "normal"]:
             raise ValueError("'bound_type' must be in ['exp', 'normal']")
         if dist not in ["t", "z"]:
@@ -453,7 +474,7 @@ class NonParametric(NonParametricDistribution):
 
         return R_out
 
-    def random(self, size):
+    def random(self, size: int) -> npt.NDArray:
         r"""
         Draws random samples from the fitted distribution. Each observed
         value x is drawn with the probability mass the estimated survival
@@ -468,7 +489,7 @@ class NonParametric(NonParametricDistribution):
         p = p / p.sum()
         return np.random.choice(self.x, size=size, p=p)
 
-    def qf(self, p):
+    def qf(self, p: npt.ArrayLike) -> npt.NDArray:
         r"""
         Quantile function of the non-parametric estimate. Returns the
         smallest observed value at which the estimated CDF reaches, or
@@ -506,7 +527,7 @@ class NonParametric(NonParametricDistribution):
         return x_padded[np.minimum(idx, len(self.x))]
 
     @property
-    def median(self):
+    def median(self) -> float:
         r"""
         The median survival time; the smallest observed value at which
         the estimated CDF reaches, or exceeds, 0.5. NaN if the estimate
@@ -514,7 +535,13 @@ class NonParametric(NonParametricDistribution):
         """
         return self.qf(0.5)[0]
 
-    def quantile_cb(self, p, alpha_ci=0.05, bound_type="exp", dist="z"):
+    def quantile_cb(
+        self,
+        p: npt.ArrayLike,
+        alpha_ci: float = 0.05,
+        bound_type: str = "exp",
+        dist: str = "z",
+    ) -> npt.NDArray:
         r"""
         Two-sided confidence interval of the quantile at each
         probability p using the Brookmeyer-Crowley method: the interval
@@ -575,7 +602,7 @@ class NonParametric(NonParametricDistribution):
             )
         return out
 
-    def mean(self, tau=None):
+    def mean(self, tau: float | None = None) -> float:
         r"""
         The (restricted) mean survival time: the area under the
         estimated survival function from 0 to tau.
@@ -622,7 +649,9 @@ class NonParametric(NonParametricDistribution):
         surv = np.hstack([[1.0], self.R[: xs.size]])
         return float(np.sum(np.diff(times) * surv))
 
-    def mean_cb(self, tau=None, alpha_ci=0.05):
+    def mean_cb(
+        self, tau: float | None = None, alpha_ci: float = 0.05
+    ) -> npt.NDArray:
         r"""
         Two-sided confidence interval of the (restricted) mean survival
         time, using the normal approximation with the standard variance
@@ -684,12 +713,12 @@ class NonParametric(NonParametricDistribution):
 
     def bootstrap_cb(
         self,
-        x,
-        bound="two-sided",
-        alpha_ci=0.05,
-        B=200,
-        random_state=None,
-    ):
+        x: npt.ArrayLike,
+        bound: str = "two-sided",
+        alpha_ci: float = 0.05,
+        B: int = 200,
+        random_state: int | None = None,
+    ) -> npt.NDArray:
         r"""
         Confidence bounds of the survival function computed with a
         non-parametric bootstrap: the data are resampled with
@@ -797,8 +826,13 @@ class NonParametric(NonParametricDistribution):
 
     @staticmethod
     def _band_critical_value(
-        a_l, a_u, alpha_ci, standardized, n_sims, random_state
-    ):
+        a_l: float,
+        a_u: float,
+        alpha_ci: float,
+        standardized: bool,
+        n_sims: int,
+        random_state: int | None,
+    ) -> float:
         # Critical value of the supremum of a Brownian bridge (for the
         # Hall-Wellner band), or of a standardized Brownian bridge
         # B(u)/sqrt(u(1 - u)) (for the equal precision band), over
@@ -822,13 +856,13 @@ class NonParametric(NonParametricDistribution):
 
     def band(
         self,
-        x=None,
-        method="hall-wellner",
-        bound_type="exp",
-        alpha_ci=0.05,
-        n_sims=10_000,
-        random_state=1,
-    ):
+        x: npt.ArrayLike | None = None,
+        method: str = "hall-wellner",
+        bound_type: str = "exp",
+        alpha_ci: float = 0.05,
+        n_sims: int = 10_000,
+        random_state: int | None = 1,
+    ) -> npt.NDArray:
         r"""
         Simultaneous confidence band of the survival function.
 
@@ -980,7 +1014,9 @@ class NonParametric(NonParametricDistribution):
 
         return out
 
-    def smoothed_hf(self, x, bandwidth=None):
+    def smoothed_hf(
+        self, x: npt.ArrayLike, bandwidth: float | None = None
+    ) -> npt.NDArray:
         r"""
         Kernel smoothed estimate of the hazard rate, using an
         Epanechnikov kernel over the increments of the cumulative
@@ -1054,7 +1090,7 @@ class NonParametric(NonParametricDistribution):
         h = np.where((x < x_min) | (x > x_max), np.nan, h)
         return h
 
-    def get_plot_data(self, **kwargs):
+    def get_plot_data(self, **kwargs) -> dict:
         y_scale_min = 0
         y_scale_max = 1
 
@@ -1079,7 +1115,7 @@ class NonParametric(NonParametricDistribution):
             "F": self.F,
         }
 
-    def plot(self, ax=None, **kwargs):
+    def plot(self, ax: "Axes | None" = None, **kwargs) -> Any:
         r"""
         Creates a plot of the survival function.
 
@@ -1173,7 +1209,9 @@ class NonParametric(NonParametricDistribution):
         return ax
 
     @classmethod
-    def fit_from_ecdf(cls, x, R):
+    def fit_from_ecdf(
+        cls, x: npt.ArrayLike, R: npt.ArrayLike
+    ) -> "NonParametric":
         out = cls()
         out.model = "from_ecdf"
         out.R = R

--- a/surpyval/univariate/nonparametric/nonparametric_fitter.py
+++ b/surpyval/univariate/nonparametric/nonparametric_fitter.py
@@ -1,4 +1,8 @@
+from numbers import Number
+from typing import Any, Callable
+
 import numpy as np
+import numpy.typing as npt
 
 from surpyval.univariate import nonparametric as nonp
 from surpyval.univariate.nonparametric.nonparametric import NonParametric
@@ -6,7 +10,19 @@ from surpyval.utils import xcnt_handler, xcnt_to_xrd, xrd_handler
 
 
 class NonParametricFitter:
-    def _create_non_p_model(self, x, r, d, estimator, data=None):
+    how: str
+    # Provided by the Turnbull estimator subclass; only called on the
+    # ``how == "Turnbull"`` path.
+    _fit: Callable[..., dict[str, Any]]
+
+    def _create_non_p_model(
+        self,
+        x: npt.ArrayLike,
+        r: npt.ArrayLike,
+        d: npt.ArrayLike,
+        estimator: str,
+        data: dict | None = None,
+    ) -> NonParametric:
         out = NonParametric()
         if data is not None:
             out.data = data
@@ -32,17 +48,17 @@ class NonParametricFitter:
 
     def fit(
         self,
-        x=None,
-        c=None,
-        n=None,
-        t=None,
-        xl=None,
-        xr=None,
-        tl=None,
-        tr=None,
-        turnbull_estimator="Fleming-Harrington",
-        set_lower_limit=None,
-    ):
+        x: npt.ArrayLike | None = None,
+        c: npt.ArrayLike | None = None,
+        n: npt.ArrayLike | None = None,
+        t: npt.ArrayLike | None = None,
+        xl: npt.ArrayLike | None = None,
+        xr: npt.ArrayLike | None = None,
+        tl: npt.ArrayLike | Number | None = None,
+        tr: npt.ArrayLike | Number | None = None,
+        turnbull_estimator: str = "Fleming-Harrington",
+        set_lower_limit: float | None = None,
+    ) -> NonParametric:
         r"""
 
         The central feature to SurPyval's capability. This function aimed to
@@ -159,7 +175,9 @@ class NonParametricFitter:
             x, r, d, estimator=estimator, data=data
         )
 
-    def from_xrd(self, x, r, d):
+    def from_xrd(
+        self, x: npt.ArrayLike, r: npt.ArrayLike, d: npt.ArrayLike
+    ) -> NonParametric:
         r"""
         The central feature to SurPyval's capability. This function aimed to
         have an API to mimic the simplicity of the scipy API. That is, to use a

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -1,8 +1,11 @@
 import json
 from collections import namedtuple
 from copy import copy, deepcopy
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
 
 import matplotlib.pyplot as plt
+import numpy.typing as npt
 from autograd import jacobian
 from scipy.special import ndtri as z
 from scipy.stats import uniform
@@ -10,6 +13,11 @@ from scipy.stats import uniform
 import surpyval as surv
 from surpyval import ParametricDistribution, np
 from surpyval.utils import fsli_to_xcnt
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
+    from surpyval.utils.surpyval_data import SurpyvalData
 
 from .probability_plotting import (
     adjust_heuristic,
@@ -35,7 +43,36 @@ class Parametric(ParametricDistribution):
     analysis and numeric integration.
     """
 
-    def __init__(self, dist, method, data, offset, lfp, zi):
+    # Attributes populated after construction (by ``fit``, ``from_dict``
+    # or ``from_params``). Declared here so static type checkers know
+    # their types; the bare annotations do not create the attributes, so
+    # the ``hasattr``/``getattr`` guards throughout still behave.
+    params: npt.NDArray
+    gamma: float
+    p: float
+    f0: float
+    support: tuple[float, float]
+    hess_inv: npt.NDArray
+    cov_matrix: npt.NDArray
+    surv_data: "SurpyvalData"
+    fitting_info: dict[str, Any]
+    tl: Any
+    tr: Any
+    _neg_ll: float
+    _mean: float
+    _bic: float
+    _aic: float
+    _aic_c: float
+
+    def __init__(
+        self,
+        dist: Any,
+        method: str,
+        data: Any,
+        offset: bool,
+        lfp: bool,
+        zi: bool,
+    ) -> None:
         self.dist = dist
         self.k = copy(dist.k)
         self.method = method
@@ -82,12 +119,12 @@ class Parametric(ParametricDistribution):
         self.param_map = param_map
 
     @classmethod
-    def from_json(cls, fp):
+    def from_json(cls, fp: str | Path) -> "Parametric":
         with open(fp, "r") as f:
             return cls.from_dict(json.load(f))
 
     @classmethod
-    def from_dict(cls, model_dict):
+    def from_dict(cls, model_dict: dict) -> "Parametric":
         # Imported here since parametric_fitter imports this module
         from surpyval.univariate.parametric.parametric_fitter import (
             ParametricFitter,
@@ -137,14 +174,14 @@ class Parametric(ParametricDistribution):
 
         return out
 
-    def to_dict(self, with_data=False):
-        out = {}
+    def to_dict(self, with_data: bool = False) -> dict:
+        out: dict[str, Any] = {}
         out["parameterization"] = "parametric"
         out["distribution"] = self.dist.name
         out["how"] = self.method
         out["param_names"] = self.dist.param_names
 
-        data_dict = {}
+        data_dict: dict[str, Any] = {}
         if with_data:
             if self.data is not None:
                 for ch in ["x", "c", "n", "t"]:
@@ -186,11 +223,11 @@ class Parametric(ParametricDistribution):
 
         return out
 
-    def to_json(self, fp):
+    def to_json(self, fp: str | Path) -> None:
         with open(fp, "w+") as f:
             json.dump(self.to_dict(), f)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if hasattr(self, "params"):
             param_string = "\n".join(
                 [
@@ -219,7 +256,9 @@ class Parametric(ParametricDistribution):
         else:
             return "Unable to fit values"
 
-    def param_cb(self, name, alpha_ci=0.05, bound="two-sided"):
+    def param_cb(
+        self, name: str, alpha_ci: float = 0.05, bound: str = "two-sided"
+    ) -> npt.NDArray:
         """
         Method to calculate the confidence bound on a parameter.
         """
@@ -270,7 +309,7 @@ class Parametric(ParametricDistribution):
             bounds = -bounds * factor
             return p_hat + bounds
 
-    def sf(self, x):
+    def sf(self, x: npt.ArrayLike) -> npt.NDArray:
         r"""
 
         Survival (or Reliability) function for a distribution using the
@@ -309,7 +348,7 @@ class Parametric(ParametricDistribution):
             + (self.p - self.f0) * self.dist.sf(x - self.gamma, *self.params)
         )
 
-    def ff(self, x):
+    def ff(self, x: npt.ArrayLike) -> npt.NDArray:
         r"""
 
         The cumulative distribution function, or failure function, for a
@@ -348,7 +387,7 @@ class Parametric(ParametricDistribution):
             x - self.gamma, *self.params
         )
 
-    def df(self, x):
+    def df(self, x: npt.ArrayLike) -> npt.NDArray:
         r"""
 
         The density function for a distribution using the parameters found
@@ -396,7 +435,7 @@ class Parametric(ParametricDistribution):
             )
         return df
 
-    def hf(self, x):
+    def hf(self, x: npt.ArrayLike) -> npt.NDArray:
         r"""
         The instantaneous hazard function for a distribution using the
         parameters found in the ``.params`` attribute.
@@ -435,7 +474,7 @@ class Parametric(ParametricDistribution):
         else:
             return self.df(x) / self.sf(x)
 
-    def Hf(self, x):
+    def Hf(self, x: npt.ArrayLike) -> npt.NDArray:
         """
         The cumulative hazard function for a distribution using the
         parameters found in the ``.params`` attribute.
@@ -475,7 +514,7 @@ class Parametric(ParametricDistribution):
         else:
             return -np.log(self.sf(x))
 
-    def qf(self, p):
+    def qf(self, p: npt.ArrayLike) -> npt.NDArray:
         r"""
 
         The quantile function for a distribution using the parameters found
@@ -511,7 +550,7 @@ class Parametric(ParametricDistribution):
         else:
             raise NotImplementedError("Quantile for LFP not implemented.")
 
-    def cs(self, x, X):
+    def cs(self, x: npt.ArrayLike, X: npt.ArrayLike) -> npt.NDArray:
         r"""
 
         The conditional survival of the model; that is, the probability
@@ -548,7 +587,12 @@ class Parametric(ParametricDistribution):
         cs[cs > 1.0] = 1
         return cs
 
-    def random(self, size, a=None, b=None):
+    def random(
+        self,
+        size: int | tuple[int, ...],
+        a: float | None = None,
+        b: float | None = None,
+    ) -> npt.NDArray:
         r"""
 
         A method to draw random samples from the distributions using the
@@ -658,7 +702,7 @@ class Parametric(ParametricDistribution):
             s = np.ones(n_cens) * np.max(f) + 1
             return fsli_to_xcnt(f, s)
 
-    def mean(self):
+    def mean(self) -> float:
         r"""
         The mean of the distribution using the parameters found in the
         ``.params`` attribute.
@@ -679,7 +723,7 @@ class Parametric(ParametricDistribution):
             self._mean = self.p * (self.dist.mean(*self.params) + self.gamma)
         return self._mean
 
-    def var(self):
+    def var(self) -> float:
         r"""
         The variance of the distribution using the parameters found in the
         ``.params`` attribute.
@@ -700,7 +744,7 @@ class Parametric(ParametricDistribution):
         m2 = self.dist._moment(2, *self.params)
         return m2 - m1**2
 
-    def moment(self, n):
+    def moment(self, n: int) -> float:
         r"""
 
         The n-th moment of the distribution using the parameters found
@@ -731,7 +775,7 @@ class Parametric(ParametricDistribution):
             msg = "LFP distributions cannot yet have their moment calculated"
             raise NotImplementedError(msg)
 
-    def entropy(self):
+    def entropy(self) -> float:
         r"""
         The entropy of the distribution using the parameters found in
         the ``.params`` attribute.
@@ -755,7 +799,13 @@ class Parametric(ParametricDistribution):
             msg = "Entropy not available for LFP distribution"
             raise NotImplementedError(msg)
 
-    def cb(self, t, on="sf", alpha_ci=0.05, bound="two-sided"):
+    def cb(
+        self,
+        t: npt.ArrayLike,
+        on: str = "sf",
+        alpha_ci: float = 0.05,
+        bound: str = "two-sided",
+    ) -> npt.NDArray:
         r"""
         Confidence bounds of the ``on`` function at the ``alpa_ci`` level of
         significance. Can be the upper, lower, or two-sided confidence by
@@ -922,7 +972,7 @@ class Parametric(ParametricDistribution):
             cb = cb.T
         return cb
 
-    def neg_ll(self):
+    def neg_ll(self) -> float:
         r"""
 
         The negative log-likelihood for the model, if it was fit with the
@@ -951,7 +1001,7 @@ class Parametric(ParametricDistribution):
 
         return self._neg_ll
 
-    def bic(self):
+    def bic(self) -> float:
         r"""
 
         The Bayesian Information Criterion (BIC) for the model, if it
@@ -991,7 +1041,7 @@ class Parametric(ParametricDistribution):
             )
             return self._bic
 
-    def aic(self):
+    def aic(self) -> float:
         r"""
         The Aikake Information Criterion (AIC) for the model, if it was
         fit with the ``fit()`` method. Not available if fit with the
@@ -1020,7 +1070,7 @@ class Parametric(ParametricDistribution):
             self._aic = 2 * self.k + 2 * self.neg_ll()
             return self._aic
 
-    def aic_c(self):
+    def aic_c(self) -> float:
         r"""
         The Corrected Aikake Information Criterion (AIC) for the model,
         if it was fit with the ``fit()`` method. Not available if fit with
@@ -1051,7 +1101,9 @@ class Parametric(ParametricDistribution):
             self._aic_c = self.aic() + (2 * k**2 + 2 * k) / (n - k - 1)
             return self._aic_c
 
-    def get_plot_data(self, heuristic="Nelson-Aalen", alpha_ci=0.05):
+    def get_plot_data(
+        self, heuristic: str = "Nelson-Aalen", alpha_ci: float = 0.05
+    ) -> dict:
         """
 
         A method to gather plot data
@@ -1083,14 +1135,17 @@ class Parametric(ParametricDistribution):
         >>> model = Weibull.fit(x)
         >>> data = model.get_plot_data()
         """
-        if hasattr(self, "hess_inv") and (self.method == "MLE"):
-            if self.hess_inv is not None:
+        cb_func: Callable[[Any], Any] | None
+        if (
+            hasattr(self, "hess_inv")
+            and (self.method == "MLE")
+            and (self.hess_inv is not None)
+        ):
 
-                def cb_func(x_model):
-                    return self.cb(x_model, on="ff", alpha_ci=alpha_ci)
+            def _cb_func(x_model):
+                return self.cb(x_model, on="ff", alpha_ci=alpha_ci)
 
-            else:
-                cb_func = None
+            cb_func = _cb_func
         else:
             cb_func = None
 
@@ -1109,11 +1164,11 @@ class Parametric(ParametricDistribution):
 
     def plot(
         self,
-        heuristic="Nelson-Aalen",
-        plot_bounds=True,
-        alpha_ci=0.05,
-        ax=None,
-    ):
+        heuristic: str = "Nelson-Aalen",
+        plot_bounds: bool = True,
+        alpha_ci: float = 0.05,
+        ax: "Axes | None" = None,
+    ) -> list:
         """
         A method to do a probability plot
 

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -1,3 +1,6 @@
+from numbers import Number
+
+import numpy.typing as npt
 import pandas as pd
 from scipy.integrate import quad
 from scipy.special import expit
@@ -438,25 +441,25 @@ class ParametricFitter:
 
     def fit(
         self,
-        x=None,
-        c=None,
-        n=None,
-        t=None,
-        how="MLE",
-        offset=False,
-        zi=False,
-        lfp=False,
-        tl=None,
-        tr=None,
-        xl=None,
-        xr=None,
-        fixed=None,
-        heuristic="Nelson-Aalen",
-        init=[],
-        rr="y",
-        on_d_is_0=False,
-        turnbull_estimator="Fleming-Harrington",
-    ):
+        x: npt.ArrayLike | None = None,
+        c: npt.ArrayLike | None = None,
+        n: npt.ArrayLike | None = None,
+        t: npt.ArrayLike | None = None,
+        how: str = "MLE",
+        offset: bool = False,
+        zi: bool = False,
+        lfp: bool = False,
+        tl: npt.ArrayLike | Number | None = None,
+        tr: npt.ArrayLike | Number | None = None,
+        xl: npt.ArrayLike | None = None,
+        xr: npt.ArrayLike | None = None,
+        fixed: dict[str, float] | None = None,
+        heuristic: str = "Nelson-Aalen",
+        init: npt.ArrayLike = [],
+        rr: str = "y",
+        on_d_is_0: bool = False,
+        turnbull_estimator: str = "Fleming-Harrington",
+    ) -> Parametric:
         """
 
         The central feature to SurPyval's capability. This function aimed to
@@ -626,16 +629,16 @@ class ParametricFitter:
 
     def fit_from_df(
         self,
-        df,
-        x=None,
-        c=None,
-        n=None,
-        xl=None,
-        xr=None,
-        tl=None,
-        tr=None,
+        df: pd.DataFrame,
+        x: str | None = None,
+        c: str | None = None,
+        n: str | None = None,
+        xl: str | None = None,
+        xr: str | None = None,
+        tl: str | float | None = None,
+        tr: str | float | None = None,
         **fit_options,
-    ):
+    ) -> Parametric:
         r"""
         The central feature to SurPyval's capability. This function aimed to
         have an API to mimic the simplicity of the scipy API. That is, to use
@@ -755,7 +758,7 @@ class ParametricFitter:
 
         return self.fit(x=x, c=c, n=n, t=t, **fit_options)
 
-    def fit_from_ecdf(self, x, F):
+    def fit_from_ecdf(self, x: npt.ArrayLike, F: npt.ArrayLike) -> Parametric:
         model = Parametric(self, "given ecdf", None, False, False, False)
         res = mpp_from_ecfd(self, x, F)
         model.dist = self
@@ -764,7 +767,7 @@ class ParametricFitter:
 
         return model
 
-    def fit_from_non_parametric(self, non_parametric_model):
+    def fit_from_non_parametric(self, non_parametric_model) -> Parametric:
         x, F = non_parametric_model.x, 1 - non_parametric_model.R
         return self.fit_from_ecdf(x, F)
 
@@ -911,18 +914,18 @@ class ParametricFitter:
 
     def fit_from_surpyval_data(
         self,
-        surv_data,
-        how="MLE",
-        offset=False,
-        zi=False,
-        lfp=False,
-        fixed=None,
-        heuristic="Nelson-Aalen",
-        init=[],
-        rr="y",
-        on_d_is_0=False,
-        turnbull_estimator="Fleming-Harrington",
-    ):
+        surv_data: SurpyvalData,
+        how: str = "MLE",
+        offset: bool = False,
+        zi: bool = False,
+        lfp: bool = False,
+        fixed: dict[str, float] | None = None,
+        heuristic: str = "Nelson-Aalen",
+        init: npt.ArrayLike = [],
+        rr: str = "y",
+        on_d_is_0: bool = False,
+        turnbull_estimator: str = "Fleming-Harrington",
+    ) -> Parametric:
         """
 
         The central feature to SurPyval's capability. This function aimed to
@@ -990,9 +993,7 @@ class ParametricFitter:
             fitting_info["not_fixed"] = not_fixed
 
             if init == []:
-                init = self._initial_guess(
-                    x, c, n, offset, zi, lfp, heuristic
-                )
+                init = self._initial_guess(x, c, n, offset, zi, lfp, heuristic)
 
             init = np.atleast_1d(init)
             if fixed and len(init) == len(not_fixed):

--- a/surpyval/univariate/regression/accelerated_failure_time/accelerated_failure_time.py
+++ b/surpyval/univariate/regression/accelerated_failure_time/accelerated_failure_time.py
@@ -1,4 +1,5 @@
 import autograd.numpy as np
+import numpy.typing as npt
 from scipy.optimize import minimize
 
 import surpyval
@@ -104,7 +105,16 @@ class AcceleratedFailureTimeFitter:
             Z_out.append(np.ones(size) * stress)
         return np.concatenate(x), np.concatenate(Z_out)
 
-    def fit(self, x, Z, c=None, n=None, t=None, init=None, fixed=None):
+    def fit(
+        self,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        c: npt.ArrayLike | None = None,
+        n: npt.ArrayLike | None = None,
+        t: npt.ArrayLike | None = None,
+        init: npt.ArrayLike | None = None,
+        fixed: dict[str, float] | None = None,
+    ) -> ParametricRegressionModel:
         x, c, n, t = surpyval.xcnt_handler(
             x=x, c=c, n=n, t=t, group_and_sort=False
         )

--- a/surpyval/univariate/regression/accelerated_failure_time/aft_fitter.py
+++ b/surpyval/univariate/regression/accelerated_failure_time/aft_fitter.py
@@ -1,4 +1,5 @@
 import autograd.numpy as np
+import numpy.typing as npt
 from scipy.optimize import minimize
 
 from surpyval.univariate.parametric.fitters import bounds_convert
@@ -88,7 +89,16 @@ class AFTFitter(DataFrameRegressionMixin):
     def neg_ll(self, data, *params):
         return regression_neg_ll(self, data, *params)
 
-    def fit(self, x, Z, c=None, n=None, t=None, init=None, fixed=None):
+    def fit(
+        self,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        c: npt.ArrayLike | None = None,
+        n: npt.ArrayLike | None = None,
+        t: npt.ArrayLike | None = None,
+        init: npt.ArrayLike | None = None,
+        fixed: dict[str, float] | None = None,
+    ) -> ParametricRegressionModel:
         data = SurpyvalData(x, c, n, t, group_and_sort=False)
         data.add_covariates(Z)
 
@@ -97,6 +107,7 @@ class AFTFitter(DataFrameRegressionMixin):
 
         if init is None:
             ps = self.dist.fit_from_surpyval_data(data).params
+            assert data.Z is not None
             phi_init = np.zeros(data.Z.shape[1])
             init = np.array([*ps, *phi_init])
         else:

--- a/surpyval/univariate/regression/accelerated_life/parameter_substitution.py
+++ b/surpyval/univariate/regression/accelerated_life/parameter_substitution.py
@@ -2,6 +2,7 @@ import inspect
 import warnings
 
 import autograd.numpy as np
+import numpy.typing as npt
 from scipy.optimize import minimize
 
 from surpyval.univariate.parametric.fitters import bounds_convert
@@ -198,7 +199,16 @@ class ParameterSubstitutionFitter(DataFrameRegressionMixin):
     def neg_ll(self, data, *params):
         return regression_neg_ll(self, data, *params)
 
-    def fit(self, x, Z, c=None, n=None, t=None, init=None, fixed=None):
+    def fit(
+        self,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        c: npt.ArrayLike | None = None,
+        n: npt.ArrayLike | None = None,
+        t: npt.ArrayLike | None = None,
+        init: npt.ArrayLike | None = None,
+        fixed: dict[str, float] | None = None,
+    ) -> ParametricRegressionModel:
         data = SurpyvalData(x=x, c=c, n=n, t=t, group_and_sort=False)
         data.add_covariates(Z)
         life_parameter_idx = self.param_map[self.life_parameter]

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -1,10 +1,17 @@
+from typing import TYPE_CHECKING, Any
+
 import autograd.numpy as np
+import numpy.typing as npt
 from matplotlib import pyplot as plt
 from scipy.stats import uniform
 
 from surpyval.utils import fsli_to_xcnt
 
 from .regression_data import prepare_Z
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from matplotlib.axes import Axes
 
 
 class ParametricRegressionModel:
@@ -21,11 +28,37 @@ class ParametricRegressionModel:
     # Covariate metadata populated when the model is fit from a pandas
     # DataFrame (see ``DataFrameRegressionMixin.fit_from_df``). These defaults
     # keep the array based interface working unchanged.
-    feature_names = None
-    formula = None
-    _model_spec = None
+    feature_names: list[str] | None = None
+    formula: str | None = None
+    _model_spec: Any = None
 
-    def _prepare_Z(self, Z):
+    # Attributes populated after construction (by ``fit`` / ``from_params``).
+    # Declared here so static type checkers know their types.
+    params: npt.NDArray
+    dist_params: npt.NDArray
+    phi_params: npt.NDArray
+    k: int
+    k_dist: int
+    gamma: float
+    p: float
+    f0: float
+    kind: str
+    fixed: dict[str, float]
+    dist: Any
+    distribution: Any
+    distribution_param_map: Any
+    phi_param_map: Any
+    reg_model: Any
+    model: Any
+    data: Any
+    res: Any
+    fun: Any
+    _neg_ll: float
+    _bic: float
+    _aic: float
+    _aic_c: float
+
+    def _prepare_Z(self, Z: "npt.ArrayLike | pd.DataFrame") -> npt.NDArray:
         """
         Convert ``Z`` to a numeric design matrix.
 
@@ -36,7 +69,7 @@ class ParametricRegressionModel:
         """
         return prepare_Z(Z, self.feature_names, self._model_spec)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         dist_params = self.params[0 : self.k_dist]
         reg_model_params = self.params[self.k_dist :]
         dist_param_string = "\n".join(
@@ -86,11 +119,13 @@ class ParametricRegressionModel:
         else:
             return "Unable to fit values"
 
-    def phi(self, Z):
+    def phi(self, Z: "npt.ArrayLike | pd.DataFrame") -> npt.NDArray:
         Z = self._prepare_Z(Z)
         return self.reg_model.phi(Z, *self.phi_params)
 
-    def sf(self, x, Z):
+    def sf(
+        self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"
+    ) -> npt.NDArray:
         r"""
         Surival (or Reliability) function for a distribution using the
         parameters found in the ``.params`` attribute.
@@ -126,7 +161,9 @@ class ParametricRegressionModel:
         Z = self._prepare_Z(Z)
         return self.model.sf(x, Z, *self.params)
 
-    def ff(self, x, Z):
+    def ff(
+        self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"
+    ) -> npt.NDArray:
         r"""
         The cumulative distribution function, or failure function, for a
         distribution using the parameters found in the ``.params`` attribute.
@@ -163,7 +200,9 @@ class ParametricRegressionModel:
         Z = self._prepare_Z(Z)
         return self.model.ff(x, Z, *self.params)
 
-    def df(self, x, Z):
+    def df(
+        self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"
+    ) -> npt.NDArray:
         r"""
         The density function for a distribution using the parameters found in
         the ``.params`` attribute.
@@ -200,7 +239,9 @@ class ParametricRegressionModel:
         Z = self._prepare_Z(Z)
         return self.model.df(x, Z, *self.params)
 
-    def hf(self, x, Z):
+    def hf(
+        self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"
+    ) -> npt.NDArray:
         r"""
         The instantaneous hazard function for a distribution using the
         parameters found in the ``.params`` attribute.
@@ -238,7 +279,9 @@ class ParametricRegressionModel:
         Z = self._prepare_Z(Z)
         return self.model.hf(x, Z, *self.params)
 
-    def Hf(self, x, Z):
+    def Hf(
+        self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"
+    ) -> npt.NDArray:
         r"""
 
         The cumulative hazard function for a distribution using the parameters
@@ -277,7 +320,9 @@ class ParametricRegressionModel:
         Z = self._prepare_Z(Z)
         return self.model.Hf(x, Z, *self.params)
 
-    def random(self, size, Z):
+    def random(
+        self, size: int, Z: "npt.ArrayLike | pd.DataFrame"
+    ) -> npt.NDArray:
         r"""
 
         A method to draw random samples from the distributions using the
@@ -354,7 +399,7 @@ class ParametricRegressionModel:
             # yet supported")
             return fsli_to_xcnt(f, s)
 
-    def neg_ll(self):
+    def neg_ll(self) -> float:
         r"""
 
         The the negative log-likelihood for the model, if it was fit with the
@@ -388,7 +433,7 @@ class ParametricRegressionModel:
 
         return self._neg_ll
 
-    def bic(self):
+    def bic(self) -> float:
         r"""
 
         The the Bayesian Information Criterion (BIC) for the model, if it was
@@ -433,7 +478,7 @@ class ParametricRegressionModel:
             )
             return self._bic
 
-    def aic(self):
+    def aic(self) -> float:
         r"""
 
         The the Aikake Information Criterion (AIC) for the model, if it was
@@ -468,7 +513,7 @@ class ParametricRegressionModel:
             self._aic = 2 * self.k + 2 * self.neg_ll()
             return self._aic
 
-    def aic_c(self):
+    def aic_c(self) -> float:
         r"""
 
         The the Corrected Aikake Information Criterion (AIC) for the model, if
@@ -505,7 +550,7 @@ class ParametricRegressionModel:
             self._aic_c = self.aic() + (2 * k**2 + 2 * k) / (n - k - 1)
             return self._aic_c
 
-    def plot(self, ax=None):
+    def plot(self, ax: "Axes | None" = None) -> "Axes":
         r"""
 
         A method to plot the survival function, cumulative hazard function,

--- a/surpyval/univariate/regression/proportional_hazards/cox_ph.py
+++ b/surpyval/univariate/regression/proportional_hazards/cox_ph.py
@@ -7,12 +7,17 @@
 
 
 from copy import copy
+from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np
 import numpy.ma as ma
+import numpy.typing as npt
 from numpy.linalg import inv, pinv
 from scipy.optimize import root
 from scipy.stats import norm
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 from surpyval.univariate.nonparametric import (
     FlemingHarrington,
@@ -402,7 +407,16 @@ class CoxPH_:
 
         return log_like, jac_hess, True
 
-    def fit(self, x, Z, c=None, n=None, tl=None, method="breslow", tol=1e-10):
+    def fit(
+        self,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        c: npt.ArrayLike | None = None,
+        n: npt.ArrayLike | None = None,
+        tl: npt.ArrayLike | None = None,
+        method: str = "breslow",
+        tol: float = 1e-10,
+    ) -> SemiParametricRegressionModel:
         """
         Fits Cox Proportional Hazards model to the provided data.
 
@@ -436,6 +450,7 @@ class CoxPH_:
         # Good initial guess assumes no impact
         beta_init = np.zeros(Z.shape[1])
 
+        func_generator: Callable[..., Any]
         if method == "efron":
             func_generator = self.create_efron_ll_jac_hess
         elif method == "breslow":
@@ -489,14 +504,14 @@ class CoxPH_:
 
     def fit_from_df(
         self,
-        df,
-        x_col,
-        Z_cols=None,
-        c_col=None,
-        n_col=None,
-        formula=None,
-        method="efron",
-    ):
+        df: "pd.DataFrame",
+        x_col: str,
+        Z_cols: str | list[str] | None = None,
+        c_col: str | None = None,
+        n_col: str | None = None,
+        formula: str | None = None,
+        method: str = "efron",
+    ) -> SemiParametricRegressionModel:
         """
         Fits a Cox PH model using a pandas dataframe as the input.
 

--- a/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
+++ b/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
@@ -1,6 +1,8 @@
 import inspect
+from typing import Any
 
 import autograd.numpy as np
+import numpy.typing as npt
 from scipy.optimize import minimize
 
 from surpyval.univariate.parametric.fitters import bounds_convert
@@ -12,7 +14,10 @@ from ..regression_data import DataFrameRegressionMixin
 
 
 class Phi:
-    pass
+    # Lightweight namespace whose attributes are populated by the fitter.
+    phi: Any
+    phi_param_map: Any
+    name: str
 
 
 class ProportionalHazardsFitter(DataFrameRegressionMixin):
@@ -148,7 +153,16 @@ class ProportionalHazardsFitter(DataFrameRegressionMixin):
             phi_init=lambda Z: np.zeros(Z.shape[1]),
         )
 
-    def fit(self, x, Z, c=None, n=None, t=None, init=None, fixed=None):
+    def fit(
+        self,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        c: npt.ArrayLike | None = None,
+        n: npt.ArrayLike | None = None,
+        t: npt.ArrayLike | None = None,
+        init: npt.ArrayLike | None = None,
+        fixed: dict[str, float] | None = None,
+    ) -> ParametricRegressionModel:
         """
         Fit the proportional hazards model to the data.
 

--- a/surpyval/univariate/regression/proportional_odds/proportional_odds_fitter.py
+++ b/surpyval/univariate/regression/proportional_odds/proportional_odds_fitter.py
@@ -1,4 +1,5 @@
 import autograd.numpy as np
+import numpy.typing as npt
 from scipy.optimize import minimize
 
 from surpyval.univariate.parametric.fitters import bounds_convert
@@ -129,7 +130,16 @@ class ProportionalOddsFitter(DataFrameRegressionMixin):
     def neg_ll(self, data, *params):
         return regression_neg_ll(self, data, *params)
 
-    def fit(self, x, Z, c=None, n=None, t=None, init=None, fixed=None):
+    def fit(
+        self,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        c: npt.ArrayLike | None = None,
+        n: npt.ArrayLike | None = None,
+        t: npt.ArrayLike | None = None,
+        init: npt.ArrayLike | None = None,
+        fixed: dict[str, float] | None = None,
+    ) -> ParametricRegressionModel:
         data = SurpyvalData(x, c, n, t, group_and_sort=False)
         data.add_covariates(Z)
 
@@ -138,6 +148,7 @@ class ProportionalOddsFitter(DataFrameRegressionMixin):
 
         if init is None:
             ps = self.dist.fit_from_surpyval_data(data).params
+            assert data.Z is not None
             phi_init = np.zeros(data.Z.shape[1])
             init = np.array([*ps, *phi_init])
         else:

--- a/surpyval/univariate/regression/regression_data.py
+++ b/surpyval/univariate/regression/regression_data.py
@@ -9,12 +9,22 @@ time so that a DataFrame can be passed to ``sf``, ``ff``, ``df``, ``hf``,
 ``Hf`` and ``random`` and the correct columns will be selected automatically.
 """
 
+from typing import TYPE_CHECKING, Any, Callable
+
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 from formulaic import Formula
 
+if TYPE_CHECKING:
+    from .parametric_regression_model import ParametricRegressionModel
 
-def design_matrix_from_df(df, Z_cols=None, formula=None):
+
+def design_matrix_from_df(
+    df: pd.DataFrame,
+    Z_cols: str | list[str] | None = None,
+    formula: str | None = None,
+) -> tuple[npt.NDArray, list[str], Any]:
     """
     Build a covariate design matrix ``Z`` from a pandas DataFrame.
 
@@ -59,6 +69,9 @@ def design_matrix_from_df(df, Z_cols=None, formula=None):
         Z = np.asarray(model_matrix, dtype=float)
         return Z, feature_names, model_spec
 
+    # Exactly one of Z_cols / formula is provided (validated above), so at
+    # this point (formula is None) Z_cols must be set.
+    assert Z_cols is not None
     if isinstance(Z_cols, str):
         Z_cols = [Z_cols]
     else:
@@ -72,7 +85,11 @@ def design_matrix_from_df(df, Z_cols=None, formula=None):
     return Z, Z_cols, None
 
 
-def prepare_Z(Z, feature_names=None, model_spec=None):
+def prepare_Z(
+    Z: "npt.ArrayLike | pd.DataFrame",
+    feature_names: list[str] | None = None,
+    model_spec: Any = None,
+) -> npt.NDArray:
     """
     Convert a covariate input ``Z`` into a numeric design matrix.
 
@@ -106,9 +123,7 @@ def prepare_Z(Z, feature_names=None, model_spec=None):
     if feature_names is not None:
         unknown = [c for c in feature_names if c not in Z.columns]
         if len(unknown) > 0:
-            raise ValueError(
-                "{} not in dataframe columns".format(unknown)
-            )
+            raise ValueError("{} not in dataframe columns".format(unknown))
         return Z[feature_names].values.astype(float)
 
     raise ValueError(
@@ -126,19 +141,22 @@ class DataFrameRegressionMixin:
     fixed=None)`` method returning a ``ParametricRegressionModel``.
     """
 
+    # Provided by the host fitter class this mixin is combined with.
+    fit: Callable[..., "ParametricRegressionModel"]
+
     def fit_from_df(
         self,
-        df,
-        x_col,
-        Z_cols=None,
-        c_col=None,
-        n_col=None,
-        tl_col=None,
-        tr_col=None,
-        formula=None,
-        init=None,
-        fixed=None,
-    ):
+        df: pd.DataFrame,
+        x_col: str,
+        Z_cols: str | list[str] | None = None,
+        c_col: str | None = None,
+        n_col: str | None = None,
+        tl_col: str | None = None,
+        tr_col: str | None = None,
+        formula: str | None = None,
+        init: npt.ArrayLike | None = None,
+        fixed: dict[str, float] | None = None,
+    ) -> "ParametricRegressionModel":
         """
         Fit the regression model using a pandas DataFrame as the input.
 

--- a/surpyval/univariate/regression/semi_parametric_regression_model.py
+++ b/surpyval/univariate/regression/semi_parametric_regression_model.py
@@ -1,29 +1,54 @@
+from typing import TYPE_CHECKING, Any, Callable
+
 import autograd.numpy as np
+import numpy.typing as npt
 
 from surpyval.utils import _get_idx
 
 from .regression_data import prepare_Z
 
+if TYPE_CHECKING:
+    import pandas as pd
+
 
 class SemiParametricRegressionModel:
     # Covariate metadata populated when the model is fit from a pandas
     # DataFrame via ``CoxPH.fit_from_df``.
-    feature_names = None
-    formula = None
-    _model_spec = None
+    feature_names: list[str] | None = None
+    formula: str | None = None
+    _model_spec: Any = None
 
-    def __init__(self, kind, parameterization):
+    # Attributes populated by the fitter (``CoxPH.fit`` / ``fit_from_df``).
+    params: npt.NDArray
+    beta: npt.NDArray
+    x: npt.NDArray
+    r: npt.NDArray
+    d: npt.NDArray
+    tl: Any
+    h0: npt.NDArray
+    H0: npt.NDArray
+    phi: Callable[..., npt.NDArray]
+    p_values: npt.NDArray
+    jac: npt.NDArray
+    hess: npt.NDArray
+    res: Any
+    neg_ll: float
+    _neg_log_like: float
+    tie_method: str
+    baseline_method: str
+
+    def __init__(self, kind: str, parameterization: str) -> None:
         self.kind = kind
         self.parameterization = parameterization
 
-    def _prepare_Z(self, Z):
+    def _prepare_Z(self, Z: "npt.ArrayLike | pd.DataFrame") -> npt.NDArray:
         """
         Convert ``Z`` to a numeric design matrix, selecting the covariate
         columns recorded at fit time when a pandas DataFrame is passed.
         """
         return prepare_Z(Z, self.feature_names, self._model_spec)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         out = (
             "Semi-Parametric Regression SurPyval Model"
             + "\n========================================="
@@ -37,21 +62,31 @@ class SemiParametricRegressionModel:
             out += "   beta_{i}  :  {p}\n".format(i=i, p=p)
         return out
 
-    def hf(self, x, Z):
+    def hf(
+        self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"
+    ) -> npt.NDArray:
         Z = self._prepare_Z(Z)
         idx, rev = _get_idx(self.x, x)
         return (self.h0[idx] * self.phi(Z))[rev]
 
-    def Hf(self, x, Z):
+    def Hf(
+        self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"
+    ) -> npt.NDArray:
         Z = self._prepare_Z(Z)
         idx, rev = _get_idx(self.x, x)
         return (self.H0[idx] * self.phi(Z))[rev]
 
-    def sf(self, x, Z):
+    def sf(
+        self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"
+    ) -> npt.NDArray:
         return np.exp(-self.Hf(x, Z))
 
-    def ff(self, x, Z):
+    def ff(
+        self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"
+    ) -> npt.NDArray:
         return -np.expm1(-self.Hf(x, Z))
 
-    def df(self, x, Z):
+    def df(
+        self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"
+    ) -> npt.NDArray:
         return self.hf(x, Z) * self.sf(x, Z)

--- a/surpyval/utils/recurrent_event_data.py
+++ b/surpyval/utils/recurrent_event_data.py
@@ -1,9 +1,13 @@
 import numpy as np
+import numpy.typing as npt
 
 from surpyval.utils.surpyval_data import SurpyvalData
 
 
 class RecurrentEventData:
+    # Optional covariate matrix, attached by ``handle_xicn`` for regression.
+    Z: npt.NDArray | None = None
+
     """
     A class to handle and manipulate recurrent event data. Recurrent events are
     those that can occur more than once for each subject or item.

--- a/surpyval/utils/recurrent_utils.py
+++ b/surpyval/utils/recurrent_utils.py
@@ -1,11 +1,12 @@
 import numpy as np
+import numpy.typing as npt
 
 from surpyval.utils import coerce_xcnt_x, format_truncation
 
 from .recurrent_event_data import RecurrentEventData
 
 
-def reject_left_truncation(data, model_name):
+def reject_left_truncation(data: RecurrentEventData, model_name: str) -> None:
     """
     Virtual-age and history-dependent models (Kijima/G1/ARA/ARI) cannot be
     fitted to left-truncated (delayed-entry) data: the virtual age or
@@ -21,7 +22,7 @@ def reject_left_truncation(data, model_name):
         )
 
 
-def validate_renewal_censoring(c, model_name):
+def validate_renewal_censoring(c: npt.ArrayLike, model_name: str) -> None:
     """
     The renewal models only define likelihood contributions for exact events
     (``c=0``) and right-censored observations (``c=1``). Interval (``c=2``) and
@@ -39,8 +40,18 @@ def validate_renewal_censoring(c, model_name):
 
 
 def handle_xicn(
-    x, i=None, c=None, n=None, t=None, tl=None, tr=None, Z=None,
-    as_recurrent_data=True,
+    x: npt.ArrayLike,
+    i: npt.ArrayLike | None = None,
+    c: npt.ArrayLike | None = None,
+    n: npt.ArrayLike | None = None,
+    t: npt.ArrayLike | None = None,
+    tl: npt.ArrayLike | None = None,
+    tr: npt.ArrayLike | None = None,
+    Z: npt.ArrayLike | dict | None = None,
+    as_recurrent_data: bool = True,
+) -> (
+    RecurrentEventData
+    | tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]
 ):
     x = coerce_xcnt_x(x)
 
@@ -68,11 +79,12 @@ def handle_xicn(
     tl_arr = truncation[:, 0]
     tr_arr = truncation[:, 1]
 
+    Z_arr: npt.NDArray | None = None
     if Z is not None:
         if isinstance(Z, dict):
-            Z = np.array([Z[ii] for ii in i])
+            Z_arr = np.array([Z[ii] for ii in i])
         else:
-            Z = np.array(Z, ndmin=2)
+            Z_arr = np.array(Z, ndmin=2)
     # TODO: Z as a dict where the keys are the item numbers and the arrays
     # are the covariates for each i at all times (x)
 
@@ -83,8 +95,8 @@ def handle_xicn(
     if x.shape[0] != n.shape[0]:
         raise ValueError("x and n must have the same length")
 
-    if Z is not None:
-        if x.shape[0] != Z.shape[0]:
+    if Z_arr is not None:
+        if x.shape[0] != Z_arr.shape[0]:
             raise ValueError("x and Z must have the same length")
 
     if np.any((n > 1) & ((c == 0) | (c == 1))):
@@ -102,8 +114,8 @@ def handle_xicn(
     x, i, c, n = x[sort_order], i[sort_order], c[sort_order], n[sort_order]
     tl_arr, tr_arr = tl_arr[sort_order], tr_arr[sort_order]
 
-    if Z is not None:
-        Z = Z[sort_order]
+    if Z_arr is not None:
+        Z_arr = Z_arr[sort_order]
 
     unique_i, idx = np.unique(i, return_index=True)
     censoring_by_i = np.split(c, idx)[1:]
@@ -162,7 +174,7 @@ def handle_xicn(
 
     if as_recurrent_data:
         data = RecurrentEventData(x, i, c, n, tl=tl_arr, tr=tr_arr)
-        data.Z = Z
+        data.Z = Z_arr
         return data
     else:
         return x, i, c, n


### PR DESCRIPTION
Annotate the most-used public surface of the parametric module:
- ParametricFitter.fit / fit_from_df / fit_from_surpyval_data /
  fit_from_ecdf / fit_from_non_parametric signatures and return types
- Parametric model computation methods (sf, ff, df, hf, Hf, qf, cs,
  random, mean, var, moment, entropy, cb, param_cb), the information
  criteria (neg_ll, aic, bic, aic_c), serialization, and plotting

Declare the dynamically-set Parametric attributes (params, gamma, p,
f0, hess_inv, cov_matrix, etc.) as class-level annotations so the
now-checked method bodies type-clean. No new mypy errors over baseline;
all 384 parametric tests pass.