### PR TITLE
Simplify recurrent module (DEVELOPMENT.md §4.C)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,22 +54,38 @@ renewal, regression, nonparametric, competing risks). Findings are grouped by
 theme; items already resolved are marked **[done]**.
 
 **C. Simplification**
-- The multi-start MLE fit scaffolding is copy-pasted across the four repair
-  fitters (`GeneralizedRenewal`, `GeneralizedOneRenewal`, `ARA`, `ARI`): the
-  `for X_init in [...]` loop, `bounds_convert`, the identical "Could not find a
-  good solution" raise, and the `_neg_ll`/`_mle`/`_n_obs` storage → a
-  `RenewalFitMixin._fit_repair_model(...)`.
-- Regression simulation is the stale pre-mixin copy (`tol=1e-5`, no `seed`/
-  `max_events`) in `ProportionalIntensityModel` → should inherit
-  `RecurrenceSimulationMixin`.
-- The parametric (`HPP`/`CrowAMSAA`/`Duane`/`CoxLewis`) and regression fitters never
-  set `_neg_ll`/`_mle`/`_n_obs`, so they get no AIC/BIC/SE even though
-  `LikelihoodInferenceMixin` exists and the repair models use it (~3 lines per
-  fit).
-- `Duane`/`CrowAMSAA`/`CoxLewis` each redefine `iif`/`log_iif`/`cif`/
-  `inv_cif` with identical docstring boilerplate (the models are mathematically
-  distinct — do not merge the math) → an `IntensityModel` ABC for the contract.
-  `HPP` could subclass `NHPPFitter` (overriding `create_negll_func`).
+- The multi-start MLE fit scaffolding that was copy-pasted across the four
+  repair fitters (`GeneralizedRenewal`, `GeneralizedOneRenewal`, `ARA`, `ARI`)
+  now lives in a shared `RenewalFitMixin` (`recurrent/renewal/fit_mixin.py`):
+  `_multistart` owns the `for X_init in [...]` loop, the best-start selection
+  and the two identical convergence-failure raises; `_bounds_transform` owns
+  the `bounds_convert` setup; `_attach_inference` owns the
+  `_neg_ll`/`_mle`/`_n_obs` storage; and `_initial_dist_params` de-duplicates
+  the first-event initialisation shared by `GeneralizedRenewal`/`ARA`. Each
+  fitter keeps only its own likelihood and optimiser call, so the numerics are
+  unchanged (`GeneralizedOneRenewal` still uses bounded Nelder-Mead, not the
+  transform, to keep its pinned results identical). **[done]**
+- `ProportionalIntensityModel` now inherits `RecurrenceSimulationMixin` instead
+  of carrying the stale pre-mixin simulation copy, so the regression model
+  gains seeding, the `max_events` backstop and the data-returning simulators;
+  the covariate vector `Z` is threaded to the sampler by the public entry
+  points. **[done]**
+- The parametric intensity models (`HPP`/`CrowAMSAA`/`Duane`/`CoxLewis`) and
+  the proportional-intensity regression fitters now set
+  `_neg_ll`/`_mle`/`_n_obs` and inherit `LikelihoodInferenceMixin`, so they
+  expose `log_likelihood`/`aic`/`bic`/`standard_errors` like the repair models.
+  `ParametricRecurrenceModel`/`ProportionalIntensityModel` define
+  `_parameter_names` for the labelling; the inference helpers were generalised
+  off the renewal-only `[q, *dist_params]` assumption. An MSE fit (or a
+  `from_params` model) sets nothing, so inference still raises there. **[done]**
+- `Duane`/`CrowAMSAA`/`CoxLewis` no longer repeat the `iif`/`log_iif`/`cif`/
+  `inv_cif` docstring boilerplate: the contract (plus `inv_cif` and
+  `parameter_initialiser`) lives once on a new `IntensityModel` ABC that
+  `NHPPFitter` subclasses, and the concrete models supply only the maths (which
+  is left distinct). `HPP` was *not* folded into `NHPPFitter` — its bespoke
+  log-space root-finding fit and pinned outputs differ enough from the
+  MSE/Nelder-Mead NHPP path that the subclassing would change behaviour for no
+  real saving; it stays a `CountingProcess`. **[done]**
 
 **D. Missing capabilities**
 - No goodness-of-fit / trend tests anywhere (Laplace, MIL-HDBK-189C).
@@ -80,7 +96,8 @@ theme; items already resolved are marked **[done]**.
   `CauseSpecificMCF.fit()` — see A.)
 - `handle_xicn` has no `e` (event-mark) parameter, so `CauseSpecificMCF.fit`
   bypasses it and can't take truncation; no `fit_from_df` for marks.
-- The regression submodule and the nonparametric MCF have **zero tests**.
+- The nonparametric MCF has **zero tests**. (The regression submodule now has
+  fit/inference and simulation tests — see C and the Test coverage note below.)
 - No residual diagnostics; no parametric CI band on `plot()`.
 
 **E. API inconsistencies**
@@ -177,12 +194,20 @@ Multiple event types in a single recurrent process (e.g., two failure modes on t
 
 ### Test coverage
 
-Only one test file with one test covers the entire recurrent module (`tests/recurrent/test_counting.py` — a single `GeneralizedOneRenewal` fit). The parametric, nonparametric, and regression sub-packages have no tests at all. Minimum viable coverage:
+The renewal, parametric and regression sub-packages now have tests
+(`tests/recurrent/test_counting.py`, `test_ara.py`, `test_ari.py`,
+`test_cox_lewis.py`, `test_counting_process.py`, `test_parametric_inference.py`,
+`test_hpp_proportional_intensity.py`, `test_regression_simulation.py`, …). The
+remaining gaps for minimum viable coverage:
 
-- Round-trip fit + CIF/IIF evaluation for each parametric model (HPP, CrowAMSAA, Duane, CoxLewis)
-- MCF and confidence bounds for `NonParametricCounting`
+- Round-trip fit + CIF/IIF evaluation for each parametric model (HPP,
+  CrowAMSAA, Duane, CoxLewis) — likelihood/AIC/BIC/SE now covered by
+  `test_parametric_inference.py`; CIF/IIF round-trips still thin.
+- MCF and confidence bounds for `NonParametricCounting`.
 - Simulation outputs for `GeneralizedRenewal` and `GeneralizedOneRenewal`
-- Proportional intensity HPP and NHPP fit + predict
+  (covered in `test_counting.py`).
+- Proportional intensity HPP and NHPP fit + predict (fit/inference covered;
+  predict round-trips still thin).
 
 ---
 

--- a/surpyval/recurrent/inference.py
+++ b/surpyval/recurrent/inference.py
@@ -36,8 +36,8 @@ class LikelihoodInferenceMixin:
     Likelihood-based inference for fitted recurrent-event models.
 
     The fitting routine must set ``_neg_ll`` (the negative log-likelihood in
-    natural parameter space), ``_mle`` (the fitted parameter vector in that same
-    space) and ``_n_obs`` (the number of events contributing to the
+    natural parameter space), ``_mle`` (the fitted parameter vector in that
+    same space) and ``_n_obs`` (the number of events contributing to the
     likelihood). Models built with ``fit_from_parameters`` (or by a non-
     likelihood method such as MSE) carry no likelihood and these methods raise.
 

--- a/surpyval/recurrent/inference.py
+++ b/surpyval/recurrent/inference.py
@@ -36,10 +36,19 @@ class LikelihoodInferenceMixin:
     Likelihood-based inference for fitted recurrent-event models.
 
     The fitting routine must set ``_neg_ll`` (the negative log-likelihood in
-    natural parameter space), ``_mle`` (the fitted parameter vector, with the
-    leading repair/restoration parameter first) and ``_n_obs`` (the number of
-    events contributing to the likelihood). Models built with
-    ``fit_from_parameters`` carry no likelihood and these methods raise.
+    natural parameter space), ``_mle`` (the fitted parameter vector in that same
+    space) and ``_n_obs`` (the number of events contributing to the
+    likelihood). Models built with ``fit_from_parameters`` (or by a non-
+    likelihood method such as MSE) carry no likelihood and these methods raise.
+
+    This is shared by every fitted recurrent model that has a likelihood: the
+    renewal / imperfect-repair models (``RenewalModel``), the parametric
+    intensity models (``ParametricRecurrenceModel``) and the proportional-
+    intensity regression models (``ProportionalIntensityModel``). Only the
+    parameter labelling differs between them, so subclasses supply
+    :meth:`_parameter_names`; everything numeric (log-likelihood, AIC, BIC,
+    covariance, standard errors) is computed here from ``_neg_ll``/``_mle``/
+    ``_n_obs`` alone.
 
     Standard errors come from inverting a numerical Hessian of the negative
     log-likelihood (the observed Fisher information). When a parameter sits on
