### PR TITLE
Wire right-truncation tr into the recurrent NHPP likelihood

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -96,11 +96,19 @@ theme; items already resolved are marked **[done]**.
   failure-truncation, and return a `TrendTestResult`. Still to do: a
   Cramér-von Mises NHPP goodness-of-fit test, and exposing the trend tests
   as a method on fitted NHPP models. **[done]**
-- Truncation half-wired: `tr` not in the NHPP integral (right window-close
-  relies on a `c=1` row); still not exposed on the proportional-intensity
-  regression `fit()`. (The nonparametric MCF risk set now honours `tl`, and
-  `tl`/`tr` are exposed on `NonParametricCounting.fit()` and
-  `CauseSpecificMCF.fit()` — see A.)
+- Truncation now fully wired into the parametric NHPP family: a finite right
+  truncation `tr` closes the observation window directly in the likelihood
+  integral, so the intensity is integrated out to `tr` without relying on an
+  explicit `c=1` row. The window-close term (`cif(x_last) - cif(tr)` per item,
+  exactly zero when `tr` is infinite or a `c=1` row already sits at `tr`, so
+  the two ways of closing the window never double-count) is shared via
+  `RecurrentEventData.get_right_truncation_close()` across `HPP`, the
+  `NHPPFitter` models (`CrowAMSAA`/`Duane`/`CoxLewis`) and both
+  proportional-intensity regression fitters. `t`/`tl`/`tr` are now exposed on
+  `ProportionalIntensityNHPP.fit()` and `ProportionalIntensityHPP.fit()`. (The
+  nonparametric MCF risk set honours `tl`, and `tl`/`tr` are exposed on
+  `NonParametricCounting.fit()` and `CauseSpecificMCF.fit()` — see A.) Still to
+  do: multi-window (gapped) observation per item. **[done]**
 - `handle_xicn` has no `e` (event-mark) parameter, so `CauseSpecificMCF.fit`
   bypasses it and can't take truncation; no `fit_from_df` for marks.
 - The nonparametric MCF has **zero tests**. (The regression submodule now has
@@ -176,7 +184,7 @@ No martingale residuals, no cumulative-hazard residuals, no probability-integral
 ### Missing capabilities — medium priority
 
 **Left-truncation support (partial)**
-`handle_xicn` now takes the surpyval `t`/`tl`/`tr` truncation fields, and the calendar-time NHPP models (`HPP`, `CrowAMSAA`, `Duane`, `CoxLewis`) integrate each item's likelihood from its entry time `tl`, so delayed-entry (warranty-from-first-sale) data is analysed correctly there. The virtual-age / history-dependent models (Kijima/G1/ARA/ARI) reject `tl > 0` with an explanatory error, since the virtual age at entry is undefined without the pre-entry history. The nonparametric MCF now uses delayed-entry risk sets (`RecurrentEventData.to_xrd` honours each item's `tl`, exposed on `NonParametricCounting.fit()` and `CauseSpecificMCF.fit()`). Still to do: truncation passthrough for the proportional-intensity regression fitters, and multi-window (gapped) observation per item.
+`handle_xicn` now takes the surpyval `t`/`tl`/`tr` truncation fields, and the calendar-time NHPP models (`HPP`, `CrowAMSAA`, `Duane`, `CoxLewis`) integrate each item's likelihood from its entry time `tl`, so delayed-entry (warranty-from-first-sale) data is analysed correctly there. The virtual-age / history-dependent models (Kijima/G1/ARA/ARI) reject `tl > 0` with an explanatory error, since the virtual age at entry is undefined without the pre-entry history. The nonparametric MCF now uses delayed-entry risk sets (`RecurrentEventData.to_xrd` honours each item's `tl`, exposed on `NonParametricCounting.fit()` and `CauseSpecificMCF.fit()`). The proportional-intensity regression fitters (`ProportionalIntensityNHPP`/`ProportionalIntensityHPP`) now accept `t`/`tl`/`tr` and close each item's window at `tr` in the likelihood (see D). Still to do: multi-window (gapped) observation per item.
 
 **No input validation**
 Negative times, NaN/inf values, and empty arrays all pass silently into the optimiser. Add a validation step in `handle_xicn()` with informative `ValueError`s.

