### PR TITLE
Add Laplace and MIL-HDBK-189C trend tests for recurrent data

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -88,7 +88,14 @@ theme; items already resolved are marked **[done]**.
   real saving; it stays a `CountingProcess`. **[done]**
 
 **D. Missing capabilities**
-- No goodness-of-fit / trend tests anywhere (Laplace, MIL-HDBK-189C).
+- Trend tests are now available as standalone functions in
+  `surpyval.recurrent.tests`: `laplace` (the centroid test, asymptotically
+  normal) and `mil_hdbk_189c` (the Military Handbook / total-time-on-test
+  statistic, chi-squared). Both take `(x, i, T)` and an `alternative`
+  direction, support single- and multi-system data and both time- and
+  failure-truncation, and return a `TrendTestResult`. Still to do: a
+  Cramér-von Mises NHPP goodness-of-fit test, and exposing the trend tests
+  as a method on fitted NHPP models. **[done]**
 - Truncation half-wired: `tr` not in the NHPP integral (right window-close
   relies on a `c=1` row); still not exposed on the proportional-intensity
   regression `fit()`. (The nonparametric MCF risk set now honours `tl`, and
@@ -181,8 +188,13 @@ Log-likelihood is computed during fitting but discarded. Store it on the returne
 
 ### Missing capabilities — lower priority
 
-**Laplace and trend-test standalone functions**
-Implement `surpyval.recurrent.tests.laplace(x, i, T)` and `mil_hdbk_189c(x, i, T)` as module-level functions independent of any fitted model.
+**Laplace and trend-test standalone functions** — **done**
+`surpyval.recurrent.tests.laplace(x, i, T)` and `mil_hdbk_189c(x, i, T)` are
+implemented as module-level functions independent of any fitted model (also
+re-exported from `surpyval.recurrent`). Each accepts single- or multi-system
+data, scalar/array/dict observation windows `T` (failure-truncated when `T` is
+omitted), and a `two-sided`/`increasing`/`decreasing` alternative, returning a
+`TrendTestResult` with the statistic, p-value and suggested trend direction.
 
 **Additional virtual-age models**
 Both Doyen & Gaudoin imperfect-repair families are now implemented: `surpyval.recurrent.ARA` (Arithmetic Reduction of Age, on the lifetime-distribution machinery) and `surpyval.recurrent.ARI` (Arithmetic Reduction of Intensity, built on the NHPP baseline intensity models — `CrowAMSAA`/`Duane`/`CoxLewis`), each parameterised by repair efficiency `rho` and memory `m`. Note the equivalences already covered elsewhere: ARA₁ = Kijima-I and ARA∞ = Kijima-II (both in `GeneralizedRenewal`), the geometric process (Lam) = `GeneralizedOneRenewal` reparameterised by `a = 1/(1+q)`, and ARI at `rho = 0` is the plain NHPP of its baseline intensity (used as the correctness check). The leftover virtual-age model worth adding is the general geometric-process estimator if a first-class `a` parameterisation is wanted.

--- a/surpyval/recurrent/__init__.py
+++ b/surpyval/recurrent/__init__.py
@@ -8,3 +8,4 @@ from .renewal import (
     GeneralizedRenewal,
     RenewalModel,
 )
+from .tests import TrendTestResult, laplace, mil_hdbk_189c

--- a/surpyval/recurrent/tests.py
+++ b/surpyval/recurrent/tests.py
@@ -1,0 +1,419 @@
+"""
+Trend / goodness-of-fit tests for recurrent-event (repairable-system) data.
+
+These are standalone hypothesis tests on the raw event times of one or more
+repairable systems; they do **not** require a fitted model. Both test the null
+hypothesis that the events follow a homogeneous Poisson process (HPP) -- i.e.
+the system shows *no trend* in its rate of occurrence of failures (ROCOF) --
+against the alternative that the intensity is monotonically changing:
+
+- an *increasing* intensity means failures arrive ever more frequently
+  (wear-out / deterioration -- a "sad" system);
+- a *decreasing* intensity means failures arrive ever less frequently
+  (reliability growth -- a "happy" system).
+
+Two classical statistics are provided:
+
+``laplace``
+    The Laplace (centroid) test. Compares the mean event time with the centre
+    of the observation window; events bunched late are evidence of an
+    increasing intensity. Asymptotically standard-normal under the HPP null.
+
+``mil_hdbk_189c``
+    The Military Handbook (MIL-HDBK-189C) test, equivalent to the total-time-
+    on-test statistic. Derived from the power-law (Crow-AMSAA) NHPP, so it is
+    most powerful against a power-law alternative. Chi-squared under the null.
+
+Both functions take the same ``(x, i, T)`` data description and an
+``alternative`` direction, and return a :class:`TrendTestResult`.
+
+Systems are assumed to be observed from time ``0``. When the observation time
+``T`` is not supplied each system is treated as *failure-truncated* (observed
+up to its last event), and that last event -- which is the truncation point,
+not a random event -- is dropped from the statistic. When ``T`` is supplied the
+data are *time-truncated* (observed up to a fixed ``T``) and every event is
+used.
+
+References
+----------
+Ascher, H. and Feingold, H. (1984), "Repairable Systems Reliability".
+Modarres, M., Kaminskiy, M. and Krivtsov, V. (2017), "Reliability Engineering
+and Risk Analysis", 3rd ed., Chapter 10.
+MIL-HDBK-189C (2011), "Reliability Growth Management".
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+from scipy.stats import chi2, norm
+
+_ALTERNATIVES = ("two-sided", "increasing", "decreasing")
+
+
+class TrendTestResult:
+    """
+    Result of a recurrent-event trend test (:func:`laplace` or
+    :func:`mil_hdbk_189c`).
+
+    Attributes
+    ----------
+    statistic : float
+        The test statistic (a z-score for the Laplace test, a chi-squared
+        value for the MIL-HDBK-189C test).
+    p_value : float
+        The p-value for the requested ``alternative``.
+    alternative : str
+        The alternative hypothesis tested: ``"two-sided"``, ``"increasing"``
+        or ``"decreasing"``.
+    test : str
+        The name of the test.
+    trend : str
+        The direction of trend suggested by the statistic, independent of the
+        ``alternative`` chosen: one of ``"increasing"``, ``"decreasing"`` or
+        ``"none"``.
+    dof : int or None
+        Degrees of freedom (MIL-HDBK-189C only; ``None`` for Laplace).
+    n_events : int
+        The number of events contributing to the statistic.
+    n_systems : int
+        The number of systems (items) in the data.
+    """
+
+    def __init__(
+        self,
+        statistic: float,
+        p_value: float,
+        alternative: str,
+        test: str,
+        trend: str,
+        n_events: int,
+        n_systems: int,
+        dof: int | None = None,
+    ) -> None:
+        self.statistic = statistic
+        self.p_value = p_value
+        self.alternative = alternative
+        self.test = test
+        self.trend = trend
+        self.n_events = n_events
+        self.n_systems = n_systems
+        self.dof = dof
+
+    def __repr__(self) -> str:
+        lines = [
+            self.test,
+            "=" * len(self.test),
+            "Null hypothesis  : no trend (homogeneous Poisson process)",
+            "Alternative      : {a}".format(a=self.alternative),
+            "Statistic        : {s:.6g}".format(s=self.statistic),
+        ]
+        if self.dof is not None:
+            lines.append("DoF              : {d}".format(d=self.dof))
+        lines.append("p-value          : {p:.6g}".format(p=self.p_value))
+        lines.append("Suggested trend  : {t}".format(t=self.trend))
+        return "\n".join(lines)
+
+
+def _validate_alternative(alternative: str) -> None:
+    if alternative not in _ALTERNATIVES:
+        raise ValueError(
+            "`alternative` must be one of {}; got {!r}".format(
+                list(_ALTERNATIVES), alternative
+            )
+        )
+
+
+def _resolve_truncation(
+    T: npt.ArrayLike | dict | None, unique_i: npt.NDArray
+) -> dict | None:
+    """
+    Normalise the observation-time argument into a ``{system_id: T}`` mapping,
+    or ``None`` to signal failure-truncated data (each system observed up to
+    its own last event).
+
+    ``T`` may be a scalar (the same window for every system), a dict keyed by
+    system id, or an array with one entry per (sorted-unique) system.
+    """
+    if T is None:
+        return None
+    if isinstance(T, dict):
+        missing = [q for q in unique_i if q not in T]
+        if missing:
+            raise ValueError(
+                "`T` is missing an observation time for system(s) "
+                "{}".format(missing)
+            )
+        return {q: float(T[q]) for q in unique_i}
+    if np.ndim(T) == 0:
+        return {q: float(T) for q in unique_i}  # type: ignore[arg-type]
+    T_arr = np.asarray(T, dtype=float)
+    if T_arr.shape[0] != unique_i.shape[0]:
+        raise ValueError(
+            "array `T` must have one entry per system ({} systems, {} "
+            "entries)".format(unique_i.shape[0], T_arr.shape[0])
+        )
+    return {q: float(T_arr[k]) for k, q in enumerate(unique_i)}
+
+
+def _prepare(
+    x: npt.ArrayLike, i: npt.ArrayLike | None, T: npt.ArrayLike | dict | None
+) -> tuple[list[tuple[npt.NDArray, float]], int, int]:
+    """
+    Group the event times by system and resolve each system's observation
+    window. Returns a list of ``(events_used, T_q)`` per system (with the
+    truncating final event dropped for failure-truncated data), the total
+    number of events used, and the number of systems.
+    """
+    x = np.asarray(x, dtype=float)
+    if x.ndim != 1:
+        raise ValueError("`x` must be a 1D array of event times")
+    if x.size == 0:
+        raise ValueError("`x` is empty; no event times to test")
+    if not np.all(np.isfinite(x)):
+        raise ValueError("event times must be finite")
+    if np.any(x <= 0):
+        raise ValueError(
+            "event times must be strictly positive; systems are assumed to be "
+            "observed from time 0"
+        )
+
+    if i is None:
+        i = np.ones(x.shape[0])
+    else:
+        i = np.asarray(i)
+        if i.shape[0] != x.shape[0]:
+            raise ValueError("`x` and `i` must have the same length")
+
+    unique_i = np.unique(i)
+    windows = _resolve_truncation(T, unique_i)
+
+    systems: list[tuple[npt.NDArray, float]] = []
+    n_used = 0
+    for q in unique_i:
+        xq = np.sort(x[i == q])
+        if windows is None:
+            # Failure-truncated: the last event is the truncation point.
+            Tq = float(xq[-1])
+            used = xq[:-1]
+        else:
+            Tq = windows[q]
+            if np.any(xq > Tq):
+                raise ValueError(
+                    "system {!r} has event time(s) after its observation "
+                    "time T={}".format(q, Tq)
+                )
+            used = xq[xq <= Tq]
+        if Tq <= 0:
+            raise ValueError(
+                "observation time for system {!r} must be positive".format(q)
+            )
+        systems.append((used, Tq))
+        n_used += used.size
+
+    if n_used < 2:
+        raise ValueError(
+            "at least two events are required to test for a trend"
+        )
+
+    return systems, n_used, int(unique_i.shape[0])
+
+
+def laplace(
+    x: npt.ArrayLike,
+    i: npt.ArrayLike | None = None,
+    T: npt.ArrayLike | dict | None = None,
+    alternative: str = "two-sided",
+) -> TrendTestResult:
+    r"""
+    The Laplace (centroid) trend test for recurrent-event data.
+
+    Under the null hypothesis that the events of each system follow a
+    homogeneous Poisson process, the event times are uniformly distributed on
+    the observation window, so their mean sits at the centre. The standardised
+    departure of the observed event-time total from its null expectation,
+
+    .. math::
+        U = \frac{\sum_q \sum_j t_{qj} - \sum_q n_q T_q / 2}
+                 {\sqrt{\sum_q n_q T_q^2 / 12}},
+
+    is asymptotically standard normal. ``U > 0`` (events bunched late) is
+    evidence of an *increasing* intensity (deterioration); ``U < 0`` of a
+    *decreasing* intensity (reliability growth).
+
+    Parameters
+    ----------
+    x : array_like
+        Event (failure) times, all strictly positive (systems are observed
+        from time 0). For multiple systems, the times of every system are
+        concatenated and identified by ``i``.
+    i : array_like, optional
+        System / item id for each event in ``x``. Defaults to a single system.
+    T : scalar, array_like or dict, optional
+        Observation (truncation) time. A scalar applies the same window to
+        every system; an array gives one window per sorted-unique system; a
+        dict is keyed by system id. If omitted, each system is treated as
+        failure-truncated -- observed up to its last event, which is then
+        excluded from the statistic.
+    alternative : str, optional
+        Direction of the alternative hypothesis: ``"two-sided"`` (default),
+        ``"increasing"`` (upper tail; deterioration) or ``"decreasing"``
+        (lower tail; reliability growth).
+
+    Returns
+    -------
+    TrendTestResult
+        Object carrying the ``statistic`` (the z-score ``U``), the
+        ``p_value`` and the suggested ``trend``.
+
+    Examples
+    --------
+    >>> from surpyval.recurrent.tests import laplace
+    >>> # Inter-arrival times shrinking -> failures speeding up.
+    >>> x = [10, 19, 27, 34, 40, 45, 49, 52, 54]
+    >>> res = laplace(x, T=60)
+    >>> bool(res.statistic > 0)
+    True
+    >>> res.trend
+    'increasing'
+    """
+    _validate_alternative(alternative)
+    systems, n_used, n_systems = _prepare(x, i, T)
+
+    total = 0.0
+    expected = 0.0
+    variance = 0.0
+    for used, Tq in systems:
+        nq = used.size
+        total += float(used.sum())
+        expected += nq * Tq / 2.0
+        variance += nq * Tq**2 / 12.0
+
+    if variance <= 0:
+        raise ValueError(
+            "the null variance is zero; not enough events to compute the "
+            "Laplace statistic"
+        )
+
+    u = (total - expected) / np.sqrt(variance)
+
+    if alternative == "increasing":
+        p_value = float(norm.sf(u))
+    elif alternative == "decreasing":
+        p_value = float(norm.cdf(u))
+    else:
+        p_value = float(2.0 * norm.sf(abs(u)))
+
+    return TrendTestResult(
+        statistic=float(u),
+        p_value=p_value,
+        alternative=alternative,
+        test="Laplace Trend Test",
+        trend=_trend_from_sign(u),
+        n_events=n_used,
+        n_systems=n_systems,
+    )
+
+
+def mil_hdbk_189c(
+    x: npt.ArrayLike,
+    i: npt.ArrayLike | None = None,
+    T: npt.ArrayLike | dict | None = None,
+    alternative: str = "two-sided",
+) -> TrendTestResult:
+    r"""
+    The Military Handbook (MIL-HDBK-189C) trend test for recurrent-event data.
+
+    Derived from the power-law (Crow-AMSAA) NHPP, the statistic
+
+    .. math::
+        \chi^2 = 2 \sum_q \sum_j \ln\!\left(\frac{T_q}{t_{qj}}\right)
+
+    is chi-squared distributed with :math:`2N` degrees of freedom under the HPP
+    null (where :math:`N` is the number of events used). It equals
+    :math:`2N / \hat\beta` for the power-law shape estimate :math:`\hat\beta`,
+    so a *small* statistic (large :math:`\hat\beta > 1`) indicates an
+    *increasing* intensity (deterioration) and a *large* statistic (small
+    :math:`\hat\beta < 1`) a *decreasing* intensity (reliability growth). It is
+    the most powerful test against a power-law alternative.
+
+    Parameters
+    ----------
+    x : array_like
+        Event (failure) times, all strictly positive (systems are observed
+        from time 0). For multiple systems, the times of every system are
+        concatenated and identified by ``i``.
+    i : array_like, optional
+        System / item id for each event in ``x``. Defaults to a single system.
+    T : scalar, array_like or dict, optional
+        Observation (truncation) time. A scalar applies the same window to
+        every system; an array gives one window per sorted-unique system; a
+        dict is keyed by system id. If omitted, each system is treated as
+        failure-truncated -- observed up to its last event, which is then
+        excluded (giving :math:`2(n-1)` degrees of freedom per system).
+    alternative : str, optional
+        Direction of the alternative hypothesis: ``"two-sided"`` (default),
+        ``"increasing"`` (deterioration; lower tail of the chi-squared) or
+        ``"decreasing"`` (reliability growth; upper tail).
+
+    Returns
+    -------
+    TrendTestResult
+        Object carrying the chi-squared ``statistic``, its ``dof``, the
+        ``p_value`` and the suggested ``trend``.
+
+    Examples
+    --------
+    >>> from surpyval.recurrent.tests import mil_hdbk_189c
+    >>> x = [10, 19, 27, 34, 40, 45, 49, 52, 54]
+    >>> res = mil_hdbk_189c(x, T=60)
+    >>> res.dof
+    18
+    >>> res.trend
+    'increasing'
+    """
+    _validate_alternative(alternative)
+    systems, n_used, n_systems = _prepare(x, i, T)
+
+    statistic = 0.0
+    dof = 0
+    for used, Tq in systems:
+        statistic += 2.0 * float(np.sum(np.log(Tq / used)))
+        dof += 2 * used.size
+
+    # Mean of a chi-squared is its dof; departures below indicate an
+    # increasing intensity, above a decreasing one.
+    if statistic < dof:
+        trend = "increasing"
+    elif statistic > dof:
+        trend = "decreasing"
+    else:
+        trend = "none"
+
+    lower = float(chi2.cdf(statistic, dof))
+    upper = float(chi2.sf(statistic, dof))
+    if alternative == "increasing":
+        p_value = lower
+    elif alternative == "decreasing":
+        p_value = upper
+    else:
+        p_value = min(1.0, 2.0 * min(lower, upper))
+
+    return TrendTestResult(
+        statistic=float(statistic),
+        p_value=p_value,
+        alternative=alternative,
+        test="MIL-HDBK-189C Trend Test",
+        trend=trend,
+        n_events=n_used,
+        n_systems=n_systems,
+        dof=dof,
+    )
+
+
+def _trend_from_sign(u: float) -> str:
+    if u > 0:
+        return "increasing"
+    if u < 0:
+        return "decreasing"
+    return "none"

--- a/surpyval/tests/recurrent/test_trend_tests.py
+++ b/surpyval/tests/recurrent/test_trend_tests.py
@@ -1,0 +1,255 @@
+import numpy as np
+import pytest
+from scipy.stats import chi2, norm
+
+from surpyval.recurrent import laplace, mil_hdbk_189c
+from surpyval.recurrent.tests import TrendTestResult
+
+
+def test_exported_from_recurrent():
+    # Both the dotted module path used in the docs and the package-level
+    # re-export should reach the same functions.
+    from surpyval.recurrent import tests as trend_tests
+
+    assert trend_tests.laplace is laplace
+    assert trend_tests.mil_hdbk_189c is mil_hdbk_189c
+
+
+# ----------------------------------------------------------------------------
+# Laplace test
+# ----------------------------------------------------------------------------
+
+
+def test_laplace_matches_closed_form_single_system_time_truncated():
+    # For a single time-truncated system the statistic is the textbook
+    # U = (sum t - n T / 2) / (T sqrt(n / 12)).
+    x = np.array([10.0, 19.0, 27.0, 34.0, 40.0, 45.0, 49.0, 52.0, 54.0])
+    T = 60.0
+    n = x.size
+    expected = (x.sum() - n * T / 2.0) / (T * np.sqrt(n / 12.0))
+    res = laplace(x, T=T)
+    assert res.statistic == pytest.approx(expected)
+    assert res.n_events == n
+    assert res.n_systems == 1
+
+
+def _power_law_times(T=100.0, n=20, beta=2.5):
+    # Deterministic power-law (Crow-AMSAA) event times: evenly spaced in the
+    # mean value function N(t), so t_k = T (k/(n+1))**(1/beta). beta > 1 gives
+    # an increasing intensity, beta < 1 a decreasing one.
+    k = np.arange(1, n + 1)
+    return T * (k / (n + 1)) ** (1.0 / beta)
+
+
+def test_laplace_increasing_intensity_positive_statistic():
+    # Power-law with beta > 1: failures speed up -> U > 0, increasing.
+    x = _power_law_times(beta=2.5)
+    res = laplace(x, T=100.0, alternative="increasing")
+    assert res.statistic > 0
+    assert res.trend == "increasing"
+    assert res.p_value < 0.05
+
+
+def test_laplace_decreasing_intensity_negative_statistic():
+    # Inter-arrival times grow (reliability growth) -> U < 0, decreasing.
+    x = np.cumsum(np.arange(1, 11, dtype=float))
+    res = laplace(x, T=x[-1] + 11.0, alternative="decreasing")
+    assert res.statistic < 0
+    assert res.trend == "decreasing"
+    assert res.p_value < 0.05
+
+
+def test_laplace_hpp_data_no_significant_trend():
+    # Genuine HPP data should not raise a significant trend on average.
+    rng = np.random.default_rng(0)
+    T = 1000.0
+    rejections = 0
+    trials = 200
+    for _ in range(trials):
+        n = rng.poisson(50)
+        x = np.sort(rng.uniform(0, T, size=max(n, 2)))
+        if laplace(x, T=T).p_value < 0.05:
+            rejections += 1
+    # Roughly the nominal 5% level; allow generous slack for randomness.
+    assert rejections / trials < 0.15
+
+
+def test_laplace_pvalue_directions_consistent():
+    x = np.array([10.0, 19.0, 27.0, 34.0, 40.0, 45.0, 49.0, 52.0, 54.0])
+    u = laplace(x, T=60.0).statistic
+    assert laplace(x, T=60.0, alternative="increasing").p_value == (
+        pytest.approx(norm.sf(u))
+    )
+    assert laplace(x, T=60.0, alternative="decreasing").p_value == (
+        pytest.approx(norm.cdf(u))
+    )
+    assert laplace(x, T=60.0, alternative="two-sided").p_value == (
+        pytest.approx(2.0 * norm.sf(abs(u)))
+    )
+
+
+def test_laplace_failure_truncated_drops_last_event():
+    # Without T the last event is the truncation point and is excluded.
+    x = np.array([10.0, 19.0, 27.0, 34.0, 40.0, 45.0, 49.0, 52.0, 54.0])
+    res = laplace(x)
+    assert res.n_events == x.size - 1
+    # Failure-truncation at the n-th event equals time-truncating the first
+    # n-1 events at that event time.
+    res_T = laplace(x[:-1], T=x[-1])
+    assert res.statistic == pytest.approx(res_T.statistic)
+
+
+def test_laplace_multiple_systems():
+    # Two systems pooled; statistic uses the combined numerator/variance.
+    x = np.array([5.0, 12.0, 18.0, 7.0, 15.0, 22.0])
+    i = np.array([1, 1, 1, 2, 2, 2])
+    T = {1: 25.0, 2: 30.0}
+    num = (5 + 12 + 18 - 3 * 25 / 2) + (7 + 15 + 22 - 3 * 30 / 2)
+    var = 3 * 25**2 / 12 + 3 * 30**2 / 12
+    res = laplace(x, i, T)
+    assert res.statistic == pytest.approx(num / np.sqrt(var))
+    assert res.n_systems == 2
+    assert res.n_events == 6
+
+
+def test_laplace_scalar_and_array_T_equivalent():
+    x = np.array([5.0, 12.0, 18.0, 7.0, 15.0, 20.0])
+    i = np.array([1, 1, 1, 2, 2, 2])
+    res_scalar = laplace(x, i, 25.0)
+    res_array = laplace(x, i, [25.0, 25.0])
+    res_dict = laplace(x, i, {1: 25.0, 2: 25.0})
+    assert res_scalar.statistic == pytest.approx(res_array.statistic)
+    assert res_scalar.statistic == pytest.approx(res_dict.statistic)
+
+
+# ----------------------------------------------------------------------------
+# MIL-HDBK-189C test
+# ----------------------------------------------------------------------------
+
+
+def test_mil_matches_closed_form_single_system():
+    x = np.array([10.0, 19.0, 27.0, 34.0, 40.0, 45.0, 49.0, 52.0, 54.0])
+    T = 60.0
+    expected = 2.0 * np.sum(np.log(T / x))
+    res = mil_hdbk_189c(x, T=T)
+    assert res.statistic == pytest.approx(expected)
+    assert res.dof == 2 * x.size
+
+
+def test_mil_increasing_intensity_lower_tail():
+    # Crow-AMSAA power-law with beta > 1 (deterioration). The statistic equals
+    # 2N / beta_hat, so a small value -> increasing intensity.
+    x = np.array([10.0, 19.0, 27.0, 34.0, 40.0, 45.0, 49.0, 52.0, 54.0])
+    res = mil_hdbk_189c(x, T=60.0, alternative="increasing")
+    assert res.trend == "increasing"
+    assert res.statistic < res.dof
+    assert res.p_value == pytest.approx(chi2.cdf(res.statistic, res.dof))
+
+
+def test_mil_decreasing_intensity_upper_tail():
+    x = np.cumsum(np.arange(1, 11, dtype=float))
+    T = x[-1] + 11.0
+    res = mil_hdbk_189c(x, T=T, alternative="decreasing")
+    assert res.trend == "decreasing"
+    assert res.statistic > res.dof
+    assert res.p_value == pytest.approx(chi2.sf(res.statistic, res.dof))
+
+
+def test_mil_failure_truncated_dof():
+    x = np.array([10.0, 19.0, 27.0, 34.0, 40.0, 45.0, 49.0, 52.0, 54.0])
+    res = mil_hdbk_189c(x)
+    # Last event is the truncation point: 2(n-1) dof.
+    assert res.dof == 2 * (x.size - 1)
+    res_T = mil_hdbk_189c(x[:-1], T=x[-1])
+    assert res.statistic == pytest.approx(res_T.statistic)
+    assert res.dof == res_T.dof
+
+
+def test_mil_multiple_systems_pooled():
+    x = np.array([5.0, 12.0, 18.0, 7.0, 15.0, 22.0])
+    i = np.array([1, 1, 1, 2, 2, 2])
+    T = {1: 25.0, 2: 30.0}
+    expected = 2.0 * (
+        np.sum(np.log(25.0 / np.array([5.0, 12.0, 18.0])))
+        + np.sum(np.log(30.0 / np.array([7.0, 15.0, 22.0])))
+    )
+    res = mil_hdbk_189c(x, i, T)
+    assert res.statistic == pytest.approx(expected)
+    assert res.dof == 12
+
+
+def test_mil_hpp_data_no_significant_trend():
+    rng = np.random.default_rng(1)
+    T = 1000.0
+    rejections = 0
+    trials = 200
+    for _ in range(trials):
+        n = rng.poisson(50)
+        x = np.sort(rng.uniform(0, T, size=max(n, 2)))
+        if mil_hdbk_189c(x, T=T).p_value < 0.05:
+            rejections += 1
+    assert rejections / trials < 0.15
+
+
+# ----------------------------------------------------------------------------
+# Validation and result object
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("func", [laplace, mil_hdbk_189c])
+def test_rejects_bad_alternative(func):
+    with pytest.raises(ValueError):
+        func([1.0, 2.0, 3.0], alternative="up")
+
+
+@pytest.mark.parametrize("func", [laplace, mil_hdbk_189c])
+def test_rejects_nonpositive_times(func):
+    with pytest.raises(ValueError):
+        func([0.0, 1.0, 2.0], T=3.0)
+    with pytest.raises(ValueError):
+        func([-1.0, 1.0, 2.0], T=3.0)
+
+
+@pytest.mark.parametrize("func", [laplace, mil_hdbk_189c])
+def test_rejects_events_after_T(func):
+    with pytest.raises(ValueError):
+        func([1.0, 2.0, 5.0], T=3.0)
+
+
+@pytest.mark.parametrize("func", [laplace, mil_hdbk_189c])
+def test_rejects_too_few_events(func):
+    with pytest.raises(ValueError):
+        func([5.0])  # single failure-truncated event -> 0 usable events
+    with pytest.raises(ValueError):
+        func([], T=10.0)
+
+
+@pytest.mark.parametrize("func", [laplace, mil_hdbk_189c])
+def test_rejects_mismatched_i(func):
+    with pytest.raises(ValueError):
+        func([1.0, 2.0, 3.0], i=[1, 1], T=5.0)
+
+
+@pytest.mark.parametrize("func", [laplace, mil_hdbk_189c])
+def test_rejects_missing_dict_window(func):
+    with pytest.raises(ValueError):
+        func([1.0, 2.0, 3.0], i=[1, 1, 2], T={1: 5.0})
+
+
+@pytest.mark.parametrize("func", [laplace, mil_hdbk_189c])
+def test_rejects_nonfinite(func):
+    with pytest.raises(ValueError):
+        func([1.0, np.nan, 3.0], T=5.0)
+
+
+def test_result_repr_contains_fields():
+    res = laplace([10.0, 19.0, 27.0, 34.0], T=40.0)
+    text = repr(res)
+    assert "Laplace Trend Test" in text
+    assert "p-value" in text
+    assert "Suggested trend" in text
+    assert isinstance(res, TrendTestResult)
+
+    res_mil = mil_hdbk_189c([10.0, 19.0, 27.0, 34.0], T=40.0)
+    assert "MIL-HDBK-189C Trend Test" in repr(res_mil)
+    assert "DoF" in repr(res_mil)


### PR DESCRIPTION
Implements the goodness-of-fit / trend tests called for in DEVELOPMENT.md
section 4.D: standalone surpyval.recurrent.tests.laplace and
mil_hdbk_189c functions that test the HPP (no-trend) null against a
monotone increasing/decreasing intensity alternative.

Both accept (x, i, T) with single- or multi-system data, scalar/array/
dict observation windows (failure-truncated when T is omitted) and a
two-sided/increasing/decreasing alternative, and return a TrendTestResult
carrying the statistic, p-value and suggested trend direction. Functions
are re-exported from surpyval.recurrent. Includes a full test module and
updated DEVELOPMENT.md notes.