### PR TITLE
Add degradation analysis: path models, pseudo-failure fitting, Bayesian RUL prediction

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -341,11 +341,12 @@ The semi-parametric counterpart to Cox PH. Fits `log(T) = β'Z + ε` without ass
 ## 7a. Degradation Analysis — Future Work
 
 `surpyval.degradation` ships the classic pseudo-failure-time approach: per-unit
-least-squares path fits (linear, exponential, power, logarithmic, Lloyd-Lipow),
-extrapolation to a threshold, and a lifetime-distribution fit to the resulting
-pseudo failure times (units whose path never reaches the threshold are right
-censored at their last observation). Natural extensions, roughly in priority
-order:
+least-squares path fits (linear, quadratic, exponential, offset-exponential,
+power, logarithmic, Lloyd-Lipow, Gompertz, Michaelis-Menten — plus
+`path="best"` AICc selection across all of them), extrapolation to a
+threshold, and a lifetime-distribution fit to the resulting pseudo failure
+times (units whose path never reaches the threshold are right censored at
+their last observation). Natural extensions, roughly in priority order:
 
 Shipped so far beyond the basic pipeline: the two-stage noise-corrected
 population path-parameter distribution (Lu–Meeker moments: pooled

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -351,9 +351,23 @@ order:
   times as exact, so life-model confidence bounds understate the true
   uncertainty. A bootstrap over units (refit paths + life model per resample)
   is the cheap fix; expose it as a `cb`/`bootstrap` option on the model.
-- **Random-effects (Lu–Meeker) degradation models.** Path parameters as draws
-  from a population distribution, fitted jointly; failure-time distribution
-  induced by the path model rather than via pseudo failures.
+- **Bayesian RUL prediction.** The two-stage noise-corrected population
+  path-parameter distribution (Lu–Meeker: pooled `measurement_var`, mean
+  `path_param_mean`, corrected between-unit `path_param_cov` via
+  `S - V̄` with a PSD clip) is now computed at fit time and exposed on the
+  model. The consumer to build on it: a `predict_rul(x, y)` that forms the
+  Gaussian posterior for a new unit's path parameters (conjugate for the
+  linear-in-parameter paths) and pushes it through `inv_path` by Monte Carlo
+  to give an RUL distribution with credible intervals — shrinking short noisy
+  trajectories toward the population instead of trusting the raw
+  extrapolation.
+- **Random-effects (Lu–Meeker) degradation models fitted properly.** The
+  moments correction above can go rank-deficient with few units; the robust
+  upgrade is marginal ML/REML on `y_i ~ N(X_i mu, X_i Sigma X_i' + sigma^2 I)`
+  (REML to avoid the fixed-effect small-sample bias in the variance
+  components, Cholesky-parameterised `Sigma` so it stays PSD). This also
+  yields the failure-time distribution induced by the path model rather than
+  via pseudo failures.
 - **Stochastic-process degradation models.** Wiener process with drift (first
   passage → inverse Gaussian lifetimes) and gamma process (monotone
   degradation) — these are genuine models with proper likelihoods, and they

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -347,27 +347,31 @@ pseudo failure times (units whose path never reaches the threshold are right
 censored at their last observation). Natural extensions, roughly in priority
 order:
 
-- **Uncertainty propagation.** The two-stage method treats pseudo failure
-  times as exact, so life-model confidence bounds understate the true
-  uncertainty. A bootstrap over units (refit paths + life model per resample)
-  is the cheap fix; expose it as a `cb`/`bootstrap` option on the model.
-- **Bayesian RUL prediction.** The two-stage noise-corrected population
-  path-parameter distribution (Lu–Meeker: pooled `measurement_var`, mean
-  `path_param_mean`, corrected between-unit `path_param_cov` via
-  `S - V̄` with a PSD clip) is now computed at fit time and exposed on the
-  model. The consumer to build on it: a `predict_rul(x, y)` that forms the
-  Gaussian posterior for a new unit's path parameters (conjugate for the
-  linear-in-parameter paths) and pushes it through `inv_path` by Monte Carlo
-  to give an RUL distribution with credible intervals — shrinking short noisy
-  trajectories toward the population instead of trusting the raw
-  extrapolation.
-- **Random-effects (Lu–Meeker) degradation models fitted properly.** The
-  moments correction above can go rank-deficient with few units; the robust
-  upgrade is marginal ML/REML on `y_i ~ N(X_i mu, X_i Sigma X_i' + sigma^2 I)`
-  (REML to avoid the fixed-effect small-sample bias in the variance
-  components, Cholesky-parameterised `Sigma` so it stays PSD). This also
-  yields the failure-time distribution induced by the path model rather than
-  via pseudo failures.
+Shipped so far beyond the basic pipeline: the two-stage noise-corrected
+population path-parameter distribution (Lu–Meeker moments: pooled
+`measurement_var`, `path_param_mean`, `path_param_cov` via `S - V̄` with a PSD
+clip); `population_method="reml"` fitting the same quantities by restricted
+marginal likelihood of the linear mixed model (Cholesky-parameterised `Sigma`,
+GLS-profiled mean; linear-in-parameter paths only, coincides with moments on
+balanced designs); and `DegradationModel.predict_rul(x, y)` — the Gaussian
+posterior for a new unit's path parameters (conjugate for linear-in-parameter
+paths, iterated linearisation otherwise) pushed through `inv_path` by Monte
+Carlo, giving shrinkage RUL predictions with credible intervals.
+
+- **Uncertainty propagation for the life model.** The two-stage method treats
+  pseudo failure times as exact, so life-model confidence bounds understate
+  the true uncertainty. A bootstrap over units (refit paths + life model per
+  resample) is the cheap fix; expose it as a `cb`/`bootstrap` option on the
+  model.
+- **Induced failure-time distribution.** With `(mu, Sigma, sigma^2)` fitted
+  (especially by REML), the population failure-time distribution can be
+  derived from the path model directly (Monte Carlo over `theta ~ MVN` through
+  `inv_path`) instead of via noisy pseudo failures — the full Lu–Meeker
+  program. Compare against the pseudo-failure Weibull as a diagnostic.
+- **REML for nonlinear paths.** Exponential/power paths need FO/FOCE-style
+  linearisation of the mixed model (or fitting the exponential path on the
+  log scale, where it is linear). Uncertainty in `(mu, Sigma)` itself
+  (hierarchical bands) is also unmodelled.
 - **Stochastic-process degradation models.** Wiener process with drift (first
   passage → inverse Gaussian lifetimes) and gamma process (monotone
   degradation) — these are genuine models with proper likelihoods, and they

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -346,7 +346,7 @@ power, logarithmic, Lloyd-Lipow, Gompertz, Michaelis-Menten — plus
 `path="best"` AICc selection across all of them), extrapolation to a
 threshold, and a lifetime-distribution fit to the resulting pseudo failure
 times (units whose path never reaches the threshold are right censored at
-their last observation). Natural extensions, roughly in priority order:
+their last observation).
 
 Shipped so far beyond the basic pipeline: the two-stage noise-corrected
 population path-parameter distribution (Lu–Meeker moments: pooled
@@ -358,6 +358,8 @@ balanced designs); and `DegradationModel.predict_rul(x, y)` — the Gaussian
 posterior for a new unit's path parameters (conjugate for linear-in-parameter
 paths, iterated linearisation otherwise) pushed through `inv_path` by Monte
 Carlo, giving shrinkage RUL predictions with credible intervals.
+
+Natural extensions, roughly in priority order:
 
 - **Uncertainty propagation for the life model.** The two-stage method treats
   pseudo failure times as exact, so life-model confidence bounds understate
@@ -377,11 +379,54 @@ Carlo, giving shrinkage RUL predictions with credible intervals.
   passage → inverse Gaussian lifetimes) and gamma process (monotone
   degradation) — these are genuine models with proper likelihoods, and they
   handle measurement error and irregular sampling more honestly.
-- **Accelerated degradation testing (ADT).** Stress covariates on the path
-  parameters (Arrhenius/power-law links), the degradation counterpart of the
-  existing ALT regression models.
 - **Destructive degradation** (one measurement per unit) — needs a different
   data model since per-unit path fits are impossible.
+
+### Covariates / accelerated degradation testing (design)
+
+Covariates (accelerating stresses such as temperature/voltage/humidity, or
+observational factors such as lot/supplier/load) can enter the pipeline at two
+different stages, and they are genuinely different features:
+
+**Stage 1 — covariates on the life fit (classic ADT; build first).** Keep the
+per-unit path fits unchanged; each unit also carries a covariate vector `Z_i`
+(constant per unit — one row per unit, or a column in `fit_from_df`). Instead
+of fitting a plain distribution to the pseudo failure times, feed
+`(pseudo_failure_time_i, c_i, Z_i)` into the *existing* univariate regression
+fitters (AFT / PH / parameter-substitution life-stress models, formulaic
+formulas and all). API sketch: `DegradationAnalysis.fit(x, y, i, Z=...,
+distribution=<regression fitter>)`, with `Z` forwarded through the delegated
+lifetime functions (`model.sf(t, Z=use_stress)`) so life at use conditions is
+one call. Censored (non-degrading) units flow through naturally since the
+regression fitters already take `c`. Mostly plumbing — a small, separate PR.
+Theoretical justification: for a linear path with stress acting on the rate,
+`T = (y_t - a) / b(Z)`, so `log T = log(y_t - a) - log b(Z)` — exactly an AFT
+model. For rate-acting stresses on threshold-crossing models the
+pseudo-failure + AFT composition is the correct functional form, not just a
+pragmatic one. Open design point: interaction with `path="best"` (default:
+select on the pooled data as now, since the path stage stays per-unit either
+way).
+
+**Stage 2 — covariates on the path parameters (mechanistic).** Model the
+degradation rate itself: `theta_i = Gamma z_i + u_i` (e.g. Arrhenius when a
+rate is log-linear in `1/T`). This buys what Stage 1 cannot: pooling strength
+across units (a unit with two points at high stress still informs `Gamma`, so
+per-unit fits need not be possible), stress-conditional priors for
+`predict_rul` (`theta ~ MVN(mu(Z), Sigma)` — the blend then knows a hot unit
+should be degrading faster *before* seeing its data), and stresses that change
+the path *shape* rather than just its scale. Implementation: for
+linear-in-parameter paths with identity links this stays a linear mixed model
+— `y_i = (z_i' ⊗ X_i) vec(Gamma) + X_i u_i + eps` — so the existing REML code
+needs only a wider fixed-effects design matrix; the GLS profiling and
+variance-parameter optimisation are untouched. Physically-motivated links
+(log/Arrhenius, to keep rates positive) make the fixed effects nonlinear:
+either fit on a transformed scale or wrap one Gauss-Newton layer around the
+LMM.
+
+**Stage 3 — time-varying stress (step-stress profiles).** Cumulative-exposure
+/ cumulative-damage models where the rate changes with the stress profile
+mid-test. Hardest by far (same reasons as time-varying covariates for the
+regression module — see section 8); defer until Stages 1-2 are stable.
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -338,6 +338,34 @@ The semi-parametric counterpart to Cox PH. Fits `log(T) = β'Z + ε` without ass
 
 ---
 
+## 7a. Degradation Analysis — Future Work
+
+`surpyval.degradation` ships the classic pseudo-failure-time approach: per-unit
+least-squares path fits (linear, exponential, power, logarithmic, Lloyd-Lipow),
+extrapolation to a threshold, and a lifetime-distribution fit to the resulting
+pseudo failure times (units whose path never reaches the threshold are right
+censored at their last observation). Natural extensions, roughly in priority
+order:
+
+- **Uncertainty propagation.** The two-stage method treats pseudo failure
+  times as exact, so life-model confidence bounds understate the true
+  uncertainty. A bootstrap over units (refit paths + life model per resample)
+  is the cheap fix; expose it as a `cb`/`bootstrap` option on the model.
+- **Random-effects (Lu–Meeker) degradation models.** Path parameters as draws
+  from a population distribution, fitted jointly; failure-time distribution
+  induced by the path model rather than via pseudo failures.
+- **Stochastic-process degradation models.** Wiener process with drift (first
+  passage → inverse Gaussian lifetimes) and gamma process (monotone
+  degradation) — these are genuine models with proper likelihoods, and they
+  handle measurement error and irregular sampling more honestly.
+- **Accelerated degradation testing (ADT).** Stress covariates on the path
+  parameters (Arrhenius/power-law links), the degradation counterpart of the
+  existing ALT regression models.
+- **Destructive degradation** (one measurement per unit) — needs a different
+  data model since per-unit path fits are impossible.
+
+---
+
 ## 8. Time-Varying Covariates and Truncation (to be confirmed)
 
 Full support for time-varying covariates (TVCs) and left/right truncation across all regression model families needs to be designed and confirmed before implementation. Key points established so far:

--- a/MODEL_ATLAS.md
+++ b/MODEL_ATLAS.md
@@ -103,6 +103,17 @@ remains future work.
 |-------|-----|-----------|--------|--------|------------|------|------------|
 | Clayton/Gumbel/Frank/Gaussian copula | multivariate | single_event | single | terminal | none | continuous | parametric |
 
+One shipped capability sits deliberately *outside* the axes:
+`surpyval.degradation` (pseudo-failure-time degradation analysis) is not itself
+an event-time model but a **data bridge** — it converts repeated degradation
+measurements into per-unit (possibly right-censored) failure times by
+extrapolating a fitted degradation path to a failure threshold, then hands
+those times to an ordinary univariate parametric fitter. The life model it
+produces classifies as univariate / single_event / single / terminal /
+parametric; the degradation stage itself is least-squares regression on
+measurements, not survival modelling. (Stochastic degradation *processes* —
+Wiener, gamma — would be genuine models on the atlas and remain future work.)
+
 ## Deferred orthogonal axes (out of scope for now)
 
 - **Inference paradigm** — frequentist vs Bayesian. The entire library is

--- a/docs/Degradation Analysis.rst
+++ b/docs/Degradation Analysis.rst
@@ -1,0 +1,128 @@
+Degradation Analysis
+====================
+
+Sometimes failure data is scarce or takes too long to collect: items are
+highly reliable, test time is limited, and few (or no) units fail during
+the observation window. But failure is often the end point of a gradual,
+measurable process — a crack grows, a resistance drifts, a lumen output
+fades, a material wears. Degradation analysis exploits this: instead of
+waiting for units to fail, we track a *degradation measurement* over time
+on each unit, define failure as the measurement crossing a *threshold*,
+and extrapolate each unit's degradation trend to that threshold to obtain
+a failure time — even for units that never actually failed on test.
+
+SurPyval implements the classic *pseudo-failure-time* approach:
+
+1. A degradation *path model* (e.g. linear) is fitted, by least squares,
+   to each unit's measurements.
+2. Each unit's fitted path is extrapolated to the failure threshold. The
+   crossing time is that unit's *pseudo failure time*.
+3. A lifetime distribution (Weibull by default) is fitted to the pseudo
+   failure times, and can then be used like any other SurPyval parametric
+   model.
+
+If a unit's fitted path never reaches the threshold (for example, the
+unit is not degrading, or is trending away from the threshold), the unit
+is treated as right censored at its last observed time, and the censoring
+is passed through to the lifetime distribution fit.
+
+Degradation path models
+-----------------------
+
+The path models available, and the pseudo failure time each implies for a
+threshold :math:`y_{t}`, are:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Name
+      - Path
+      - Threshold crossing time
+    * - ``"linear"``
+      - :math:`y = a + b x`
+      - :math:`(y_{t} - a) / b`
+    * - ``"exponential"``
+      - :math:`y = a e^{b x}`
+      - :math:`\ln(y_{t} / a) / b`
+    * - ``"power"``
+      - :math:`y = a x^{b}`
+      - :math:`(y_{t} / a)^{1/b}`
+    * - ``"logarithmic"``
+      - :math:`y = a + b \ln(x)`
+      - :math:`e^{(y_{t} - a) / b}`
+    * - ``"lloyd-lipow"``
+      - :math:`y = a - b / x`
+      - :math:`b / (a - y_{t})`
+
+Degradation can be increasing (crack length) or decreasing (luminous
+flux); the direction is captured by the sign of the fitted parameters and
+needs no configuration. Models that are linear in their parameters
+(linear, logarithmic, Lloyd-Lipow) are fitted in closed form; the others
+(exponential, power) are fitted by nonlinear least squares started from
+the log-linearised fit.
+
+Example
+-------
+
+Consider four units whose degradation is measured every 100 hours, with
+failure defined as the measurement reaching 150:
+
+.. code:: python
+
+    import numpy as np
+    from surpyval.degradation import DegradationAnalysis
+
+    x = np.tile(np.arange(100, 1100, 100), 4)
+    i = np.repeat([1, 2, 3, 4], 10)
+    slopes = np.repeat([0.31, 0.28, 0.44, 0.37], 10)
+    y = 10 + slopes * x
+
+    model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    print(model)
+
+.. code:: text
+
+    Degradation Analysis SurPyval Model
+    ===================================
+    Path Model          : Linear
+    Threshold           : 150.0
+    Number of Units     : 4
+    Censored Units      : 0
+    Life Distribution   : Weibull
+    Parameters          :
+         alpha: 441.4780882117898
+          beta: 6.987078993008337
+
+The fitted model exposes the per-unit results and forwards the usual
+lifetime functions to the fitted life model:
+
+.. code:: python
+
+    model.pseudo_failure_times
+    # array([451.61290323, 500.        , 318.18181818, 378.37837838])
+
+    model.sf([300, 400, 500])
+    # array([0.93496716, 0.60538471, 0.09196813])
+
+    model.life_model    # the underlying Parametric Weibull model
+    model.plot()        # data, fitted paths, and the threshold
+
+Data can also come straight from a DataFrame with
+``DegradationAnalysis.fit_from_df(df, x="time", y="measurement",
+i="unit", threshold=150)``, the life distribution and fitting method can
+be changed with the ``distribution`` and ``how`` arguments (e.g.
+``distribution=LogNormal, how="MPP"``), and a custom path shape can be
+used by passing a ``surpyval.degradation.PathModel`` subclass instance as
+``path``.
+
+A note on uncertainty
+---------------------
+
+The pseudo-failure-time approach is a two-stage method: the life
+distribution is fitted to *estimated* failure times as if they had been
+observed exactly, so the reported confidence bounds on the life model do
+not include the path-fitting or extrapolation uncertainty. This is the
+standard, pragmatic form of degradation analysis; random-effects
+(Lu-Meeker) and stochastic-process (Wiener, gamma process) degradation
+models, which propagate that uncertainty, are candidates for future
+work.

--- a/docs/Degradation Analysis.rst
+++ b/docs/Degradation Analysis.rst
@@ -139,6 +139,42 @@ view instead of a per-unit extrapolation, the fitted life model can be
 used directly — e.g. the survival of a unit that has already survived
 to time ``a``: ``model.life_model.cs(t, a)``.
 