--- a/surpyval/recurrent/parametric/hpp.py
+++ b/surpyval/recurrent/parametric/hpp.py
@@ -190,6 +190,13 @@ class HPP(CountingProcess):
         else:
             right_censored_time = 0.0
 
+        # Right window-close: extend the integral to each item's finite
+        # right-truncation time tr. For the HPP cif(x) = rate * x, so the
+        # extension cif(x_last) - cif(tr) contributes rate * (x_last - tr).
+        # Empty / zero when no item carries a finite tr.
+        x_close_last, x_close_tr, _ = data.get_right_truncation_close()
+        right_truncation_time = (x_close_last - x_close_tr).sum()
+
         if has_interval_censoring:
             interval_mask = c == 2
             x_i_l = x_l[interval_mask]
@@ -215,6 +222,7 @@ class HPP(CountingProcess):
             rate = anp.exp(log_rate)
             ll = len_observed * log_rate + rate * observed_time
             ll += rate * right_censored_time
+            ll += rate * right_truncation_time
             ll += (
                 log_rate * n_left_sum
                 + n_log_x_left_sum

--- a/surpyval/recurrent/parametric/nhpp_fitter.py
+++ b/surpyval/recurrent/parametric/nhpp_fitter.py
@@ -48,6 +48,12 @@ class NHPPFitter(IntensityModel):
         x_i_r = x_r[c == 2] if has_interval_censoring else np.array([])
         n_i = n[c == 2] if has_interval_censoring else np.array([])
 
+        # Right window-close: for items with a finite right-truncation time
+        # ``tr`` the intensity is integrated out to ``tr`` rather than merely to
+        # the last observed event / censoring row. These arrays are empty for
+        # untruncated data, so the term adds nothing in that case.
+        x_close_last, x_close_tr, _ = data.get_right_truncation_close()
+
         # Using the empty arrays avoids the need for if statements in the
         # likelihood function. It also means that the likelihood function
         # will not encounter any invalid values since taking the log of 0
@@ -83,6 +89,14 @@ class NHPPFitter(IntensityModel):
                 n_i * np.log(interval_delta_cif)
                 - (interval_delta_cif)
                 - gammaln(n_i + 1)
+            ).sum()
+
+            # extend the integral from each item's last in-window time to its
+            # right-truncation time tr (zero when tr is infinite or already
+            # coincides with a right-censoring row)
+            ll += (
+                self.cif(x_close_last, *params)
+                - self.cif(x_close_tr, *params)
             ).sum()
 
             return -ll

--- a/surpyval/recurrent/regression/hpp_proportional_intensity.py
+++ b/surpyval/recurrent/regression/hpp_proportional_intensity.py
@@ -154,6 +154,14 @@ class ProportionalIntensityHPP:
             Z_i = np.zeros((1, Z.shape[1]))
             delta_xi = 0.0
 
+        # Right window-close: for items with a finite right-truncation time
+        # ``tr`` the integral closes at ``tr``. For the constant-rate HPP the
+        # extension contributes rate * phi * (x_last - tr). Empty for
+        # untruncated data.
+        x_close_last, x_close_tr, close_idx = data.get_right_truncation_close()
+        x_close = x_close_last - x_close_tr
+        Z_close = Z[close_idx]
+
         def negll_func(params):
             log_rate = params[0]
             rate = np.exp(log_rate)
@@ -168,6 +176,9 @@ class ProportionalIntensityHPP:
 
             phi_right = np.exp(np.dot(Z_right, beta_coeffs))
             ll += rate * (x_right * phi_right).sum()
