### PR TITLE
Restructure model landscape table: drop discrete-time axis, add pass/fail outcome dimension

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ not yet built (e.g. the recurrent pass/fail / binomial cell).
 | Time-to-event | Recurrent | Competing | Without | &mdash; | &mdash; | `CauseSpecificMCF` |
 | Time-to-event | Recurrent | Competing | With | &mdash; | &mdash; | &mdash; |
 | Pass/fail | Single event | Single | Without | `Bernoulli` | &mdash; | &mdash; |
+| Pass/fail | Single event | Single | With | use logistic regression (out of scope for this package) | &mdash; | &mdash; |
 | Pass/fail | Recurrent | Single | Without | &mdash; | &mdash; | &mdash; |
 
 # Install and Quick Intro

--- a/README.md
+++ b/README.md
@@ -46,23 +46,27 @@ This project spawned from a Reliaility Engineering project; due to the history o
 # The Model Landscape
 
 SurPyval's models can be placed on a set of orthogonal axes. The table below
-cross-tabulates three of those axes &mdash; **event recurrence**, **competing
-events**, and **covariates** &mdash; against the **time scale** and
-**estimation** axes, and fills each cell with what can be used to implement it.
+cross-tabulates four of those axes &mdash; the **outcome** (a time-to-event
+duration vs a single pass/fail trial), **event recurrence**, **competing
+events**, and **covariates** &mdash; against the **estimation** axis, and fills
+each cell with what can be used to implement it. Every time-to-event model
+listed is continuous-time.
 A `&mdash;` marks a combination that is
-either not applicable (e.g. semiparametric estimation requires covariates) or
-not yet built.
+either not applicable (e.g. semiparametric estimation requires covariates,
+and recurrence/competing events are time-to-event concepts that do not apply
+to a pass/fail trial) or not yet built.
 
-| Recurrence | Events | Covariates | Continuous &middot; Parametric | Continuous &middot; Semiparametric | Continuous &middot; Nonparametric | Discrete &middot; Parametric | Discrete &middot; Semiparametric | Discrete &middot; Nonparametric |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Single event | Single | Without | `Weibull`, `Exponential`, `LogNormal`, `Gamma`, &hellip; | &mdash; | `KaplanMeier`, `NelsonAalen`, `FlemingHarrington`, `Turnbull` | `Bernoulli` | &mdash; | &mdash; |
-| Single event | Single | With | `WeibullPH`/`WeibullAFT` (PH/AFT/PO families) | `CoxPH` | &mdash; | &mdash; | &mdash; | &mdash; |
-| Single event | Competing | Without | &mdash; | &mdash; | `CompetingRisks` (CIF) | &mdash; | &mdash; | &mdash; |
-| Single event | Competing | With | &mdash; | `FineGray`, `CRPH` | &mdash; | &mdash; | &mdash; | &mdash; |
-| Recurrent | Single | Without | `HPP`, `NHPP`, `CrowAMSAA`, `Duane`, `CoxLewis` | &mdash; | `NonParametricCounting` (MCF) | &mdash; | &mdash; | &mdash; |
-| Recurrent | Single | With | `ProportionalIntensityHPP`, `ProportionalIntensityNHPP` | &mdash; | &mdash; | &mdash; | &mdash; | &mdash; |
-| Recurrent | Competing | Without | &mdash; | &mdash; | `CauseSpecificMCF` | &mdash; | &mdash; | &mdash; |
-| Recurrent | Competing | With | &mdash; | &mdash; | &mdash; | &mdash; | &mdash; | &mdash; |
+| Outcome | Recurrence | Events | Covariates | Parametric | Semiparametric | Nonparametric |
+| --- | --- | --- | --- | --- | --- | --- |
+| Time-to-event | Single event | Single | Without | `Weibull`, `Exponential`, `LogNormal`, `Gamma`, &hellip; | &mdash; | `KaplanMeier`, `NelsonAalen`, `FlemingHarrington`, `Turnbull` |
+| Time-to-event | Single event | Single | With | `WeibullPH`/`WeibullAFT` (PH/AFT/PO families) | `CoxPH` | &mdash; |
+| Time-to-event | Single event | Competing | Without | &mdash; | &mdash; | `CompetingRisks` (CIF) |
+| Time-to-event | Single event | Competing | With | &mdash; | `FineGray`, `CRPH` | &mdash; |
+| Time-to-event | Recurrent | Single | Without | `HPP`, `NHPP`, `CrowAMSAA`, `Duane`, `CoxLewis` | &mdash; | `NonParametricCounting` (MCF) |
+| Time-to-event | Recurrent | Single | With | `ProportionalIntensityHPP`, `ProportionalIntensityNHPP` | &mdash; | &mdash; |
+| Time-to-event | Recurrent | Competing | Without | &mdash; | &mdash; | `CauseSpecificMCF` |
+| Time-to-event | Recurrent | Competing | With | &mdash; | &mdash; | &mdash; |
+| Pass/fail | &mdash; | &mdash; | Without | `Bernoulli` | &mdash; | &mdash; |
 
 # Install and Quick Intro
 