+Bayesian remaining-life prediction
+----------------------------------
+
+``predict_failure_time`` trusts the new unit's least-squares fit
+completely — dangerous when the trajectory is short or noisy.
+``predict_rul`` instead blends the unit's own trend with the
+population: the population path-parameter distribution (below) is the
+prior, the unit's measurements are the likelihood, and the Gaussian
+posterior of the unit's path parameters is pushed through the
+threshold crossing by Monte Carlo:
+
+.. code:: python
+
+    pred = model.predict_rul(x_new, y_new, alpha_ci=0.05)
+
+    pred.failure_time           # posterior median failure time
+    pred.failure_time_interval  # 95% credible interval
+    pred.rul                    # median remaining useful life
+    pred.rul_interval           # 95% credible interval
+    pred.prob_failed            # P(already crossed the threshold)
+    pred.prob_never_fails       # P(path never reaches the threshold)
+    pred.posterior_mean         # the unit's posterior path parameters
+    pred.posterior_cov
+
+The posterior mean is a precision-weighted compromise: a short or
+noisy trajectory is shrunk toward the population's typical path, and
+as measurements accumulate the prediction converges to the plain
+least-squares extrapolation. Unlike ``predict_failure_time``, it works
+from a single measurement, and a not-yet-degrading trajectory yields a
+long-but-finite prediction with wide bounds rather than ``nan``. The
+posterior is exact (conjugate) for path models that are linear in
+their parameters (linear, logarithmic, Lloyd-Lipow) and an
+iterated-linearisation (Laplace) approximation for the others. It
+requires a positive ``measurement_var`` — with noiseless training
+paths there is nothing to blend.
+
 The population path-parameter distribution
 ------------------------------------------
 
@@ -170,6 +206,42 @@ per unit), a warning is raised and the corrected covariance should be
 treated as unreliable. When every unit has only as many measurements
 as path parameters, the measurement variance cannot be estimated and
 no correction is applied.
+
+REML estimation of the population
+---------------------------------
+
+The moments correction can go rank-deficient when the estimation noise
+rivals the between-unit scatter. The robust alternative is to fit the
+random-effects (Lu-Meeker) formulation directly as a linear mixed
+model — each unit's parameters are draws
+:math:`\theta_i \sim MVN(\mu, \Sigma)`, so with the random effects
+integrated out each unit's measurement vector is marginally
+
+.. math::
+
+    y_i \sim N(X_i \mu, \; X_i \Sigma X_i^T + \sigma^2 I)
+
+and :math:`(\mu, \Sigma, \sigma^2)` are estimated by maximising the
+restricted (REML) marginal likelihood — REML rather than plain ML so
+the variance components do not inherit the small-sample downward bias
+from estimating :math:`\mu`. Select it with:
+
+.. code:: python
+
+    model = DegradationAnalysis.fit(
+        x, y, i, threshold=150, population_method="reml"
+    )
+
+The estimates land in the same attributes (``path_param_mean``,
+``path_param_cov``, ``measurement_var``), so ``predict_rul`` and
+everything else work unchanged. :math:`\Sigma` is parameterised by its
+Cholesky factor, so it is positive definite by construction — no
+clipping. On balanced designs (every unit measured at the same times)
+REML coincides with the corrected moments estimate; they differ on
+unbalanced data and when the unit count is small, where REML is
+preferable. REML is available for path models that are linear in
+their parameters (linear, logarithmic, Lloyd-Lipow) and requires a
+positive measurement variance.
 
 A note on uncertainty
 ---------------------

--- a/docs/Degradation Analysis.rst
+++ b/docs/Degradation Analysis.rst
@@ -115,6 +115,30 @@ be changed with the ``distribution`` and ``how`` arguments (e.g.
 used by passing a ``surpyval.degradation.PathModel`` subclass instance as
 ``path``.
 
+Predicting a new unit's failure time
+------------------------------------
+
+A fitted model can estimate the failure time of a *new*, partially
+observed unit from its degradation trajectory. The model fits its path
+shape to the new measurements and extrapolates to the same threshold:
+
+.. code:: python
+
+    # a new unit observed for only 300 hours, degrading at ~0.35/hour
+    x_new = [100, 200, 300]
+    y_new = [45, 80, 115]
+
+    model.predict_failure_time(x_new, y_new)   # ~400: when y reaches 150
+    model.predict_remaining_life(x_new, y_new) # ~100: minus its age (300)
+
+If the trajectory has already crossed the threshold, the predicted
+failure time is in the past and the remaining life is negative. If the
+new unit's fitted path never reaches the threshold (it is not
+degrading), both return ``nan`` with a warning. For a population-level
+view instead of a per-unit extrapolation, the fitted life model can be
+used directly — e.g. the survival of a unit that has already survived
+to time ``a``: ``model.life_model.cs(t, a)``.
+
 A note on uncertainty
 ---------------------
 

--- a/docs/Degradation Analysis.rst
+++ b/docs/Degradation Analysis.rst
@@ -41,9 +41,15 @@ threshold :math:`y_{t}`, are:
     * - ``"linear"``
       - :math:`y = a + b x`
       - :math:`(y_{t} - a) / b`
+    * - ``"quadratic"``
+      - :math:`y = a + b x + c x^{2}`
+      - first positive root of :math:`c t^{2} + b t + (a - y_{t})`
     * - ``"exponential"``
       - :math:`y = a e^{b x}`
       - :math:`\ln(y_{t} / a) / b`
+    * - ``"offset-exponential"``
+      - :math:`y = a + b e^{c x}`
+      - :math:`\ln((y_{t} - a) / b) / c`
     * - ``"power"``
       - :math:`y = a x^{b}`
       - :math:`(y_{t} / a)^{1/b}`
@@ -53,13 +59,39 @@ threshold :math:`y_{t}`, are:
     * - ``"lloyd-lipow"``
       - :math:`y = a - b / x`
       - :math:`b / (a - y_{t})`
+    * - ``"gompertz"``
+      - :math:`y = a e^{-b e^{-c x}}`
+      - :math:`-\ln(-\ln(y_{t}/a)/b) / c`
+    * - ``"michaelis-menten"``
+      - :math:`y = a x / (b + x)`
+      - :math:`b y_{t} / (a - y_{t})`
 
 Degradation can be increasing (crack length) or decreasing (luminous
 flux); the direction is captured by the sign of the fitted parameters and
 needs no configuration. Models that are linear in their parameters
-(linear, logarithmic, Lloyd-Lipow) are fitted in closed form; the others
-(exponential, power) are fitted by nonlinear least squares started from
-the log-linearised fit.
+(linear, quadratic, logarithmic, Lloyd-Lipow) are fitted in closed form;
+the others are fitted by nonlinear least squares started from a
+linearised fit. The offset-exponential covers growth or decay toward an
+asymptote (``a = 0`` reduces it to the exponential); Gompertz is
+S-shaped; Michaelis-Menten saturates from zero toward ``a``.
+
+Not sure which shape fits? Pass ``path="best"``:
+
+.. code:: python
+
+    model = DegradationAnalysis.fit(x, y, i, threshold=150, path="best")
+    model.path_model.name   # the selected model
+    model.path_selection    # AICc score per candidate
+
+Every registered path model is fitted to every unit and the model with
+the smallest AICc (pooled over all units, penalising the per-unit
+parameter count) is selected; candidates that cannot be fitted to every
+unit — domain violations such as negative measurements for the
+exponential, too few distinct measurement times for their parameter
+count, or non-convergence — are excluded and score ``nan``. The
+selection is by measurement fit only; as always, prefer a shape with
+physical justification when one is known, since the winner is
+extrapolated well beyond the data.
 
 Example
 -------
@@ -170,7 +202,7 @@ least-squares extrapolation. Unlike ``predict_failure_time``, it works
 from a single measurement, and a not-yet-degrading trajectory yields a
 long-but-finite prediction with wide bounds rather than ``nan``. The
 posterior is exact (conjugate) for path models that are linear in
-their parameters (linear, logarithmic, Lloyd-Lipow) and an
+their parameters (linear, quadratic, logarithmic, Lloyd-Lipow) and an
 iterated-linearisation (Laplace) approximation for the others. It
 requires a positive ``measurement_var`` — with noiseless training
 paths there is nothing to blend.
@@ -240,7 +272,8 @@ clipping. On balanced designs (every unit measured at the same times)
 REML coincides with the corrected moments estimate; they differ on
 unbalanced data and when the unit count is small, where REML is
 preferable. REML is available for path models that are linear in
-their parameters (linear, logarithmic, Lloyd-Lipow) and requires a
+their parameters (linear, quadratic, logarithmic, Lloyd-Lipow) and
+requires a
 positive measurement variance.
 
 A note on uncertainty

--- a/docs/Degradation Analysis.rst
+++ b/docs/Degradation Analysis.rst
@@ -139,6 +139,38 @@ view instead of a per-unit extrapolation, the fitted life model can be
 used directly — e.g. the survival of a unit that has already survived
 to time ``a``: ``model.life_model.cs(t, a)``.
 