+
+            phi_close = np.exp(np.dot(Z_close, beta_coeffs))
+            ll += rate * (x_close * phi_close).sum()
 
             phi_exponent_left = np.dot(Z_left, beta_coeffs)
             ll += (
@@ -191,7 +202,9 @@ class ProportionalIntensityHPP:
 
         return negll_func
 
-    def fit(self, x, Z, i=None, c=None, n=None, init=None):
+    def fit(
+        self, x, Z, i=None, c=None, n=None, t=None, tl=None, tr=None, init=None
+    ):
         """
         Fit the model using the provided data and initial parameters (if given)
 
@@ -208,6 +221,15 @@ class ProportionalIntensityHPP:
             Censoring indicators.
         n : array_like, optional
             Number of events.
+        t : array_like, optional
+            (N, 2) array of [left, right] truncation bounds per observation.
+        tl : array_like or scalar, optional
+            Left truncation (delayed entry) time per item; the observation of
+            each item begins here. Scalar broadcasts to all items.
+        tr : array_like or scalar, optional
+            Right truncation time per item; the observation window closes here,
+            so the intensity is integrated out to ``tr`` even without an
+            explicit right-censoring (``c=1``) row.
         init : array_like, optional
             Initial parameter estimates.
 
@@ -218,7 +240,9 @@ class ProportionalIntensityHPP:
             An object containing the results of the fitting process, including
             parameter estimates.
         """
-        data = handle_xicn(x, i, c, n, Z=Z, as_recurrent_data=True)
+        data = handle_xicn(
+            x, i, c, n, t=t, tl=tl, tr=tr, Z=Z, as_recurrent_data=True
+        )
 
         out = ProportionalIntensityModel()
         out.data = data

--- a/surpyval/recurrent/regression/nhpp_proportional_intensity.py
+++ b/surpyval/recurrent/regression/nhpp_proportional_intensity.py
@@ -126,6 +126,14 @@ class ProportionalIntensityNHPP:
             Z[c == 2] if has_interval_censoring else np.zeros((1, Z.shape[1]))
         )
 
+        # Right window-close: for items with a finite right-truncation time
+        # ``tr`` the baseline intensity is integrated out to ``tr`` (scaled by
+        # the item's proportional factor). Empty for untruncated data.
+        x_close_last, x_close_tr, close_idx = (
+            data.get_right_truncation_close()
+        )
+        Z_close = Z[close_idx]
+
         # Using the empty arrays avoids the need for if statements in the
         # likelihood function. It also means that the likelihood function
         # will not encounter any invalid values since taking the log of 0
@@ -178,6 +186,13 @@ class ProportionalIntensityNHPP:
                 - gammaln(n_i + 1)
             ).sum()
 
+            # right window-close: extend each item's integral to its tr
+            phi_close = np.exp(np.dot(Z_close, beta_coeffs))
+            delta_cif_close = dist.cif(x_close_last, *dist_params) - dist.cif(
+                x_close_tr, *dist_params
+            )
+            ll += (phi_close * delta_cif_close).sum()
+
             return -ll
 
         return negll_func
@@ -220,7 +235,19 @@ class ProportionalIntensityNHPP:
 
         return out
 
-    def fit(self, x, Z, i=None, c=None, n=None, dist=Duane, init=None):
+    def fit(
+        self,
+        x,
+        Z,
+        i=None,
+        c=None,
+        n=None,
+        t=None,
+        tl=None,
+        tr=None,
+        dist=Duane,
+        init=None,
+    ):
         """
         Fit the model using the provided data and initial parameters.
 
@@ -237,6 +264,15 @@ class ProportionalIntensityNHPP:
             Censoring indicators.
         n : array_like, optional
             Number of events.
+        t : array_like, optional
+            (N, 2) array of [left, right] truncation bounds per observation.
+        tl : array_like or scalar, optional
+            Left truncation (delayed entry) time per item; the observation of
+            each item begins here. Scalar broadcasts to all items.
+        tr : array_like or scalar, optional
+            Right truncation time per item; the observation window closes here,
+            so the baseline intensity is integrated out to ``tr`` even without
+            an explicit right-censoring (``c=1``) row.
         dist : surpyval.recurrent.regression.NHPPFitter, optional
             The parametric model to use for the hazard rate.
         init : array_like, optional
@@ -249,5 +285,7 @@ class ProportionalIntensityNHPP:
             An object containing the results of the fitting process, including
             parameter estimates.
         """
