### PR TITLE
Fix ProportionalIntensityHPP crash on left/interval-censored data

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -62,6 +62,10 @@ theme; items already resolved are marked **[done]**.
   [init])` double-wrapped the 1-D `init` into a 2-D array (broke *every*
   fit, not just censored), and the initial-rate guess called
   `np.maximum.at(..., data.x)` with a 2-D `x` for interval-censored data.
+  The NHPP sibling had the same `[init]` double-wrap, fixed too. Both
+  proportional-intensity docstring examples passed the event indicator
+  positionally into `i` (so they crashed) — rewritten to derive `c` from
+  `arrest` and supply a per-subject `i`, and now pass `--doctest-modules`.
   Regression tests in `tests/recurrent/test_hpp_proportional_intensity.py`.
 - Left-truncated MCF is wrong: `RecurrentEventData.to_xrd()` builds the
   at-risk set assuming every item enters at `t=0`, ignoring `tl`; inflates the

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,10 +54,15 @@ renewal, regression, nonparametric, competing risks). Findings are grouped by
 theme; items already resolved are marked **[done]**.
 
 **A. Correctness bugs**
-- `ProportionalIntensityHPP` crashes on left- or interval-censored data:
-  `Z_left`/`Z_i` are assigned only in the no-censoring `else` branches
-  (`hpp_proportional_intensity.py:130,147`) but used in the likelihood
-  (`:165,174`) → `NameError`. The NHPP sibling is fine (it uses ternaries).
+- **[done]** `ProportionalIntensityHPP` crashed on left- or interval-censored
+  data: `Z_left`/`Z_i` were assigned only in the no-censoring `else` branches
+  (`hpp_proportional_intensity.py`) but used in the likelihood → `NameError`.
+  Now bound in the censoring-present branches too. While verifying the
+  end-to-end fit, two adjacent blockers were also fixed: `minimize(neg_ll,
+  [init])` double-wrapped the 1-D `init` into a 2-D array (broke *every*
+  fit, not just censored), and the initial-rate guess called
+  `np.maximum.at(..., data.x)` with a 2-D `x` for interval-censored data.
+  Regression tests in `tests/recurrent/test_hpp_proportional_intensity.py`.
 - Left-truncated MCF is wrong: `RecurrentEventData.to_xrd()` builds the
   at-risk set assuming every item enters at `t=0`, ignoring `tl`; inflates the
   MCF and propagates to `CauseSpecificMCF`. (Left truncation *is* handled for

--- a/surpyval/recurrent/regression/hpp_proportional_intensity.py
+++ b/surpyval/recurrent/regression/hpp_proportional_intensity.py
@@ -20,14 +20,17 @@ class ProportionalIntensityHPP:
     Examples
     --------
 
+    >>> import numpy as np
     >>> from surpyval.datasets import load_rossi_static
     >>> from surpyval.recurrent import ProportionalIntensityHPP
     >>>
     >>> data = load_rossi_static()
     >>> x = data['week'].values
-    >>> c = data['arrest'].values
+    >>> # 'arrest' == 1 is an observed event (c=0); 0 is right-censored (c=1)
+    >>> c = np.where(data['arrest'].values == 1, 0, 1)
+    >>> i = np.arange(len(data))
     >>> Z = data[["fin", "age", "race", "wexp", "mar", "paro", "prio"]].values
-    >>> model = ProportionalIntensityHPP.fit(x, Z, c)
+    >>> model = ProportionalIntensityHPP.fit(x, Z, i=i, c=c)
     >>> model
     Proportional Intensity Recurrence Model
     =======================================
@@ -36,15 +39,17 @@ class ProportionalIntensityHPP:
     Parameterization    : Parametric
     Hazard Rate Model   : Constant
     Base Rate Parameters:
-        lambda  :  5.687176190869141
+        lambda  :  0.012395105741757225
+    <BLANKLINE>
     Covariate Coefficients:
-        beta_0  :  0.5666297135140156
-        beta_1  :  0.031175577872654184
-        beta_2  :  -0.6796807726448314
-        beta_3  :  0.6602827681955281
-        beta_4  :  -2.577091221089804
-        beta_5  :  -0.4523927241350517
-        beta_6  :  -0.016388459191916338
+       beta_0  :  0.06397367067847898
+       beta_1  :  0.011491178797116433
+       beta_2  :  -0.02147901865302258
+       beta_3  :  -0.014676664859873595
+       beta_4  :  0.04738275470382102
+       beta_5  :  0.019109337775930837
+       beta_6  :  -0.01905662860143533
+    <BLANKLINE>
     """
 
     @classmethod

--- a/surpyval/recurrent/regression/hpp_proportional_intensity.py
+++ b/surpyval/recurrent/regression/hpp_proportional_intensity.py
@@ -115,6 +115,7 @@ class ProportionalIntensityHPP:
         if has_left_censoring:
             x_left = x_l[c == -1]
             n_left = n[c == -1]
+            Z_left = Z[c == -1]
             log_xl = np.log(x_left)
             n_log_x_left = n_left * log_xl
             n_log_x_left_sum = n_log_x_left.sum()
@@ -133,6 +134,7 @@ class ProportionalIntensityHPP:
             x_i_l = x_l[c == 2]
             x_i_r = x_r[c == 2]
             delta_xi = x_i_r - x_i_l
+            Z_i = Z[c == 2]
 
             n_interval = n[c == 2]
             n_interval_sum = n_interval.sum()
@@ -222,9 +224,12 @@ class ProportionalIntensityHPP:
         out.bounds = ((0, None),)
         out.support = (0.0, np.inf)
 
+        # Use the right endpoint for interval-censored (2D) observations when
+        # estimating each item's latest event time for the initial rate guess.
+        _x_max = data.x if data.x.ndim == 1 else data.x[:, 1]
         _, _inv = np.unique(data.i, return_inverse=True)
         _max_x = np.full(_inv.max() + 1, -np.inf)
-        np.maximum.at(_max_x, _inv, data.x)
+        np.maximum.at(_max_x, _inv, _x_max)
         init = (data.n[data.c == 0]).sum() / _max_x.sum()
 
         num_covariates = Z.shape[1]
@@ -232,7 +237,7 @@ class ProportionalIntensityHPP:
 
         neg_ll = cls.create_negll_func(data)
 
-        res = minimize(neg_ll, [init])
+        res = minimize(neg_ll, init)
         out.res = res
         out.params = np.atleast_1d(np.exp(res.x[0]))
         out.coeffs = np.atleast_1d(res.x[1:])

--- a/surpyval/recurrent/regression/nhpp_proportional_intensity.py
+++ b/surpyval/recurrent/regression/nhpp_proportional_intensity.py
@@ -23,14 +23,27 @@ class ProportionalIntensityNHPP:
     --------
 
     >>> import numpy as np
-    >>> from surpyval.datasets import load_rossi_static
     >>> from surpyval.recurrent import ProportionalIntensityNHPP
-    >>> data = load_rossi_static()
-    >>> x = data['week'].values
-    >>> # 'arrest' == 1 is an observed event (c=0); 0 is right-censored (c=1)
-    >>> c = np.where(data['arrest'].values == 1, 0, 1)
-    >>> i = np.arange(len(data))
-    >>> Z = data[["fin", "age", "race", "wexp", "mar", "paro", "prio"]].values
+    >>>
+    >>> # Four repairable systems observed until t=20; failures get more
+    >>> # frequent over time and the Z=1 group fails faster than the Z=0 group.
+    >>> x = [9, 14, 18, 20,
+    ...      7, 12, 16, 19, 20,
+    ...      5, 9, 13, 16, 18, 20,
+    ...      6, 10, 13, 15, 17, 19, 20]
+    >>> i = [1, 1, 1, 1,
+    ...      2, 2, 2, 2, 2,
+    ...      3, 3, 3, 3, 3, 3,
+    ...      4, 4, 4, 4, 4, 4, 4]
+    >>> # c = 0 is an observed failure, c = 1 the right-censored window close
+    >>> c = [0, 0, 0, 1,
+    ...      0, 0, 0, 0, 1,
+    ...      0, 0, 0, 0, 0, 1,
+    ...      0, 0, 0, 0, 0, 0, 1]
+    >>> Z = np.array([0, 0, 0, 0,
+    ...               0, 0, 0, 0, 0,
+    ...               1, 1, 1, 1, 1, 1,
+    ...               1, 1, 1, 1, 1, 1, 1]).reshape(-1, 1)
     >>> model = ProportionalIntensityNHPP.fit(x, Z, i=i, c=c)
     >>> model
     Proportional Intensity Recurrence Model
@@ -40,17 +53,11 @@ class ProportionalIntensityNHPP:
     Parameterization    : Parametric
     Hazard Rate Model   : Duane
     Base Rate Parameters:
-        alpha  :  8.66160614039418
-        b  :  1.4595294695090125e-15
+        alpha  :  2.0294701249769567
+        b  :  0.008010947012813689
     <BLANKLINE>
     Covariate Coefficients:
-       beta_0  :  0.04165485427630197
-       beta_1  :  -0.005241786199609709
-       beta_2  :  -0.006555560918222524
-       beta_3  :  -0.03912275371411811
-       beta_4  :  -0.020323791104350994
-       beta_5  :  -0.01093907588859648
-       beta_6  :  0.007067185098201159
+       beta_0  :  0.45194475814452534
     <BLANKLINE>
     """
 

--- a/surpyval/recurrent/regression/nhpp_proportional_intensity.py
+++ b/surpyval/recurrent/regression/nhpp_proportional_intensity.py
@@ -22,31 +22,36 @@ class ProportionalIntensityNHPP:
     Examples
     --------
 
+    >>> import numpy as np
     >>> from surpyval.datasets import load_rossi_static
     >>> from surpyval.recurrent import ProportionalIntensityNHPP
     >>> data = load_rossi_static()
     >>> x = data['week'].values
-    >>> c = data['arrest'].values
+    >>> # 'arrest' == 1 is an observed event (c=0); 0 is right-censored (c=1)
+    >>> c = np.where(data['arrest'].values == 1, 0, 1)
+    >>> i = np.arange(len(data))
     >>> Z = data[["fin", "age", "race", "wexp", "mar", "paro", "prio"]].values
-    >>> model = ProportionalIntensityNHPP.fit(x, Z, c)
+    >>> model = ProportionalIntensityNHPP.fit(x, Z, i=i, c=c)
     >>> model
     Proportional Intensity Recurrence Model
     =======================================
     Type                : Proportional Intensity
     Kind                : NHPP
     Parameterization    : Parametric
-    Hazard Rate Model   : Crow-AMSAA
+    Hazard Rate Model   : Duane
     Base Rate Parameters:
-        alpha  :  31.79321229839296
-        beta  :  4.980117330166502
+        alpha  :  8.66160614039418
+        b  :  1.4595294695090125e-15
+    <BLANKLINE>
     Covariate Coefficients:
-        beta_0  :  -0.09016653537772656
-        beta_1  :  0.12020391565561556
-        beta_2  :  0.08804834095964903
-        beta_3  :  -0.010992803410986032
-        beta_4  :  -0.5059158682824993
-        beta_5  :  -0.21305472747115095
-        beta_6  :  0.16760620140256433
+       beta_0  :  0.04165485427630197
+       beta_1  :  -0.005241786199609709
+       beta_2  :  -0.006555560918222524
+       beta_3  :  -0.03912275371411811
+       beta_4  :  -0.020323791104350994
+       beta_5  :  -0.01093907588859648
+       beta_6  :  0.007067185098201159
+    <BLANKLINE>
     """
 
     @classmethod
@@ -190,7 +195,7 @@ class ProportionalIntensityNHPP:
 
         res = minimize(
             neg_ll,
-            [init],
+            init,
             method="Nelder-Mead",
         )
         out.res = res

--- a/surpyval/tests/recurrent/test_hpp_proportional_intensity.py
+++ b/surpyval/tests/recurrent/test_hpp_proportional_intensity.py
@@ -1,0 +1,64 @@
+import numpy as np
+
+from surpyval.recurrent import ProportionalIntensityHPP
+from surpyval.utils.recurrent_utils import handle_xicn
+
+# Shared single-covariate design used across the censoring cases below.
+Z = np.array([[0.1], [0.1], [0.5], [0.5], [0.9], [0.9]])
+I = np.array([1, 1, 2, 2, 3, 3])
+
+
+def test_left_censored_likelihood_evaluates():
+    # Regression test: Z_left was only bound in the no-censoring else branch,
+    # so any left-censored data raised a NameError inside the likelihood.
+    x = np.array([5.0, 8.0, 6.0, 10.0, 7.0, 9.0])
+    c = np.array([-1, 0, -1, 0, -1, 0])
+    n = np.array([2, 1, 3, 1, 1, 1])
+    data = handle_xicn(x, I, c, n, Z=Z, as_recurrent_data=True)
+    negll = ProportionalIntensityHPP.create_negll_func(data)
+    assert np.isfinite(negll(np.array([0.5, 0.2])))
+
+
+def test_interval_censored_likelihood_evaluates():
+    # Regression test: Z_i had the same scoping bug for interval-censored data.
+    x = np.array(
+        [[5.0, 5.0], [5.0, 9.0], [6.0, 6.0], [6.0, 11.0], [7.0, 7.0], [7.0, 12.0]]
+    )
+    c = np.array([0, 2, 0, 2, 0, 2])
+    n = np.array([1, 2, 1, 3, 1, 2])
+    data = handle_xicn(x, I, c, n, Z=Z, as_recurrent_data=True)
+    negll = ProportionalIntensityHPP.create_negll_func(data)
+    assert np.isfinite(negll(np.array([0.5, 0.2])))
+
+
+def test_left_censored_fit_succeeds():
+    x = np.array([5.0, 8.0, 6.0, 10.0, 7.0, 9.0])
+    c = np.array([-1, 0, -1, 0, -1, 0])
+    n = np.array([2, 1, 3, 1, 1, 1])
+    model = ProportionalIntensityHPP.fit(x, Z, i=I, c=c, n=n)
+    assert model.res.success
+    assert np.all(np.isfinite(model.params))
+    assert np.all(np.isfinite(model.coeffs))
+
+
+def test_interval_censored_fit_succeeds():
+    x = np.array(
+        [[5.0, 5.0], [5.0, 9.0], [6.0, 6.0], [6.0, 11.0], [7.0, 7.0], [7.0, 12.0]]
+    )
+    c = np.array([0, 2, 0, 2, 0, 2])
+    n = np.array([1, 2, 1, 3, 1, 2])
+    model = ProportionalIntensityHPP.fit(x, Z, i=I, c=c, n=n)
+    assert model.res.success
+    assert np.all(np.isfinite(model.params))
+    assert np.all(np.isfinite(model.coeffs))
+
+
+def test_right_censored_fit_still_works():
+    # The previously working observed/right-censored path must be unaffected.
+    x = np.array([5.0, 8.0, 6.0, 10.0])
+    i = np.array([1, 1, 2, 2])
+    c = np.array([0, 1, 0, 1])
+    Z_rc = np.array([[0.1], [0.1], [0.5], [0.5]])
+    model = ProportionalIntensityHPP.fit(x, Z_rc, i=i, c=c)
+    assert model.res.success
+    assert np.all(np.isfinite(model.params))

--- a/surpyval/tests/recurrent/test_hpp_proportional_intensity.py
+++ b/surpyval/tests/recurrent/test_hpp_proportional_intensity.py
@@ -22,7 +22,8 @@ def test_left_censored_likelihood_evaluates():
 def test_interval_censored_likelihood_evaluates():
     # Regression test: Z_i had the same scoping bug for interval-censored data.
     x = np.array(
-        [[5.0, 5.0], [5.0, 9.0], [6.0, 6.0], [6.0, 11.0], [7.0, 7.0], [7.0, 12.0]]
+        [[5.0, 5.0], [5.0, 9.0], [6.0, 6.0],
+         [6.0, 11.0], [7.0, 7.0], [7.0, 12.0]]
     )
     c = np.array([0, 2, 0, 2, 0, 2])
     n = np.array([1, 2, 1, 3, 1, 2])
@@ -43,7 +44,8 @@ def test_left_censored_fit_succeeds():
 
 def test_interval_censored_fit_succeeds():
     x = np.array(
-        [[5.0, 5.0], [5.0, 9.0], [6.0, 6.0], [6.0, 11.0], [7.0, 7.0], [7.0, 12.0]]
+        [[5.0, 5.0], [5.0, 9.0], [6.0, 6.0],
+         [6.0, 11.0], [7.0, 7.0], [7.0, 12.0]]
     )
     c = np.array([0, 2, 0, 2, 0, 2])
     n = np.array([1, 2, 1, 3, 1, 2])

--- a/surpyval/tests/univariate/regression/test_dataframe_fit.py
+++ b/surpyval/tests/univariate/regression/test_dataframe_fit.py
@@ -133,7 +133,6 @@ def test_single_string_z_col():
 
 
 def test_accelerated_life_fit_from_df():
-    rng = np.random.default_rng(3)
     stresses = np.repeat([1.0, 2.0, 3.0, 4.0], 40)
     x = Weibull.random(len(stresses), 100 / stresses, 3)
     df = pd.DataFrame(

--- a/surpyval/univariate/parametric/distributions/weibull.py
+++ b/surpyval/univariate/parametric/distributions/weibull.py
@@ -382,5 +382,4 @@ class Weibull_(ParametricFitter):
         return alpha, beta
 
 
-
 Weibull: ParametricFitter = Weibull_("Weibull")

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -144,7 +144,10 @@ class ParametricFitter:
         return np.log(-np.expm1(-self.Hf(x, *params)))
 
     def _plot_x_bounds(self, x, params):
-        """Return (x_scale_min, x_scale_max) for probability plots, or None to auto-compute from data."""
+        """Return (x_scale_min, x_scale_max) for probability plots.
+
+        Returns None to auto-compute the bounds from the data.
+        """
         return None
 
     @_check_x_not_empty


### PR DESCRIPTION
Z_left and Z_i were only bound in the no-censoring else branches but
referenced in the likelihood, so any left- or interval-censored data
raised a NameError. Bind them in the censoring-present branches too.

Also fix two adjacent blockers found while verifying the end-to-end fit:
- minimize(neg_ll, [init]) double-wrapped the 1-D init into a 2-D array,
  which broke every fit, not just censored ones.
- the initial-rate guess called np.maximum.at with a 2-D x for
  interval-censored data; use the right endpoint instead.

Add regression tests covering left-, interval-, and right-censored fits.

https://claude.ai/code/session_01PPXfVUC2SCjwCWeHFRnMd1