+The population path-parameter distribution
+------------------------------------------
+
+The fitted model also estimates the *population* distribution of the
+path parameters, which is what a random-effects treatment (and any
+Bayesian blending of a new unit's trajectory with the population) needs
+as its prior:
+
+.. code:: python
+
+    model.path_param_mean        # mean path parameters across units
+    model.path_param_cov         # between-unit covariance (corrected)
+    model.path_param_sample_cov  # raw sample covariance (uncorrected)
+    model.measurement_var        # pooled measurement-error variance
+
+Because each unit's fitted parameters are least-squares *estimates*,
+their scatter across units mixes two sources: real unit-to-unit
+variability and per-unit estimation noise
+(:math:`\mathrm{Cov}(\hat{\theta}_i) = \Sigma + V_i`). The raw sample
+covariance therefore overstates the between-unit variability.
+``path_param_cov`` applies the Lu-Meeker two-stage correction: the
+measurement variance is pooled from the per-unit residuals, each
+unit's estimation covariance :math:`V_i = \sigma^2 (J_i^T J_i)^{-1}`
+is computed from the path Jacobian, and the average is subtracted from
+the sample covariance. The result is projected onto the positive
+semi-definite cone; if material clipping was needed (estimation noise
+comparable to the between-unit scatter — few units or few measurements
+per unit), a warning is raised and the corrected covariance should be
+treated as unreliable. When every unit has only as many measurements
+as path parameters, the measurement variance cannot be estimated and
+no correction is applied.
+
 A note on uncertainty
 ---------------------
 
@@ -147,6 +179,6 @@ distribution is fitted to *estimated* failure times as if they had been
 observed exactly, so the reported confidence bounds on the life model do
 not include the path-fitting or extrapolation uncertainty. This is the
 standard, pragmatic form of degradation analysis; random-effects
-(Lu-Meeker) and stochastic-process (Wiener, gamma process) degradation
-models, which propagate that uncertainty, are candidates for future
-work.
+(Lu-Meeker, fitted by REML) and stochastic-process (Wiener, gamma
+process) degradation models, which propagate that uncertainty, are
+candidates for future work.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,6 +98,7 @@ Contents:
    Competing Risks Analysis
    Recurrent Event Analysis
    Recurrent Event Regression Analysis
+   Degradation Analysis
 
 .. toctree::
    :maxdepth: 2

--- a/docs/surpyval.degradation.rst
+++ b/docs/surpyval.degradation.rst
@@ -1,0 +1,37 @@
+Degradation Analysis
+====================
+
+Degradation Analysis Fitter
+---------------------------
+
+.. autoclass:: surpyval.degradation.degradation_analysis.DegradationAnalysis_
+   :members:
+
+Degradation Model
+-----------------
+
+.. autoclass:: surpyval.degradation.degradation_analysis.DegradationModel
+   :members:
+
+Path Models
+-----------
+
+.. autoclass:: surpyval.degradation.path_models.PathModel
+   :members:
+
+.. autoclass:: surpyval.degradation.path_models.LinearPath_
+   :members:
+
+.. autoclass:: surpyval.degradation.path_models.ExponentialPath_
+   :members:
+
+.. autoclass:: surpyval.degradation.path_models.PowerPath_
+   :members:
+
+.. autoclass:: surpyval.degradation.path_models.LogarithmicPath_
+   :members:
+
+.. autoclass:: surpyval.degradation.path_models.LloydLipowPath_
+   :members:
+
+.. autofunction:: surpyval.degradation.path_models.get_path_model

--- a/docs/surpyval.degradation.rst
+++ b/docs/surpyval.degradation.rst
@@ -25,7 +25,13 @@ Path Models
 .. autoclass:: surpyval.degradation.path_models.LinearPath_
    :members:
 
+.. autoclass:: surpyval.degradation.path_models.QuadraticPath_
+   :members:
+
 .. autoclass:: surpyval.degradation.path_models.ExponentialPath_
+   :members:
+
+.. autoclass:: surpyval.degradation.path_models.OffsetExponentialPath_
    :members:
 
 .. autoclass:: surpyval.degradation.path_models.PowerPath_
@@ -35,6 +41,12 @@ Path Models
    :members:
 
 .. autoclass:: surpyval.degradation.path_models.LloydLipowPath_
+   :members:
+
+.. autoclass:: surpyval.degradation.path_models.GompertzPath_
+   :members:
+
+.. autoclass:: surpyval.degradation.path_models.MichaelisMentenPath_
    :members:
 
 .. autofunction:: surpyval.degradation.path_models.get_path_model

--- a/docs/surpyval.degradation.rst
+++ b/docs/surpyval.degradation.rst
@@ -13,6 +13,9 @@ Degradation Model
 .. autoclass:: surpyval.degradation.degradation_analysis.DegradationModel
    :members:
 
+.. autoclass:: surpyval.degradation.degradation_analysis.RULPrediction
+   :members:
+
 Path Models
 -----------
 

--- a/docs/surpyval.rst
+++ b/docs/surpyval.rst
@@ -8,5 +8,6 @@ API
    surpyval.parametric
    surpyval.regression
    surpyval.counting
+   surpyval.degradation
    surpyval.utilities
    surpyval.datasets

--- a/surpyval/degradation/__init__.py
+++ b/surpyval/degradation/__init__.py
@@ -1,0 +1,29 @@
+"""Degradation analysis.
+
+Classic (pseudo-failure-time) degradation analysis: fit a degradation
+path model to each unit's repeated measurements, extrapolate each
+fitted path to the failure threshold to get per-unit pseudo failure
+times, and fit a lifetime distribution to those times.
+
+Examples
+--------
+
+>>> from surpyval.degradation import DegradationAnalysis
+>>> model = DegradationAnalysis.fit(x, y, i, threshold=150)  # doctest: +SKIP
+"""
+
+from .path_models import (
+    PATH_MODELS,
+    ExponentialPath,
+    LinearPath,
+    LloydLipowPath,
+    LogarithmicPath,
+    PathModel,
+    PowerPath,
+    get_path_model,
+)
+
+from .degradation_analysis import (  # isort: skip
+    DegradationAnalysis,
+    DegradationModel,
+)

--- a/surpyval/degradation/__init__.py
+++ b/surpyval/degradation/__init__.py
@@ -26,4 +26,5 @@ from .path_models import (
 from .degradation_analysis import (  # isort: skip
     DegradationAnalysis,
     DegradationModel,
+    RULPrediction,
 )

--- a/surpyval/degradation/__init__.py
+++ b/surpyval/degradation/__init__.py
@@ -15,11 +15,15 @@ Examples
 from .path_models import (
     PATH_MODELS,
     ExponentialPath,
+    GompertzPath,
     LinearPath,
     LloydLipowPath,
     LogarithmicPath,
+    MichaelisMentenPath,
+    OffsetExponentialPath,
     PathModel,
     PowerPath,
+    QuadraticPath,
     get_path_model,
 )
 

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -1,0 +1,410 @@
+"""Degradation analysis.
+
+Classic (pseudo-failure-time) degradation analysis: a degradation
+measurement is tracked over time on each unit, a
+:class:`~surpyval.degradation.PathModel` is fitted to each unit's
+measurements, each fitted path is extrapolated to the failure threshold
+to get that unit's pseudo failure time, and a lifetime distribution is
+fitted to the pseudo failure times. Units whose fitted path never
+reaches the threshold are treated as right censored at their last
+observed time.
+"""
+
+import warnings
+from numbers import Number
+
+import matplotlib.pyplot as plt
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+
+from surpyval.univariate.parametric import Weibull
+from surpyval.univariate.parametric.parametric import Parametric
+
+from .path_models import PathModel, get_path_model
+
+
+class DegradationModel:
+    """
+    A fitted degradation analysis model.
+
+    This is the model object returned by
+    :meth:`DegradationAnalysis.fit`. It holds the per-unit fitted
+    degradation paths, the pseudo failure times extrapolated from them,
+    and the lifetime distribution fitted to those pseudo failure times.
+    The usual lifetime functions (``sf``, ``ff``, ``df``, ``hf``,
+    ``Hf``, ``qf``, ``mean``, ``random``) are forwarded to the fitted
+    life model.
+
+    Parameters
+    ----------
+    x, y, i : ndarray
+        The degradation data: measurement times, measurements, and the
+        unit each measurement belongs to.
+    units : ndarray
+        The distinct unit identifiers.
+    threshold : float
+        The degradation level at which a unit is considered failed.
+    path_model : PathModel
+        The degradation path model fitted to each unit.
+    path_params : ndarray
+        Per-unit fitted path parameters, one row per entry of
+        ``units``.
+    pseudo_failure_times : ndarray
+        Per-unit pseudo failure time: the extrapolated threshold
+        crossing time, or the unit's last observed time for censored
+        units.
+    c : ndarray
+        Per-unit censor flags: 0 where the fitted path crosses the
+        threshold, 1 (right censored) where it never does.
+    life_model : Parametric
+        The lifetime distribution fitted to the pseudo failure times.
+    """
+
+    x: npt.NDArray
+    y: npt.NDArray
+    i: npt.NDArray
+    units: npt.NDArray
+    threshold: float
+    path_model: PathModel
+    path_params: npt.NDArray
+    pseudo_failure_times: npt.NDArray
+    c: npt.NDArray
+    life_model: Parametric
+
+    def __init__(
+        self,
+        x,
+        y,
+        i,
+        units,
+        threshold,
+        path_model,
+        path_params,
+        pseudo_failure_times,
+        c,
+        life_model,
+    ):
+        self.x = x
+        self.y = y
+        self.i = i
+        self.units = units
+        self.threshold = threshold
+        self.path_model = path_model
+        self.path_params = path_params
+        self.pseudo_failure_times = pseudo_failure_times
+        self.c = c
+        self.life_model = life_model
+        self._unit_index = {unit: idx for idx, unit in enumerate(units)}
+
+    def path(self, x: npt.ArrayLike, unit) -> npt.NDArray:
+        """Evaluate the fitted degradation path of ``unit`` at ``x``."""
+        idx = self._unit_index[unit]
+        return self.path_model.path(x, *self.path_params[idx])
+
+    def sf(self, x: npt.ArrayLike) -> npt.NDArray:
+        """Survival function of the fitted life model."""
+        return self.life_model.sf(x)
+
+    def ff(self, x: npt.ArrayLike) -> npt.NDArray:
+        """CDF of the fitted life model."""
+        return self.life_model.ff(x)
+
+    def df(self, x: npt.ArrayLike) -> npt.NDArray:
+        """Density of the fitted life model."""
+        return self.life_model.df(x)
+
+    def hf(self, x: npt.ArrayLike) -> npt.NDArray:
+        """Hazard rate of the fitted life model."""
+        return self.life_model.hf(x)
+
+    def Hf(self, x: npt.ArrayLike) -> npt.NDArray:
+        """Cumulative hazard of the fitted life model."""
+        return self.life_model.Hf(x)
+
+    def qf(self, p: npt.ArrayLike) -> npt.NDArray:
+        """Quantile function of the fitted life model."""
+        return self.life_model.qf(p)
+
+    def mean(self) -> float:
+        """Mean of the fitted life model."""
+        return self.life_model.mean()
+
+    def random(self, size: int) -> npt.NDArray:
+        """Random pseudo failure times from the fitted life model."""
+        return self.life_model.random(size)
+
+    def plot(self, ax=None):
+        """
+        Plot the degradation data, the fitted per-unit paths (extended
+        to each unit's pseudo failure time), and the failure threshold.
+
+        Parameters
+        ----------
+        ax : matplotlib axes, optional
+            An axes object to draw the plot on. Creates a new one if
+            not provided.
+
+        Returns
+        -------
+        matplotlib axes
+            An axes object with the plot.
+        """
+        if ax is None:
+            ax = plt.gcf().gca()
+
+        for idx, unit in enumerate(self.units):
+            mask = self.i == unit
+            x_unit = self.x[mask]
+            y_unit = self.y[mask]
+            start, end = x_unit.min(), x_unit.max()
+            if self.c[idx] == 0:
+                pseudo = self.pseudo_failure_times[idx]
+                start, end = min(start, pseudo), max(end, pseudo)
+            x_plot = np.linspace(start, end, 200)
+            (line,) = ax.plot(
+                x_plot,
+                self.path_model.path(x_plot, *self.path_params[idx]),
+                linewidth=1,
+                alpha=0.8,
+            )
+            ax.scatter(x_unit, y_unit, s=12, color=line.get_color())
+
+        ax.axhline(
+            self.threshold, color="k", linestyle="--", label="Threshold"
+        )
+        ax.set_xlabel("Time")
+        ax.set_ylabel("Degradation")
+        ax.legend()
+        return ax
+
+    def __repr__(self):
+        param_string = "\n".join(
+            [
+                f"{name:>10}: {p}"
+                for p, name in zip(
+                    self.life_model.params, self.life_model.dist.param_names
+                )
+            ]
+        )
+        return (
+            "Degradation Analysis SurPyval Model"
+            "\n==================================="
+            f"\nPath Model          : {self.path_model.name}"
+            f"\nThreshold           : {self.threshold}"
+            f"\nNumber of Units     : {len(self.units)}"
+            f"\nCensored Units      : {int((self.c == 1).sum())}"
+            f"\nLife Distribution   : {self.life_model.dist.name}"
+            "\nParameters          :\n" + param_string
+        )
+
+
+class DegradationAnalysis_:
+    """
+    Pseudo-failure-time degradation analysis.
+
+    Fits a degradation path model to each unit's measurements,
+    extrapolates each fitted path to the failure ``threshold`` to
+    obtain per-unit pseudo failure times, and fits a lifetime
+    distribution to those times. Units whose fitted path never reaches
+    the threshold at a positive finite time are right censored at their
+    last observed time (with a warning).
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> from surpyval.degradation import DegradationAnalysis
+    >>> # 4 units measured every 100 hours; degradation grows linearly
+    >>> # at a different rate per unit; failure is defined at level 150.
+    >>> x = np.tile(np.arange(100, 1100, 100), 4)
+    >>> slopes = np.repeat([0.31, 0.28, 0.44, 0.37], 10)
+    >>> i = np.repeat([1, 2, 3, 4], 10)
+    >>> y = 10 + slopes * x
+    >>> model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    >>> print(model)
+    Degradation Analysis SurPyval Model
+    ===================================
+    Path Model          : Linear
+    Threshold           : 150.0
+    Number of Units     : 4
+    Censored Units      : 0
+    Life Distribution   : Weibull
+    Parameters          :
+         alpha: 441.4780882117898
+          beta: 6.987078993008337
+    >>> model.pseudo_failure_times
+    array([451.61290323, 500.        , 318.18181818, 378.37837838])
+    """
+
+    def fit(
+        self,
+        x: npt.ArrayLike,
+        y: npt.ArrayLike,
+        i: npt.ArrayLike,
+        threshold: float,
+        path: "str | PathModel" = "linear",
+        distribution=Weibull,
+        how: str = "MLE",
+    ) -> DegradationModel:
+        """
+        Fit a degradation analysis model.
+
+        Parameters
+        ----------
+        x : array like
+            Times at which the degradation measurements were taken.
+        y : array like
+            The degradation measurements.
+        i : array like
+            The unit each measurement belongs to. Must have the same
+            length as ``x`` and ``y``.
+        threshold : float
+            The degradation level at which a unit is defined to have
+            failed.
+        path : str or PathModel, optional
+            The degradation path model fitted to each unit: one of
+            ``"linear"`` (default), ``"exponential"``, ``"power"``,
+            ``"logarithmic"``, ``"lloyd-lipow"``, or a
+            :class:`~surpyval.degradation.PathModel` instance.
+        distribution : ParametricFitter, optional
+            The lifetime distribution fitted to the pseudo failure
+            times. Defaults to ``Weibull``.
+        how : str, optional
+            The method used to fit the lifetime distribution (passed
+            to ``distribution.fit``). Defaults to ``"MLE"``.
+
+        Returns
+        -------
+        DegradationModel
+            The fitted degradation model, with the per-unit paths,
+            pseudo failure times, and the fitted life model.
+        """
+        x_arr, y_arr, i_arr = self._handle_xyi(x, y, i)
+
+        if not isinstance(threshold, Number) or not np.isfinite(threshold):
+            raise ValueError("threshold must be a finite number")
+        threshold = float(threshold)
+
+        path_model = get_path_model(path)
+
+        units = np.unique(i_arr)
+        if len(units) < 2:
+            raise ValueError(
+                "Degradation analysis requires at least 2 units; "
+                "got {}".format(len(units))
+            )
+
+        n_params = len(path_model.param_names)
+        path_params = np.empty((len(units), n_params))
+        pseudo = np.empty(len(units))
+        last_time = np.empty(len(units))
+
+        for idx, unit in enumerate(units):
+            mask = i_arr == unit
+            x_unit, y_unit = x_arr[mask], y_arr[mask]
+            if len(x_unit) < n_params or len(np.unique(x_unit)) < 2:
+                raise ValueError(
+                    "Unit {} needs at least {} measurements at 2 or more "
+                    "distinct times to fit the {} path model".format(
+                        unit, n_params, path_model.name
+                    )
+                )
+            params = path_model.fit(x_unit, y_unit)
+            path_params[idx] = params
+            pseudo[idx] = path_model.inv_path(threshold, *params)
+            last_time[idx] = x_unit.max()
+
+        events = np.isfinite(pseudo) & (pseudo > 0)
+        if not events.any():
+            raise ValueError(
+                "No unit's fitted degradation path reaches the threshold "
+                "{}; check the threshold and the path model".format(threshold)
+            )
+        if not events.all():
+            warnings.warn(
+                "The fitted degradation path(s) of unit(s) {} never reach "
+                "the threshold {}; these units are treated as right "
+                "censored at their last observed time".format(
+                    list(units[~events]), threshold
+                ),
+                stacklevel=2,
+            )
+
+        pseudo_failure_times = np.where(events, pseudo, last_time)
+        c = np.where(events, 0, 1)
+
+        life_model = distribution.fit(x=pseudo_failure_times, c=c, how=how)
+
+        return DegradationModel(
+            x=x_arr,
+            y=y_arr,
+            i=i_arr,
+            units=units,
+            threshold=threshold,
+            path_model=path_model,
+            path_params=path_params,
+            pseudo_failure_times=pseudo_failure_times,
+            c=c,
+            life_model=life_model,
+        )
+
+    def fit_from_df(
+        self,
+        df: pd.DataFrame,
+        x: str = "x",
+        y: str = "y",
+        i: str = "i",
+        **fit_kwargs,
+    ) -> DegradationModel:
+        """
+        Fit a degradation analysis model from a DataFrame.
+
+        Parameters
+        ----------
+        df : DataFrame
+            DataFrame with the degradation data.
+        x : str, optional
+            Column of the measurement times. Defaults to ``"x"``.
+        y : str, optional
+            Column of the degradation measurements. Defaults to
+            ``"y"``.
+        i : str, optional
+            Column of the unit identifiers. Defaults to ``"i"``.
+        **fit_kwargs
+            Remaining arguments (``threshold``, ``path``,
+            ``distribution``, ``how``) passed to :meth:`fit`.
+
+        Returns
+        -------
+        DegradationModel
+            The fitted degradation model.
+        """
+        return self.fit(
+            df[x].to_numpy(), df[y].to_numpy(), df[i].to_numpy(), **fit_kwargs
+        )
+
+    @staticmethod
+    def _handle_xyi(
+        x: npt.ArrayLike, y: npt.ArrayLike, i: npt.ArrayLike
+    ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
+        x = np.atleast_1d(np.asarray(x, dtype=float))
+        y = np.atleast_1d(np.asarray(y, dtype=float))
+        i = np.atleast_1d(np.asarray(i))
+        if x.ndim != 1 or y.ndim != 1 or i.ndim != 1:
+            raise ValueError("x, y, and i must be one dimensional")
+        if not (len(x) == len(y) == len(i)):
+            raise ValueError(
+                "x, y, and i must have the same length; got {}, {}, "
+                "and {}".format(len(x), len(y), len(i))
+            )
+        if len(x) == 0:
+            raise ValueError("x, y, and i must not be empty")
+        if not np.isfinite(x).all():
+            raise ValueError("x must contain only finite values")
+        if not np.isfinite(y).all():
+            raise ValueError("y must contain only finite values")
+        return x, y, i
+
+
+DegradationAnalysis = DegradationAnalysis_()

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -34,7 +34,9 @@ class DegradationModel:
     and the lifetime distribution fitted to those pseudo failure times.
     The usual lifetime functions (``sf``, ``ff``, ``df``, ``hf``,
     ``Hf``, ``qf``, ``mean``, ``random``) are forwarded to the fitted
-    life model.
+    life model, and the failure time of a new, partially observed unit
+    can be estimated from its trajectory with
+    :meth:`predict_failure_time` / :meth:`predict_remaining_life`.
 
     Parameters
     ----------
@@ -101,6 +103,88 @@ class DegradationModel:
         """Evaluate the fitted degradation path of ``unit`` at ``x``."""
         idx = self._unit_index[unit]
         return self.path_model.path(x, *self.path_params[idx])
+
+    def predict_failure_time(
+        self, x: npt.ArrayLike, y: npt.ArrayLike
+    ) -> float:
+        """
+        Estimate the failure time of a new unit from its (partial)
+        degradation trajectory.
+
+        Fits this model's path model to the new unit's measurements
+        and extrapolates the fitted path to this model's failure
+        threshold, exactly as was done for each unit during fitting.
+
+        Parameters
+        ----------
+        x : array like
+            Times at which the new unit's measurements were taken.
+        y : array like
+            The new unit's degradation measurements.
+
+        Returns
+        -------
+        float
+            The time at which the new unit's fitted path reaches the
+            threshold. This can be smaller than the last observed time
+            if the trajectory has already crossed the threshold.
+            Returns ``nan`` (with a warning) if the fitted path never
+            reaches the threshold.
+        """
+        x_arr, y_arr = self._handle_new_trajectory(x, y)
+        params = self.path_model.fit(x_arr, y_arr)
+        t = float(self.path_model.inv_path(self.threshold, *params))
+        if not (np.isfinite(t) and t > 0):
+            warnings.warn(
+                "The fitted degradation path of the new trajectory never "
+                "reaches the threshold {}; returning nan".format(
+                    self.threshold
+                ),
+                stacklevel=2,
+            )
+            return float("nan")
+        return t
+
+    def predict_remaining_life(
+        self, x: npt.ArrayLike, y: npt.ArrayLike
+    ) -> float:
+        """
+        Estimate the remaining life of a new unit from its (partial)
+        degradation trajectory.
+
+        This is :meth:`predict_failure_time` minus the new unit's last
+        observed time. A negative value means the fitted path crossed
+        the threshold before the last observation (the unit is
+        predicted to have already failed); ``nan`` (with a warning)
+        means the fitted path never reaches the threshold.
+        """
+        x_arr, y_arr = self._handle_new_trajectory(x, y)
+        return self.predict_failure_time(x_arr, y_arr) - float(x_arr.max())
+
+    def _handle_new_trajectory(
+        self, x: npt.ArrayLike, y: npt.ArrayLike
+    ) -> tuple[npt.NDArray, npt.NDArray]:
+        x = np.atleast_1d(np.asarray(x, dtype=float))
+        y = np.atleast_1d(np.asarray(y, dtype=float))
+        if x.ndim != 1 or y.ndim != 1:
+            raise ValueError("x and y must be one dimensional")
+        if len(x) != len(y):
+            raise ValueError(
+                "x and y must have the same length; got {} and {}".format(
+                    len(x), len(y)
+                )
+            )
+        if not (np.isfinite(x).all() and np.isfinite(y).all()):
+            raise ValueError("x and y must contain only finite values")
+        n_params = len(self.path_model.param_names)
+        if len(x) < n_params or len(np.unique(x)) < 2:
+            raise ValueError(
+                "The trajectory needs at least {} measurements at 2 or "
+                "more distinct times to fit the {} path model".format(
+                    n_params, self.path_model.name
+                )
+            )
+        return x, y
 
     def sf(self, x: npt.ArrayLike) -> npt.NDArray:
         """Survival function of the fitted life model."""

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -24,6 +24,22 @@ from surpyval.univariate.parametric.parametric import Parametric
 from .path_models import PathModel, get_path_model
 
 
+def _clip_psd(matrix: npt.NDArray) -> tuple[npt.NDArray, bool]:
+    """
+    Project a symmetric matrix onto the positive semi-definite cone
+    by clipping negative eigenvalues to zero.
+
+    Returns the projected matrix and whether any eigenvalue was
+    *materially* negative (beyond floating-point noise).
+    """
+    matrix = (matrix + matrix.T) / 2.0
+    eigvals, eigvecs = np.linalg.eigh(matrix)
+    tol = 1e-10 * max(np.abs(eigvals).max(), np.finfo(float).tiny)
+    clipped = bool((eigvals < -tol).any())
+    eigvals = np.clip(eigvals, 0.0, None)
+    return eigvecs @ np.diag(eigvals) @ eigvecs.T, clipped
+
+
 class DegradationModel:
     """
     A fitted degradation analysis model.
@@ -61,6 +77,25 @@ class DegradationModel:
         threshold, 1 (right censored) where it never does.
     life_model : Parametric
         The lifetime distribution fitted to the pseudo failure times.
+    measurement_var : float
+        Pooled estimate of the measurement-error variance around the
+        per-unit paths (the per-unit residual sums of squares over the
+        total residual degrees of freedom). Zero when every unit has
+        exactly as many measurements as path parameters.
+    path_param_mean : ndarray
+        Mean of the per-unit fitted path parameters: the estimated
+        population mean path.
+    path_param_cov : ndarray
+        Noise-corrected estimate of the *between-unit* covariance of
+        the true path parameters (Lu-Meeker two-stage): the sample
+        covariance of the per-unit estimates minus the average
+        least-squares estimation covariance, projected onto the
+        positive semi-definite cone.
+    path_param_sample_cov : ndarray
+        The raw (uncorrected) sample covariance of the per-unit
+        fitted path parameters. This overstates the between-unit
+        variability because each per-unit estimate also carries
+        least-squares estimation noise.
     """
 
     x: npt.NDArray
@@ -73,6 +108,10 @@ class DegradationModel:
     pseudo_failure_times: npt.NDArray
     c: npt.NDArray
     life_model: Parametric
+    measurement_var: float
+    path_param_mean: npt.NDArray
+    path_param_cov: npt.NDArray
+    path_param_sample_cov: npt.NDArray
 
     def __init__(
         self,
@@ -86,6 +125,10 @@ class DegradationModel:
         pseudo_failure_times,
         c,
         life_model,
+        measurement_var,
+        path_param_mean,
+        path_param_cov,
+        path_param_sample_cov,
     ):
         self.x = x
         self.y = y
@@ -97,6 +140,10 @@ class DegradationModel:
         self.pseudo_failure_times = pseudo_failure_times
         self.c = c
         self.life_model = life_model
+        self.measurement_var = measurement_var
+        self.path_param_mean = path_param_mean
+        self.path_param_cov = path_param_cov
+        self.path_param_sample_cov = path_param_sample_cov
         self._unit_index = {unit: idx for idx, unit in enumerate(units)}
 
     def path(self, x: npt.ArrayLike, unit) -> npt.NDArray:
@@ -383,6 +430,9 @@ class DegradationAnalysis_:
         path_params = np.empty((len(units), n_params))
         pseudo = np.empty(len(units))
         last_time = np.empty(len(units))
+        rss_total = 0.0
+        dof_total = 0
+        estimation_cov_sum = np.zeros((n_params, n_params))
 
         for idx, unit in enumerate(units):
             mask = i_arr == unit
@@ -398,6 +448,38 @@ class DegradationAnalysis_:
             path_params[idx] = params
             pseudo[idx] = path_model.inv_path(threshold, *params)
             last_time[idx] = x_unit.max()
+
+            residuals = y_unit - path_model.path(x_unit, *params)
+            rss_total += residuals @ residuals
+            dof_total += len(x_unit) - n_params
+            jacobian = path_model.jacobian(x_unit, *params)
+            jtj = jacobian.T @ jacobian
+            try:
+                estimation_cov_sum += np.linalg.inv(jtj)
+            except np.linalg.LinAlgError:
+                estimation_cov_sum += np.linalg.pinv(jtj)
+
+        # Two-stage (Lu-Meeker) noise correction: the scatter of the
+        # per-unit estimates is Sigma + V_i, so subtracting the average
+        # estimation covariance leaves the between-unit covariance.
+        measurement_var = rss_total / dof_total if dof_total > 0 else 0.0
+        path_param_mean = path_params.mean(axis=0)
+        path_param_sample_cov = np.atleast_2d(
+            np.cov(path_params, rowvar=False, ddof=1)
+        )
+        mean_estimation_cov = measurement_var * estimation_cov_sum / len(units)
+        path_param_cov, was_clipped = _clip_psd(
+            path_param_sample_cov - mean_estimation_cov
+        )
+        if was_clipped:
+            warnings.warn(
+                "The noise-corrected between-unit covariance of the path "
+                "parameters was not positive semi-definite (the estimation "
+                "noise is comparable to the between-unit scatter); negative "
+                "eigenvalues were clipped to zero. With this few units or "
+                "measurements per unit, path_param_cov is unreliable",
+                stacklevel=2,
+            )
 
         events = np.isfinite(pseudo) & (pseudo > 0)
         if not events.any():
@@ -431,6 +513,10 @@ class DegradationAnalysis_:
             pseudo_failure_times=pseudo_failure_times,
             c=c,
             life_model=life_model,
+            measurement_var=measurement_var,
+            path_param_mean=path_param_mean,
+            path_param_cov=path_param_cov,
+            path_param_sample_cov=path_param_sample_cov,
         )
 
     def fit_from_df(

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -11,6 +11,7 @@ observed time.
 """
 
 import warnings
+from dataclasses import dataclass, field
 from numbers import Number
 
 import matplotlib.pyplot as plt
@@ -22,6 +23,7 @@ from surpyval.univariate.parametric import Weibull
 from surpyval.univariate.parametric.parametric import Parametric
 
 from .path_models import PathModel, get_path_model
+from .population import reml_estimate
 
 
 def _clip_psd(matrix: npt.NDArray) -> tuple[npt.NDArray, bool]:
@@ -38,6 +40,62 @@ def _clip_psd(matrix: npt.NDArray) -> tuple[npt.NDArray, bool]:
     clipped = bool((eigvals < -tol).any())
     eigvals = np.clip(eigvals, 0.0, None)
     return eigvecs @ np.diag(eigvals) @ eigvecs.T, clipped
+
+
+@dataclass
+class RULPrediction:
+    """
+    Posterior failure-time / remaining-useful-life prediction for a
+    new unit, returned by :meth:`DegradationModel.predict_rul`.
+
+    All summaries come from Monte Carlo samples of the new unit's
+    path parameters drawn from their Gaussian posterior and pushed
+    through the path model's threshold crossing. Samples whose path
+    never reaches the threshold contribute ``inf`` failure times, so
+    the median and interval endpoints can be ``inf`` when much of the
+    posterior mass never fails.
+
+    Parameters
+    ----------
+    failure_time : float
+        Posterior median of the unit's failure time (measured from
+        the unit's time zero, like the fitted life model).
+    failure_time_interval : tuple of float
+        Equal-tailed ``1 - alpha_ci`` credible interval for the
+        failure time.
+    rul : float
+        Posterior median remaining useful life: failure time minus
+        the unit's last observed time. Negative means the unit has
+        most likely already crossed the threshold.
+    rul_interval : tuple of float
+        Equal-tailed ``1 - alpha_ci`` credible interval for the
+        remaining useful life.
+    prob_failed : float
+        Posterior probability that the unit's path has already
+        crossed the threshold (failure time at or before its last
+        observed time).
+    prob_never_fails : float
+        Posterior probability that the unit's path never reaches the
+        threshold.
+    posterior_mean, posterior_cov : ndarray
+        The Gaussian posterior of the unit's path parameters.
+    alpha_ci : float
+        The interval significance level used.
+    samples : ndarray
+        The Monte Carlo failure-time samples (``inf`` where the
+        sampled path never reaches the threshold).
+    """
+
+    failure_time: float
+    failure_time_interval: "tuple[float, float]"
+    rul: float
+    rul_interval: "tuple[float, float]"
+    prob_failed: float
+    prob_never_fails: float
+    posterior_mean: npt.NDArray
+    posterior_cov: npt.NDArray
+    alpha_ci: float
+    samples: npt.NDArray = field(repr=False)
 
 
 class DegradationModel:
@@ -96,6 +154,10 @@ class DegradationModel:
         fitted path parameters. This overstates the between-unit
         variability because each per-unit estimate also carries
         least-squares estimation noise.
+    population_method : str
+        How the population estimates (``measurement_var``,
+        ``path_param_mean``, ``path_param_cov``) were obtained:
+        ``"moments"`` (two-stage correction) or ``"reml"``.
     """
 
     x: npt.NDArray
@@ -112,6 +174,7 @@ class DegradationModel:
     path_param_mean: npt.NDArray
     path_param_cov: npt.NDArray
     path_param_sample_cov: npt.NDArray
+    population_method: str
 
     def __init__(
         self,
@@ -129,6 +192,7 @@ class DegradationModel:
         path_param_mean,
         path_param_cov,
         path_param_sample_cov,
+        population_method,
     ):
         self.x = x
         self.y = y
@@ -144,6 +208,7 @@ class DegradationModel:
         self.path_param_mean = path_param_mean
         self.path_param_cov = path_param_cov
         self.path_param_sample_cov = path_param_sample_cov
+        self.population_method = population_method
         self._unit_index = {unit: idx for idx, unit in enumerate(units)}
 
     def path(self, x: npt.ArrayLike, unit) -> npt.NDArray:
@@ -207,6 +272,173 @@ class DegradationModel:
         """
         x_arr, y_arr = self._handle_new_trajectory(x, y)
         return self.predict_failure_time(x_arr, y_arr) - float(x_arr.max())
+
+    def predict_rul(
+        self,
+        x: npt.ArrayLike,
+        y: npt.ArrayLike,
+        alpha_ci: float = 0.05,
+        n_samples: int = 10_000,
+        random_state=None,
+    ) -> RULPrediction:
+        """
+        Bayesian remaining-useful-life prediction for a new unit.
+
+        The population distribution of path parameters estimated at
+        fit time (``path_param_mean``, ``path_param_cov``) is used as
+        a prior, the new unit's measurements as the likelihood (with
+        the pooled ``measurement_var`` as the noise variance), and the
+        Gaussian posterior of the unit's path parameters is pushed
+        through the threshold crossing by Monte Carlo. The posterior
+        is exact (conjugate) for path models that are linear in their
+        parameters, and an iterated-linearisation (Laplace)
+        approximation otherwise.
+
+        Compared to :meth:`predict_failure_time`, this shrinks short
+        or noisy trajectories toward the population instead of
+        trusting the raw extrapolation, works from a single
+        measurement, and returns credible intervals. With many
+        measurements the posterior concentrates on the least-squares
+        fit and the two agree.
+
+        Parameters
+        ----------
+        x : array like
+            Times at which the new unit's measurements were taken.
+            One or more measurements are required.
+        y : array like
+            The new unit's degradation measurements.
+        alpha_ci : float, optional
+            Significance level for the equal-tailed credible
+            intervals. Defaults to 0.05 (95% intervals).
+        n_samples : int, optional
+            Number of Monte Carlo posterior samples. Defaults to
+            10,000.
+        random_state : optional
+            Seed passed to ``numpy.random.default_rng`` for
+            reproducible sampling.
+
+        Returns
+        -------
+        RULPrediction
+            Posterior medians, credible intervals, failure
+            probabilities, and the parameter posterior.
+        """
+        # a numerically-zero variance (exact path fits) makes the
+        # posterior degenerate; compare against the scale of y
+        noise_floor = np.finfo(float).eps * float(np.mean(self.y**2))
+        if not self.measurement_var > noise_floor:
+            raise ValueError(
+                "predict_rul requires a positive measurement variance, but "
+                "the fitted model's measurement_var is 0 (every training "
+                "unit's path fitted its measurements exactly, or there were "
+                "no residual degrees of freedom); use predict_failure_time "
+                "instead"
+            )
+        x_arr = np.atleast_1d(np.asarray(x, dtype=float))
+        y_arr = np.atleast_1d(np.asarray(y, dtype=float))
+        if x_arr.ndim != 1 or y_arr.ndim != 1 or len(x_arr) != len(y_arr):
+            raise ValueError(
+                "x and y must be one dimensional and the same length"
+            )
+        if len(x_arr) == 0:
+            raise ValueError("At least one measurement is required")
+        if not (np.isfinite(x_arr).all() and np.isfinite(y_arr).all()):
+            raise ValueError("x and y must contain only finite values")
+        self.path_model.check_data(x_arr, y_arr)
+
+        posterior_mean, posterior_cov = self._path_posterior(x_arr, y_arr)
+
+        rng = np.random.default_rng(random_state)
+        theta_samples = rng.multivariate_normal(
+            posterior_mean, posterior_cov, size=n_samples
+        )
+        try:
+            failure_times = np.asarray(
+                self.path_model.inv_path(self.threshold, *theta_samples.T),
+                dtype=float,
+            )
+            if failure_times.shape != (n_samples,):
+                raise ValueError("inv_path did not broadcast")
+        except Exception:
+            # custom path models need not broadcast over parameter
+            # arrays; fall back to a per-sample loop
+            failure_times = np.array(
+                [
+                    float(self.path_model.inv_path(self.threshold, *theta))
+                    for theta in theta_samples
+                ]
+            )
+        reaches = np.isfinite(failure_times) & (failure_times > 0)
+        failure_times = np.where(reaches, failure_times, np.inf)
+
+        age = float(x_arr.max())
+        quantiles = [0.5, alpha_ci / 2.0, 1.0 - alpha_ci / 2.0]
+        ft_med, ft_lower, ft_upper = np.quantile(failure_times, quantiles)
+        rul_samples = failure_times - age
+        rul_med, rul_lower, rul_upper = np.quantile(rul_samples, quantiles)
+
+        return RULPrediction(
+            failure_time=float(ft_med),
+            failure_time_interval=(float(ft_lower), float(ft_upper)),
+            rul=float(rul_med),
+            rul_interval=(float(rul_lower), float(rul_upper)),
+            prob_failed=float((failure_times <= age).mean()),
+            prob_never_fails=float((~reaches).mean()),
+            posterior_mean=posterior_mean,
+            posterior_cov=posterior_cov,
+            alpha_ci=alpha_ci,
+            samples=failure_times,
+        )
+
+    def _path_posterior(
+        self, x: npt.NDArray, y: npt.NDArray
+    ) -> tuple[npt.NDArray, npt.NDArray]:
+        """
+        Gaussian posterior of a new unit's path parameters given the
+        population prior and the unit's measurements.
+
+        Exact for linear-in-parameter path models (one Gauss-Newton
+        step is the conjugate update); iterated linearisation to the
+        MAP otherwise.
+        """
+        prior_mean = self.path_param_mean
+        # floor the prior covariance's eigenvalues so a clipped
+        # (rank-deficient) covariance still gives a proper, very tight
+        # prior in the deficient directions
+        eigvals, eigvecs = np.linalg.eigh(self.path_param_cov)
+        floor = max(eigvals.max() * 1e-8, np.finfo(float).tiny)
+        prior_precision = (
+            eigvecs @ np.diag(1.0 / np.clip(eigvals, floor, None)) @ eigvecs.T
+        )
+        noise_var = self.measurement_var
+
+        theta = prior_mean.copy()
+        precision = prior_precision
+        max_iter = 1 if self.path_model.linear_in_parameters else 100
+        for _ in range(max_iter):
+            jacobian = self.path_model.jacobian(x, *theta)
+            fitted = self.path_model.path(x, *theta)
+            precision = prior_precision + jacobian.T @ jacobian / noise_var
+            rhs = (
+                prior_precision @ prior_mean
+                + jacobian.T @ (y - fitted + jacobian @ theta) / noise_var
+            )
+            theta_new = np.linalg.solve(precision, rhs)
+            if not np.isfinite(theta_new).all():
+                raise ValueError(
+                    "The linearised posterior update diverged for this "
+                    "trajectory; the {} path model could not be updated "
+                    "against the population prior".format(self.path_model.name)
+                )
+            if np.allclose(theta_new, theta, rtol=1e-10, atol=1e-12):
+                theta = theta_new
+                break
+            theta = theta_new
+
+        posterior_cov = np.linalg.inv(precision)
+        posterior_cov = (posterior_cov + posterior_cov.T) / 2.0
+        return theta, posterior_cov
 
     def _handle_new_trajectory(
         self, x: npt.ArrayLike, y: npt.ArrayLike
@@ -377,6 +609,7 @@ class DegradationAnalysis_:
         path: "str | PathModel" = "linear",
         distribution=Weibull,
         how: str = "MLE",
+        population_method: str = "moments",
     ) -> DegradationModel:
         """
         Fit a degradation analysis model.
@@ -404,6 +637,17 @@ class DegradationAnalysis_:
         how : str, optional
             The method used to fit the lifetime distribution (passed
             to ``distribution.fit``). Defaults to ``"MLE"``.
+        population_method : str, optional
+            How the population path-parameter distribution
+            (``path_param_mean``, ``path_param_cov``,
+            ``measurement_var``) is estimated. ``"moments"`` (default)
+            uses the two-stage noise-corrected sample moments;
+            ``"reml"`` maximises the restricted marginal likelihood of
+            the linear mixed model, which cannot go rank-deficient and
+            is preferable with few units. REML is available for path
+            models that are linear in their parameters (linear,
+            logarithmic, lloyd-lipow) and requires measurement noise
+            (some unit with more measurements than path parameters).
 
         Returns
         -------
@@ -419,6 +663,19 @@ class DegradationAnalysis_:
 
         path_model = get_path_model(path)
 
+        if population_method not in ("moments", "reml"):
+            raise ValueError(
+                "population_method must be 'moments' or 'reml', got "
+                "'{}'".format(population_method)
+            )
+        if population_method == "reml" and not path_model.linear_in_parameters:
+            raise ValueError(
+                "population_method='reml' requires a path model that is "
+                "linear in its parameters (linear, logarithmic, "
+                "lloyd-lipow); the {} path model is not. Use "
+                "population_method='moments'".format(path_model.name)
+            )
+
         units = np.unique(i_arr)
         if len(units) < 2:
             raise ValueError(
@@ -433,6 +690,8 @@ class DegradationAnalysis_:
         rss_total = 0.0
         dof_total = 0
         estimation_cov_sum = np.zeros((n_params, n_params))
+        y_by_unit = []
+        design_by_unit = []
 
         for idx, unit in enumerate(units):
             mask = i_arr == unit
@@ -458,6 +717,8 @@ class DegradationAnalysis_:
                 estimation_cov_sum += np.linalg.inv(jtj)
             except np.linalg.LinAlgError:
                 estimation_cov_sum += np.linalg.pinv(jtj)
+            y_by_unit.append(y_unit)
+            design_by_unit.append(jacobian)
 
         # Two-stage (Lu-Meeker) noise correction: the scatter of the
         # per-unit estimates is Sigma + V_i, so subtracting the average
@@ -471,15 +732,42 @@ class DegradationAnalysis_:
         path_param_cov, was_clipped = _clip_psd(
             path_param_sample_cov - mean_estimation_cov
         )
-        if was_clipped:
+        if was_clipped and population_method == "moments":
             warnings.warn(
                 "The noise-corrected between-unit covariance of the path "
                 "parameters was not positive semi-definite (the estimation "
                 "noise is comparable to the between-unit scatter); negative "
                 "eigenvalues were clipped to zero. With this few units or "
-                "measurements per unit, path_param_cov is unreliable",
+                "measurements per unit, path_param_cov is unreliable; "
+                "consider population_method='reml'",
                 stacklevel=2,
             )
+
+        if population_method == "reml":
+            noise_floor = np.finfo(float).eps * float(np.mean(y_arr**2))
+            if not measurement_var > noise_floor:
+                raise ValueError(
+                    "population_method='reml' requires measurement noise, "
+                    "but the pooled measurement variance is 0 (every unit's "
+                    "path fitted its measurements exactly, or no unit has "
+                    "more measurements than path parameters)"
+                )
+            # the moment estimates are the starting values
+            reml_mean, reml_cov, reml_var, converged = reml_estimate(
+                y_by_unit,
+                design_by_unit,
+                path_param_cov,
+                measurement_var,
+            )
+            if not converged:
+                warnings.warn(
+                    "The REML optimisation did not report convergence; the "
+                    "population path-parameter estimates may be inaccurate",
+                    stacklevel=2,
+                )
+            path_param_mean = reml_mean
+            path_param_cov = reml_cov
+            measurement_var = reml_var
 
         events = np.isfinite(pseudo) & (pseudo > 0)
         if not events.any():
@@ -517,6 +805,7 @@ class DegradationAnalysis_:
             path_param_mean=path_param_mean,
             path_param_cov=path_param_cov,
             path_param_sample_cov=path_param_sample_cov,
+            population_method=population_method,
         )
 
     def fit_from_df(

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -22,7 +22,7 @@ import pandas as pd
 from surpyval.univariate.parametric import Weibull
 from surpyval.univariate.parametric.parametric import Parametric
 
-from .path_models import PathModel, get_path_model
+from .path_models import PATH_MODELS, PathModel, get_path_model
 from .population import reml_estimate
 
 
@@ -158,6 +158,11 @@ class DegradationModel:
         How the population estimates (``measurement_var``,
         ``path_param_mean``, ``path_param_cov``) were obtained:
         ``"moments"`` (two-stage correction) or ``"reml"``.
+    path_selection : dict or None
+        When fitted with ``path="best"``, the AICc score of every
+        candidate path model (``nan`` for candidates that could not be
+        fitted to every unit); ``None`` otherwise. The fitted
+        ``path_model`` is the candidate with the smallest score.
     """
 
     x: npt.NDArray
@@ -175,6 +180,7 @@ class DegradationModel:
     path_param_cov: npt.NDArray
     path_param_sample_cov: npt.NDArray
     population_method: str
+    path_selection: "dict[str, float] | None"
 
     def __init__(
         self,
@@ -193,6 +199,7 @@ class DegradationModel:
         path_param_cov,
         path_param_sample_cov,
         population_method,
+        path_selection=None,
     ):
         self.x = x
         self.y = y
@@ -209,6 +216,7 @@ class DegradationModel:
         self.path_param_cov = path_param_cov
         self.path_param_sample_cov = path_param_sample_cov
         self.population_method = population_method
+        self.path_selection = path_selection
         self._unit_index = {unit: idx for idx, unit in enumerate(units)}
 
     def path(self, x: npt.ArrayLike, unit) -> npt.NDArray:
@@ -628,9 +636,15 @@ class DegradationAnalysis_:
             failed.
         path : str or PathModel, optional
             The degradation path model fitted to each unit: one of
-            ``"linear"`` (default), ``"exponential"``, ``"power"``,
-            ``"logarithmic"``, ``"lloyd-lipow"``, or a
-            :class:`~surpyval.degradation.PathModel` instance.
+            ``"linear"`` (default), ``"quadratic"``, ``"exponential"``,
+            ``"offset-exponential"``, ``"power"``, ``"logarithmic"``,
+            ``"lloyd-lipow"``, ``"gompertz"``, ``"michaelis-menten"``,
+            a :class:`~surpyval.degradation.PathModel` instance, or
+            ``"best"`` to fit every registered model to all units and
+            select the one with the smallest AICc (the per-candidate
+            scores are exposed as ``path_selection`` on the returned
+            model; candidates that cannot be fitted to every unit are
+            excluded).
         distribution : ParametricFitter, optional
             The lifetime distribution fitted to the pseudo failure
             times. Defaults to ``Weibull``.
@@ -646,8 +660,9 @@ class DegradationAnalysis_:
             the linear mixed model, which cannot go rank-deficient and
             is preferable with few units. REML is available for path
             models that are linear in their parameters (linear,
-            logarithmic, lloyd-lipow) and requires measurement noise
-            (some unit with more measurements than path parameters).
+            quadratic, logarithmic, lloyd-lipow) and requires
+            measurement noise (some unit with more measurements than
+            path parameters).
 
         Returns
         -------
@@ -661,19 +676,10 @@ class DegradationAnalysis_:
             raise ValueError("threshold must be a finite number")
         threshold = float(threshold)
 
-        path_model = get_path_model(path)
-
         if population_method not in ("moments", "reml"):
             raise ValueError(
                 "population_method must be 'moments' or 'reml', got "
                 "'{}'".format(population_method)
-            )
-        if population_method == "reml" and not path_model.linear_in_parameters:
-            raise ValueError(
-                "population_method='reml' requires a path model that is "
-                "linear in its parameters (linear, logarithmic, "
-                "lloyd-lipow); the {} path model is not. Use "
-                "population_method='moments'".format(path_model.name)
             )
 
         units = np.unique(i_arr)
@@ -681,6 +687,22 @@ class DegradationAnalysis_:
             raise ValueError(
                 "Degradation analysis requires at least 2 units; "
                 "got {}".format(len(units))
+            )
+
+        path_selection = None
+        if isinstance(path, str) and path.lower() == "best":
+            path_model, path_selection = self._select_path_model(
+                x_arr, y_arr, i_arr, units
+            )
+        else:
+            path_model = get_path_model(path)
+
+        if population_method == "reml" and not path_model.linear_in_parameters:
+            raise ValueError(
+                "population_method='reml' requires a path model that is "
+                "linear in its parameters (linear, quadratic, logarithmic, "
+                "lloyd-lipow); the {} path model is not. Use "
+                "population_method='moments'".format(path_model.name)
             )
 
         n_params = len(path_model.param_names)
@@ -696,10 +718,10 @@ class DegradationAnalysis_:
         for idx, unit in enumerate(units):
             mask = i_arr == unit
             x_unit, y_unit = x_arr[mask], y_arr[mask]
-            if len(x_unit) < n_params or len(np.unique(x_unit)) < 2:
+            if len(np.unique(x_unit)) < n_params:
                 raise ValueError(
-                    "Unit {} needs at least {} measurements at 2 or more "
-                    "distinct times to fit the {} path model".format(
+                    "Unit {} needs measurements at {} or more distinct "
+                    "times to fit the {} path model".format(
                         unit, n_params, path_model.name
                     )
                 )
@@ -806,7 +828,70 @@ class DegradationAnalysis_:
             path_param_cov=path_param_cov,
             path_param_sample_cov=path_param_sample_cov,
             population_method=population_method,
+            path_selection=path_selection,
         )
+
+    @staticmethod
+    def _select_path_model(
+        x_arr, y_arr, i_arr, units
+    ) -> "tuple[PathModel, dict[str, float]]":
+        """
+        Select the registered path model with the smallest AICc over
+        all units' measurements.
+
+        Every unit is fitted with every candidate; the residual sums
+        of squares are pooled under a common Gaussian error variance,
+        so a candidate's AICc is
+        ``N ln(RSS/N) + 2k + 2k(k+1)/(N - k - 1)`` with
+        ``k = n_units * n_params + 1``. Candidates that cannot be
+        fitted to every unit (domain violations, too few distinct
+        times, non-convergence, or too few total measurements for the
+        AICc correction) are excluded and scored ``nan``.
+        """
+        n_total = len(x_arr)
+        rss_floor = n_total * np.finfo(float).eps * float(np.mean(y_arr**2))
+        scores: "dict[str, float]" = {}
+        for candidate in PATH_MODELS.values():
+            n_params = len(candidate.param_names)
+            k = n_params * len(units) + 1
+            if n_total - k - 1 < 1:
+                scores[candidate.name] = np.nan
+                continue
+            rss = 0.0
+            try:
+                for unit in units:
+                    mask = i_arr == unit
+                    x_unit, y_unit = x_arr[mask], y_arr[mask]
+                    if len(np.unique(x_unit)) < n_params:
+                        raise ValueError("too few distinct times")
+                    params = candidate.fit(x_unit, y_unit)
+                    residuals = y_unit - candidate.path(x_unit, *params)
+                    if not np.isfinite(residuals).all():
+                        raise ValueError("non-finite fit")
+                    rss += float(residuals @ residuals)
+            except Exception:
+                scores[candidate.name] = np.nan
+                continue
+            rss = max(rss, rss_floor)
+            scores[candidate.name] = (
+                n_total * np.log(rss / n_total)
+                + 2.0 * k
+                + 2.0 * k * (k + 1.0) / (n_total - k - 1.0)
+            )
+
+        finite = {
+            name: score for name, score in scores.items() if np.isfinite(score)
+        }
+        if not finite:
+            raise ValueError(
+                "path='best' could not fit any registered path model to "
+                "every unit's measurements"
+            )
+        best_name = min(finite, key=lambda name: finite[name])
+        best_model = next(
+            model for model in PATH_MODELS.values() if model.name == best_name
+        )
+        return best_model, scores
 
     def fit_from_df(
         self,

--- a/surpyval/degradation/path_models.py
+++ b/surpyval/degradation/path_models.py
@@ -49,6 +49,11 @@ class PathModel(ABC):
 
     name: str
     param_names: list[str]
+    #: True when ``path`` is linear in its parameters, i.e.
+    #: ``path(x, *theta) == jacobian(x) @ theta`` with a Jacobian that
+    #: does not depend on ``theta``. Enables exact conjugate posterior
+    #: updates and REML population estimation.
+    linear_in_parameters: bool = False
 
     @abstractmethod
     def path(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
@@ -116,6 +121,7 @@ class LinearPath_(PathModel):
 
     name = "Linear"
     param_names = ["a", "b"]
+    linear_in_parameters = True
 
     def path(self, x, *params):
         a, b = params
@@ -216,6 +222,7 @@ class LogarithmicPath_(PathModel):
 
     name = "Logarithmic"
     param_names = ["a", "b"]
+    linear_in_parameters = True
 
     def path(self, x, *params):
         a, b = params
@@ -250,6 +257,7 @@ class LloydLipowPath_(PathModel):
 
     name = "Lloyd-Lipow"
     param_names = ["a", "b"]
+    linear_in_parameters = True
 
     def path(self, x, *params):
         a, b = params

--- a/surpyval/degradation/path_models.py
+++ b/surpyval/degradation/path_models.py
@@ -64,6 +64,30 @@ class PathModel(ABC):
         positive finite time.
         """
 
+    def jacobian(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
+        """
+        Partial derivatives of ``path`` with respect to the
+        parameters, evaluated at time(s) ``x``: a
+        ``(len(x), n_params)`` matrix.
+
+        Used to estimate the least-squares estimation covariance of
+        per-unit fitted parameters. The base implementation uses
+        central finite differences; the built-in models override it
+        with the analytic derivatives.
+        """
+        x = np.asarray(x, dtype=float)
+        params_arr = np.asarray(params, dtype=float)
+        columns = []
+        for j in range(len(params_arr)):
+            h = 1e-6 * max(abs(params_arr[j]), 1.0)
+            upper, lower = params_arr.copy(), params_arr.copy()
+            upper[j] += h
+            lower[j] -= h
+            columns.append(
+                (self.path(x, *upper) - self.path(x, *lower)) / (2.0 * h)
+            )
+        return np.column_stack(columns)
+
     def check_data(self, x: npt.NDArray, y: npt.NDArray) -> None:
         """Raise ``ValueError`` if the data is outside the model domain."""
 
@@ -103,6 +127,10 @@ class LinearPath_(PathModel):
         with np.errstate(divide="ignore", invalid="ignore"):
             return (y - a) / b
 
+    def jacobian(self, x, *params):
+        x = np.asarray(x, dtype=float)
+        return np.column_stack([np.ones_like(x), x])
+
     def fit(self, x, y):
         x = np.asarray(x, dtype=float)
         y = np.asarray(y, dtype=float)
@@ -125,6 +153,12 @@ class ExponentialPath_(PathModel):
         y = np.asarray(y, dtype=float)
         with np.errstate(divide="ignore", invalid="ignore"):
             return np.log(y / a) / b
+
+    def jacobian(self, x, *params):
+        a, b = params
+        x = np.asarray(x, dtype=float)
+        e = np.exp(b * x)
+        return np.column_stack([e, a * x * e])
 
     def check_data(self, x, y):
         if (y <= 0).any():
@@ -154,6 +188,12 @@ class PowerPath_(PathModel):
         y = np.asarray(y, dtype=float)
         with np.errstate(divide="ignore", invalid="ignore"):
             return np.power(y / a, 1.0 / b)
+
+    def jacobian(self, x, *params):
+        a, b = params
+        x = np.asarray(x, dtype=float)
+        xb = np.power(x, b)
+        return np.column_stack([xb, a * xb * np.log(x)])
 
     def check_data(self, x, y):
         if (x <= 0).any():
@@ -188,6 +228,10 @@ class LogarithmicPath_(PathModel):
         with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
             return np.exp((y - a) / b)
 
+    def jacobian(self, x, *params):
+        x = np.asarray(x, dtype=float)
+        return np.column_stack([np.ones_like(x), np.log(x)])
+
     def check_data(self, x, y):
         if (x <= 0).any():
             raise ValueError(
@@ -217,6 +261,10 @@ class LloydLipowPath_(PathModel):
         y = np.asarray(y, dtype=float)
         with np.errstate(divide="ignore", invalid="ignore"):
             return b / (a - y)
+
+    def jacobian(self, x, *params):
+        x = np.asarray(x, dtype=float)
+        return np.column_stack([np.ones_like(x), -1.0 / x])
 
     def check_data(self, x, y):
         if (x <= 0).any():

--- a/surpyval/degradation/path_models.py
+++ b/surpyval/degradation/path_models.py
@@ -97,6 +97,7 @@ class PathModel(ABC):
         """Raise ``ValueError`` if the data is outside the model domain."""
 
     def _initial_guess(self, x, y):
+        """One starting parameter vector, or a list of candidates."""
         raise NotImplementedError
 
     def fit(self, x: npt.ArrayLike, y: npt.ArrayLike) -> npt.NDArray:
@@ -107,10 +108,24 @@ class PathModel(ABC):
         x = np.asarray(x, dtype=float)
         y = np.asarray(y, dtype=float)
         self.check_data(x, y)
-        params, _ = curve_fit(
-            self.path, x, y, p0=self._initial_guess(x, y), maxfev=10_000
+        guesses = np.atleast_2d(
+            np.asarray(self._initial_guess(x, y), dtype=float)
         )
-        return params
+        best_params, best_rss = None, np.inf
+        for p0 in guesses:
+            try:
+                params, _ = curve_fit(self.path, x, y, p0=p0, maxfev=10_000)
+            except RuntimeError:
+                continue
+            residuals = y - self.path(x, *params)
+            rss = float(residuals @ residuals)
+            if np.isfinite(rss) and rss < best_rss:
+                best_params, best_rss = params, rss
+        if best_params is None:
+            raise ValueError(
+                "Could not fit the {} path model to the data".format(self.name)
+            )
+        return best_params
 
     def __repr__(self):
         return "{} Degradation Path Model".format(self.name)
@@ -288,18 +303,211 @@ class LloydLipowPath_(PathModel):
         return np.array([intercept, -slope])
 
 
+class QuadraticPath_(PathModel):
+    """Quadratic degradation path: ``y = a + b * x + c * x**2``."""
+
+    name = "Quadratic"
+    param_names = ["a", "b", "c"]
+    linear_in_parameters = True
+
+    def path(self, x, *params):
+        a, b, c = params
+        x = np.asarray(x, dtype=float)
+        return a + b * x + c * x**2
+
+    def inv_path(self, y, *params):
+        """First positive time at which the parabola reaches ``y``."""
+        a, b, c = params
+        y = np.asarray(y, dtype=float)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            linear_root = (y - a) / b
+            disc = b**2 - 4.0 * c * (a - y)
+            sqrt_disc = np.sqrt(np.where(disc >= 0, disc, np.nan))
+            root_minus = (-b - sqrt_disc) / (2.0 * c)
+            root_plus = (-b + sqrt_disc) / (2.0 * c)
+            root_minus = np.where(
+                np.isfinite(root_minus) & (root_minus > 0),
+                root_minus,
+                np.inf,
+            )
+            root_plus = np.where(
+                np.isfinite(root_plus) & (root_plus > 0), root_plus, np.inf
+            )
+            first = np.minimum(root_minus, root_plus)
+            first = np.where(np.isfinite(first), first, np.nan)
+            return np.where(c == 0, linear_root, first)
+
+    def jacobian(self, x, *params):
+        x = np.asarray(x, dtype=float)
+        return np.column_stack([np.ones_like(x), x, x**2])
+
+    def fit(self, x, y):
+        x = np.asarray(x, dtype=float)
+        y = np.asarray(y, dtype=float)
+        self.check_data(x, y)
+        design = np.column_stack([np.ones_like(x), x, x**2])
+        params, *_ = np.linalg.lstsq(design, y, rcond=None)
+        return params
+
+
+class GompertzPath_(PathModel):
+    """Gompertz degradation path: ``y = a * exp(-b * exp(-c * x))``.
+
+    An S-shaped path approaching the asymptote ``a``.
+    """
+
+    name = "Gompertz"
+    param_names = ["a", "b", "c"]
+
+    def path(self, x, *params):
+        a, b, c = params
+        x = np.asarray(x, dtype=float)
+        with np.errstate(over="ignore"):
+            return a * np.exp(-b * np.exp(-c * x))
+
+    def inv_path(self, y, *params):
+        a, b, c = params
+        y = np.asarray(y, dtype=float)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return -np.log(-np.log(y / a) / b) / c
+
+    def jacobian(self, x, *params):
+        a, b, c = params
+        x = np.asarray(x, dtype=float)
+        inner = np.exp(-c * x)
+        outer = np.exp(-b * inner)
+        return np.column_stack(
+            [outer, -a * inner * outer, a * b * x * inner * outer]
+        )
+
+    def check_data(self, x, y):
+        if (y <= 0).any():
+            raise ValueError(
+                "The Gompertz path model requires strictly positive "
+                "degradation measurements"
+            )
+
+    def _initial_guess(self, x, y):
+        # slightly above the largest measurement as the asymptote, then
+        # -ln(y/a) decays exponentially: linearise on its logarithm
+        a0 = 1.05 * y.max()
+        z = -np.log(y / a0)
+        intercept, slope = _ols(x, np.log(z))
+        return [a0, np.exp(intercept), -slope]
+
+
+class OffsetExponentialPath_(PathModel):
+    """Offset exponential degradation path: ``y = a + b * exp(c * x)``.
+
+    Covers exponential growth or decay toward/away from the asymptote
+    ``a``; with ``a = 0`` it reduces to the exponential path.
+    """
+
+    name = "Offset Exponential"
+    param_names = ["a", "b", "c"]
+
+    def path(self, x, *params):
+        a, b, c = params
+        x = np.asarray(x, dtype=float)
+        with np.errstate(over="ignore"):
+            return a + b * np.exp(c * x)
+
+    def inv_path(self, y, *params):
+        a, b, c = params
+        y = np.asarray(y, dtype=float)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return np.log((y - a) / b) / c
+
+    def jacobian(self, x, *params):
+        a, b, c = params
+        x = np.asarray(x, dtype=float)
+        e = np.exp(c * x)
+        return np.column_stack([np.ones_like(x), e, b * x * e])
+
+    def _initial_guess(self, x, y):
+        # for an offset outside the observed range, y - a0 has one
+        # sign, so its magnitude linearises on a log scale; try an
+        # offset on each side and keep the better fit
+        span = y.max() - y.min()
+        if span == 0:
+            span = max(abs(y.max()), 1.0)
+        guesses = []
+        for a0 in (y.min() - 0.1 * span, y.max() + 0.1 * span):
+            shifted = y - a0
+            sign = 1.0 if shifted[0] > 0 else -1.0
+            intercept, slope = _ols(x, np.log(np.abs(shifted)))
+            guesses.append([a0, sign * np.exp(intercept), slope])
+        return guesses
+
+
+class MichaelisMentenPath_(PathModel):
+    """Michaelis-Menten degradation path: ``y = a * x / (b + x)``.
+
+    A saturating path rising from zero toward the asymptote ``a``,
+    reaching half of it at ``x = b``.
+    """
+
+    name = "Michaelis-Menten"
+    param_names = ["a", "b"]
+
+    def path(self, x, *params):
+        a, b = params
+        x = np.asarray(x, dtype=float)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return a * x / (b + x)
+
+    def inv_path(self, y, *params):
+        a, b = params
+        y = np.asarray(y, dtype=float)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return b * y / (a - y)
+
+    def jacobian(self, x, *params):
+        a, b = params
+        x = np.asarray(x, dtype=float)
+        denominator = b + x
+        return np.column_stack([x / denominator, -a * x / denominator**2])
+
+    def check_data(self, x, y):
+        if (x <= 0).any():
+            raise ValueError(
+                "The Michaelis-Menten path model requires strictly "
+                "positive times"
+            )
+        if (y <= 0).any():
+            raise ValueError(
+                "The Michaelis-Menten path model requires strictly "
+                "positive degradation measurements"
+            )
+
+    def _initial_guess(self, x, y):
+        # Lineweaver-Burk linearisation: 1/y = 1/a + (b/a) / x
+        intercept, slope = _ols(1.0 / x, 1.0 / y)
+        if intercept > 0:
+            return [1.0 / intercept, slope / intercept]
+        return [1.2 * y.max(), float(np.median(x))]
+
+
 LinearPath: PathModel = LinearPath_()
+QuadraticPath: PathModel = QuadraticPath_()
 ExponentialPath: PathModel = ExponentialPath_()
+OffsetExponentialPath: PathModel = OffsetExponentialPath_()
 PowerPath: PathModel = PowerPath_()
 LogarithmicPath: PathModel = LogarithmicPath_()
 LloydLipowPath: PathModel = LloydLipowPath_()
+GompertzPath: PathModel = GompertzPath_()
+MichaelisMentenPath: PathModel = MichaelisMentenPath_()
 
 PATH_MODELS: dict[str, PathModel] = {
     "linear": LinearPath,
+    "quadratic": QuadraticPath,
     "exponential": ExponentialPath,
+    "offset-exponential": OffsetExponentialPath,
     "power": PowerPath,
     "logarithmic": LogarithmicPath,
     "lloyd-lipow": LloydLipowPath,
+    "gompertz": GompertzPath,
+    "michaelis-menten": MichaelisMentenPath,
 }
 
 
@@ -308,9 +516,12 @@ def get_path_model(path: "str | PathModel") -> PathModel:
     Resolve ``path`` to a :class:`PathModel` instance.
 
     Accepts a :class:`PathModel` instance (returned unchanged) or one
-    of the registered names: ``"linear"``, ``"exponential"``,
-    ``"power"``, ``"logarithmic"``, ``"lloyd-lipow"``
-    (case-insensitive).
+    of the registered names in ``PATH_MODELS`` (case-insensitive):
+    ``"linear"``, ``"quadratic"``, ``"exponential"``,
+    ``"offset-exponential"``, ``"power"``, ``"logarithmic"``,
+    ``"lloyd-lipow"``, ``"gompertz"``, ``"michaelis-menten"``.
+    (``"best"`` — automatic selection — is handled by
+    ``DegradationAnalysis.fit``, not here.)
     """
     if isinstance(path, PathModel):
         return path

--- a/surpyval/degradation/path_models.py
+++ b/surpyval/degradation/path_models.py
@@ -1,0 +1,273 @@
+"""Degradation path models.
+
+A path model describes the deterministic trend of a degradation
+measurement over time. Fitting one to a single unit's repeated
+measurements gives that unit's expected degradation path; extrapolating
+the path to the failure threshold gives the unit's *pseudo failure
+time*. The models here are the ones in common reliability engineering
+use for this purpose.
+
+Each model implements:
+
+- ``path(x, *params)``: the degradation level at time(s) ``x``,
+- ``inv_path(y, *params)``: the time at which the path reaches level
+  ``y`` (non-finite when the path never does),
+- ``fit(x, y)``: least-squares estimates of the path parameters from
+  one unit's measurements.
+
+Models that are linear in their parameters (``LinearPath``,
+``LogarithmicPath``, ``LloydLipowPath``) are fitted with ordinary least
+squares in closed form; the others (``ExponentialPath``, ``PowerPath``)
+use nonlinear least squares started from the log-linearised fit.
+"""
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+import numpy.typing as npt
+from scipy.optimize import curve_fit
+
+
+def _ols(z, y):
+    """Closed-form least squares fit of ``y = intercept + slope * z``."""
+    A = np.column_stack([np.ones_like(z), z])
+    (intercept, slope), *_ = np.linalg.lstsq(A, y, rcond=None)
+    return intercept, slope
+
+
+class PathModel(ABC):
+    """
+    Base class for degradation path models.
+
+    A path model is a deterministic function of time with a small
+    number of parameters that is fitted, per unit, to that unit's
+    degradation measurements. Subclass this (implementing ``path``,
+    ``inv_path``, ``fit`` and the ``name``/``param_names`` attributes)
+    to use a custom degradation path with
+    :class:`~surpyval.degradation.DegradationAnalysis`.
+    """
+
+    name: str
+    param_names: list[str]
+
+    @abstractmethod
+    def path(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
+        """Evaluate the degradation path at time(s) ``x``."""
+
+    @abstractmethod
+    def inv_path(self, y: npt.ArrayLike, *params: float) -> npt.NDArray:
+        """
+        Time at which the path reaches level ``y``.
+
+        Returns a non-finite value (``nan`` or ``inf``) or a
+        non-positive value when the path never reaches ``y`` at a
+        positive finite time.
+        """
+
+    def check_data(self, x: npt.NDArray, y: npt.NDArray) -> None:
+        """Raise ``ValueError`` if the data is outside the model domain."""
+
+    def _initial_guess(self, x, y):
+        raise NotImplementedError
+
+    def fit(self, x: npt.ArrayLike, y: npt.ArrayLike) -> npt.NDArray:
+        """
+        Fit the path parameters to one unit's measurements by
+        (nonlinear) least squares.
+        """
+        x = np.asarray(x, dtype=float)
+        y = np.asarray(y, dtype=float)
+        self.check_data(x, y)
+        params, _ = curve_fit(
+            self.path, x, y, p0=self._initial_guess(x, y), maxfev=10_000
+        )
+        return params
+
+    def __repr__(self):
+        return "{} Degradation Path Model".format(self.name)
+
+
+class LinearPath_(PathModel):
+    """Linear degradation path: ``y = a + b * x``."""
+
+    name = "Linear"
+    param_names = ["a", "b"]
+
+    def path(self, x, *params):
+        a, b = params
+        return a + b * np.asarray(x, dtype=float)
+
+    def inv_path(self, y, *params):
+        a, b = params
+        y = np.asarray(y, dtype=float)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return (y - a) / b
+
+    def fit(self, x, y):
+        x = np.asarray(x, dtype=float)
+        y = np.asarray(y, dtype=float)
+        self.check_data(x, y)
+        return np.array(_ols(x, y))
+
+
+class ExponentialPath_(PathModel):
+    """Exponential degradation path: ``y = a * exp(b * x)``."""
+
+    name = "Exponential"
+    param_names = ["a", "b"]
+
+    def path(self, x, *params):
+        a, b = params
+        return a * np.exp(b * np.asarray(x, dtype=float))
+
+    def inv_path(self, y, *params):
+        a, b = params
+        y = np.asarray(y, dtype=float)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return np.log(y / a) / b
+
+    def check_data(self, x, y):
+        if (y <= 0).any():
+            raise ValueError(
+                "The exponential path model requires strictly positive "
+                "degradation measurements"
+            )
+
+    def _initial_guess(self, x, y):
+        intercept, slope = _ols(x, np.log(y))
+        return np.exp(intercept), slope
+
+
+class PowerPath_(PathModel):
+    """Power degradation path: ``y = a * x**b``."""
+
+    name = "Power"
+    param_names = ["a", "b"]
+
+    def path(self, x, *params):
+        a, b = params
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return a * np.power(np.asarray(x, dtype=float), b)
+
+    def inv_path(self, y, *params):
+        a, b = params
+        y = np.asarray(y, dtype=float)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return np.power(y / a, 1.0 / b)
+
+    def check_data(self, x, y):
+        if (x <= 0).any():
+            raise ValueError(
+                "The power path model requires strictly positive times"
+            )
+        if (y <= 0).any():
+            raise ValueError(
+                "The power path model requires strictly positive "
+                "degradation measurements"
+            )
+
+    def _initial_guess(self, x, y):
+        intercept, slope = _ols(np.log(x), np.log(y))
+        return np.exp(intercept), slope
+
+
+class LogarithmicPath_(PathModel):
+    """Logarithmic degradation path: ``y = a + b * ln(x)``."""
+
+    name = "Logarithmic"
+    param_names = ["a", "b"]
+
+    def path(self, x, *params):
+        a, b = params
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return a + b * np.log(np.asarray(x, dtype=float))
+
+    def inv_path(self, y, *params):
+        a, b = params
+        y = np.asarray(y, dtype=float)
+        with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+            return np.exp((y - a) / b)
+
+    def check_data(self, x, y):
+        if (x <= 0).any():
+            raise ValueError(
+                "The logarithmic path model requires strictly positive times"
+            )
+
+    def fit(self, x, y):
+        x = np.asarray(x, dtype=float)
+        y = np.asarray(y, dtype=float)
+        self.check_data(x, y)
+        return np.array(_ols(np.log(x), y))
+
+
+class LloydLipowPath_(PathModel):
+    """Lloyd-Lipow degradation path: ``y = a - b / x``."""
+
+    name = "Lloyd-Lipow"
+    param_names = ["a", "b"]
+
+    def path(self, x, *params):
+        a, b = params
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return a - b / np.asarray(x, dtype=float)
+
+    def inv_path(self, y, *params):
+        a, b = params
+        y = np.asarray(y, dtype=float)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return b / (a - y)
+
+    def check_data(self, x, y):
+        if (x <= 0).any():
+            raise ValueError(
+                "The Lloyd-Lipow path model requires strictly positive times"
+            )
+
+    def fit(self, x, y):
+        x = np.asarray(x, dtype=float)
+        y = np.asarray(y, dtype=float)
+        self.check_data(x, y)
+        intercept, slope = _ols(1.0 / x, y)
+        return np.array([intercept, -slope])
+
+
+LinearPath: PathModel = LinearPath_()
+ExponentialPath: PathModel = ExponentialPath_()
+PowerPath: PathModel = PowerPath_()
+LogarithmicPath: PathModel = LogarithmicPath_()
+LloydLipowPath: PathModel = LloydLipowPath_()
+
+PATH_MODELS: dict[str, PathModel] = {
+    "linear": LinearPath,
+    "exponential": ExponentialPath,
+    "power": PowerPath,
+    "logarithmic": LogarithmicPath,
+    "lloyd-lipow": LloydLipowPath,
+}
+
+
+def get_path_model(path: "str | PathModel") -> PathModel:
+    """
+    Resolve ``path`` to a :class:`PathModel` instance.
+
+    Accepts a :class:`PathModel` instance (returned unchanged) or one
+    of the registered names: ``"linear"``, ``"exponential"``,
+    ``"power"``, ``"logarithmic"``, ``"lloyd-lipow"``
+    (case-insensitive).
+    """
+    if isinstance(path, PathModel):
+        return path
+    if isinstance(path, str):
+        key = path.lower()
+        if key in PATH_MODELS:
+            return PATH_MODELS[key]
+        raise ValueError(
+            "Unknown path model '{}'; must be one of {} or a PathModel "
+            "instance".format(path, sorted(PATH_MODELS))
+        )
+    raise ValueError(
+        "path must be a string or a PathModel instance, got {}".format(
+            type(path)
+        )
+    )

--- a/surpyval/degradation/population.py
+++ b/surpyval/degradation/population.py
@@ -1,0 +1,146 @@
+"""REML estimation of the population path-parameter distribution.
+
+The random-effects degradation model for path models that are linear in
+their parameters is a linear mixed model: unit ``i``'s measurements are
+
+    y_i = X_i theta_i + eps_i,   theta_i ~ MVN(mu, Sigma),
+                                 eps_i ~ N(0, sigma^2 I)
+
+so, with the random effects integrated out,
+
+    y_i ~ N(X_i mu, V_i),   V_i = X_i Sigma X_i' + sigma^2 I.
+
+This module maximises the REML log-likelihood of that marginal model:
+the fixed effect ``mu`` is profiled out with generalised least squares
+and the REML adjustment term ``logdet(sum_i X_i' V_i^-1 X_i)`` removes
+the small-sample downward bias that plain ML variance components have
+from estimating ``mu``. ``Sigma`` is parameterised by its Cholesky
+factor (log-diagonal) so it stays positive definite by construction.
+
+The two-stage moments estimate (computed in
+``DegradationAnalysis.fit``) is used as the starting point.
+"""
+
+import numpy as np
+import numpy.typing as npt
+from scipy.linalg import cho_factor, cho_solve
+from scipy.optimize import minimize
+
+_LARGE = 1e30
+
+
+def _n_z(p: int) -> int:
+    """Length of the variance-parameter vector for ``p`` path params."""
+    return p + p * (p - 1) // 2 + 1
+
+
+def _chol_from_z(z: npt.NDArray, p: int) -> npt.NDArray:
+    """Lower-triangular Cholesky factor of Sigma from the z vector."""
+    chol = np.zeros((p, p))
+    chol[np.diag_indices(p)] = np.exp(z[:p])
+    if p > 1:
+        chol[np.tril_indices(p, -1)] = z[p : p + p * (p - 1) // 2]
+    return chol
+
+
+def _z_from_init(
+    cov_init: npt.NDArray, sigma2_init: float, p: int
+) -> npt.NDArray:
+    """Starting z vector from (possibly rank-deficient) moment estimates."""
+    cov_init = (cov_init + cov_init.T) / 2.0
+    eigvals, eigvecs = np.linalg.eigh(cov_init)
+    floor = max(eigvals.max() * 1e-4, sigma2_init * 1e-6, 1e-12)
+    eigvals = np.clip(eigvals, floor, None)
+    cov_init = eigvecs @ np.diag(eigvals) @ eigvecs.T
+    chol = np.linalg.cholesky(cov_init)
+    z = np.empty(_n_z(p))
+    z[:p] = np.log(np.diag(chol))
+    if p > 1:
+        z[p : p + p * (p - 1) // 2] = chol[np.tril_indices(p, -1)]
+    z[-1] = 0.5 * np.log(sigma2_init)
+    return z
+
+
+def _reml_pieces(z, y_list, x_mat_list, p):
+    """
+    Evaluate the model at ``z``.
+
+    Returns ``(neg_reml, mu, Sigma, sigma2)`` where ``neg_reml`` is the
+    negative REML log-likelihood (up to a constant) with the fixed
+    effect ``mu`` profiled out by GLS.
+    """
+    chol = _chol_from_z(z, p)
+    covariance = chol @ chol.T
+    sigma2 = np.exp(2.0 * z[-1])
+
+    gls_information = np.zeros((p, p))  # sum X' V^-1 X
+    gls_rhs = np.zeros(p)  # sum X' V^-1 y
+    y_v_y = 0.0  # sum y' V^-1 y
+    logdet_v = 0.0
+
+    for y_i, x_mat in zip(y_list, x_mat_list):
+        v_i = x_mat @ covariance @ x_mat.T + sigma2 * np.eye(len(y_i))
+        cho = cho_factor(v_i, lower=True)
+        logdet_v += 2.0 * np.log(np.diag(cho[0])).sum()
+        v_inv_y = cho_solve(cho, y_i)
+        v_inv_x = cho_solve(cho, x_mat)
+        gls_information += x_mat.T @ v_inv_x
+        gls_rhs += x_mat.T @ v_inv_y
+        y_v_y += y_i @ v_inv_y
+
+    mu = np.linalg.solve(gls_information, gls_rhs)
+    quad = y_v_y - 2.0 * mu @ gls_rhs + mu @ gls_information @ mu
+    sign, logdet_info = np.linalg.slogdet(gls_information)
+    if sign <= 0:
+        raise np.linalg.LinAlgError("GLS information not positive definite")
+    neg_reml = 0.5 * (logdet_v + quad + logdet_info)
+    return neg_reml, mu, covariance, sigma2
+
+
+def reml_estimate(
+    y_list: "list[npt.NDArray]",
+    x_mat_list: "list[npt.NDArray]",
+    cov_init: npt.NDArray,
+    sigma2_init: float,
+) -> tuple[npt.NDArray, npt.NDArray, float, bool]:
+    """
+    REML fit of ``y_i ~ N(X_i mu, X_i Sigma X_i' + sigma^2 I)``.
+
+    Parameters
+    ----------
+    y_list : list of ndarray
+        Each unit's measurement vector.
+    x_mat_list : list of ndarray
+        Each unit's design matrix (the path Jacobian, constant in the
+        parameters for linear-in-parameter path models).
+    cov_init, sigma2_init : ndarray, float
+        Starting values for ``Sigma`` and ``sigma^2`` (typically the
+        two-stage moment estimates); ``cov_init`` may be
+        rank-deficient, its eigenvalues are floored.
+
+    Returns
+    -------
+    (mu, Sigma, sigma2, converged)
+    """
+    p = x_mat_list[0].shape[1]
+
+    def objective(z):
+        try:
+            return _reml_pieces(z, y_list, x_mat_list, p)[0]
+        except np.linalg.LinAlgError:
+            return _LARGE
+
+    z0 = _z_from_init(cov_init, sigma2_init, p)
+    result = minimize(
+        objective,
+        z0,
+        method="Nelder-Mead",
+        options={
+            "maxiter": 20_000,
+            "maxfev": 20_000,
+            "xatol": 1e-10,
+            "fatol": 1e-10,
+        },
+    )
+    _, mu, covariance, sigma2 = _reml_pieces(result.x, y_list, x_mat_list, p)
+    return mu, covariance, sigma2, bool(result.success)

--- a/surpyval/tests/degradation/test_degradation_analysis.py
+++ b/surpyval/tests/degradation/test_degradation_analysis.py
@@ -169,6 +169,71 @@ def test_custom_path_model_instance():
     assert model.path_model is ExponentialPath
 
 
+def test_noiseless_population_estimates():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37])
+    x, y, i = linear_data(slopes)
+    model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    # exact paths: no measurement noise, so no correction is applied
+    assert model.measurement_var == pytest.approx(0.0, abs=1e-12)
+    assert np.allclose(model.path_param_mean, [10.0, slopes.mean()])
+    assert np.allclose(model.path_param_cov, model.path_param_sample_cov)
+    true_cov = np.cov(
+        np.column_stack([np.full(4, 10.0), slopes]), rowvar=False, ddof=1
+    )
+    assert np.allclose(model.path_param_sample_cov, true_cov)
+
+
+def test_noise_correction_recovers_between_unit_covariance():
+    # Small design (4 points close together) so the least-squares
+    # estimation noise is comparable to the between-unit variance and
+    # the correction is material.
+    rng = np.random.default_rng(7)
+    n_units = 200
+    x_times = np.array([10.0, 20.0, 30.0, 40.0])
+    a_true = rng.normal(10.0, 1.0, n_units)  # var(a) = 1.0
+    b_true = rng.normal(0.4, 0.05, n_units)  # var(b) = 0.0025
+    sigma = 1.0  # measurement noise
+    x = np.tile(x_times, n_units)
+    i = np.repeat(np.arange(n_units), len(x_times))
+    y = (
+        np.repeat(a_true, len(x_times))
+        + np.repeat(b_true, len(x_times)) * x
+        + rng.normal(0, sigma, len(x))
+    )
+    model = DegradationAnalysis.fit(x, y, i, threshold=100)
+
+    assert np.isclose(model.measurement_var, sigma**2, rtol=0.25)
+
+    # for this design: V_a = sigma^2 * 3000 / (4 * 500) = 1.5 and
+    # V_b = sigma^2 / 500 = 0.002, so the naive sample covariance is
+    # inflated to ~2.5 and ~0.0045 respectively
+    naive_a = model.path_param_sample_cov[0, 0]
+    naive_b = model.path_param_sample_cov[1, 1]
+    corrected_a = model.path_param_cov[0, 0]
+    corrected_b = model.path_param_cov[1, 1]
+    assert naive_a > 1.7
+    assert naive_b > 0.0035
+    assert abs(corrected_a - 1.0) < 0.6
+    assert abs(corrected_b - 0.0025) < 0.0012
+    assert abs(corrected_a - 1.0) < abs(naive_a - 1.0)
+    assert abs(corrected_b - 0.0025) < abs(naive_b - 0.0025)
+
+
+def test_clip_psd():
+    from surpyval.degradation.degradation_analysis import _clip_psd
+
+    # eigenvalues 3 and -1: must be clipped
+    clipped_matrix, clipped = _clip_psd(np.array([[1.0, 2.0], [2.0, 1.0]]))
+    assert clipped
+    assert np.allclose(clipped_matrix, clipped_matrix.T)
+    assert (np.linalg.eigvalsh(clipped_matrix) >= 0).all()
+    # already PSD: unchanged and not flagged
+    psd = np.array([[2.0, 0.5], [0.5, 1.0]])
+    same_matrix, clipped = _clip_psd(psd)
+    assert not clipped
+    assert np.allclose(same_matrix, psd)
+
+
 def test_predict_failure_time_new_trajectory():
     slopes = np.array([0.31, 0.28, 0.44, 0.37])
     x, y, i = linear_data(slopes)

--- a/surpyval/tests/degradation/test_degradation_analysis.py
+++ b/surpyval/tests/degradation/test_degradation_analysis.py
@@ -1,0 +1,203 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+
+from surpyval import LogNormal, Weibull  # noqa: E402
+from surpyval.degradation import (  # noqa: E402
+    DegradationAnalysis,
+    ExponentialPath,
+)
+
+
+def linear_data(slopes, intercept=10.0, n_obs=10):
+    """Noiseless linear degradation data, one row of times per unit."""
+    x = np.tile(np.arange(100, 100 * (n_obs + 1), 100), len(slopes))
+    i = np.repeat(np.arange(1, len(slopes) + 1), n_obs)
+    y = intercept + np.repeat(slopes, n_obs) * x
+    return x, y, i
+
+
+def test_linear_pseudo_failure_times_exact():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37])
+    x, y, i = linear_data(slopes)
+    model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    expected = (150 - 10.0) / slopes
+    assert np.allclose(model.pseudo_failure_times, expected)
+    assert (model.c == 0).all()
+    assert model.path_model.name == "Linear"
+    assert np.allclose(model.path_params[:, 0], 10.0)
+    assert np.allclose(model.path_params[:, 1], slopes)
+
+
+def test_life_model_matches_direct_fit_of_pseudo_times():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37, 0.52])
+    x, y, i = linear_data(slopes)
+    model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    direct = Weibull.fit((150 - 10.0) / slopes)
+    assert np.allclose(model.life_model.params, direct.params, rtol=1e-4)
+
+
+def test_weibull_parameters_recovered():
+    # slopes chosen so the exact threshold-crossing times are Weibull
+    rng = np.random.default_rng(123)
+    alpha, beta = 345.0, 4.5
+    times = alpha * rng.weibull(beta, 50)
+    threshold, intercept = 150.0, 10.0
+    slopes = (threshold - intercept) / times
+    x, y, i = linear_data(slopes)
+    model = DegradationAnalysis.fit(x, y, i, threshold=threshold)
+    direct = Weibull.fit(times)
+    assert np.allclose(model.pseudo_failure_times, times)
+    assert np.allclose(model.life_model.params, direct.params, rtol=1e-4)
+    assert np.allclose(model.life_model.params, [alpha, beta], rtol=0.15)
+
+
+def test_exponential_path_end_to_end():
+    a = np.array([2.0, 2.5, 1.8, 2.2])
+    b = np.array([0.004, 0.005, 0.006, 0.0045])
+    n_obs = 10
+    x = np.tile(np.arange(50, 50 * (n_obs + 1), 50), len(a))
+    i = np.repeat(np.arange(1, len(a) + 1), n_obs)
+    y = np.repeat(a, n_obs) * np.exp(np.repeat(b, n_obs) * x)
+    model = DegradationAnalysis.fit(x, y, i, threshold=20, path="exponential")
+    expected = np.log(20 / a) / b
+    assert np.allclose(model.pseudo_failure_times, expected, rtol=1e-5)
+    assert (model.c == 0).all()
+
+
+def test_non_degrading_unit_is_right_censored():
+    slopes = np.array([0.31, 0.28, 0.44, -0.05])
+    x, y, i = linear_data(slopes)
+    with pytest.warns(UserWarning, match="right censored"):
+        model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    assert model.c.tolist() == [0, 0, 0, 1]
+    # censored at the unit's last observed time
+    assert model.pseudo_failure_times[-1] == 1000
+    assert int((model.c == 1).sum()) == 1
+
+
+def test_all_censored_raises():
+    slopes = np.array([-0.31, -0.28])
+    x, y, i = linear_data(slopes)
+    with pytest.raises(ValueError, match="reaches the threshold"):
+        DegradationAnalysis.fit(x, y, i, threshold=150)
+
+
+def test_alternative_distribution_and_method():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37, 0.52])
+    x, y, i = linear_data(slopes)
+    model = DegradationAnalysis.fit(
+        x, y, i, threshold=150, distribution=LogNormal, how="MPP"
+    )
+    assert model.life_model.dist.name == "LogNormal"
+    assert model.life_model.method == "MPP"
+
+
+def test_fit_from_df_matches_fit():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37])
+    x, y, i = linear_data(slopes)
+    df = pd.DataFrame({"time": x, "measurement": y, "unit": i})
+    model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    df_model = DegradationAnalysis.fit_from_df(
+        df, x="time", y="measurement", i="unit", threshold=150
+    )
+    assert np.allclose(
+        model.pseudo_failure_times, df_model.pseudo_failure_times
+    )
+    assert np.allclose(model.life_model.params, df_model.life_model.params)
+
+
+def test_life_model_delegation():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37])
+    x, y, i = linear_data(slopes)
+    model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    t = np.array([300.0, 400.0, 500.0])
+    assert np.allclose(model.sf(t), model.life_model.sf(t))
+    assert np.allclose(model.ff(t), model.life_model.ff(t))
+    assert np.allclose(model.df(t), model.life_model.df(t))
+    assert np.allclose(model.hf(t), model.life_model.hf(t))
+    assert np.allclose(model.Hf(t), model.life_model.Hf(t))
+    assert np.allclose(model.qf(0.5), model.life_model.qf(0.5))
+    assert np.allclose(model.mean(), model.life_model.mean())
+    assert len(model.random(5)) == 5
+
+
+def test_unit_path_evaluation():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37])
+    x, y, i = linear_data(slopes)
+    model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    assert np.allclose(
+        model.path([100, 200], 3), 10 + 0.44 * np.array([100, 200])
+    )
+
+
+def test_repr():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37])
+    x, y, i = linear_data(slopes)
+    model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    out = repr(model)
+    assert "Degradation Analysis SurPyval Model" in out
+    assert "Linear" in out
+    assert "Weibull" in out
+
+
+def test_plot():
+    slopes = np.array([0.31, 0.28, 0.44, -0.05])
+    x, y, i = linear_data(slopes)
+    with pytest.warns(UserWarning):
+        model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    ax = model.plot()
+    # one path line per unit plus the threshold line
+    assert len(ax.get_lines()) == len(slopes) + 1
+    matplotlib.pyplot.close("all")
+
+
+def test_custom_path_model_instance():
+    a = np.array([2.0, 2.5, 1.8, 2.2])
+    b = np.array([0.004, 0.005, 0.006, 0.0045])
+    n_obs = 10
+    x = np.tile(np.arange(50, 50 * (n_obs + 1), 50), len(a))
+    i = np.repeat(np.arange(1, len(a) + 1), n_obs)
+    y = np.repeat(a, n_obs) * np.exp(np.repeat(b, n_obs) * x)
+    model = DegradationAnalysis.fit(
+        x, y, i, threshold=20, path=ExponentialPath
+    )
+    assert model.path_model is ExponentialPath
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        # mismatched lengths
+        dict(x=[1, 2, 3], y=[1, 2], i=[1, 1, 1], threshold=10),
+        # empty
+        dict(x=[], y=[], i=[], threshold=10),
+        # non-finite measurement
+        dict(
+            x=[1, 2, 1, 2], y=[1, np.nan, 1, 2], i=[1, 1, 2, 2], threshold=10
+        ),
+        # non-finite threshold
+        dict(x=[1, 2, 1, 2], y=[1, 2, 1, 2], i=[1, 1, 2, 2], threshold=np.inf),
+        # only one unit
+        dict(x=[1, 2, 3], y=[1, 2, 3], i=[1, 1, 1], threshold=10),
+        # unknown path model
+        dict(
+            x=[1, 2, 1, 2],
+            y=[1, 2, 1, 2],
+            i=[1, 1, 2, 2],
+            threshold=10,
+            path="cubic",
+        ),
+        # unit 2 has only one measurement
+        dict(x=[1, 2, 1], y=[1, 2, 1], i=[1, 1, 2], threshold=10),
+        # unit measured at a single distinct time
+        dict(x=[1, 2, 3, 3], y=[1, 2, 1, 2], i=[1, 1, 2, 2], threshold=10),
+    ],
+)
+def test_input_validation(kwargs):
+    with pytest.raises(ValueError):
+        DegradationAnalysis.fit(**kwargs)

--- a/surpyval/tests/degradation/test_degradation_analysis.py
+++ b/surpyval/tests/degradation/test_degradation_analysis.py
@@ -169,6 +169,62 @@ def test_custom_path_model_instance():
     assert model.path_model is ExponentialPath
 
 
+def test_predict_failure_time_new_trajectory():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37])
+    x, y, i = linear_data(slopes)
+    model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    # a new unit observed for only 300 hours, degrading at 0.5/hour
+    x_new = np.array([100.0, 200.0, 300.0])
+    y_new = 10 + 0.5 * x_new
+    predicted = model.predict_failure_time(x_new, y_new)
+    assert np.isclose(predicted, (150 - 10) / 0.5)
+    remaining = model.predict_remaining_life(x_new, y_new)
+    assert np.isclose(remaining, (150 - 10) / 0.5 - 300)
+
+
+def test_predict_failure_time_already_crossed():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37])
+    x, y, i = linear_data(slopes)
+    model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    # a unit whose trajectory crossed the threshold before its last
+    # observation: predicted failure is in the past, remaining life < 0
+    x_new = np.array([100.0, 200.0, 300.0])
+    y_new = 10 + 1.0 * x_new
+    assert np.isclose(model.predict_failure_time(x_new, y_new), 140)
+    assert model.predict_remaining_life(x_new, y_new) < 0
+
+
+def test_predict_failure_time_non_degrading_is_nan():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37])
+    x, y, i = linear_data(slopes)
+    model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    x_new = np.array([100.0, 200.0, 300.0])
+    y_new = 10 - 0.1 * x_new
+    with pytest.warns(UserWarning, match="never\\s+reaches"):
+        predicted = model.predict_failure_time(x_new, y_new)
+    assert np.isnan(predicted)
+    with pytest.warns(UserWarning, match="never\\s+reaches"):
+        remaining = model.predict_remaining_life(x_new, y_new)
+    assert np.isnan(remaining)
+
+
+@pytest.mark.parametrize(
+    "x_new,y_new",
+    [
+        ([1, 2, 3], [1, 2]),  # mismatched lengths
+        ([100], [20]),  # too few points
+        ([100, 100], [20, 21]),  # single distinct time
+        ([100, 200], [20, np.nan]),  # non-finite measurement
+    ],
+)
+def test_predict_failure_time_validation(x_new, y_new):
+    slopes = np.array([0.31, 0.28, 0.44, 0.37])
+    x, y, i = linear_data(slopes)
+    model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    with pytest.raises(ValueError):
+        model.predict_failure_time(x_new, y_new)
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [

--- a/surpyval/tests/degradation/test_degradation_analysis.py
+++ b/surpyval/tests/degradation/test_degradation_analysis.py
@@ -8,6 +8,7 @@ import pytest  # noqa: E402
 
 from surpyval import LogNormal, Weibull  # noqa: E402
 from surpyval.degradation import (  # noqa: E402
+    PATH_MODELS,
     DegradationAnalysis,
     ExponentialPath,
 )
@@ -445,6 +446,91 @@ def test_invalid_population_method():
         DegradationAnalysis.fit(
             x, y, i, threshold=150, population_method="bayes"
         )
+
+
+def test_best_path_selects_linear_on_linear_data():
+    x, y, i = _noisy_population_data(n_units=30)
+    model = DegradationAnalysis.fit(x, y, i, threshold=100, path="best")
+    assert model.path_model.name == "Linear"
+    assert set(model.path_selection) == {m.name for m in PATH_MODELS.values()}
+    assert np.isfinite(model.path_selection["Linear"])
+    # a model fitted with an explicit path records no selection
+    explicit = DegradationAnalysis.fit(x, y, i, threshold=100)
+    assert explicit.path_selection is None
+    # the selected model feeds the normal pipeline
+    pred = model.predict_rul([20.0, 40.0], [18.0, 26.0], random_state=9)
+    assert np.isfinite(pred.failure_time)
+
+
+def test_best_path_selects_exponential_on_exponential_data():
+    a = np.array([2.0, 2.5, 1.8, 2.2])
+    b = np.array([0.004, 0.005, 0.006, 0.0045])
+    n_obs = 10
+    x = np.tile(np.arange(50, 50 * (n_obs + 1), 50), len(a))
+    i = np.repeat(np.arange(1, len(a) + 1), n_obs)
+    y = np.repeat(a, n_obs) * np.exp(np.repeat(b, n_obs) * x)
+    model = DegradationAnalysis.fit(x, y, i, threshold=20, path="best")
+    assert model.path_model.name == "Exponential"
+    # the linear candidate was fitted but scored worse
+    assert model.path_selection["Exponential"] < model.path_selection["Linear"]
+
+
+def test_best_path_selects_quadratic_on_quadratic_data():
+    rng = np.random.default_rng(17)
+    n_units, x_times = 4, np.arange(10.0, 110.0, 10.0)
+    a = rng.normal(5.0, 0.2, n_units)
+    b = rng.normal(0.2, 0.01, n_units)
+    c = rng.normal(0.005, 0.0002, n_units)
+    x = np.tile(x_times, n_units)
+    i = np.repeat(np.arange(n_units), len(x_times))
+    y = (
+        np.repeat(a, len(x_times))
+        + np.repeat(b, len(x_times)) * x
+        + np.repeat(c, len(x_times)) * x**2
+    )
+    model = DegradationAnalysis.fit(x, y, i, threshold=60, path="best")
+    assert model.path_model.name == "Quadratic"
+
+
+def test_best_path_excludes_domain_violating_models():
+    # decreasing linear degradation through negative values: the
+    # positive-measurement models cannot be fitted and score nan
+    slopes = np.array([-0.09, -0.11, -0.1, -0.105])
+    x, y, i = linear_data(slopes)  # y reaches ~ -100 at x = 1000
+    model = DegradationAnalysis.fit(x, y, i, threshold=-50, path="best")
+    assert model.path_model.name == "Linear"
+    assert np.isnan(model.path_selection["Exponential"])
+    assert np.isnan(model.path_selection["Michaelis-Menten"])
+    assert (model.c == 0).all()
+
+
+def test_quadratic_pipeline_with_reml_and_prediction():
+    rng = np.random.default_rng(23)
+    n_units, x_times = 20, np.arange(10.0, 60.0, 10.0)
+    a = rng.normal(5.0, 0.5, n_units)
+    b = rng.normal(0.2, 0.02, n_units)
+    c = rng.normal(0.01, 0.001, n_units)
+    x = np.tile(x_times, n_units)
+    i = np.repeat(np.arange(n_units), len(x_times))
+    y = (
+        np.repeat(a, len(x_times))
+        + np.repeat(b, len(x_times)) * x
+        + np.repeat(c, len(x_times)) * x**2
+        + rng.normal(0, 0.3, len(x))
+    )
+    model = DegradationAnalysis.fit(
+        x,
+        y,
+        i,
+        threshold=60,
+        path="quadratic",
+        population_method="reml",
+    )
+    assert model.path_param_cov.shape == (3, 3)
+    assert (np.linalg.eigvalsh(model.path_param_cov) > 0).all()
+    pred = model.predict_rul([10.0, 20.0], [8.0, 13.0], random_state=10)
+    assert np.isfinite(pred.failure_time)
+    assert pred.failure_time > 0
 
 
 def test_predict_failure_time_new_trajectory():

--- a/surpyval/tests/degradation/test_degradation_analysis.py
+++ b/surpyval/tests/degradation/test_degradation_analysis.py
@@ -234,6 +234,219 @@ def test_clip_psd():
     assert np.allclose(same_matrix, psd)
 
 
+def _noisy_population_data(n_units=100, seed=7):
+    """Balanced noisy linear degradation data: a ~ N(10, 1),
+    b ~ N(0.4, 0.05^2), measurement noise sd 1."""
+    rng = np.random.default_rng(seed)
+    x_times = np.array([10.0, 20.0, 30.0, 40.0])
+    a = rng.normal(10.0, 1.0, n_units)
+    b = rng.normal(0.4, 0.05, n_units)
+    x = np.tile(x_times, n_units)
+    i = np.repeat(np.arange(n_units), len(x_times))
+    y = (
+        np.repeat(a, len(x_times))
+        + np.repeat(b, len(x_times)) * x
+        + rng.normal(0, 1.0, len(x))
+    )
+    return x, y, i
+
+
+def _unbalanced_population_data(n_units=100, seed=3):
+    """Unbalanced noisy linear degradation data (different measurement
+    schedules per unit), same population as _noisy_population_data."""
+    rng = np.random.default_rng(seed)
+    xs, ys, iis = [], [], []
+    for k in range(n_units):
+        n_k = int(rng.integers(3, 9))
+        x_k = np.sort(rng.uniform(5, 60, n_k))
+        a_k, b_k = rng.normal(10.0, 1.0), rng.normal(0.4, 0.05)
+        y_k = a_k + b_k * x_k + rng.normal(0, 1.0, n_k)
+        xs.append(x_k)
+        ys.append(y_k)
+        iis.append(np.full(n_k, k))
+    return np.concatenate(xs), np.concatenate(ys), np.concatenate(iis)
+
+
+def _noisy_model(**kwargs):
+    x, y, i = _noisy_population_data()
+    return DegradationAnalysis.fit(x, y, i, threshold=100, **kwargs)
+
+
+def test_predict_rul_agrees_with_extrapolation_given_much_data():
+    model = _noisy_model()
+    rng = np.random.default_rng(11)
+    x_new = np.arange(10.0, 210.0, 10.0)
+    y_new = 10 + 0.4 * x_new + rng.normal(0, 1.0, len(x_new))
+    pred = model.predict_rul(x_new, y_new, random_state=1)
+    plain = model.predict_failure_time(x_new, y_new)
+    assert abs(pred.failure_time - plain) / plain < 0.1
+    lower, upper = pred.failure_time_interval
+    assert lower < pred.failure_time < upper
+    assert pred.rul == pytest.approx(pred.failure_time - 200.0, rel=1e-9)
+    assert pred.prob_failed == 0.0
+    assert pred.prob_never_fails == 0.0
+
+
+def test_predict_rul_single_measurement():
+    model = _noisy_model()
+    pred_one = model.predict_rul([20.0], [18.0], random_state=2)
+    assert np.isfinite(pred_one.failure_time)
+    assert pred_one.failure_time > 0
+    # a single point must give a wider interval than a long trajectory
+    rng = np.random.default_rng(11)
+    x_new = np.arange(10.0, 210.0, 10.0)
+    y_new = 10 + 0.4 * x_new + rng.normal(0, 1.0, len(x_new))
+    pred_long = model.predict_rul(x_new, y_new, random_state=2)
+    width_one = np.diff(pred_one.failure_time_interval)[0]
+    width_long = np.diff(pred_long.failure_time_interval)[0]
+    assert width_one > width_long
+
+
+def test_predict_rul_shrinks_toward_population():
+    model = _noisy_model()
+    # two points implying a slope of 1.2, way above the population
+    x_new = np.array([10.0, 20.0])
+    y_new = np.array([22.0, 34.0])
+    pred = model.predict_rul(x_new, y_new, random_state=3)
+    ls_slope = 1.2
+    population_slope = model.path_param_mean[1]
+    assert population_slope < pred.posterior_mean[1] < ls_slope
+
+
+def test_predict_rul_already_failed_unit():
+    model = _noisy_model()
+    # a plausible fast unit (slope ~0.5, intercept ~10) observed well
+    # past its threshold crossing at ~185
+    x_new = np.array([150.0, 200.0, 250.0])
+    y_new = np.array([85.0, 110.0, 135.0])
+    pred = model.predict_rul(x_new, y_new, random_state=4)
+    assert pred.prob_failed > 0.9
+    assert pred.rul < 0
+
+
+def test_predict_rul_reproducible():
+    model = _noisy_model()
+    pred_a = model.predict_rul([20.0, 40.0], [18.0, 26.0], random_state=5)
+    pred_b = model.predict_rul([20.0, 40.0], [18.0, 26.0], random_state=5)
+    assert pred_a.failure_time == pred_b.failure_time
+    assert pred_a.rul_interval == pred_b.rul_interval
+    assert np.array_equal(pred_a.samples, pred_b.samples)
+
+
+def test_predict_rul_raises_without_measurement_noise():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37])
+    x, y, i = linear_data(slopes)
+    model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    with pytest.raises(ValueError, match="measurement"):
+        model.predict_rul([100.0, 200.0], [40.0, 70.0])
+
+
+@pytest.mark.parametrize(
+    "x_new,y_new",
+    [
+        ([], []),
+        ([1, 2, 3], [1, 2]),
+        ([100, 200], [20, np.nan]),
+    ],
+)
+def test_predict_rul_validation(x_new, y_new):
+    model = _noisy_model()
+    with pytest.raises(ValueError):
+        model.predict_rul(x_new, y_new)
+
+
+def test_predict_rul_nonlinear_path():
+    rng = np.random.default_rng(21)
+    n_units, x_times = 40, np.arange(50.0, 550.0, 50.0)
+    a = rng.normal(2.0, 0.05, n_units)
+    b = rng.normal(0.005, 0.0003, n_units)
+    x = np.tile(x_times, n_units)
+    i = np.repeat(np.arange(n_units), len(x_times))
+    y = np.repeat(a, len(x_times)) * np.exp(
+        np.repeat(b, len(x_times)) * x
+    ) + rng.normal(0, 0.1, len(x))
+    model = DegradationAnalysis.fit(x, y, i, threshold=20, path="exponential")
+    # new unit: a = 2, b = 0.0055, observed to 200 hours
+    x_new = np.arange(25.0, 225.0, 25.0)
+    y_new = 2.0 * np.exp(0.0055 * x_new)
+    pred = model.predict_rul(x_new, y_new, random_state=6)
+    truth = np.log(20 / 2.0) / 0.0055
+    assert 0.5 * truth < pred.failure_time < 2.0 * truth
+    assert pred.rul == pytest.approx(pred.failure_time - 200.0, rel=1e-9)
+
+
+def test_reml_matches_moments_on_balanced_data():
+    # classical result: for balanced designs (every unit measured at
+    # the same times) REML coincides with the two-stage moments
+    # estimator
+    x, y, i = _noisy_population_data()
+    moments = DegradationAnalysis.fit(x, y, i, threshold=100)
+    reml = DegradationAnalysis.fit(
+        x, y, i, threshold=100, population_method="reml"
+    )
+    assert moments.population_method == "moments"
+    assert reml.population_method == "reml"
+    assert np.allclose(
+        reml.path_param_mean, moments.path_param_mean, rtol=1e-4
+    )
+    assert np.allclose(reml.path_param_cov, moments.path_param_cov, rtol=1e-3)
+    assert np.isclose(reml.measurement_var, moments.measurement_var, rtol=1e-4)
+
+
+def test_reml_on_unbalanced_data():
+    x, y, i = _unbalanced_population_data()
+    reml = DegradationAnalysis.fit(
+        x, y, i, threshold=100, population_method="reml"
+    )
+    moments = DegradationAnalysis.fit(x, y, i, threshold=100)
+    # recovers the generating population
+    assert np.allclose(reml.path_param_mean, [10.0, 0.4], atol=[0.5, 0.03])
+    assert np.isclose(reml.measurement_var, 1.0, rtol=0.3)
+    assert np.isclose(reml.path_param_cov[0, 0], 1.0, rtol=0.6)
+    assert np.isclose(reml.path_param_cov[1, 1], 0.0025, rtol=0.6)
+    # a genuine optimisation: positive definite and not identical to
+    # the moments starting point on unbalanced data
+    assert (np.linalg.eigvalsh(reml.path_param_cov) > 0).all()
+    assert not np.allclose(
+        reml.path_param_cov, moments.path_param_cov, rtol=1e-6
+    )
+    # the fitted model supports Bayesian prediction
+    pred = reml.predict_rul([20.0, 40.0], [18.0, 26.0], random_state=8)
+    assert np.isfinite(pred.failure_time)
+
+
+def test_reml_rejects_nonlinear_path():
+    x, y, i = _noisy_population_data()
+    # rejected before any per-unit fitting happens
+    with pytest.raises(ValueError, match="linear in its parameters"):
+        DegradationAnalysis.fit(
+            x,
+            y,
+            i,
+            threshold=100,
+            path="exponential",
+            population_method="reml",
+        )
+
+
+def test_reml_requires_noise():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37])
+    x, y, i = linear_data(slopes)
+    with pytest.raises(ValueError, match="measurement"):
+        DegradationAnalysis.fit(
+            x, y, i, threshold=150, population_method="reml"
+        )
+
+
+def test_invalid_population_method():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37])
+    x, y, i = linear_data(slopes)
+    with pytest.raises(ValueError, match="population_method"):
+        DegradationAnalysis.fit(
+            x, y, i, threshold=150, population_method="bayes"
+        )
+
+
 def test_predict_failure_time_new_trajectory():
     slopes = np.array([0.31, 0.28, 0.44, 0.37])
     x, y, i = linear_data(slopes)

--- a/surpyval/tests/degradation/test_path_models.py
+++ b/surpyval/tests/degradation/test_path_models.py
@@ -43,6 +43,16 @@ def test_inv_path_round_trip(model, params):
     assert np.allclose(model.path(t, *params), level)
 
 
+@pytest.mark.parametrize("model,params", MODELS_AND_PARAMS)
+def test_analytic_jacobian_matches_finite_differences(model, params):
+    x = np.linspace(1, 10, 20)
+    analytic = model.jacobian(x, *params)
+    # invoke the base class' finite-difference implementation directly
+    numeric = PathModel.jacobian(model, x, *params)
+    assert analytic.shape == (len(x), len(model.param_names))
+    assert np.allclose(analytic, numeric, rtol=1e-4, atol=1e-6)
+
+
 def test_fit_with_noise_is_close():
     rng = np.random.default_rng(42)
     x = np.linspace(1, 10, 50)

--- a/surpyval/tests/degradation/test_path_models.py
+++ b/surpyval/tests/degradation/test_path_models.py
@@ -1,0 +1,97 @@
+import numpy as np
+import pytest
+
+from surpyval.degradation import (
+    PATH_MODELS,
+    ExponentialPath,
+    LinearPath,
+    LloydLipowPath,
+    LogarithmicPath,
+    PathModel,
+    PowerPath,
+    get_path_model,
+)
+
+MODELS_AND_PARAMS = [
+    (LinearPath, (2.0, 0.5)),
+    (LinearPath, (10.0, -0.3)),
+    (ExponentialPath, (2.0, 0.05)),
+    (ExponentialPath, (5.0, -0.1)),
+    (PowerPath, (2.0, 0.8)),
+    (LogarithmicPath, (1.0, 2.0)),
+    (LloydLipowPath, (10.0, 5.0)),
+]
+
+
+@pytest.mark.parametrize("model,params", MODELS_AND_PARAMS)
+def test_fit_recovers_exact_parameters(model, params):
+    x = np.linspace(1, 10, 20)
+    y = model.path(x, *params)
+    fitted = model.fit(x, y)
+    assert np.allclose(fitted, params, rtol=1e-5)
+
+
+@pytest.mark.parametrize("model,params", MODELS_AND_PARAMS)
+def test_inv_path_round_trip(model, params):
+    x = np.linspace(1, 10, 20)
+    y = model.path(x, *params)
+    # a level strictly inside the observed range of the path
+    level = 0.25 * y.min() + 0.75 * y.max()
+    t = model.inv_path(level, *params)
+    assert np.isfinite(t)
+    assert t > 0
+    assert np.allclose(model.path(t, *params), level)
+
+
+def test_fit_with_noise_is_close():
+    rng = np.random.default_rng(42)
+    x = np.linspace(1, 10, 50)
+    y = ExponentialPath.path(x, 2.0, 0.2) + rng.normal(0, 0.05, 50)
+    fitted = ExponentialPath.fit(x, y)
+    assert np.allclose(fitted, [2.0, 0.2], rtol=0.05)
+
+
+def test_unreachable_levels_are_not_positive_finite():
+    # increasing linear path never drops below its intercept
+    t = LinearPath.inv_path(1.0, 2.0, 0.5)
+    assert not (np.isfinite(t) and t > 0)
+    # decaying exponential path never rises above its start
+    t = ExponentialPath.inv_path(10.0, 5.0, -0.1)
+    assert not (np.isfinite(t) and t > 0)
+    # constant path never moves at all
+    t = LinearPath.inv_path(5.0, 2.0, 0.0)
+    assert not (np.isfinite(t) and t > 0)
+    # Lloyd-Lipow path never exceeds its asymptote a
+    t = LloydLipowPath.inv_path(11.0, 10.0, 5.0)
+    assert not (np.isfinite(t) and t > 0)
+
+
+@pytest.mark.parametrize(
+    "model,x,y",
+    [
+        (ExponentialPath, [1, 2, 3], [1.0, -1.0, 2.0]),
+        (PowerPath, [0, 1, 2], [1.0, 2.0, 3.0]),
+        (PowerPath, [1, 2, 3], [1.0, 0.0, 3.0]),
+        (LogarithmicPath, [-1, 1, 2], [1.0, 2.0, 3.0]),
+        (LloydLipowPath, [0, 1, 2], [1.0, 2.0, 3.0]),
+    ],
+)
+def test_domain_validation(model, x, y):
+    with pytest.raises(ValueError):
+        model.fit(x, y)
+
+
+def test_get_path_model():
+    assert get_path_model("linear") is LinearPath
+    assert get_path_model("Lloyd-Lipow") is LloydLipowPath
+    assert get_path_model(PowerPath) is PowerPath
+    with pytest.raises(ValueError):
+        get_path_model("not-a-model")
+    with pytest.raises(ValueError):
+        get_path_model(1)
+
+
+def test_registry_is_complete():
+    for name, model in PATH_MODELS.items():
+        assert isinstance(model, PathModel)
+        assert get_path_model(name) is model

--- a/surpyval/tests/degradation/test_path_models.py
+++ b/surpyval/tests/degradation/test_path_models.py
@@ -4,22 +4,31 @@ import pytest
 from surpyval.degradation import (
     PATH_MODELS,
     ExponentialPath,
+    GompertzPath,
     LinearPath,
     LloydLipowPath,
     LogarithmicPath,
+    MichaelisMentenPath,
+    OffsetExponentialPath,
     PathModel,
     PowerPath,
+    QuadraticPath,
     get_path_model,
 )
 
 MODELS_AND_PARAMS = [
     (LinearPath, (2.0, 0.5)),
     (LinearPath, (10.0, -0.3)),
+    (QuadraticPath, (1.0, 0.3, 0.01)),
+    (QuadraticPath, (20.0, -0.5, -0.02)),
     (ExponentialPath, (2.0, 0.05)),
     (ExponentialPath, (5.0, -0.1)),
+    (OffsetExponentialPath, (10.0, -8.0, -0.2)),
     (PowerPath, (2.0, 0.8)),
     (LogarithmicPath, (1.0, 2.0)),
     (LloydLipowPath, (10.0, 5.0)),
+    (GompertzPath, (10.0, 3.0, 0.3)),
+    (MichaelisMentenPath, (10.0, 5.0)),
 ]
 
 
@@ -84,11 +93,24 @@ def test_unreachable_levels_are_not_positive_finite():
         (PowerPath, [1, 2, 3], [1.0, 0.0, 3.0]),
         (LogarithmicPath, [-1, 1, 2], [1.0, 2.0, 3.0]),
         (LloydLipowPath, [0, 1, 2], [1.0, 2.0, 3.0]),
+        (GompertzPath, [1, 2, 3], [1.0, -1.0, 2.0]),
+        (MichaelisMentenPath, [0, 1, 2], [1.0, 2.0, 3.0]),
+        (MichaelisMentenPath, [1, 2, 3], [1.0, 0.0, 3.0]),
     ],
 )
 def test_domain_validation(model, x, y):
     with pytest.raises(ValueError):
         model.fit(x, y)
+
+
+def test_quadratic_inv_path_takes_first_crossing():
+    # downward parabola y = x - 0.01 x^2 crosses 16 at t=20 and t=80
+    assert np.isclose(QuadraticPath.inv_path(16.0, 0.0, 1.0, -0.01), 20.0)
+    # the vertex peaks at 25, so 30 is never reached
+    t = QuadraticPath.inv_path(30.0, 0.0, 1.0, -0.01)
+    assert not (np.isfinite(t) and t > 0)
+    # degenerate c = 0 falls back to the linear crossing
+    assert np.isclose(QuadraticPath.inv_path(6.0, 2.0, 0.5, 0.0), 8.0)
 
 
 def test_get_path_model():


### PR DESCRIPTION
## Summary

Adds a new `surpyval.degradation` package implementing degradation analysis: track a degradation measurement over time on each unit, define failure as the measurement crossing a threshold, and turn degradation trends into lifetime inference — including for units that never failed on test.

### Core pipeline (classic pseudo-failure-time approach)
- Fit a **path model** to each unit's measurements by least squares, extrapolate each fitted path to the failure `threshold` to get per-unit **pseudo failure times**, and fit a lifetime distribution (Weibull by default, any fitter via `distribution=`) to those times. Units whose path never reaches the threshold are right censored at their last observation (with a warning).
- `DegradationAnalysis.fit(x, y, i, threshold, ...)`, `fit_from_df`, full input validation, `plot()` (data + fitted paths + threshold), and lifetime functions (`sf`/`ff`/`df`/`hf`/`Hf`/`qf`/`mean`/`random`) forwarded to the fitted life model.

### Path models
Nine built-ins — linear, quadratic, exponential, offset-exponential, power, logarithmic, Lloyd-Lipow, Gompertz, Michaelis-Menten — each with least-squares fitting (closed form where linear in parameters), analytic Jacobians, and threshold-crossing inversion (the quadratic takes the first positive root). Custom shapes plug in by subclassing `PathModel`.

`path="best"` fits every registered model to all units and selects by AICc (pooled RSS, per-unit parameter penalty, small-sample correction); candidates that can't be fitted to every unit are excluded, and the per-candidate scores are exposed as `model.path_selection`.

### Population path-parameter distribution
- **Two-stage (Lu–Meeker) noise correction**: the sample covariance of per-unit estimates overstates unit-to-unit variability by the estimation noise (`Cov(θ̂ᵢ) = Σ + Vᵢ`), so fit pools `measurement_var` from residuals, subtracts the mean estimation covariance `Vᵢ = σ²(JᵢᵀJᵢ)⁻¹`, and projects onto the PSD cone (warning if material clipping was needed).
- **`population_method="reml"`**: restricted marginal likelihood of the linear mixed model `yᵢ ~ N(Xᵢμ, XᵢΣXᵢᵀ + σ²I)` (GLS-profiled mean, Cholesky-parameterised Σ so it stays positive definite), for linear-in-parameter paths. Coincides with the corrected moments on balanced designs (asserted in tests); preferable on unbalanced data and small unit counts.

### Prediction for new units
- `predict_failure_time` / `predict_remaining_life`: least-squares extrapolation of a new unit's partial trajectory.
- `predict_rul`: **Bayesian blend** — population distribution as prior, the unit's measurements as likelihood, Gaussian posterior (exact conjugate for linear-in-parameter paths, iterated linearisation otherwise) pushed through the threshold crossing by Monte Carlo. Returns posterior median failure time and RUL, credible intervals, P(already failed), P(never fails). Shrinks short/noisy trajectories toward the population, works from a single measurement, and converges to the plain extrapolation with long trajectories.

### Docs & tests
- New docs: narrative "Degradation Analysis" page (theory, path table, examples, honest uncertainty caveats) and an API autodoc page, wired into the toctrees.
- 100 tests in `surpyval/tests/degradation/` (exact recovery, inversion round trips, Jacobians vs finite differences, censoring, correction recovery on noisy data, REML==moments on balanced designs, shrinkage behaviour, model selection, validation errors).
- `MODEL_ATLAS.md` notes where degradation sits relative to the axes; `DEVELOPMENT.md` records shipped scope and future work (bootstrap CBs, induced failure-time distribution from (μ, Σ), REML for nonlinear paths, ADT covariates).

## Test plan
- [x] `pytest surpyval` — 847 passed, 1 skipped (the pre-existing `test_copula_censoring` environment failure is unrelated to this branch)
- [x] `flake8` / `black --check` / `isort --check-only` clean on the new package
- [x] `mypy surpyval` — no new errors over the master baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsDnaARoHBiZPeN4mbuTQJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsDnaARoHBiZPeN4mbuTQJ)_