### PR TITLE
Fix left-truncation handling in nonparametric MCF risk sets

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,9 +74,13 @@ theme; items already resolved are marked **[done]**.
   once observation begins at its `tl` (and the no-truncation case still
   reduces exactly to all-enter-at-origin). `tl`/`tr` are now exposed on
   `NonParametricCounting.fit()` and `CauseSpecificMCF.fit()` so the bound can
-  actually be supplied. Regression tests in
-  `tests/recurrent/test_mcf_truncation.py`. (Left truncation was already
-  handled for the parametric NHPP likelihood via `get_previous_x`.)
+  actually be supplied. The nonparametric estimators now also reject the
+  cases their risk-set construction does *not* yet handle — right truncation
+  (finite `tr`), left censoring (`c=-1`) and interval censoring (`c=2`) —
+  with explanatory `ValueError`s instead of silently returning a wrong MCF.
+  Regression tests in `tests/recurrent/test_mcf_truncation.py`. (Left
+  truncation was already handled for the parametric NHPP likelihood via
+  `get_previous_x`.)
 - `nhpp_proportional_intensity.py:131` calls `dist.log_iif(...)`
   unconditionally under a `# TODO`; crashes for any baseline lacking it, with
   no log-path fallback (underflow risk).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -67,11 +67,16 @@ theme; items already resolved are marked **[done]**.
   positionally into `i` (so they crashed) — rewritten to derive `c` from
   `arrest` and supply a per-subject `i`, and now pass `--doctest-modules`.
   Regression tests in `tests/recurrent/test_hpp_proportional_intensity.py`.
-- Left-truncated MCF is wrong: `RecurrentEventData.to_xrd()` builds the
-  at-risk set assuming every item enters at `t=0`, ignoring `tl`; inflates the
-  MCF and propagates to `CauseSpecificMCF`. (Left truncation *is* handled for
-  the parametric NHPP likelihood via `get_previous_x`; only the nonparametric
-  risk set is wrong.)
+- **[done]** Left-truncated MCF was wrong: `RecurrentEventData.to_xrd()`
+  built the at-risk set assuming every item enters at `t=0`, ignoring `tl`,
+  which biased the MCF and propagated to `CauseSpecificMCF`. The risk set is
+  now `#{items : tl_i ≤ x ≤ max_x_i}`, so a delayed-entry item only joins
+  once observation begins at its `tl` (and the no-truncation case still
+  reduces exactly to all-enter-at-origin). `tl`/`tr` are now exposed on
+  `NonParametricCounting.fit()` and `CauseSpecificMCF.fit()` so the bound can
+  actually be supplied. Regression tests in
+  `tests/recurrent/test_mcf_truncation.py`. (Left truncation was already
+  handled for the parametric NHPP likelihood via `get_previous_x`.)
 - `nhpp_proportional_intensity.py:131` calls `dist.log_iif(...)`
   unconditionally under a `# TODO`; crashes for any baseline lacking it, with
   no log-path fallback (underflow risk).
@@ -110,8 +115,10 @@ theme; items already resolved are marked **[done]**.
 **D. Missing capabilities**
 - No goodness-of-fit / trend tests anywhere (Laplace, MIL-HDBK-189C).
 - Truncation half-wired: `tr` not in the NHPP integral (right window-close
-  relies on a `c=1` row); MCF risk set ignores `tl` (see A); not exposed on
-  nonparametric `fit()`, regression `fit()`, or `CauseSpecificMCF.fit()`.
+  relies on a `c=1` row); still not exposed on the proportional-intensity
+  regression `fit()`. (The nonparametric MCF risk set now honours `tl`, and
+  `tl`/`tr` are exposed on `NonParametricCounting.fit()` and
+  `CauseSpecificMCF.fit()` — see A.)
 - `handle_xicn` has no `e` (event-mark) parameter, so `CauseSpecificMCF.fit`
   bypasses it and can't take truncation; no `fit_from_df` for marks.
 - The regression submodule and the nonparametric MCF have **zero tests**.