--- a/README.md
+++ b/README.md
@@ -47,14 +47,15 @@ This project spawned from a Reliaility Engineering project; due to the history o
 
 SurPyval's models can be placed on a set of orthogonal axes. The table below
 cross-tabulates four of those axes &mdash; the **outcome** (a time-to-event
-duration vs a single pass/fail trial), **event recurrence**, **competing
+duration vs a pass/fail result), **event recurrence**, **competing
 events**, and **covariates** &mdash; against the **estimation** axis, and fills
-each cell with what can be used to implement it. Every time-to-event model
+each cell with what can be used to implement it. The recurrence axis spans both
+outcomes: a single pass/fail trial is `Bernoulli`, while repeated trials
+(the binomial case) are the recurrent counterpart. Every time-to-event model
 listed is continuous-time.
 A `&mdash;` marks a combination that is
-either not applicable (e.g. semiparametric estimation requires covariates,
-and recurrence/competing events are time-to-event concepts that do not apply
-to a pass/fail trial) or not yet built.
+either not applicable (e.g. semiparametric estimation requires covariates) or
+not yet built (e.g. the recurrent pass/fail / binomial cell).
 
 | Outcome | Recurrence | Events | Covariates | Parametric | Semiparametric | Nonparametric |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -66,7 +67,8 @@ to a pass/fail trial) or not yet built.
 | Time-to-event | Recurrent | Single | With | `ProportionalIntensityHPP`, `ProportionalIntensityNHPP` | &mdash; | &mdash; |
 | Time-to-event | Recurrent | Competing | Without | &mdash; | &mdash; | `CauseSpecificMCF` |
 | Time-to-event | Recurrent | Competing | With | &mdash; | &mdash; | &mdash; |
-| Pass/fail | &mdash; | &mdash; | Without | `Bernoulli` | &mdash; | &mdash; |
+| Pass/fail | Single event | Single | Without | `Bernoulli` | &mdash; | &mdash; |
+| Pass/fail | Recurrent | Single | Without | &mdash; | &mdash; | &mdash; |
 
 # Install and Quick Intro
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ cross-tabulates four of those axes &mdash; the **outcome** (a time-to-event
 duration vs a pass/fail result), **event recurrence**, **competing
 events**, and **covariates** &mdash; against the **estimation** axis, and fills
 each cell with what can be used to implement it. The recurrence axis spans both
-outcomes: a single pass/fail trial is `Bernoulli`, while repeated trials
-(the binomial case) are the recurrent counterpart. Every time-to-event model
+outcomes: a single pass/fail trial is `Bernoulli`, while repeated trials are
+the recurrent counterpart, `Binomial`. Every time-to-event model
 listed is continuous-time.
 A `&mdash;` marks a combination that is
 either not applicable (e.g. semiparametric estimation requires covariates) or