@@ -55,14 +64,18 @@ class LikelihoodInferenceMixin:
                 "fit_from_parameters does not compute a likelihood."
             )
 
-    # Name of the leading repair/restoration parameter in ``_mle``. Subclasses
-    # using a different symbol (e.g. ARA's ``rho``) override this.
-    _restoration_param_name = "q"
+    def _parameter_names(self):
+        """
+        Names of the entries of ``_mle``, in order. Subclasses override this to
+        label their parameters (e.g. the renewal models prepend the restoration
+        parameter, the regression models append the covariate coefficients).
+        """
+        raise NotImplementedError
 
     @property
     def parameter_names(self):
         self._check_fitted()
-        return [self._restoration_param_name, *self.model.dist.param_names]
+        return list(self._parameter_names())
 
     @property
     def log_likelihood(self):
@@ -83,9 +96,9 @@ class LikelihoodInferenceMixin:
 
     def covariance(self):
         """
-        Approximate parameter covariance matrix, ordered as
-        ``[q, *dist_params]``. Computed as the inverse of the numerical Hessian
-        of the negative log-likelihood at the MLE.
+        Approximate parameter covariance matrix, ordered to match
+        :attr:`parameter_names`. Computed as the inverse of the numerical
+        Hessian of the negative log-likelihood at the MLE.
         """
         self._check_fitted()
         H = numerical_hessian(self._neg_ll, self._mle)
@@ -104,8 +117,9 @@ class LikelihoodInferenceMixin:
 
     def standard_errors(self):
         """
-        Standard errors of ``[q, *dist_params]`` (the square roots of the
-        diagonal of :meth:`covariance`). Entries are NaN where the variance is
+        Standard errors of the fitted parameters (the square roots of the
+        diagonal of :meth:`covariance`), ordered to match
+        :attr:`parameter_names`. Entries are NaN where the variance is
         non-positive, which typically indicates a boundary optimum.
         """
         var = np.diag(self.covariance())

--- a/surpyval/recurrent/parametric/__init__.py
+++ b/surpyval/recurrent/parametric/__init__.py
@@ -1,4 +1,4 @@
-from .counting_process import CountingProcess
+from .counting_process import CountingProcess, IntensityModel
 from .cox_lewis import CoxLewis
 from .crow_amsaa import CrowAMSAA
 from .duane import Duane

--- a/surpyval/recurrent/parametric/counting_process.py
+++ b/surpyval/recurrent/parametric/counting_process.py
@@ -38,3 +38,39 @@ class CountingProcess(ABC):
     def log_iif(self, x: ArrayLike, *params) -> ArrayLike:
         """Natural logarithm of the instantaneous intensity at ``x``."""
         ...
+
+
+class IntensityModel(CountingProcess):
+    """
+    Contract shared by the closed-form NHPP intensity baselines
+    (:class:`Crow-AMSAA <surpyval.recurrent.parametric.crow_amsaa.CrowAMSAA_>`,
+    :class:`Duane <surpyval.recurrent.parametric.duane.Duane_>`,
+    :class:`Cox-Lewis <surpyval.recurrent.parametric.cox_lewis.CoxLewis_>`).
+
+    These models are mathematically distinct but expose the *same* four
+    functions of time and their parameters, plus a parameter initialiser. The
+    contract -- and the docstrings describing each function -- lives here once
+    so the concrete models only have to supply the maths:
+
+    - ``cif(x, *params)`` cumulative intensity (expected event count) by ``x``,
+      the integral of ``iif`` from the origin, with ``cif(0) == 0``;
+    - ``iif(x, *params)`` instantaneous intensity (event rate) at ``x``;
+    - ``log_iif(x, *params)`` natural logarithm of ``iif``, used directly in
+      the log-likelihood for numerical stability;
+    - ``inv_cif(N, *params)`` the time at which ``N`` events are expected to
+      have occurred, i.e. the inverse of ``cif``;
+    - ``parameter_initialiser(x)`` a starting parameter vector for the
+      optimiser given the event times ``x``.
+
+    All array arguments are evaluated elementwise.
+    """
+
+    @abstractmethod
+    def inv_cif(self, N: ArrayLike, *params) -> ArrayLike:
+        """Time by which ``N`` events are expected; the inverse of ``cif``."""
+        ...
+
+    @abstractmethod
+    def parameter_initialiser(self, x: ArrayLike) -> ArrayLike:
+        """Starting parameter vector for the optimiser given event times."""
+        ...

--- a/surpyval/recurrent/parametric/cox_lewis.py
+++ b/surpyval/recurrent/parametric/cox_lewis.py
@@ -52,97 +52,23 @@ class CoxLewis(NHPPFitter):
         return np.array([1.0, 1.0])
 
     def cif(self, x, *params):
-        """
-        Cumulative intensity function (CIF) of the Cox-Lewis model.
-
-        This is the integral of the instantaneous intensity from 0 to ``x``,
-        i.e. the expected number of events by ``x``. It satisfies
-        ``cif(0) == 0``.
-
-        Parameters
-        ----------
-
-        x : float
-            The value at which CIF is evaluated.
-        params : tuple
-            Parameters of the Cox-Lewis model.
-
-        Returns
-        -------
-
-        float
-            The CIF value.
-        """
+        # The Cox-Lewis intensity is log-linear, so its cumulative intensity
+        # is the integral of ``exp(alpha + beta * x)`` from 0 to ``x``.
         alpha = params[0]
         beta = params[1]
         return np.exp(alpha) / beta * (np.exp(beta * x) - 1.0)
 
     def iif(self, x, *params):
-        """
-        Instantaneous intensity function (IIF) or the failure rate of the
-        Cox-Lewis model. This is the log-linear intensity that defines the
-        Cox-Lewis model.
-
-        Parameters
-        ----------
-
-        x : float
-            The value at which IIF is evaluated.
-        params : tuple
-            Parameters of the Cox-Lewis model.
-
-        Returns
-        -------
-
-        float
-            The IIF value.
-        """
         alpha = params[0]
         beta = params[1]
         return np.exp(alpha + beta * x)
 
     def log_iif(self, x, *params):
-        """
-        Natural logarithm of the instantaneous intensity function (IIF) of
-        the Cox-Lewis model.
-
-        Parameters
-        ----------
-
-        x : float
-            The value at which log(IIF) is evaluated.
-        params : tuple
-            Parameters of the Cox-Lewis model.
-
-        Returns
-        -------
-
-        float
-            The log(IIF) value.
-        """
         alpha = params[0]
         beta = params[1]
         return alpha + beta * x
 
     def inv_cif(self, N, *params):
-        """
-        Inverse of the cumulative intensity function (CIF) of the
-        Cox-Lewis model.
-
-        Parameters
-        ----------
-
-        N : float
-            The number of events expected to have occured.
-        params : tuple
-            Parameters of the Cox-Lewis model.
-
-        Returns
-        -------
-
-        float
-            The value of x at which N events are expected to have occured.
-        """
         alpha = params[0]
         beta = params[1]
         return np.log(1.0 + N * beta * np.exp(-alpha)) / beta

--- a/surpyval/recurrent/parametric/crow_amsaa.py
+++ b/surpyval/recurrent/parametric/crow_amsaa.py
@@ -52,93 +52,21 @@ class CrowAMSAA(NHPPFitter):
         return np.array([1.0, 1.0])
 
     def cif(self, x, *params):
-        """
-        Cumulative intensity function (CIF) of the Crow-AMSAA model.
-
-        Parameters
-        ----------
-
-        x : float
-            The value at which CIF is evaluated.
-        params : tuple
-            Parameters of the Crow-AMSAA model.
-
-
-        Returns
-        -------
-
-        float
-            The CIF value.
-        """
         alpha = params[0]
         beta = params[1]
         return (x / alpha) ** beta
 
     def iif(self, x, *params):
-        """
-        Instantaneous intensity function (IIF) or the failure rate of the
-        Crow-AMSAA model.
-
-        Parameters
-        ----------
-
-        x : float
-            The value at which IIF is evaluated.
-        params : tuple
-            Parameters of the Crow-AMSAA model.
-
-        Returns
-        -------
-
-        float
-            The IIF value.
-        """
         alpha = params[0]
         beta = params[1]
         return (beta / alpha**beta) * (x ** (beta - 1))
 
     def log_iif(self, x, *params):