@@ -178,7 +185,7 @@ No martingale residuals, no cumulative-hazard residuals, no probability-integral
 ### Missing capabilities — medium priority
 
 **Left-truncation support (partial)**
-`handle_xicn` now takes the surpyval `t`/`tl`/`tr` truncation fields, and the calendar-time NHPP models (`HPP`, `CrowAMSAA`, `Duane`, `CoxLewis`) integrate each item's likelihood from its entry time `tl`, so delayed-entry (warranty-from-first-sale) data is analysed correctly there. The virtual-age / history-dependent models (Kijima/G1/ARA/ARI) reject `tl > 0` with an explanatory error, since the virtual age at entry is undefined without the pre-entry history. Still to do: delayed-entry risk sets in the nonparametric MCF (`NonParametricCounting.to_xrd` still assumes entry at 0), truncation passthrough for the proportional-intensity regression fitters, and multi-window (gapped) observation per item.
+`handle_xicn` now takes the surpyval `t`/`tl`/`tr` truncation fields, and the calendar-time NHPP models (`HPP`, `CrowAMSAA`, `Duane`, `CoxLewis`) integrate each item's likelihood from its entry time `tl`, so delayed-entry (warranty-from-first-sale) data is analysed correctly there. The virtual-age / history-dependent models (Kijima/G1/ARA/ARI) reject `tl > 0` with an explanatory error, since the virtual age at entry is undefined without the pre-entry history. The nonparametric MCF now uses delayed-entry risk sets (`RecurrentEventData.to_xrd` honours each item's `tl`, exposed on `NonParametricCounting.fit()` and `CauseSpecificMCF.fit()`). Still to do: truncation passthrough for the proportional-intensity regression fitters, and multi-window (gapped) observation per item.
 
 **No input validation**
 Negative times, NaN/inf values, and empty arrays all pass silently into the optimiser. Add a validation step in `handle_xicn()` with informative `ValueError`s.

--- a/surpyval/recurrent/competing_risks/nonparametric/cause_specific_mcf.py
+++ b/surpyval/recurrent/competing_risks/nonparametric/cause_specific_mcf.py
@@ -17,6 +17,7 @@ from matplotlib import pyplot as plt
 
 from surpyval.recurrent.nonparametric.mcf import NonParametricCounting
 from surpyval.utils.recurrent_event_data import RecurrentEventData
+from surpyval.utils.recurrent_utils import reject_unsupported_nonparametric
 
 
 def _counting_model_from_xrd(x, r, d):
@@ -73,6 +74,7 @@ class CauseSpecificMCF:
                 "RecurrentEventData has no event-type marks; pass `e` to "
                 "fit a cause-specific MCF."
             )
+        reject_unsupported_nonparametric(data, "CauseSpecificMCF")
         out = cls()
         out.data = data
         out.event_types = data.event_types

--- a/surpyval/recurrent/competing_risks/nonparametric/cause_specific_mcf.py
+++ b/surpyval/recurrent/competing_risks/nonparametric/cause_specific_mcf.py
@@ -84,7 +84,7 @@ class CauseSpecificMCF:
         return out
 
     @classmethod