-not yet built (e.g. the recurrent pass/fail / binomial cell).
+not yet built.
 
 | Outcome | Recurrence | Events | Covariates | Parametric | Semiparametric | Nonparametric |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -69,7 +69,8 @@ not yet built (e.g. the recurrent pass/fail / binomial cell).
 | Time-to-event | Recurrent | Competing | With | &mdash; | &mdash; | &mdash; |
 | Pass/fail | Single event | Single | Without | `Bernoulli` | &mdash; | &mdash; |
 | Pass/fail | Single event | Single | With | use logistic regression (out of scope for this package) | &mdash; | &mdash; |
-| Pass/fail | Recurrent | Single | Without | &mdash; | &mdash; | &mdash; |
+| Pass/fail | Recurrent | Single | Without | `Binomial` | &mdash; | &mdash; |
+| Pass/fail | Recurrent | Single | With | use binomial regression (out of scope for this package) | &mdash; | &mdash; |
 
 # Install and Quick Intro
 

--- a/surpyval/__init__.py
+++ b/surpyval/__init__.py
@@ -21,6 +21,7 @@ from surpyval.univariate.parametric import (
     Bernoulli,
     Beta,
     Beta4,
+    Binomial,
     CustomDistribution,
     ExactEventTime,
     Exponential,

--- a/surpyval/tests/univariate/parametric/test_binomial.py
+++ b/surpyval/tests/univariate/parametric/test_binomial.py
@@ -1,0 +1,141 @@
+"""
+Tests for the Binomial distribution.
+
+The Binomial is a discrete count distribution (number of events in a fixed
+number of pass/fail trials) and, like the Bernoulli, sits outside the
+gradient-based MLE machinery. These tests check the closed-form identities,
+the closed-form fit, the reduction to the Bernoulli at ``n = 1``, input
+validation and serialisation.
+"""
+
+import numpy as np
+import pytest
+from scipy.stats import binom
+
+from surpyval import Bernoulli, Binomial, Parametric
+
+N, P = 5, 0.3
+
+
+def test_from_params_repr_and_params():
+    model = Binomial.from_params([N, P])
+    assert np.allclose(model.params, [N, P])
+    assert "Binomial" in repr(model)
+
+
+def test_pmf_cdf_sf_match_scipy():
+    model = Binomial.from_params([N, P])
+    k = np.arange(0, N + 1)
+    assert np.allclose(model.df(k), binom.pmf(k, N, P))
+    assert np.allclose(model.ff(k), binom.cdf(k, N, P))
+    assert np.allclose(model.sf(k), binom.sf(k, N, P))
+
+
+def test_sf_plus_ff_is_one():
+    model = Binomial.from_params([N, P])
+    k = np.arange(0, N + 1)
+    assert np.allclose(model.sf(k) + model.ff(k), 1.0)
+
+
+def test_pmf_sums_to_one():
+    model = Binomial.from_params([N, P])
+    assert np.isclose(model.df(np.arange(0, N + 1)).sum(), 1.0)
+
+
+def test_mean_var_moment_entropy():
+    model = Binomial.from_params([N, P])
+    assert np.isclose(model.mean(), N * P)
+    assert np.isclose(model.var(), N * P * (1 - P))
+    assert np.isclose(model.moment(2), binom.moment(2, N, P))
+    assert np.isclose(model.entropy(), binom.entropy(N, P))
+
+
+def test_hazard_and_cumulative_hazard():
+    model = Binomial.from_params([N, P])
+    k = np.arange(0, N)
+    expected_hf = binom.pmf(k, N, P) / (binom.sf(k, N, P) + binom.pmf(k, N, P))
+    assert np.allclose(model.hf(k), expected_hf)
+    assert np.allclose(model.Hf(k), -np.log(binom.sf(k, N, P)))
+
+
+def test_qf_roundtrip():
+    model = Binomial.from_params([N, P])
+    k = np.arange(0, N + 1)
+    # The quantile of the cdf returns a value no smaller than k
+    assert np.all(model.qf(binom.cdf(k, N, P)) >= k)
+
+
+def test_conditional_survival():
+    model = Binomial.from_params([N, P])
+    assert np.isclose(model.cs(1, 2), model.sf(3) / model.sf(2))
+
+
+def test_random_moments():
+    model = Binomial.from_params([N, P])
+    np.random.seed(1)
+    samples = model.random(100_000)
+    assert np.isclose(samples.mean(), N * P, atol=0.05)
+    assert np.isclose(samples.var(), N * P * (1 - P), atol=0.05)
+    assert samples.min() >= 0
+    assert samples.max() <= N
+
+
+def test_fit_closed_form():
+    # 2 + 3 + 1 + 4 = 10 events out of 4 * 5 = 20 trials -> p = 0.5
+    model = Binomial.fit([2, 3, 1, 4], n_trials=5)
+    assert np.allclose(model.params, [5, 0.5])
+    assert isinstance(model, Parametric)
+
+
+def test_fit_with_counts():
+    # 0 events once, 5 events once -> 5 / (2 * 5) = 0.5
+    model = Binomial.fit([0, 5], n_trials=5, n=[1, 1])
+    assert np.isclose(model.params[1], 0.5)
+
+
+def test_reduces_to_bernoulli_at_n_one():
+    # At n = 1 the event probabilities match the Bernoulli: P(K=1) = p and
+    # P(K=0) = 1 - p. Note surpyval's Bernoulli is a degenerate
+    # "fixed event probability" model whose survival is the constant
+    # probability of *no* event (1 - p), so it lines up with the binomial's
+    # P(K = 0) = ff(0), not its sf(0).
+    binomial = Binomial.from_params([1, P])
+    bernoulli = Bernoulli.from_params(P)
+    assert np.isclose(binomial.df(1), P)
+    assert np.isclose(binomial.df(0), 1 - P)
+    assert np.isclose(binomial.ff(0), bernoulli.sf(0))
+    assert np.isclose(binomial.sf(0), bernoulli.ff(0))
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"x": [1, 6], "n_trials": 5},  # out of range
+        {"x": [1, 2], "n_trials": 5, "c": [0, 1]},  # censoring unsupported
+        {"x": [1.5, 2], "n_trials": 5},  # non-integer counts
+    ],
+)
+def test_fit_input_validation(kwargs):
+    with pytest.raises(ValueError):
+        Binomial.fit(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        [5.5, 0.3],  # non-integer n
+        [0, 0.3],  # n must be positive
+        [5, 1.3],  # p out of bounds
+        [5],  # wrong number of params
+    ],
+)
+def test_from_params_validation(params):
+    with pytest.raises(ValueError):
+        Binomial.from_params(params)
+
+
+def test_to_dict_roundtrip():
+    model = Binomial.from_params([N, P])
+    restored = Parametric.from_dict(model.to_dict())
+    assert np.allclose(restored.params, [N, P])
+    assert np.isclose(restored.mean(), N * P)