-        data = handle_xicn(x, i, c, n, Z=Z, as_recurrent_data=True)
+        data = handle_xicn(
+            x, i, c, n, t=t, tl=tl, tr=tr, Z=Z, as_recurrent_data=True
+        )
         return self.fit_from_recurrent_data(data, dist, init)

--- a/surpyval/tests/recurrent/test_truncation.py
+++ b/surpyval/tests/recurrent/test_truncation.py
@@ -1,7 +1,15 @@
 import numpy as np
 import pytest
 
-from surpyval.recurrent import ARA, ARI, CrowAMSAA, GeneralizedRenewal, HPP
+from surpyval.recurrent import (
+    ARA,
+    ARI,
+    CrowAMSAA,
+    GeneralizedRenewal,
+    HPP,
+    ProportionalIntensityHPP,
+    ProportionalIntensityNHPP,
+)
 from surpyval.utils.recurrent_utils import handle_xicn
 
 
@@ -78,6 +86,67 @@ def test_nhpp_left_truncation_changes_fit():
     untruncated = CrowAMSAA.fit(x, i)
     truncated = CrowAMSAA.fit(x, i, tl=float(x[0]) - 0.5)
     assert not np.allclose(untruncated.params, truncated.params)
+
+
+def test_hpp_right_truncation_closes_window_like_censoring_row():
+    # A finite tr closes the observation window in the NHPP integral, so the
+    # rate is events / exposure even with no explicit right-censoring row:
+    # two events observed over [2, 10] gives exactly 0.25.
+    x = np.array([3.0, 7.0])
+    i = np.array([1, 1])
+    model = HPP.fit(x, i, c=np.array([0, 0]), tl=2.0, tr=10.0)
+    assert np.isclose(model.params[0], 0.25)
+
+    # The same window expressed with an explicit c=1 row at the close time
+    # must give an identical fit.
+    model_c1 = HPP.fit(
+        np.array([3.0, 7.0, 10.0]),
+        np.array([1, 1, 1]),
+        c=np.array([0, 0, 1]),
+        tl=2.0,
+    )
+    assert np.isclose(model.params[0], model_c1.params[0])
+
+    # Without tr (or a c=1 row) the window closes at the last event (t=7), so
+    # the integral is shorter and the rate is larger: 2 / 5.
+    model_open = HPP.fit(x, i, c=np.array([0, 0]), tl=2.0)
+    assert np.isclose(model_open.params[0], 0.4)
+
+
+def test_nhpp_right_truncation_matches_censoring_row():
+    # For a genuine NHPP the tr window-close must agree with supplying the
+    # close time as an explicit right-censoring row.
+    x = [3.0, 7.0, 12.0]
+    i = [1, 1, 1]
+    via_tr = CrowAMSAA.fit(x, i, c=[0, 0, 0], tr=15.0)
+    via_row = CrowAMSAA.fit(
+        [3.0, 7.0, 12.0, 15.0], [1, 1, 1, 1], c=[0, 0, 0, 1]
+    )
+    assert np.allclose(via_tr.params, via_row.params, atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "fitter", [ProportionalIntensityNHPP, ProportionalIntensityHPP]
+)
+def test_proportional_intensity_right_truncation(fitter):
+    # The proportional-intensity regression fitters now accept truncation and
+    # close each item's window at tr; this must match the equivalent fit with
+    # explicit c=1 rows at the window close.
+    x = [9, 14, 18, 7, 12, 16, 19, 5, 9, 13, 16, 18, 6, 10, 13, 15, 17, 19]
+    i = [1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4]
+    Z = np.array(
+        [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    ).reshape(-1, 1)
+    via_tr = fitter.fit(x, Z, i=i, tr=20.0)
+
+    x_c1 = x + [20, 20, 20, 20]
+    i_c1 = i + [1, 2, 3, 4]
+    Z_c1 = np.vstack([Z, np.array([[0], [0], [1], [1]])])
+    c_c1 = [0] * len(x) + [1, 1, 1, 1]
+    via_row = fitter.fit(x_c1, Z_c1, i=i_c1, c=c_c1)
+
+    assert np.allclose(via_tr.params, via_row.params, atol=1e-3)
+    assert np.allclose(via_tr.coeffs, via_row.coeffs, atol=1e-3)
 
 
 @pytest.mark.parametrize(

--- a/surpyval/utils/recurrent_event_data.py
+++ b/surpyval/utils/recurrent_event_data.py
@@ -254,6 +254,51 @@ class RecurrentEventData:
 
         return np.concatenate(x_previous)
 
+    def get_right_truncation_close(self):
+        """
+        Per-item integration bounds for the NHPP likelihood's right
+        window-close.
+
+        The NHPP integral runs from each item's entry time (its left
+        truncation ``tl``, handled by :meth:`get_previous_x`) to the time its
+        observation window closes. Historically that close was only known from
+        an explicit right-censoring (``c=1``) row, so the integral stopped at
+        the item's last recorded time. When an item instead carries a finite
+        right-truncation time ``tr`` the window closes there, and the integral
+        must be extended from the last in-window time out to ``tr``.
+
+        Returns three aligned arrays ``(x_last, x_close, rep_idx)`` with one
+        entry per item whose ``tr`` is finite: ``x_last`` is the item's last
+        in-window time (its last event or right-censoring row), ``x_close`` is
+        its ``tr``, and ``rep_idx`` is a representative row index for the item
+        (so per-item covariates ``Z`` can be gathered). Items with the default
+        ``tr = inf`` are omitted, so untruncated data yields empty arrays and
+        contributes nothing to the integral. Adding
+        ``cif(x_last) - cif(x_close)`` to the log-likelihood therefore extends
+        the telescoped integral to ``tr`` (and is exactly zero when a ``c=1``
+        row already sits at ``tr``, so the two ways of closing the window never
+        double-count).
+
+        Returns
+        -------
+        tuple of numpy.ndarray
+            ``(x_last, x_close, rep_idx)`` as described above.
+        """
+        x_upper = self.x if self.x.ndim == 1 else self.x[:, 1]
+        x_last, x_close, rep_idx = [], [], []
+        for item in self.items:
+            mask = self.i == item
+            tr_item = float(self.tr[mask][0])
+            if np.isfinite(tr_item):
+                x_last.append(float(x_upper[mask].max()))
+                x_close.append(tr_item)
+                rep_idx.append(int(np.flatnonzero(mask)[0]))
+        return (
+            np.array(x_last, dtype=float),
+            np.array(x_close, dtype=float),
+            np.array(rep_idx, dtype=int),
+        )
+
     def get_events_for_item(self, item):
         """
         Get all events for a specific item or subject.


### PR DESCRIPTION
The NHPP family previously closed each item's observation window only via
an explicit right-censoring (c=1) row; a finite right-truncation time tr
was ignored by the likelihood integral. Integrate the baseline intensity
out to tr directly, via a shared RecurrentEventData.get_right_truncation_close()
helper used by HPP, the NHPPFitter models (CrowAMSAA/Duane/CoxLewis) and
both proportional-intensity regression fitters. The per-item window-close
term is zero when tr is infinite or a c=1 row already sits at tr, so the
two ways of closing the window never double-count and untruncated fits are
unchanged.

Also expose t/tl/tr on ProportionalIntensityNHPP.fit() and
ProportionalIntensityHPP.fit(), and add tests covering the tr window-close
against the equivalent c=1-row fits.