-        """
-        Natural logarithm of the instantaneous intensity function (IIF) of
-        the Crow-AMSAA model.
-
-        Parameters
-        ----------
-
-        x : float
-            The value at which log(IIF) is evaluated.
-        params : tuple
-            Parameters of the Crow-AMSAA model.
-
-        Returns
-        -------
-
-        float
-            The log(IIF) value.
-        """
         alpha = params[0]
         beta = params[1]
         return np.log(beta) - beta * np.log(alpha) + (beta - 1) * np.log(x)
 
     def inv_cif(self, N, *params):
-        """
-        Inverse of the cumulative intensity function (CIF) of the
-        Crow-AMSAA model.
-
-        Parameters
-        ----------
-
-        N : float
-            The number of events expected to have occured.
-        params : tuple
-            Parameters of the Crow-AMSAA model.
-
-        Returns
-        -------
-
-        float
-            The value of x at which N events are expected to have occured.
-        """
         alpha = params[0]
         beta = params[1]
         return alpha * (N ** (1.0 / beta))

--- a/surpyval/recurrent/parametric/duane.py
+++ b/surpyval/recurrent/parametric/duane.py
@@ -52,85 +52,15 @@ class Duane(NHPPFitter):
         return np.array([1.0, 1.0])
 
     def cif(self, x, *params):
-        """
-        Cumulative intensity function (CIF) of the Duane model.
-
-        Parameters
-        ----------
-
-        x : float
-            The value at which CIF is evaluated.
-        params : tuple
-            Parameters of the Duane model.
-
-        Returns
-        -------
-
-        float
-            The CIF value.
-        """
         return params[1] * x ** params[0]
 
     def iif(self, x, *params):
-        """
-        Instantaneous intensity function (IIF) or the failure rate of the
-        Duane model.
-
-        Parameters
-        ----------
-
-        x : float
-            The value at which IIF is evaluated.
-        params : tuple
-            Parameters of the Duane model.
-
-        Returns
-        -------
-
-        float
-            The IIF value.
-        """
         return params[0] * params[1] * x ** (params[0] - 1.0)
 
     def log_iif(self, x, *params):
-        """
-        Natural logarithm of the instantaneous intensity function (IIF) of the
-        Duane model.
-
-        Parameters
-        ----------
-
-        x : float
-            The value at which log(IIF) is evaluated.
-        params : tuple
-            Parameters of the Duane model.
-
-        Returns
-        -------
-
-        float
-            The log(IIF) value.
-        """
         return (
             np.log(params[0]) + np.log(params[1]) + (params[0] - 1) * np.log(x)
         )
 
     def inv_cif(self, N, *params):
-        """
-        Inverse of the cumulative intensity function (CIF) of the Duane model.
-
-        Parameters
-        ----------
-
-        N : float
-            The value at which inverse CIF is evaluated.
-        params : tuple
-            Parameters of the Duane model.
-
-        Returns
-        -------
-
-        float
-            The inverse CIF value.
-        """
         return (N / params[1]) ** (1.0 / params[0])

--- a/surpyval/recurrent/parametric/hpp.py
+++ b/surpyval/recurrent/parametric/hpp.py
@@ -270,6 +270,13 @@ class HPP(CountingProcess):
         out.res = res
         out.params = np.exp(res.x)
 