--- a/surpyval/univariate/parametric/__init__.py
+++ b/surpyval/univariate/parametric/__init__.py
@@ -19,6 +19,7 @@ from .distributions import (
     Bernoulli,
     Beta,
     Beta4,
+    Binomial,
     CustomDistribution,
     ExactEventTime,
     ExpoWeibull,

--- a/surpyval/univariate/parametric/distributions/__init__.py
+++ b/surpyval/univariate/parametric/distributions/__init__.py
@@ -1,6 +1,7 @@
 from .bernoulli import Bernoulli, FixedEventProbability
 from .beta import Beta
 from .beta4 import Beta4
+from .binomial import Binomial
 from .custom_distribution import CustomDistribution
 from .exact_event_time import ExactEventTime
 from .expo_weibull import ExpoWeibull

--- a/surpyval/univariate/parametric/distributions/binomial.py
+++ b/surpyval/univariate/parametric/distributions/binomial.py
@@ -1,0 +1,443 @@
+from scipy.stats import binom
+
+from surpyval import np
+from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
+
+from ..parametric import Parametric
+
+
+class Binomial_(ParametricFitter):
+    r"""
+    The Binomial distribution: the number of events (failures) ``k`` in a
+    fixed number ``n`` of independent pass/fail trials, each with event
+    probability ``p``.
+
+    It is the recurrent (repeated-trials) counterpart of the
+    :class:`Bernoulli` distribution, which is the special case ``n = 1``.
+
+    The distribution is parameterised by ``n`` (the number of trials, a
+    positive integer) and ``p`` (the per-trial event probability). Because
+    ``n`` is an integer structural parameter, the distribution does not use
+    the gradient-based MLE machinery; instead ``fit`` uses the closed-form
+    maximum likelihood estimate of ``p`` for a known number of trials, in the
+    same spirit as :class:`Bernoulli`.
+    """
+
+    def __init__(self, name):
+        super().__init__(
+            name=name,
+            k=2,
+            bounds=((1, None), (0, 1)),
+            support=(0, np.inf),
+            param_names=["n", "p"],
+            param_map={"n": 0, "p": 1},
+            plot_x_scale="linear",
+        )
+        # A binomial is a discrete count distribution with a fixed number
+        # of trials; probability plotting (which assumes a continuous,
+        # invertible CDF) does not apply.
+        self.supports_mpp = False
+
+    def df(self, x, n, p):
+        r"""
+
+        Probability mass function for the Binomial distribution:
+
+        .. math::
+            P(X = x) = \binom{n}{x} p^{x} (1 - p)^{n - x}
+
+        Parameters
+        ----------
+
+        x : numpy array or scalar
+            The number of events at which the mass function is evaluated
+        n : integer
+            The number of trials
+        p : float
+            The per-trial probability of an event
+
+        Returns
+        -------
+
+        df : scalar or numpy array
+            The value(s) of the mass function at x
+
+        Examples
+        --------
+        >>> from surpyval import Binomial
+        >>> Binomial.df(2, 5, 0.3)
+        0.3086999999999998
+        """
+        return binom.pmf(x, n, p)
+
+    def ff(self, x, n, p):
+        r"""
+
+        Failure (CDF) function for the Binomial distribution:
+
+        .. math::
+            F(x) = P(X \leq x) = \sum_{i=0}^{\lfloor x \rfloor}
+            \binom{n}{i} p^{i} (1 - p)^{n - i}
+
+        Parameters
+        ----------
+
+        x : numpy array or scalar
+            The values at which the function will be calculated
+        n : integer
+            The number of trials
+        p : float
+            The per-trial probability of an event
+
+        Returns
+        -------
+
+        ff : scalar or numpy array
+            The value(s) of the failure function at x
+
+        Examples
+        --------
+        >>> from surpyval import Binomial
+        >>> Binomial.ff(2, 5, 0.3)
+        0.83692
+        """
+        return binom.cdf(x, n, p)
+
+    def sf(self, x, n, p):
+        r"""
+
+        Survival (reliability) function for the Binomial distribution:
+
+        .. math::
+            R(x) = P(X > x) = 1 - F(x)
+
+        Parameters
+        ----------
+
+        x : numpy array or scalar
+            The values at which the function will be calculated
+        n : integer
+            The number of trials
+        p : float
+            The per-trial probability of an event
+
+        Returns
+        -------
+
+        sf : scalar or numpy array
+            The value(s) of the survival function at x
+
+        Examples
+        --------
+        >>> from surpyval import Binomial
+        >>> Binomial.sf(2, 5, 0.3)
+        0.16308
+        """
+        return binom.sf(x, n, p)
+
+    def hf(self, x, n, p):
+        r"""
+
+        Discrete hazard rate for the Binomial distribution; the conditional
+        probability of exactly ``x`` events given at least ``x``:
+
+        .. math::
+            h(x) = \frac{P(X = x)}{P(X \geq x)}
+
+        Parameters
+        ----------
+
+        x : numpy array or scalar
+            The values at which the function will be calculated
+        n : integer
+            The number of trials
+        p : float
+            The per-trial probability of an event
+
+        Returns
+        -------
+
+        hf : scalar or numpy array
+            The value(s) of the discrete hazard rate at x
+        """
+        d = self.df(x, n, p)
+        # P(X >= x) = P(X > x) + P(X = x)
+        denom = self.sf(x, n, p) + d
+        return np.where(denom > 0, d / denom, 0.0)
+
+    def Hf(self, x, n, p):
+        r"""
+
+        Cumulative hazard function for the Binomial distribution:
+
+        .. math::
+            H(x) = -\ln R(x)
+
+        Parameters
+        ----------
+
+        x : numpy array or scalar
+            The values at which the function will be calculated
+        n : integer
+            The number of trials
+        p : float
+            The per-trial probability of an event
+
+        Returns
+        -------
+
+        Hf : scalar or numpy array
+            The value(s) of the cumulative hazard function at x
+        """
+        return -np.log(self.sf(x, n, p))
+
+    def qf(self, q, n, p):
+        r"""
+
+        Quantile (inverse CDF) function for the Binomial distribution; the
+        smallest number of events ``x`` such that :math:`F(x) \geq q`.
+
+        Parameters
+        ----------
+
+        q : numpy array or scalar
+            The values, between 0 and 1, at which the quantile is evaluated
+        n : integer
+            The number of trials
+        p : float
+            The per-trial probability of an event
+
+        Returns
+        -------
+
+        qf : scalar or numpy array
+            The quantile(s) at q
+
+        Examples
+        --------
+        >>> from surpyval import Binomial
+        >>> Binomial.qf(0.5, 5, 0.3)
+        1.0
+        """
+        return binom.ppf(q, n, p)
+
+    def cs(self, x, X, n, p):
+        r"""
+
+        Conditional survival; the probability of surviving a further ``x``
+        events having already survived ``X``:
+
+        .. math::
+            R(x \mid X) = \frac{R(x + X)}{R(X)}
+
+        Parameters
+        ----------
+
+        x : numpy array or scalar
+            The further number of events
+        X : numpy array or scalar
+            The number of events already survived
+        n : integer
+            The number of trials
+        p : float
+            The per-trial probability of an event
+
+        Returns
+        -------
+
+        cs : scalar or numpy array
+            The conditional survival probability
+        """
+        return self.sf(x + X, n, p) / self.sf(X, n, p)
+
+    def mean(self, n, p):
+        r"""
+
+        Mean of the Binomial distribution:
+
+        .. math::
+            E[X] = n p
+
+        Examples
+        --------
+        >>> from surpyval import Binomial
+        >>> Binomial.mean(5, 0.3)
+        1.5
+        """
+        return n * p
+
+    def moment(self, m, n, p):
+        r"""
+
+        m-th (raw) moment of the Binomial distribution.
+
+        Parameters
+        ----------
+
+        m : integer
+            The ordinal of the moment to calculate
+        n : integer
+            The number of trials
+        p : float
+            The per-trial probability of an event
+
+        Returns
+        -------
+
+        moment : scalar
+            The m-th raw moment of the Binomial distribution
+
+        Examples
+        --------
+        >>> from surpyval import Binomial
+        >>> Binomial.moment(1, 5, 0.3)
+        1.5
+        """
+        return binom.moment(m, n, p)
+
+    def entropy(self, n, p):
+        r"""
+
+        Entropy of the Binomial distribution (in nats).
+
+        Examples
+        --------
+        >>> from surpyval import Binomial
+        >>> Binomial.entropy(5, 0.3)
+        1.413614855283445
+        """
+        return binom.entropy(n, p)
+
+    def random(self, size, n, p):
+        r"""
+
+        Draws random samples from the distribution in shape `size`
+
+        Parameters
+        ----------
+
+        size : integer or tuple of positive integers
+            Shape or size of the random draw
+        n : integer
+            The number of trials
+        p : float
+            The per-trial probability of an event
+
+        Returns
+        -------
+
+        random : scalar or numpy array
+            Random values drawn from the distribution in shape `size`
+        """
+        return binom.rvs(n, p, size=size)
+
+    def fit(self, x, n_trials, c=None, n=None):
+        r"""
+
+        Fit the Binomial distribution for a known number of trials,
+        ``n_trials``, using the closed-form maximum likelihood estimate of
+        the per-trial event probability ``p``.
+
+        Parameters
+        ----------
+
+        x : array like
+            The observed number of events for each experiment. Every value
+            must be an integer in ``[0, n_trials]``.
+        n_trials : integer
+            The (known) number of trials in each experiment.
+        c : array like, optional
+            Censoring flags. Censoring is not supported for the Binomial
+            distribution and any non-zero flag raises a ``ValueError``.
+        n : array like, optional
+            The count (multiplicity) of each observation in ``x``. If
+            ``None`` each observation is assumed to have occurred once.
+
+        Returns
+        -------
+
+        model : Parametric
+            A parametric model with the fitted ``[n_trials, p]`` parameters.
+
+        Examples
+        --------
+        >>> from surpyval import Binomial
+        >>> model = Binomial.fit([2, 3, 1, 4], n_trials=5)
+        >>> model.params
+        array([5. , 0.5])
+        """
+        x = np.atleast_1d(np.asarray(x))
+
+        if not np.equal(np.mod(x, 1), 0).all():
+            raise ValueError("'x' must contain only integer counts")
+
+        n_trials = int(n_trials)
+        if n_trials < 1:
+            raise ValueError("'n_trials' must be a positive integer")
+
+        if ((x < 0) | (x > n_trials)).any():
+            raise ValueError("'x' must be between 0 and 'n_trials'")
+
+        if c is not None and (np.atleast_1d(np.asarray(c)) != 0).any():
+            raise ValueError(
+                "Binomial distribution does not support censored data"
+            )
+
+        if n is None:
+            n = np.ones_like(x)
+        n = np.atleast_1d(np.asarray(n))
+
+        model = Parametric(self, "MLE", None, False, False, False)
+        p = (x * n).sum() / (n_trials * n.sum())
+        model.params = np.array([float(n_trials), p])
+        model.support = np.array([0, n_trials])
+        return model
+
+    def from_params(self, params):
+        r"""
+
+        Create a Binomial model from the parameters ``[n, p]``.
+
+        Parameters
+        ----------
+
+        params : array like
+            The two parameters ``[n, p]``; ``n`` the (integer) number of
+            trials and ``p`` the per-trial event probability.
+
+        Returns
+        -------
+
+        model : Parametric
+            A parametric model with the provided parameters.
+
+        Examples
+        --------
+        >>> from surpyval import Binomial
+        >>> model = Binomial.from_params([5, 0.3])
+        >>> model.mean()
+        1.5
+        """
+        params = np.atleast_1d(np.asarray(params, dtype=float))
+
+        if params.shape[0] != 2:
+            raise ValueError("Binomial distribution requires '[n, p]' params")
+
+        n, p = params
+
+        if np.mod(n, 1) != 0:
+            raise ValueError("'n' must be an integer number of trials")
+
+        if n < 1:
+            raise ValueError("'n' must be a positive integer")
+
+        if not (0 <= p <= 1):
+            raise ValueError("'p' must be between 0 and 1")
+
+        model = Parametric(self, "given parameters", None, False, False, False)
+        model.params = np.array([float(n), p])
+        model.support = np.array([0, n])
+        return model
+
+
+Binomial = Binomial_("Binomial")


### PR DESCRIPTION
The discrete-time column group implied integer time-to-event support that
SurPyval does not have; its only entry, Bernoulli, is not a discrete-time
model but a single pass/fail (binary outcome) model. Remove the time-scale
axis (all remaining models are continuous-time) and introduce an Outcome
axis (time-to-event vs pass/fail) so Bernoulli is filed accurately.