-    def fit(cls, x, i=None, c=None, n=None, e=None):
+    def fit(cls, x, i=None, c=None, n=None, e=None, tl=None, tr=None):
         """
         Fit a cause-specific MCF.
 
@@ -100,6 +100,12 @@ class CauseSpecificMCF:
             Count of events at each row. Defaults to 1.
         e : array like
             Event type (mark) for each row. ``None`` for censored rows.
+        tl : array like or scalar, optional
+            Left-truncation (delayed-entry) time per item. The at-risk set
+            is shared across causes, so a delayed entry shrinks the risk set
+            for every cause until the item enters at ``tl``.
+        tr : array like or scalar, optional
+            Right-truncation time per item.
 
         Returns
         -------
@@ -116,5 +122,13 @@ class CauseSpecificMCF:
             c = np.zeros_like(x, dtype=int)
         if n is None:
             n = np.ones_like(x, dtype=int)
-        data = RecurrentEventData(x, i, c, n, e)
+        # RecurrentEventData expects per-row truncation bounds, so broadcast
+        # a scalar tl/tr to the full length here (handle_xicn does this via
+        # format_truncation, but the mark column means we build the data
+        # object directly).
+        if tl is not None:
+            tl = np.broadcast_to(np.asarray(tl, dtype=float), x.shape).copy()
+        if tr is not None:
+            tr = np.broadcast_to(np.asarray(tr, dtype=float), x.shape).copy()
+        data = RecurrentEventData(x, i, c, n, e, tl=tl, tr=tr)
         return cls.fit_from_recurrent_data(data)

--- a/surpyval/recurrent/nonparametric/mcf.py
+++ b/surpyval/recurrent/nonparametric/mcf.py
@@ -115,8 +115,9 @@ class NonParametricCounting:
     def fit_from_recurrent_data(cls, data):
         out = cls()
         out.data = data
-        x, r, d = data.to_xrd()
         out.x, out.r, out.d = data.to_xrd()
+        d = out.d
+        r = out.r
 
         out.mcf_hat = np.cumsum(d / r)
         var = (
@@ -130,6 +131,32 @@ class NonParametricCounting:
         return out
 
     @classmethod
-    def fit(cls, x, i=None, c=None, n=None):
-        data = handle_xicn(x, i, c, n, as_recurrent_data=True)
+    def fit(cls, x, i=None, c=None, n=None, tl=None, tr=None):
+        """
+        Fit a nonparametric (Nelson-Aalen) MCF.
+
+        Parameters
+        ----------
+        x : array like
+            Event (and censoring) times.
+        i : array like, optional
+            Item / subject id for each row. Defaults to a single item.
+        c : array like, optional
+            Censoring flag for each row (0 observed, 1 right censored).
+        n : array like, optional
+            Count of events at each row. Defaults to 1.
+        tl : array like or scalar, optional
+            Left-truncation (delayed-entry) time per item. An item only
+            enters the at-risk set once observation begins at ``tl``, so
+            earlier event times are estimated over a smaller risk set.
+        tr : array like or scalar, optional
+            Right-truncation time per item.
+
+        Returns
+        -------
+        NonParametricCounting
+        """
+        data = handle_xicn(
+            x, i, c, n, tl=tl, tr=tr, as_recurrent_data=True
+        )
         return cls.fit_from_recurrent_data(data)

--- a/surpyval/recurrent/nonparametric/mcf.py
+++ b/surpyval/recurrent/nonparametric/mcf.py
@@ -160,7 +160,5 @@ class NonParametricCounting:
         -------
         NonParametricCounting
         """
-        data = handle_xicn(
-            x, i, c, n, tl=tl, tr=tr, as_recurrent_data=True
-        )
+        data = handle_xicn(x, i, c, n, tl=tl, tr=tr, as_recurrent_data=True)
         return cls.fit_from_recurrent_data(data)

--- a/surpyval/recurrent/nonparametric/mcf.py
+++ b/surpyval/recurrent/nonparametric/mcf.py
@@ -2,7 +2,10 @@ from autograd import numpy as np
 from matplotlib import pyplot as plt
 from scipy.stats import norm, t
 
-from surpyval.utils.recurrent_utils import handle_xicn
+from surpyval.utils.recurrent_utils import (
+    handle_xicn,
+    reject_unsupported_nonparametric,
+)
 
 
 class NonParametricCounting:
@@ -113,6 +116,7 @@ class NonParametricCounting:
 
     @classmethod
     def fit_from_recurrent_data(cls, data):
+        reject_unsupported_nonparametric(data, "NonParametricCounting")
         out = cls()
         out.data = data
         out.x, out.r, out.d = data.to_xrd()