+        # ``neg_ll`` is parameterised by ``log_rate`` for a stable optimisation;
+        # expose it in natural (rate) space so the shared likelihood-inference
+        # machinery sees ``_neg_ll(_mle)`` with ``_mle`` the fitted rate.
+        out._neg_ll = lambda params: neg_ll(np.log(np.asarray(params)))
+        out._mle = np.asarray(out.params, dtype=float)
+        out._n_obs = len(data.x)
+
         return out
 
     def fit(

--- a/surpyval/recurrent/parametric/hpp.py
+++ b/surpyval/recurrent/parametric/hpp.py
@@ -270,7 +270,7 @@ class HPP(CountingProcess):
         out.res = res
         out.params = np.exp(res.x)
 
-        # ``neg_ll`` is parameterised by ``log_rate`` for a stable optimisation;
+        # ``neg_ll`` is parameterised by ``log_rate`` for a stable optimiser;
         # expose it in natural (rate) space so the shared likelihood-inference
         # machinery sees ``_neg_ll(_mle)`` with ``_mle`` the fitted rate.
         out._neg_ll = lambda params: neg_ll(np.log(np.asarray(params)))

--- a/surpyval/recurrent/parametric/nhpp_fitter.py
+++ b/surpyval/recurrent/parametric/nhpp_fitter.py
@@ -2,14 +2,14 @@ from autograd import numpy as np
 from scipy.optimize import minimize
 from scipy.special import gammaln
 
-from surpyval.recurrent.parametric.counting_process import CountingProcess
+from surpyval.recurrent.parametric.counting_process import IntensityModel
 from surpyval.recurrent.parametric.parametric_recurrence import (
     ParametricRecurrenceModel,
 )
 from surpyval.utils.recurrent_utils import handle_xicn
 
 
-class NHPPFitter(CountingProcess):
+class NHPPFitter(IntensityModel):
     def create_negll_func(self, data):
         x, c, n = data.x, data.c, data.n
         x_prev = data.get_previous_x()
@@ -127,6 +127,7 @@ class NHPPFitter(CountingProcess):
         res = minimize(fun, param_init, bounds=self.bounds)
         param_init = res.x
 
+        ll_func = None
         if how == "MSE":
             params = res.x
 
@@ -147,6 +148,14 @@ class NHPPFitter(CountingProcess):
         model.data = data
         model.dist = self
         model.how = how
+        # The MLE objective is already in natural parameter space, so it serves
+        # directly as the likelihood used for AIC/BIC/standard errors. The MSE
+        # fit has no likelihood, so leave the inference attributes unset (the
+        # inference methods then raise).
+        if ll_func is not None:
+            model._neg_ll = ll_func
+            model._mle = np.asarray(params, dtype=float)
+            model._n_obs = len(data.x)
         return model
 
     def fit(

--- a/surpyval/recurrent/parametric/parametric_recurrence.py
+++ b/surpyval/recurrent/parametric/parametric_recurrence.py
@@ -1,14 +1,23 @@
 import numpy as np
 from matplotlib import pyplot as plt
 
+from surpyval.recurrent.inference import LikelihoodInferenceMixin
 from surpyval.recurrent.simulation import RecurrenceSimulationMixin
 
 
-class ParametricRecurrenceModel(RecurrenceSimulationMixin):
+class ParametricRecurrenceModel(
+    RecurrenceSimulationMixin, LikelihoodInferenceMixin
+):
     """
     A class for holding the parameters, data, and usefult methods for a
     fitted parametric recurrence model. This is the result of the ``fit`` calls
     from the counting distributions.
+
+    When fitted by maximum likelihood the model also carries the likelihood-
+    inference behaviour (``log_likelihood``, ``aic``, ``bic``,
+    ``standard_errors``) from :class:`LikelihoodInferenceMixin`. Models built
+    by ``from_params`` or fitted by ``how="MSE"`` carry no likelihood, so those
+    methods raise.
 
     Example
     -------
@@ -20,6 +29,9 @@ class ParametricRecurrenceModel(RecurrenceSimulationMixin):
     >>> x = Exponential.random(10, 1e-3).cumsum()
     >>> model = HPP.fit(x)
     """
+
+    def _parameter_names(self):
+        return list(self.dist.param_names)
 
     def __repr__(self):
         param_string = "\n".join(

--- a/surpyval/recurrent/regression/hpp_proportional_intensity.py
+++ b/surpyval/recurrent/regression/hpp_proportional_intensity.py
@@ -247,6 +247,12 @@ class ProportionalIntensityHPP:
         out.name = "Homogeneous Poisson Process"
         out.kind = "HPP"
         out.parameterization = "Parametric"
+        # ``neg_ll`` is parameterised by ``log_rate``; expose it in natural
+        # (rate) space so ``_neg_ll(_mle)`` works with ``_mle`` the fitted rate
+        # and covariate coefficients.
+        out._neg_ll = lambda p: neg_ll(np.concatenate([[np.log(p[0])], p[1:]]))
+        out._mle = np.concatenate([out.params, out.coeffs])
+        out._n_obs = len(data.x)
         # The baseline rate is constant, so there is no fitted intensity
         # distribution; expose a lightweight stand-in carrying just the name
         # used by ``ProportionalIntensityModel``'s repr.

--- a/surpyval/recurrent/regression/nhpp_proportional_intensity.py
+++ b/surpyval/recurrent/regression/nhpp_proportional_intensity.py
@@ -211,6 +211,12 @@ class ProportionalIntensityNHPP:
         out.kind = "NHPP"
         out.parameterization = "Parametric"
         out.param_names = dist.param_names
+        # The likelihood is in natural parameter space, so the full fitted
+        # vector ``[*dist_params, *coeffs]`` is the MLE the shared inference
+        # machinery needs for AIC/BIC/standard errors.
+        out._neg_ll = neg_ll
+        out._mle = np.asarray(res.x, dtype=float)
+        out._n_obs = len(data.x)
 
         return out
 

--- a/surpyval/recurrent/regression/proportional_intensity.py
+++ b/surpyval/recurrent/regression/proportional_intensity.py
@@ -1,15 +1,24 @@
-import warnings
-
 import numpy as np
 from matplotlib import pyplot as plt
 
-from surpyval.recurrent.nonparametric import NonParametricCounting
+from surpyval.recurrent.inference import LikelihoodInferenceMixin
+from surpyval.recurrent.simulation import RecurrenceSimulationMixin
 
 
-class ProportionalIntensityModel:
+class ProportionalIntensityModel(
+    RecurrenceSimulationMixin, LikelihoodInferenceMixin
+):
     """
     Model to provide methods and attributes when using a fitted proportional
     intensity model.
+
+    Simulation reuses the shared :class:`RecurrenceSimulationMixin` (seeding,
+    ``max_events`` backstop and the count/time-terminated drivers); the only
+    addition here is the per-item covariate vector ``Z``, which the simulation
+    entry points take and thread through to the sampler. When the model was
+    fitted by maximum likelihood it also carries the likelihood-inference
+    behaviour (``log_likelihood``, ``aic``, ``bic``, ``standard_errors``) from
+    :class:`LikelihoodInferenceMixin`.
 
     Examples
     --------
@@ -123,22 +132,50 @@ class ProportionalIntensityModel:
         ax.plot(x_plot, self.cif(x_plot, Z_0), color="b")
         return ax
 
-    def count_terminated_simulation(self, events, Z, items=1):
+    def _parameter_names(self):
+        # The base-rate (intensity) parameters lead ``_mle``, followed by the
+        # covariate coefficients.
+        return [
+            *self.param_names,
+            *["beta_{}".format(i) for i in range(len(self.coeffs))],
+        ]
+
+    def _new_sequence_sampler(self):
+        # The shared simulation driver requests one of these per item; the
+        # covariate vector for the run is stashed on ``_sim_Z`` by the public
+        # simulation entry points below.
+        Z = self._sim_Z
+        x_prev = 0.0
+
+        def sample(ui):
+            nonlocal x_prev
+            u_adj = ui * np.exp(-self.cif(x_prev, Z))
+            xi = self.inv_cif(-np.log(u_adj), Z) - x_prev
+            x_prev += xi
+            return xi
+
+        return sample
+
+    def _postprocess_simulated_model(self, model):
+        if self.dist.name == "CoxLewis":
+            model.mcf_hat += np.exp(self.params[0])
+        return model
+
+    def count_terminated_simulation(self, events, Z, items=1, seed=None):
         """
         Simulate count-terminated recurrence data based on the fitted model.
-        That is, if you want to simulate up to 10 events terminating the
-        simulation at 10 events, this is the method to use.
-
-        This method is for use with monte carlo methods that use the NHPP model
-        to simulate recurrence data.
 
         Parameters
         ----------
 
         events: int
-            Number of events to simulate.
+            Number of events to simulate per sequence.
+        Z: array_like
+            Covariate vector applied to every simulated sequence.
         items: int, optional
             Number of items (or sequences) to simulate. Default is 1.
+        seed: int or numpy.random.Generator, optional
+            Seed for a reproducible simulation.
 
         Returns
         -------
@@ -146,57 +183,34 @@ class ProportionalIntensityModel:
         NonParametricCounting
             An NonParametricCounting model built from the simulated data.
         """
-        self.initialize_simulation()
+        self._sim_Z = np.asarray(Z, dtype=float)
+        return super().count_terminated_simulation(
+            events, items=items, seed=seed
+        )
 
-        xicn = {"x": [], "i": [], "c": [], "n": []}
-
-        for i in range(0, items):
-            running = 0
-            j = 0
-            x_prev = 0
-            for j in range(0, events + 1):
-                ui = self.get_uniform_random_number()
-                u_adj = ui * np.exp(-self.cif(x_prev, Z))
-                xi = self.inv_cif(-np.log(u_adj), Z) - x_prev
-                running += xi
-                x_prev = running
-                xicn["i"].append(i + 1)
-                xicn["n"].append(1)
-                xicn["x"].append(running)
-                xicn["c"].append(0)
-
-        self.clear_simulation()
-
-        model = NonParametricCounting.fit(**xicn)
-
-        if self.dist.name == "CoxLewis":
-            model.mcf_hat += np.exp(self.params[0])
-
-        mask = model.mcf_hat <= events
-        model.x = model.x[mask]
-        model.mcf_hat = model.mcf_hat[mask]
-        model.var = None
-        return model
-
-    def time_terminated_simulation(self, T, Z, items=1, tol=1e-5):
+    def time_terminated_simulation(
+        self, T, Z, items=1, tol=1e-8, max_events=10_000, seed=None
+    ):
         """
-        Simulate time-terminated recurrence data based on the fitted model. If
-        you want to simulate up to some time T, this is the method to use. This
-        simulation can run into errors when a sequence approaches very steep
-        hazard rates. Warnings are provided if this is likely the case.
-
-        This model is useful for doing monte carlo simulations with the NHPP
-        model.
+        Simulate time-terminated recurrence data based on the fitted model.
 
         Parameters
         ----------
 
         T: float
             Time termination value.
+        Z: array_like
+            Covariate vector applied to every simulated sequence.
         items: int, optional
             Number of items (or sequences) to simulate. Default is 1.
         tol: float, optional
-            Tolerance for interarrival times to stop an individual sequence.
+            Interarrival times below this value end a sequence early (a
+            possible asymptote). Default is 1e-8.
+        max_events: int, optional
+            Hard per-sequence event cap that guarantees termination.
+            Default is 10000.
+        seed: int or numpy.random.Generator, optional
+            Seed for a reproducible simulation.
 
         Returns
         -------
@@ -207,53 +221,47 @@ class ProportionalIntensityModel:
         Warnings
         --------
 
-        If any of the simulated sequences seem to not reach the time
-        termination value T due to possible asymptote, a warning message will
-        be printed to notify the user about potential convergence problems in
-        the simulation.
+        A sequence is terminated early and right-censored at its last event if
+        an interarrival time falls below ``tol`` or it reaches ``max_events``
+        before T. A warning is raised in either case.
         """
-        self.initialize_simulation()
-        convergence_problem = False
+        self._sim_Z = np.asarray(Z, dtype=float)
+        return super().time_terminated_simulation(
+            T, items=items, tol=tol, max_events=max_events, seed=seed
+        )
 
-        xicn = {"x": [], "i": [], "c": [], "n": []}
+    def count_terminated_simulation_data(self, events, Z, items=1, seed=None):
+        """
+        Simulate count-terminated recurrence data and return the raw events.
+        Like :meth:`count_terminated_simulation` but yields the simulated
+        ``RecurrentEventData`` rather than the fitted MCF.
+        """
+        self._sim_Z = np.asarray(Z, dtype=float)
+        return super().count_terminated_simulation_data(
+            events, items=items, seed=seed
+        )
 
-        for i in range(0, items):
-            running = 0
-            j = 0
-            x_prev = 0
-            while True:
-                ui = self.get_uniform_random_number()
-                u_adj = ui * np.exp(-self.cif(x_prev, Z))
-                xi = self.inv_cif(-np.log(u_adj), Z) - x_prev
-                running += xi
-                x_prev = running
-                xicn["i"].append(i + 1)
-                xicn["n"].append(1)
-                if running > T:
-                    xicn["x"].append(T)
-                    xicn["c"].append(1)
-                    break
-                elif xi < tol:
-                    convergence_problem = True
-                    xicn["x"].append(running)
-                    xicn["c"].append(0)
-                    break
-                else:
-                    xicn["x"].append(running)
-                    xicn["c"].append(0)
-                    j += 1
+    def time_terminated_simulation_data(
+        self, T, Z, items=1, tol=1e-8, max_events=10_000, seed=None
+    ):
+        """
+        Simulate time-terminated recurrence data and return the raw events.
+        Like :meth:`time_terminated_simulation` but yields the simulated
+        ``RecurrentEventData`` rather than the fitted MCF.
+        """
+        self._sim_Z = np.asarray(Z, dtype=float)
+        return super().time_terminated_simulation_data(
+            T, items=items, tol=tol, max_events=max_events, seed=seed
+        )
 
-        self.clear_simulation()
-
-        if convergence_problem:
-            warnings.warn(
-                "Some timelines unable to reach T due to possible asymptote"
-            )
-
-        model = NonParametricCounting.fit(**xicn)
-
-        if self.dist.name == "CoxLewis":
-            model.mcf_hat += np.exp(self.params[0])
-        model.var = None
-
-        return model
+    def mcf(self, x, Z, items=1000, seed=None):
+        """
+        Estimate the mean cumulative function at ``x`` for covariates ``Z`` by
+        simulating ``items`` time-terminated sequences out to ``max(x)``.
+        """
+        self._sim_Z = np.asarray(Z, dtype=float)
+        x = np.atleast_1d(np.asarray(x, dtype=float))
+        np_model = self.time_terminated_simulation(
+            float(x.max()), Z, items=items, seed=seed
+        )
+        return np_model.mcf(x)

--- a/surpyval/recurrent/renewal/ara.py
+++ b/surpyval/recurrent/renewal/ara.py
@@ -2,8 +2,8 @@ import numpy as np
 from scipy.optimize import minimize
 
 from surpyval import Weibull
+from surpyval.recurrent.renewal.fit_mixin import RenewalFitMixin
 from surpyval.recurrent.renewal.renewal_model import RenewalModel
-from surpyval.univariate.parametric.fitters import bounds_convert
 from surpyval.utils.fitter import singleton_fitter
 from surpyval.utils.recurrent_utils import (
     handle_xicn,
@@ -54,7 +54,7 @@ def ara_virtual_ages(arrival_times, rho, m):
 
 
 @singleton_fitter
-class ARA:
+class ARA(RenewalFitMixin):
     """
     Arithmetic Reduction of Age (ARA) imperfect-repair model of Doyen and
     Gaudoin (2004).
@@ -175,59 +175,31 @@ class ARA:
         validate_renewal_censoring(data.c, type(self).__name__)
         reject_left_truncation(data, type(self).__name__)
 
-        if init is None:
-            first_events = data.get_times_to_first_events()
-            try:
-                dist_params = dist.fit(
-                    first_events.x, first_events.c, first_events.n
-                ).params
-                if np.isnan(dist_params).any():
-                    dist_params = None
-            except Exception:
-                dist_params = None
-            if dist_params is None:
-                dist_params = dist.fit(
-                    data.interarrival_times, data.c, data.n
-                ).params
-
-        param_map = {"rho": 0, **dist.param_map}
-        transform, inv_trans, _, _, _ = bounds_convert(
-            data.x, [(0, 1), *dist.bounds], {}, param_map
+        neg_ll = self.create_negll_func(data, dist, m)
+        transform, inv_trans = self._bounds_transform(
+            data.x, [(0, 1), *dist.bounds], ["rho", *dist.param_names]
         )
 
-        neg_ll = self.create_negll_func(data, dist, m)
-        neg_ll_unbounded = lambda p: neg_ll(inv_trans(p))  # noqa: E731
+        def fit_once(x0):
+            return minimize(
+                lambda p: neg_ll(inv_trans(p)),
+                transform(np.asarray(x0, dtype=float)),
+                method="Nelder-Mead",
+            )
 
         if init is None:
-            results = []
-            for rho_init in [0.1, 0.5, 0.9]:
-                x0 = transform(np.array([rho_init, *dist_params]))
-                res = minimize(neg_ll_unbounded, x0, method="Nelder-Mead")
-                if res.success:
-                    results.append(res)
-            if not results:
-                raise ValueError(
-                    "Could not find a good solution. "
-                    + "Try using `init` for better initial guess."
-                )
-            res = results[np.argmin([r.fun for r in results])]
+            dist_params = self._initial_dist_params(data, dist)
+            inits = [[rho_init, *dist_params] for rho_init in (0.1, 0.5, 0.9)]
         else:
-            x0 = transform(np.array(init))
-            res = minimize(neg_ll_unbounded, x0, method="Nelder-Mead")
-            if not res.success:
-                raise ValueError(
-                    "Optimization with the provided `init` did not "
-                    "converge. Try a different initial guess."
-                )
+            inits = None
+        res = self._multistart(fit_once, inits, init)
 
         rho, *dist_params = inv_trans(res.x)
         model = dist.from_params(list(dist_params))
         out = self._make_model(model, rho, m)
-        out.res = res
-        out.data = data
-        out._neg_ll = neg_ll
-        out._mle = np.asarray([rho, *dist_params], dtype=float)
-        out._n_obs = len(data.x)
+        self._attach_inference(
+            out, neg_ll, [rho, *dist_params], len(data.x), res, data
+        )
         return out
 
     def fit(self, x, i=None, c=None, n=None, dist=Weibull, m=1, init=None):

--- a/surpyval/recurrent/renewal/ari.py
+++ b/surpyval/recurrent/renewal/ari.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy.optimize import brentq, minimize
 
 from surpyval.recurrent.parametric.crow_amsaa import CrowAMSAA
-from surpyval.univariate.parametric.fitters import bounds_convert
+from surpyval.recurrent.renewal.fit_mixin import RenewalFitMixin
 from surpyval.utils.fitter import singleton_fitter
 from surpyval.utils.recurrent_utils import (
     handle_xicn,
@@ -37,7 +37,7 @@ def ari_reduction(failure_intensities, rho, m):
 
 
 @singleton_fitter
-class ARI:
+class ARI(RenewalFitMixin):
     """
     Arithmetic Reduction of Intensity (ARI) imperfect-repair model of Doyen and
     Gaudoin (2004).
@@ -181,55 +181,56 @@ class ARI:
         validate_renewal_censoring(data.c, type(self).__name__)
         reject_left_truncation(data, type(self).__name__)
 
-        if init is None:
-            try:
-                base_params = dist.fit_from_recurrent_data(data).params
-                base_params = np.asarray(base_params, dtype=float)
-                if not np.all(np.isfinite(base_params)):
-                    raise ValueError
-            except Exception:
-                base_params = np.asarray(dist.parameter_initialiser(data.x))
-
-        param_map = {
-            name: k for k, name in enumerate(["rho", *dist.param_names])
-        }
-        transform, inv_trans, _, _, _ = bounds_convert(
-            data.x, [(0, 1), *dist.bounds], {}, param_map
+        neg_ll = self.create_negll_func(data, dist, m)
+        transform, inv_trans = self._bounds_transform(
+            data.x, [(0, 1), *dist.bounds], ["rho", *dist.param_names]
         )
 
-        neg_ll = self.create_negll_func(data, dist, m)
-        neg_ll_unbounded = lambda p: neg_ll(inv_trans(p))  # noqa: E731
+        def fit_once(x0):
+            return minimize(
+                lambda p: neg_ll(inv_trans(p)),
+                transform(np.asarray(x0, dtype=float)),
+                method="Nelder-Mead",
+            )
 
         if init is None:
-            results = []
-            for rho_init in [0.1, 0.5, 0.9]:
-                x0 = transform(np.array([rho_init, *base_params]))
-                res = minimize(neg_ll_unbounded, x0, method="Nelder-Mead")
-                if res.success:
-                    results.append(res)
-            if not results:
-                raise ValueError(
-                    "Could not find a good solution. "
-                    + "Try using `init` for better initial guess."
-                )
-            res = results[np.argmin([r.fun for r in results])]
+            base_params = self._initial_baseline_params(data, dist)
+            inits = [[rho_init, *base_params] for rho_init in (0.1, 0.5, 0.9)]
         else:
-            x0 = transform(np.array(init))
-            res = minimize(neg_ll_unbounded, x0, method="Nelder-Mead")
-            if not res.success:
-                raise ValueError(
-                    "Optimization with the provided `init` did not "
-                    "converge. Try a different initial guess."
-                )
+            inits = None
+        res = self._multistart(fit_once, inits, init)
 
         rho, *dist_params = inv_trans(res.x)
         out = self._make_model(dist, dist_params, rho, m)
-        out.res = res
-        out.data = data
-        out._neg_ll = neg_ll
-        out._mle = np.asarray([rho, *dist_params], dtype=float)
-        out._n_obs = int((data.c == 0).sum())
+        # Only the observed failures (c == 0) contribute an intensity term, so
+        # they are the events that enter the BIC sample size.
+        self._attach_inference(
+            out,
+            neg_ll,
+            [rho, *dist_params],
+            int((data.c == 0).sum()),
+            res,
+            data,
+        )
         return out
+
+    @staticmethod
+    def _initial_baseline_params(data, dist):
+        """
+        Initial parameters for the baseline intensity model: the plain NHPP fit
+        of that baseline if it succeeds, otherwise its own parameter
+        initialiser. (ARI's baseline is an intensity model, not a lifetime
+        distribution, so this differs from the other repair fitters.)
+        """
+        try:
+            base_params = np.asarray(
+                dist.fit_from_recurrent_data(data).params, dtype=float
+            )
+            if not np.all(np.isfinite(base_params)):
+                raise ValueError
+        except Exception:
+            base_params = np.asarray(dist.parameter_initialiser(data.x))
+        return base_params
 
     def fit(self, x, i=None, c=None, n=None, dist=CrowAMSAA, m=1, init=None):
         """

--- a/surpyval/recurrent/renewal/fit_mixin.py
+++ b/surpyval/recurrent/renewal/fit_mixin.py
@@ -1,0 +1,102 @@
+import numpy as np
+
+from surpyval.univariate.parametric.fitters import bounds_convert
+
+
+class RenewalFitMixin:
+    """
+    Shared maximum-likelihood scaffolding for the imperfect-repair fitters
+    (``GeneralizedRenewal``, ``GeneralizedOneRenewal``, ``ARA``, ``ARI``).
+
+    Each of those fits a leading restoration parameter (``q``/``rho``) together
+    with the parameters of an underlying lifetime or intensity model by
+    multi-start Nelder-Mead on the negative log-likelihood, then attaches the
+    attributes that :class:`LikelihoodInferenceMixin` reads (``_neg_ll``,
+    ``_mle``, ``_n_obs``). The genuinely model-specific pieces -- how the
+    negative log-likelihood is built, whether the search runs in an
+    unconstrained transform space, the multi-start values to try, and what
+    counts as an observation -- are supplied by the caller. The parts that were
+    copy-pasted across all four fitters live here: the multi-start loop, the two
+    convergence-failure errors, picking the best start, the bounded->unbounded
+    parameter transform, and storing the inference attributes.
+    """
+
+    @staticmethod
+    def _initial_dist_params(data, dist):
+        """
+        Initial parameters for the underlying lifetime distribution, fitted to
+        the times-to-first-event when there are enough of them (these are
+        genuine renewal cycles) and otherwise to the raw interarrival times.
+        """
+        first_events = data.get_times_to_first_events()
+        dist_params = None
+        if len(first_events.x) >= 2:
+            try:
+                dist_params = dist.fit(
+                    first_events.x, first_events.c, first_events.n
+                ).params
+                if np.isnan(dist_params).any():
+                    dist_params = None
+            except Exception:
+                dist_params = None
+        if dist_params is None:
+            dist_params = dist.fit(
+                data.interarrival_times, data.c, data.n
+            ).params
+        return dist_params
+
+    @staticmethod
+    def _bounds_transform(data_x, bounds, param_names):
+        """
+        Build the (bounded -> unbounded) parameter transforms used by the
+        fitters that optimise in an unconstrained space. ``bounds`` are the
+        natural-space bounds ``[(restoration bounds), *dist.bounds]`` and
+        ``param_names`` are the names of those parameters, restoration first.
+        """
+        param_map = {name: k for k, name in enumerate(param_names)}
+        transform, inv_trans, _, _, _ = bounds_convert(
+            data_x, bounds, {}, param_map
+        )
+        return transform, inv_trans
+
+    @staticmethod
+    def _multistart(fit_once, inits, user_init):
+        """
+        Drive the multi-start fit. ``fit_once(x0) -> OptimizeResult`` runs the
+        optimiser from a single natural-space start ``x0``. With no user
+        ``init`` every start in ``inits`` is tried and the converged result with
+        the lowest objective is returned; with a user ``init`` it is run once.
+
+        Raises ``ValueError`` with the shared messages when nothing converges.
+        """
+        if user_init is None:
+            results = [res for res in map(fit_once, inits) if res.success]
+            if not results:
+                raise ValueError(
+                    "Could not find a good solution. "
+                    + "Try using `init` for better initial guess."
+                )
+            return results[int(np.argmin([res.fun for res in results]))]
+
+        res = fit_once(user_init)
+        if not res.success:
+            raise ValueError(
+                "Optimization with the provided `init` did not "
+                "converge. Try a different initial guess."
+            )
+        return res
+
+    @staticmethod
+    def _attach_inference(model, neg_ll, mle, n_obs, res, data):
+        """
+        Store the fit artefacts and the attributes
+        :class:`LikelihoodInferenceMixin` needs: ``_neg_ll`` (the negative
+        log-likelihood in natural parameter space), ``_mle`` (the fitted
+        parameters in that space) and ``_n_obs``.
+        """
+        model.res = res
+        model.data = data
+        model._neg_ll = neg_ll
+        model._mle = np.asarray(mle, dtype=float)
+        model._n_obs = int(n_obs)
+        return model

--- a/surpyval/recurrent/renewal/fit_mixin.py
+++ b/surpyval/recurrent/renewal/fit_mixin.py
@@ -15,10 +15,10 @@ class RenewalFitMixin:
     ``_mle``, ``_n_obs``). The genuinely model-specific pieces -- how the
     negative log-likelihood is built, whether the search runs in an
     unconstrained transform space, the multi-start values to try, and what
-    counts as an observation -- are supplied by the caller. The parts that were
-    copy-pasted across all four fitters live here: the multi-start loop, the two
-    convergence-failure errors, picking the best start, the bounded->unbounded
-    parameter transform, and storing the inference attributes.
+    counts as an observation -- are supplied by the caller. The parts that
+    were copy-pasted across all four fitters live here: the multi-start loop,
+    the two convergence-failure errors, picking the best start, the bounded-to-
+    unbounded parameter transform, and storing the inference attributes.
     """
 
     @staticmethod
@@ -64,8 +64,8 @@ class RenewalFitMixin:
         """
         Drive the multi-start fit. ``fit_once(x0) -> OptimizeResult`` runs the
         optimiser from a single natural-space start ``x0``. With no user
-        ``init`` every start in ``inits`` is tried and the converged result with
-        the lowest objective is returned; with a user ``init`` it is run once.
+        ``init`` every start in ``inits`` is tried and the converged result
+        with the lowest objective is returned; a user ``init`` is run once.
 
         Raises ``ValueError`` with the shared messages when nothing converges.
         """

--- a/surpyval/recurrent/renewal/generalized_one_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_one_renewal.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.optimize import minimize
 
 from surpyval import Weibull
+from surpyval.recurrent.renewal.fit_mixin import RenewalFitMixin
 from surpyval.recurrent.renewal.renewal_model import RenewalModel
 from surpyval.utils.fitter import singleton_fitter
 from surpyval.utils.recurrent_utils import (
@@ -12,7 +13,7 @@ from surpyval.utils.recurrent_utils import (
 
 
 @singleton_fitter
-class GeneralizedOneRenewal:
+class GeneralizedOneRenewal(RenewalFitMixin):
     """
     A class to handle the G1 renewal process of Kaminskiy and Krivtsov, in
     which the jth interarrival time is the underlying lifetime distribution
@@ -178,58 +179,35 @@ class GeneralizedOneRenewal:
         self._check_dist_eligible(dist)
         validate_renewal_censoring(data.c, type(self).__name__)
         reject_left_truncation(data, type(self).__name__)
-        if init is None:
-            dist_params = dist.fit(
-                data.interarrival_times, data.c, data.n
-            ).params
 
         neg_ll = self.create_negll_func(
             data.interarrival_times, data.i, data.c, data.n, dist
         )
 
-        results = []
-        # Iterate over different initial values for q
-        # result is sensitive to initial value of q
-        if init is None:
-            for q_init in [0.0001, 1.0, 2.0]:
-                init = [q_init, *dist_params]
-                res = minimize(
-                    neg_ll,
-                    init,
-                    bounds=[(-1, None), *dist.bounds],
-                    method="Nelder-Mead",
-                )
-                if res.success:
-                    results.append(res)
-
-            if results == []:
-                raise ValueError(
-                    "Could not find a good solution. "
-                    + "Try using `init` for better initial guess."
-                )
-            else:
-                res = results[np.argmin([res.fun for res in results])]
-        else:
-            res = minimize(
+        # The G1 likelihood only needs ``q > -1``, so it is optimised directly
+        # under simple box bounds rather than an unconstrained transform.
+        # result is sensitive to the initial value of q.
+        def fit_once(x0):
+            return minimize(
                 neg_ll,
-                init,
+                np.asarray(x0, dtype=float),
                 bounds=[(-1, None), *dist.bounds],
                 method="Nelder-Mead",
             )
-            if not res.success:
-                raise ValueError(
-                    "Optimization with the provided `init` did not "
-                    "converge. Try a different initial guess."
-                )
+
+        if init is None:
+            dist_params = dist.fit(
+                data.interarrival_times, data.c, data.n
+            ).params
+            inits = [[q_init, *dist_params] for q_init in (0.0001, 1.0, 2.0)]
+        else:
+            inits = None
+        res = self._multistart(fit_once, inits, init)
 
         underlying_model = dist.from_params(list(res.x[1:]))
         q = res.x[0]
         out = self._make_model(underlying_model, q)
-        out.res = res
-        out.data = data
-        out._neg_ll = neg_ll
-        out._mle = np.asarray(res.x, dtype=float)
-        out._n_obs = len(data.x)
+        self._attach_inference(out, neg_ll, res.x, len(data.x), res, data)
         return out
 
     def fit(self, x, i=None, c=None, n=None, dist=Weibull, init=None):

--- a/surpyval/recurrent/renewal/generalized_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_renewal.py
@@ -2,8 +2,8 @@ import numpy as np
 from scipy.optimize import minimize
 
 from surpyval import Weibull
+from surpyval.recurrent.renewal.fit_mixin import RenewalFitMixin
 from surpyval.recurrent.renewal.renewal_model import RenewalModel
-from surpyval.univariate.parametric.fitters import bounds_convert
 from surpyval.utils.fitter import singleton_fitter
 from surpyval.utils.recurrent_utils import (
     handle_xicn,
@@ -32,7 +32,7 @@ def kijima_ii_from_prev_interarrival(previous_interarrival_times, q):
 
 
 @singleton_fitter
-class GeneralizedRenewal:
+class GeneralizedRenewal(RenewalFitMixin):
     """
     A class to handle the generalized renewal process with different Kijima
     models.
@@ -221,79 +221,33 @@ class GeneralizedRenewal:
         """
         validate_renewal_censoring(data.c, type(self).__name__)
         reject_left_truncation(data, type(self).__name__)
-        first_events = data.get_times_to_first_events()
-        if init is None:
-            if len(first_events.x) < 2:
-                dist_params = None
-            else:
-                try:
-                    dist_params = dist.fit(
-                        first_events.x, first_events.c, first_events.n
-                    ).params
-                    if np.isnan(dist_params).any():
-                        dist_params = None
-                except Exception:
-                    dist_params = None
 
-            if dist_params is None:
-                dist_params = dist.fit(
-                    data.interarrival_times,
-                    data.c,
-                    data.n,
-                ).params
-
-        param_map = {"q": 0, **dist.param_map}
-        transform, inv_trans, _, _, not_fixed = bounds_convert(
-            data.x, [(0, None), *dist.bounds], {}, param_map
+        neg_ll = self.create_negll_func(data, dist, kijima=kijima)
+        transform, inv_trans = self._bounds_transform(
+            data.x, [(0, None), *dist.bounds], ["q", *dist.param_names]
         )
 
-        neg_ll_bounded = self.create_negll_func(data, dist, kijima=kijima)
-        neg_ll_unbounded = lambda params: neg_ll_bounded(  # noqa: E731
-            inv_trans(params)
-        )
-
-        if init is None:
-            # Iterate over different initial values for q
-            # result is (very!!) sensitive to initial value of q
-            results = []
-            for q_init in [0.0001, 1.0, 2.0]:
-                init = transform(np.array([q_init, *dist_params]))
-                res = minimize(
-                    neg_ll_unbounded,
-                    init,
-                    method="Nelder-Mead",
-                )
-                if res.success:
-                    results.append(res)
-            if not results:
-                raise ValueError(
-                    "Could not find a good solution. "
-                    + "Try using `init` for better initial guess."
-                )
-            else:
-                res = results[np.argmin([res.fun for res in results])]
-        else:
-            init = transform(np.array(init))
-            res = minimize(
-                neg_ll_unbounded,
-                init,
+        # result is (very!!) sensitive to the initial value of q
+        def fit_once(x0):
+            return minimize(
+                lambda p: neg_ll(inv_trans(p)),
+                transform(np.asarray(x0, dtype=float)),
                 method="Nelder-Mead",
             )
-            if not res.success:
-                raise ValueError(
-                    "Optimization with the provided `init` did not "
-                    "converge. Try a different initial guess."
-                )
+
+        if init is None:
+            dist_params = self._initial_dist_params(data, dist)
+            inits = [[q_init, *dist_params] for q_init in (0.0001, 1.0, 2.0)]
+        else:
+            inits = None
+        res = self._multistart(fit_once, inits, init)
 
         q, *dist_params = inv_trans(res.x)
         model = dist.from_params(list(dist_params))
         out = self._make_model(model, q, kijima)
-        out.res = res
-        out.data = data
-        out._neg_ll = neg_ll_bounded
-        out._mle = np.asarray([q, *dist_params], dtype=float)
-        out._n_obs = len(data.x)
-
+        self._attach_inference(
+            out, neg_ll, [q, *dist_params], len(data.x), res, data
+        )
         return out
 
     def fit(

--- a/surpyval/recurrent/renewal/renewal_model.py
+++ b/surpyval/recurrent/renewal/renewal_model.py
@@ -63,6 +63,11 @@ class RenewalModel(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
     def _new_sequence_sampler(self):
         return self._sampler_factory(self)
 
+    def _parameter_names(self):
+        # The restoration parameter (``q``/``rho``) leads ``_mle``, followed by
+        # the underlying lifetime/intensity model's parameters.
+        return [self._restoration_param_name, *self.model.dist.param_names]
+
     def __repr__(self):
         title = f"{self.kind} SurPyval Model"
         lines = [

--- a/surpyval/tests/recurrent/test_counting_process.py
+++ b/surpyval/tests/recurrent/test_counting_process.py
@@ -36,7 +36,7 @@ def test_nhpp_intensity_models_satisfy_intensity_contract(dist):
 
 def test_intensity_model_is_abstract():
     # IntensityModel only declares the contract; the maths is supplied by the
-    # concrete models, so neither it nor the partial NHPPFitter is instantiable.
+    # concrete models, so neither it nor the partial NHPPFitter can be built.
     with pytest.raises(TypeError):
         IntensityModel()
     with pytest.raises(TypeError):

--- a/surpyval/tests/recurrent/test_counting_process.py
+++ b/surpyval/tests/recurrent/test_counting_process.py
@@ -10,6 +10,8 @@ from surpyval.recurrent import (
     ProportionalIntensityNHPP,
 )
 from surpyval.recurrent.parametric import CountingProcess as ParametricCP
+from surpyval.recurrent.parametric import IntensityModel
+from surpyval.recurrent.parametric.nhpp_fitter import NHPPFitter
 from surpyval.utils.recurrent_utils import handle_xicn
 
 
@@ -21,6 +23,24 @@ def test_countingprocess_exported_consistently():
 @pytest.mark.parametrize("dist", [Duane, CrowAMSAA, CoxLewis])
 def test_nhpp_intensity_models_are_counting_processes(dist):
     assert isinstance(dist, CountingProcess)
+
+
+@pytest.mark.parametrize("dist", [Duane, CrowAMSAA, CoxLewis])
+def test_nhpp_intensity_models_satisfy_intensity_contract(dist):
+    # The closed-form NHPP baselines share the IntensityModel contract, which
+    # is what lets ARI accept any of them as a baseline interchangeably.
+    assert isinstance(dist, IntensityModel)
+    for name in ("iif", "cif", "log_iif", "inv_cif", "parameter_initialiser"):
+        assert callable(getattr(dist, name))
+
+
+def test_intensity_model_is_abstract():
+    # IntensityModel only declares the contract; the maths is supplied by the
+    # concrete models, so neither it nor the partial NHPPFitter is instantiable.
+    with pytest.raises(TypeError):
+        IntensityModel()
+    with pytest.raises(TypeError):
+        NHPPFitter()
 
 
 def test_hpp_is_a_counting_process():

--- a/surpyval/tests/recurrent/test_parametric_inference.py
+++ b/surpyval/tests/recurrent/test_parametric_inference.py
@@ -1,0 +1,113 @@
+"""Likelihood inference (AIC/BIC/SE) for the parametric and regression
+recurrent models -- the behaviour added when these fitters started setting
+``_neg_ll``/``_mle``/``_n_obs`` and inheriting ``LikelihoodInferenceMixin``."""
+
+import numpy as np
+import pytest
+
+from surpyval import Exponential
+from surpyval.recurrent import (
+    HPP,
+    CoxLewis,
+    CrowAMSAA,
+    Duane,
+    ProportionalIntensityHPP,
+    ProportionalIntensityNHPP,
+)
+
+
+def _intensity_events():
+    np.random.seed(1)
+    return Exponential.random(40, 1e-2).cumsum()
+
+
+def _assert_information_criteria(model, dist):
+    k = model._mle.size
+    n = model._n_obs
+    ll = model.log_likelihood
+    assert np.isclose(ll, -float(model._neg_ll(model._mle)))
+    assert np.isclose(model.aic, 2 * k - 2 * ll)
+    assert np.isclose(model.bic, k * np.log(n) - 2 * ll)
+    assert model.parameter_names == list(dist.param_names)
+
+
+@pytest.mark.parametrize("dist", [HPP, CrowAMSAA, Duane])
+def test_parametric_intensity_information_criteria(dist):
+    # Every MLE-fitted intensity model now exposes a likelihood and the
+    # standard information criteria derived from it.
+    model = dist.fit(_intensity_events())
+    _assert_information_criteria(model, dist)
+
+
+def test_cox_lewis_information_criteria():
+    # Cox-Lewis needs a log-linear intensity over a bounded window (its
+    # exponential CIF overflows on very large cumulative times), so it gets a
+    # tailored dataset rather than the shared one.
+    rng = np.random.default_rng(0)
+    alpha, beta, T = 0.0, 0.3, 20.0
+    lam_max = np.exp(alpha + beta * T)
+    cand = np.sort(rng.uniform(0, T, rng.poisson(lam_max * T)))
+    keep = rng.uniform(0, 1, cand.size) < np.exp(alpha + beta * cand) / lam_max
+    model = CoxLewis.fit(cand[keep], tl=0.0, tr=T)
+    _assert_information_criteria(model, CoxLewis)
+
+
+@pytest.mark.parametrize("dist", [HPP, CrowAMSAA, Duane])
+def test_parametric_intensity_standard_errors(dist):
+    # Standard errors come from the observed information and are finite and
+    # positive for these well-identified fits.
+    x = _intensity_events()
+    model = dist.fit(x)
+    se = model.standard_errors()
+    assert se.shape == (model._mle.size,)
+    assert np.all(np.isfinite(se)) and np.all(se > 0)
+
+
+def test_mse_fit_has_no_likelihood():
+    # The MSE fit minimises a sum of squares, not a likelihood, so inference
+    # must raise rather than report a meaningless AIC.
+    x = _intensity_events()
+    model = CrowAMSAA.fit(x, how="MSE")
+    for attr in ("log_likelihood", "aic", "bic"):
+        with pytest.raises(ValueError, match="fitted from data"):
+            getattr(model, attr)
+
+
+def test_from_params_has_no_likelihood():
+    # A model built directly from parameters carries no data/likelihood.
+    model = CrowAMSAA.from_params([1000.0, 1.2])
+    with pytest.raises(ValueError, match="fitted from data"):
+        model.aic
+
+
+def _regression_data():
+    x = [9, 14, 18, 20, 7, 12, 16, 19, 20, 5, 9, 13, 16, 18, 20]
+    i = [1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3]
+    c = [0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1]
+    Z = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]).reshape(-1, 1)
+    return x, i, c, Z
+
+
+def test_nhpp_regression_information_criteria():
+    x, i, c, Z = _regression_data()
+    model = ProportionalIntensityNHPP.fit(x, Z, i=i, c=c, dist=CrowAMSAA)
+    k = model._mle.size
+    n = model._n_obs
+    ll = model.log_likelihood
+    assert np.isclose(ll, -float(model._neg_ll(model._mle)))
+    assert np.isclose(model.aic, 2 * k - 2 * ll)
+    assert np.isclose(model.bic, k * np.log(n) - 2 * ll)
+    # Base-rate parameters first, then one coefficient per covariate column.
+    assert model.parameter_names == ["alpha", "beta", "beta_0"]
+    assert np.all(np.isfinite(model.standard_errors()))
+
+
+def test_hpp_regression_information_criteria():
+    x, i, c, Z = _regression_data()
+    model = ProportionalIntensityHPP.fit(x, Z, i=i, c=c)
+    ll = model.log_likelihood
+    # ``_mle`` is in natural (rate) space; ``_neg_ll`` must agree there.
+    assert np.isclose(ll, -float(model._neg_ll(model._mle)))
+    assert model.parameter_names == ["lambda", "beta_0"]
+    assert np.isfinite(model.aic) and np.isfinite(model.bic)
+    assert np.all(np.isfinite(model.standard_errors()))

--- a/surpyval/tests/recurrent/test_regression_simulation.py
+++ b/surpyval/tests/recurrent/test_regression_simulation.py
@@ -1,0 +1,75 @@
+"""The proportional-intensity regression model now inherits the shared
+``RecurrenceSimulationMixin`` instead of carrying its own stale copy, so it
+gains seeding, the ``max_events`` backstop, and the data-returning simulators
+-- threading the covariate vector ``Z`` through to the sampler."""
+
+import warnings
+
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")
+
+from surpyval.recurrent import (  # noqa: E402
+    CrowAMSAA,
+    ProportionalIntensityNHPP,
+)
+from surpyval.utils.recurrent_event_data import (  # noqa: E402
+    RecurrentEventData,
+)
+
+
+def _fit():
+    x = [9, 14, 18, 20, 7, 12, 16, 19, 20, 5, 9, 13, 16, 18, 20]
+    i = [1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3]
+    c = [0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1]
+    Z = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]).reshape(-1, 1)
+    return ProportionalIntensityNHPP.fit(x, Z, i=i, c=c, dist=CrowAMSAA)
+
+
+def test_regression_simulation_seed_is_reproducible():
+    model = _fit()
+    Z = np.array([1.0])
+    xs = [5.0, 10.0, 15.0, 20.0]
+    a = model.mcf(xs, Z, items=300, seed=11)
+    b = model.mcf(xs, Z, items=300, seed=11)
+    c = model.mcf(xs, Z, items=300, seed=22)
+    assert np.allclose(a, b)
+    assert not np.allclose(a, c)
+
+
+def test_regression_count_terminated_simulation():
+    model = _fit()
+    sim = model.count_terminated_simulation(
+        6, Z=np.array([0.0]), items=40, seed=0
+    )
+    # The trimmed simulated MCF is non-decreasing and stays within the events.
+    assert np.all(np.diff(sim.mcf_hat) >= -1e-9)
+    assert sim.mcf_hat.max() < 6
+
+
+def test_regression_data_simulators_return_recurrent_data():
+    model = _fit()
+    count = model.count_terminated_simulation_data(
+        5, Z=np.array([1.0]), items=12, seed=0
+    )
+    assert isinstance(count, RecurrentEventData)
+    assert len(count.x) == 12 * (5 + 1)
+
+    timed = model.time_terminated_simulation_data(
+        T=20, Z=np.array([1.0]), items=12, seed=0
+    )
+    assert isinstance(timed, RecurrentEventData)
+    assert (timed.c == 1).any()
+
+
+def test_regression_time_terminated_max_events_backstop():
+    # The covariate that makes the intensity decay can leave a sequence unable
+    # to reach a huge T; the inherited max_events cap must still terminate it.
+    model = _fit()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        model.time_terminated_simulation(
+            T=1e6, Z=np.array([-5.0]), items=3, max_events=5, seed=0
+        )
+    assert any("max_events" in str(w.message) for w in caught)


### PR DESCRIPTION
Address the four simplification points for the recurrent package:

- Extract the copy-pasted multi-start MLE scaffolding from the four repair
  fitters (GeneralizedRenewal, GeneralizedOneRenewal, ARA, ARI) into a shared
  RenewalFitMixin: _multistart owns the start loop, best-start selection and
  the two convergence-failure raises; _bounds_transform owns bounds_convert;
  _attach_inference owns _neg_ll/_mle/_n_obs storage; _initial_dist_params
  de-duplicates the first-event initialisation. Each fitter keeps its own
  likelihood/optimiser call so the numerics are unchanged.

- Make ProportionalIntensityModel inherit RecurrenceSimulationMixin instead of
  the stale pre-mixin simulation copy, gaining seeding, the max_events
  backstop and the data-returning simulators; the covariate vector Z is
  threaded through to the sampler by the public entry points.

- Give the parametric intensity models (HPP/CrowAMSAA/Duane/CoxLewis) and the
  proportional-intensity regression fitters AIC/BIC/standard errors by setting
  _neg_ll/_mle/_n_obs and inheriting LikelihoodInferenceMixin, which is
  generalised off its renewal-only parameter-naming assumption via a
  _parameter_names hook. MSE / from_params models carry no likelihood and
  still raise.

- Add an IntensityModel ABC carrying the iif/log_iif/cif/inv_cif/
  parameter_initialiser contract once, and strip the duplicated docstring
  boilerplate from Duane/CrowAMSAA/CoxLewis (the maths is left distinct).

Add tests for the new inference, regression simulation and ABC contract.