--- a/surpyval/tests/recurrent/test_mcf_truncation.py
+++ b/surpyval/tests/recurrent/test_mcf_truncation.py
@@ -99,9 +99,7 @@ def test_cause_specific_mcf_shares_truncated_risk_set():
     model = CauseSpecificMCF.fit(x, i, c=c, e=e, tl=tl)
 
     # The shared at-risk grid matches the truncation-aware to_xrd.
-    np.testing.assert_array_equal(
-        model.x, [2.0, 5.0, 6.0, 8.0, 10.0, 12.0]
-    )
+    np.testing.assert_array_equal(model.x, [2.0, 5.0, 6.0, 8.0, 10.0, 12.0])
     np.testing.assert_array_equal(model.r, [1, 2, 2, 2, 2, 1])
 
 
@@ -142,13 +140,9 @@ def test_cause_specific_mcf_rejects_unsupported():
     i = np.array([1, 1, 1])
     e = ["a", "b", None]
     with pytest.raises(ValueError, match="left-censored"):
-        CauseSpecificMCF.fit(
-            x, i, c=np.array([-1, 0, 1]), e=e
-        )
+        CauseSpecificMCF.fit(x, i, c=np.array([-1, 0, 1]), e=e)
     with pytest.raises(ValueError, match="right truncation"):
-        CauseSpecificMCF.fit(
-            x, i, c=np.array([0, 0, 1]), e=e, tr=10.0
-        )
+        CauseSpecificMCF.fit(x, i, c=np.array([0, 0, 1]), e=e, tr=10.0)
 
 
 def test_cause_specific_mcf_scalar_truncation_broadcasts():

--- a/surpyval/tests/recurrent/test_mcf_truncation.py
+++ b/surpyval/tests/recurrent/test_mcf_truncation.py
@@ -1,0 +1,116 @@
+"""
+Tests for delayed-entry (left-truncation) handling in the nonparametric
+recurrent risk set.
+
+``RecurrentEventData.to_xrd`` used to build the at-risk set assuming every
+item enters observation at ``t=0``, ignoring each item's left-truncation
+bound ``tl``. A delayed-entry item must only join the risk set once
+observation begins at its ``tl``; counting it earlier gives the wrong risk
+set and a biased MCF (and the same error propagated to ``CauseSpecificMCF``,
+which shares this risk set).
+"""
+
+import numpy as np
+
+from surpyval import RecurrentEventData
+from surpyval.recurrent.competing_risks import CauseSpecificMCF
+from surpyval.recurrent.nonparametric import NonParametricCounting
+from surpyval.utils.recurrent_utils import handle_xicn
+
+
+def _delayed_entry_data():
+    # Item 1 enters at t=0 with events at 2, 5 and is right-censored at 10.
+    # Item 2 has a *delayed entry* at t=4 with events at 6, 8 and is
+    # right-censored at 12. Item 2 must not be in the risk set before t=4.
+    x = np.array([2.0, 5.0, 10.0, 6.0, 8.0, 12.0])
+    i = np.array([1, 1, 1, 2, 2, 2])
+    c = np.array([0, 0, 1, 0, 0, 1])
+    tl = np.array([0.0, 0.0, 0.0, 4.0, 4.0, 4.0])
+    return x, i, c, tl
+
+
+def test_to_xrd_respects_left_truncation():
+    x, i, c, tl = _delayed_entry_data()
+    data = handle_xicn(x, i, c=c, tl=tl, as_recurrent_data=True)
+
+    x_unique, r, d = data.to_xrd()
+
+    # Risk set: item 2 only enters at t=4, so at t=2 only item 1 is at risk.
+    np.testing.assert_array_equal(x_unique, [2.0, 5.0, 6.0, 8.0, 10.0, 12.0])
+    np.testing.assert_array_equal(r, [1, 2, 2, 2, 2, 1])
+    np.testing.assert_array_equal(d, [1, 1, 1, 1, 0, 0])
+
+
+def test_left_truncation_changes_risk_set_vs_naive_entry():
+    # Without the fix every item is assumed present from t=0, so the risk set
+    # at the first event would be 2 instead of 1. Confirm the delayed entry
+    # genuinely shrinks the early risk set relative to the all-enter-at-0 case.
+    x, i, c, tl = _delayed_entry_data()
+
+    truncated = handle_xicn(x, i, c=c, tl=tl, as_recurrent_data=True)
+    naive = handle_xicn(x, i, c=c, as_recurrent_data=True)
+
+    _, r_trunc, _ = truncated.to_xrd()
+    _, r_naive, _ = naive.to_xrd()
+
+    # Same event grid, but the delayed-entry item is excluded before t=4.
+    assert r_trunc[0] == 1
+    assert r_naive[0] == 2
+    assert np.all(r_trunc <= r_naive)
+
+
+def test_mcf_uses_truncated_risk_set():
+    x, i, c, tl = _delayed_entry_data()
+    model = NonParametricCounting.fit(x, i, c=c, tl=tl)
+
+    # MCF = cumsum(d / r) over the truncation-aware risk set.
+    expected = np.cumsum(
+        np.array([1, 1, 1, 1, 0, 0]) / np.array([1, 2, 2, 2, 2, 1])
+    )
+    np.testing.assert_allclose(model.mcf_hat, expected)
+    # Non-decreasing, as an MCF must be.
+    assert np.all(np.diff(model.mcf_hat) >= -1e-12)
+
+
+def test_default_fit_unchanged_without_truncation():
+    # The default (no tl) path must be byte-for-byte the old behaviour: every
+    # item enters at the origin.
+    x = np.array([1, 2, 3, 4, 5, 1, 2, 3, 4, 5])
+    i = np.array([1, 1, 1, 1, 1, 2, 2, 2, 2, 2])
+    c = np.array([0, 0, 1, 1, 1, 0, 0, 0, 0, 1])
+
+    data = RecurrentEventData(x, i, c, np.ones_like(x))
+    x_unique, r, d = data.to_xrd()
+
+    np.testing.assert_array_equal(x_unique, [1, 2, 3, 4, 5])
+    np.testing.assert_array_equal(r, [2, 2, 2, 2, 2])
+
+
+def test_cause_specific_mcf_shares_truncated_risk_set():
+    # The cause-specific MCF reuses the shared risk set, so left truncation
+    # must flow through to every cause.
+    x = np.array([2.0, 5.0, 10.0, 6.0, 8.0, 12.0])
+    i = np.array([1, 1, 1, 2, 2, 2])
+    c = np.array([0, 0, 1, 0, 0, 1])
+    e = ["a", "b", None, "a", "b", None]
+    tl = np.array([0.0, 0.0, 0.0, 4.0, 4.0, 4.0])
+
+    model = CauseSpecificMCF.fit(x, i, c=c, e=e, tl=tl)
+
+    # The shared at-risk grid matches the truncation-aware to_xrd.
+    np.testing.assert_array_equal(
+        model.x, [2.0, 5.0, 6.0, 8.0, 10.0, 12.0]
+    )
+    np.testing.assert_array_equal(model.r, [1, 2, 2, 2, 2, 1])
+
+
+def test_cause_specific_mcf_scalar_truncation_broadcasts():
+    # A scalar tl is broadcast across all rows (handle_xicn is bypassed for
+    # marked data, so the fit must broadcast itself).
+    x = np.array([3.0, 7.0, 4.0, 8.0])
+    i = np.array([1, 1, 2, 2])
+    c = np.array([0, 1, 0, 1])
+    e = ["a", None, "a", None]
+
+    model = CauseSpecificMCF.fit(x, i, c=c, e=e, tl=2.0)
+    assert np.all(model.data.tl == 2.0)

--- a/surpyval/tests/recurrent/test_mcf_truncation.py
+++ b/surpyval/tests/recurrent/test_mcf_truncation.py
@@ -11,6 +11,7 @@ which shares this risk set).
 """
 
 import numpy as np
+import pytest
 
 from surpyval import RecurrentEventData
 from surpyval.recurrent.competing_risks import CauseSpecificMCF
@@ -102,6 +103,52 @@ def test_cause_specific_mcf_shares_truncated_risk_set():
         model.x, [2.0, 5.0, 6.0, 8.0, 10.0, 12.0]
     )
     np.testing.assert_array_equal(model.r, [1, 2, 2, 2, 2, 1])
+
+
+def test_nonparametric_rejects_right_truncation():
+    # Right truncation is not yet handled by the risk-set construction; the
+    # nonparametric MCF must fail rather than silently ignore tr.
+    with pytest.raises(ValueError, match="right truncation"):
+        NonParametricCounting.fit(
+            np.array([3.0, 7.0]), np.array([1, 1]), tr=10.0
+        )
+
+
+def test_nonparametric_rejects_left_censoring():
+    data = RecurrentEventData(
+        np.array([1.0, 3.0, 5.0]),
+        np.array([1, 1, 1]),
+        np.array([-1, 0, 1]),
+        np.ones(3),
+    )
+    with pytest.raises(ValueError, match="left-censored"):
+        NonParametricCounting.fit_from_recurrent_data(data)
+
+
+def test_nonparametric_rejects_interval_censoring():
+    data = RecurrentEventData(
+        np.array([1.0, 3.0, 5.0]),
+        np.array([1, 1, 1]),
+        np.array([0, 2, 1]),
+        np.ones(3),
+    )
+    with pytest.raises(ValueError, match="interval-censored"):
+        NonParametricCounting.fit_from_recurrent_data(data)
+
+
+def test_cause_specific_mcf_rejects_unsupported():
+    # The same restriction flows through the cause-specific estimator.
+    x = np.array([1.0, 3.0, 5.0])
+    i = np.array([1, 1, 1])
+    e = ["a", "b", None]
+    with pytest.raises(ValueError, match="left-censored"):
+        CauseSpecificMCF.fit(
+            x, i, c=np.array([-1, 0, 1]), e=e
+        )
+    with pytest.raises(ValueError, match="right truncation"):
+        CauseSpecificMCF.fit(
+            x, i, c=np.array([0, 0, 1]), e=e, tr=10.0
+        )
 
 
 def test_cause_specific_mcf_scalar_truncation_broadcasts():

--- a/surpyval/utils/recurrent_event_data.py
+++ b/surpyval/utils/recurrent_event_data.py
@@ -114,16 +114,27 @@ class RecurrentEventData:
                     for xi in x_unique
                 ]
             )
-            # count the number of items at their maximum x for each x_unique
-            # find the maximum x for each item
+            # Each item is at risk over its observation window: from its
+            # entry time up to and including its last observed time.
+            #
+            # The exit time is the item's maximum x (its last event or its
+            # right-censoring time). The entry time is the item's left
+            # truncation bound ``tl`` (delayed entry); when no truncation is
+            # supplied ``tl`` defaults to -inf, so the item is at risk from
+            # the start and this reduces to the all-enter-at-origin case. An
+            # item with a delayed entry only joins the risk set once ``x``
+            # reaches its ``tl``, so event times before that entry see a
+            # correspondingly smaller risk set (ignoring ``tl`` here would
+            # inflate the MCF).
             max_x = np.array(
                 [self.x[self.i == item].max() for item in self.items]
             )
-            # sum the number of items at each x in x_unique
-            # that are at their max
-            r = np.array([(max_x == xi).sum() for xi in x_unique])
-
-            r = len(self.items) * np.ones_like(x_unique) - r.cumsum() + r
+            entry = np.array(
+                [self.tl[self.i == item][0] for item in self.items]
+            )
+            r = np.array(
+                [((entry <= xi) & (xi <= max_x)).sum() for xi in x_unique]
+            )
 
             self.xrd = x_unique, r, d
         return self.xrd

--- a/surpyval/utils/recurrent_utils.py
+++ b/surpyval/utils/recurrent_utils.py
@@ -22,6 +22,38 @@ def reject_left_truncation(data: RecurrentEventData, model_name: str) -> None:
         )
 
 
+def reject_unsupported_nonparametric(
+    data: RecurrentEventData, model_name: str
+) -> None:
+    """
+    The nonparametric MCF estimators (``NonParametricCounting`` and
+    ``CauseSpecificMCF``) currently only support exact events (``c=0``) and
+    right-censored end-of-observation rows (``c=1``), with at most a left
+    truncation (delayed entry) on the observation window. Right truncation,
+    left censoring and interval censoring are not yet handled correctly by the
+    risk-set construction, so reject them up front rather than silently
+    returning a wrong MCF.
+    """
+    if np.any(np.isfinite(np.asarray(data.tr))):
+        raise ValueError(
+            "{} does not support right truncation (finite tr) yet.".format(
+                model_name
+            )
+        )
+
+    c = np.asarray(data.c)
+    if np.any(c == -1):
+        raise ValueError(
+            "{} does not support left-censored (c=-1) observations "
+            "yet.".format(model_name)
+        )
+    if np.any(c == 2):
+        raise ValueError(
+            "{} does not support interval-censored (c=2) observations "
+            "yet.".format(model_name)
+        )
+
+
 def validate_renewal_censoring(c: npt.ArrayLike, model_name: str) -> None:
     """
     The renewal models only define likelihood contributions for exact events


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where the nonparametric MCF (Mean Cumulative Function) estimators were ignoring left-truncation (delayed-entry) bounds when constructing at-risk sets, leading to biased MCF estimates. The fix ensures that items only enter the risk set once their observation window begins at their left-truncation time `tl`.

## Key Changes

- **Fixed `RecurrentEventData.to_xrd()`**: The at-risk set calculation now respects each item's left-truncation bound. An item is only counted as at-risk for times `x` where `tl ≤ x ≤ max_x`, rather than assuming all items enter at `t=0`. This correctly handles delayed-entry scenarios (e.g., warranty data where observation starts after purchase).

- **Exposed truncation parameters on `NonParametricCounting.fit()`**: Added `tl` and `tr` parameters so users can supply left and right truncation bounds. The method now passes these through to the underlying `RecurrentEventData`.

- **Exposed truncation parameters on `CauseSpecificMCF.fit()`**: Added `tl` and `tr` parameters with proper broadcasting for scalar values, since this method builds `RecurrentEventData` directly rather than via `handle_xicn`.

- **Added validation for unsupported censoring types**: Created `reject_unsupported_nonparametric()` utility to explicitly reject right truncation (finite `tr`), left censoring (`c=-1`), and interval censoring (`c=2`) with clear error messages, rather than silently returning incorrect results.

- **Updated `NonParametricCounting.fit_from_recurrent_data()`**: Now calls the validation function to catch unsupported data types early.

## Implementation Details

- The risk set calculation now uses: `r[x] = #{items : tl_i ≤ x ≤ max_x_i}` instead of the previous `#{items : x ≤ max_x_i}`.
- When no truncation is supplied, `tl` defaults to `-inf`, so the calculation reduces exactly to the original all-enter-at-origin behavior, maintaining backward compatibility.
- The fix automatically propagates to `CauseSpecificMCF` since it shares the same risk set construction.
- Comprehensive regression tests added in `tests/recurrent/test_mcf_truncation.py` covering delayed-entry scenarios, risk set validation, and error handling.

## Backward Compatibility

The default behavior (no truncation) is unchanged—all items are treated as entering at the origin, preserving existing code behavior.

https://claude.ai/code/session_01CCNxL6sXMy1rQbw4uGgW8X