### PR TITLE
Recurrent module: parameter uncertainty, model diagnostics, and CoxLewis simulation fix

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,20 +34,18 @@ numeric kernels loosely typed (they buy little from precise typing).
 
 ### Missing capabilities — high priority
 
-**No parameter uncertainty**
-All models return point estimates only. No standard errors, covariance matrix, or confidence intervals for fitted parameters. For HPP, `autograd` already computes the Hessian; use `np.linalg.inv(-H)` to get the observed Fisher information. For NHPP, `scipy.optimize.minimize` returns `result.hess_inv` (BFGS) or a numerical Hessian can be computed via `numdifftools`. This is the single highest-value missing feature across the entire recurrent sub-package.
+Parameter uncertainty is done: every likelihood-fitted recurrent model
+(parametric intensity, proportional-intensity regression, renewal) exposes
+`covariance()`, `standard_errors()` and `param_cb()` (Wald bounds on a
+transformed scale respecting each parameter's support) via
+`LikelihoodInferenceMixin`, and the parametric and regression models have a
+delta-method `cif_cb()` drawn as a band by `plot()`. The remaining gaps:
 
 **No goodness-of-fit or trend tests**
 There is no Cramér-von Mises test for NHPP goodness-of-fit, and no method to run the existing trend tests directly on a fitted NHPP model.
 
 **No residual diagnostics**
 No martingale residuals, no cumulative-hazard residuals, no probability-integral-transform (PIT) check. Without these, model validation is limited to eyeballing the MCF overlay.
-
-**Renewal models have no `plot()` method**
-`GeneralizedRenewal` and `GeneralizedOneRenewal` fit and simulate but cannot plot — unlike every other model in the module. Add the same MCF-overlay `plot()` that `ParametricRecurrenceModel` already implements.
-
-**Parametric `plot()` shows no confidence band**
-`ParametricRecurrenceModel.plot()` overlays the fitted CIF on the nonparametric MCF but draws no band around the parametric curve. Once parameter covariance is available (see above), add a delta-method band using the same Greenwood logic already in `NonParametricCounting.mcf_cb`.
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,24 +32,26 @@ numeric kernels loosely typed (they buy little from precise typing).
 
 ## 2. Recurrent Module — Gaps
 
-### Missing capabilities — high priority
-
-Parameter uncertainty is done: every likelihood-fitted recurrent model
-(parametric intensity, proportional-intensity regression, renewal) exposes
-`covariance()`, `standard_errors()` and `param_cb()` (Wald bounds on a
-transformed scale respecting each parameter's support) via
-`LikelihoodInferenceMixin`, and the parametric and regression models have a
-delta-method `cif_cb()` drawn as a band by `plot()`. The remaining gaps:
-
-**No goodness-of-fit or trend tests**
-There is no Cramér-von Mises test for NHPP goodness-of-fit, and no method to run the existing trend tests directly on a fitted NHPP model.
-
-**No residual diagnostics**
-No martingale residuals, no cumulative-hazard residuals, no probability-integral-transform (PIT) check. Without these, model validation is limited to eyeballing the MCF overlay.
-
----
+The former high-priority gaps are closed. Parameter uncertainty: every
+likelihood-fitted recurrent model (parametric intensity,
+proportional-intensity regression, renewal) exposes `covariance()`,
+`standard_errors()` and `param_cb()` (Wald bounds on a transformed scale
+respecting each parameter's support) via `LikelihoodInferenceMixin`, and the
+parametric and regression models have a delta-method `cif_cb()` drawn as a
+band by `plot()`. Model validation: `ParametricRecurrenceModel` has
+`residuals()` (cumulative-hazard / PIT / per-item martingale, via the
+time-rescaling theorem), `trend_test()` (runs the standalone Laplace /
+MIL-HDBK-189C tests on the fitted data's windows) and `cramer_von_mises()`
+(conditional-uniform CvM statistic with a parametric-bootstrap p-value).
 
 ### Missing capabilities — medium priority
+
+**Diagnostics for the regression and renewal families**
+`residuals()`, `trend_test()` and `cramer_von_mises()` exist only on
+`ParametricRecurrenceModel`. The proportional-intensity extension is
+mostly plumbing (scale each item's CIF by its `exp(Z'beta)` factor); the
+renewal/virtual-age models need conditional-intensity residuals instead,
+which is a genuinely different construction.
 
 **Left-truncation support (partial)**
 `handle_xicn` takes the surpyval `t`/`tl`/`tr` truncation fields, and the calendar-time NHPP models (`HPP`, `CrowAMSAA`, `Duane`, `CoxLewis`) integrate each item's likelihood from its entry time `tl`, so delayed-entry (warranty-from-first-sale) data is analysed correctly there. The virtual-age / history-dependent models (Kijima/G1/ARA/ARI) reject `tl > 0` with an explanatory error, since the virtual age at entry is undefined without the pre-entry history. Still to do: multi-window (gapped) observation per item.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Notes
 
-This document tracks known issues, technical debt, and improvement priorities for surpyval. Issues are grouped by theme and ordered by severity within each section. Implemented items are removed; this reflects the state of the codebase as of 2026-07-11. The full test suite passes on Python 3.11+ with numpy 2.x / scipy 1.17 / pandas 3.x.
+This document tracks known issues, technical debt, and improvement priorities for surpyval. Issues are grouped by theme and ordered by severity within each section. Implemented items are removed; this reflects the state of the codebase as of 2026-07-12. The full test suite passes on Python 3.11+ with numpy 2.x / scipy 1.17 / pandas 3.x.
 
 ---
 
@@ -30,22 +30,7 @@ numeric kernels loosely typed (they buy little from precise typing).
 
 ---
 
-## 2. Recurrent Module — Bugs and Gaps
-
-### Confirmed bugs
-
-**Typo `has_left_censoing` (missing 'r')**
-**Files:** `surpyval/recurrent/parametric/nhpp_fitter.py:18`, `surpyval/recurrent/regression/nhpp_proportional_intensity.py:72`
-Variable is never read back so it is silent dead code today, but it will break any future code that reads the flag.
-
-**`log_iif()` not implemented for proportional-intensity NHPP**
-**File:** `surpyval/recurrent/regression/nhpp_proportional_intensity.py:129` — marked TODO.
-The MLE likelihood falls back to the non-log path; for small intensities this causes underflow and silent NaN log-likelihoods.
-
-**`CoxLewis.inv_cif()` can return negative times**
-When `ln(N) < alpha`, the expression `(ln(N) - alpha) / beta` is negative. No guard or error is raised; simulation silently produces invalid (negative) event times.
-
----
+## 2. Recurrent Module — Gaps
 
 ### Missing capabilities — high priority
 

--- a/surpyval/recurrent/__init__.py
+++ b/surpyval/recurrent/__init__.py
@@ -1,3 +1,4 @@
+from .diagnostics import GoodnessOfFitResult
 from .nonparametric import NonParametricCounting
 from .parametric import HPP, CountingProcess, CoxLewis, CrowAMSAA, Duane
 from .regression import ProportionalIntensityHPP, ProportionalIntensityNHPP

--- a/surpyval/recurrent/diagnostics.py
+++ b/surpyval/recurrent/diagnostics.py
@@ -1,0 +1,285 @@
+"""
+Model-validation diagnostics for fitted parametric recurrent models.
+
+Everything here rests on the time-rescaling theorem: if events follow an
+NHPP with cumulative intensity ``L(t)``, then the transformed event times
+``L(t_1) < L(t_2) < ...`` follow a unit-rate homogeneous Poisson process.
+Three consequences are used:
+
+- the rescaled interarrival times ``L(t_k) - L(t_{k-1})`` are iid Exp(1)
+  (cumulative-hazard residuals), so ``1 - exp(-e)`` are iid U(0, 1)
+  (probability-integral-transform residuals);
+- the observed count minus the expected count over each item's window is a
+  martingale evaluated at the window close (martingale residuals);
+- conditional on the number of events an item has in its observation
+  window, the normalised transforms ``[L(t) - L(entry)] / [L(close) -
+  L(entry)]`` are iid U(0, 1), which a Cramer-von Mises statistic tests
+  (the construction behind Crow's power-law goodness-of-fit test,
+  generalised to any fitted intensity).
+
+The functions take the fitted model's ``RecurrentEventData`` plus its CIF,
+and are exposed as methods on ``ParametricRecurrenceModel``.
+"""
+
+import warnings
+
+import numpy as np
+
+
+def _validate_diagnostic_data(data, what):
+    """
+    The diagnostics need exact event times: interval-censored (2D ``x`` or
+    ``c == 2``) and left-censored (``c == -1``) observations cannot be
+    placed in time, so they are rejected with an explanation.
+    """
+    if data.x.ndim != 1:
+        raise ValueError(
+            "{} requires exact event times; interval-censored data is not "
+            "supported.".format(what)
+        )
+    if np.any((data.c != 0) & (data.c != 1)):
+        raise ValueError(
+            "{} requires exact event times; left- or interval-censored "
+            "rows (c = -1 or c = 2) are not supported.".format(what)
+        )
+
+
+def _per_item_windows(data):
+    """
+    Group the data by item and resolve each item's observation window.
+
+    Returns a list with one entry per (sorted-unique) item:
+    ``(events, entry, close, explicit_close)`` where ``events`` are the
+    item's observed event times (sorted, repeated per their counts ``n``),
+    ``entry`` is its observation start (its finite left-truncation bound,
+    else 0), ``close`` is the time its window closes (its finite
+    right-truncation bound, else its right-censoring row, else its last
+    event) and ``explicit_close`` says whether that close was given by the
+    data (``tr`` or a ``c = 1`` row) or inferred from the last event
+    (failure-truncated).
+    """
+    items = []
+    for item in np.unique(data.i):
+        mask = data.i == item
+        x, c, n = data.x[mask], data.c[mask], data.n[mask]
+        events = np.sort(np.repeat(x[c == 0], n[c == 0].astype(int)))
+        entry = float(data.tl[mask][0])
+        entry = entry if np.isfinite(entry) else 0.0
+
+        tr = float(data.tr[mask][0])
+        if np.isfinite(tr):
+            close, explicit_close = tr, True
+        elif np.any(c == 1):
+            close, explicit_close = float(x[c == 1].max()), True
+        elif events.size:
+            close, explicit_close = float(events[-1]), False
+        else:
+            continue
+        items.append((events, entry, close, explicit_close))
+    return items
+
+
+def cumulative_hazard_residuals(data, cif):
+    """
+    Rescaled interarrival times ``cif(t_k) - cif(t_{k-1})`` for every
+    observed event (with ``t_0`` each item's entry time), pooled across
+    items in sorted-item then time order. Under the fitted model these are
+    iid Exp(1).
+    """
+    _validate_diagnostic_data(data, "Residuals")
+    residuals = []
+    for events, entry, _, _ in _per_item_windows(data):
+        if events.size == 0:
+            continue
+        transformed = cif(np.concatenate([[entry], events]))
+        residuals.append(np.diff(transformed))
+    if not residuals:
+        raise ValueError("No observed events; no residuals to compute.")
+    return np.concatenate(residuals)
+
+
+def martingale_residuals(data, cif):
+    """
+    Per-item martingale residuals: the observed event count minus the
+    expected count ``cif(close) - cif(entry)`` over the item's observation
+    window, one per sorted-unique item. Positive values mean the item had
+    more events than the model expects.
+    """
+    _validate_diagnostic_data(data, "Residuals")
+    residuals = []
+    for events, entry, close, _ in _per_item_windows(data):
+        expected = float(cif(close) - cif(entry))
+        residuals.append(events.size - expected)
+    return np.array(residuals)
+
+
+class GoodnessOfFitResult:
+    """
+    Result of the Cramer-von Mises goodness-of-fit test
+    (:meth:`ParametricRecurrenceModel.cramer_von_mises`).
+
+    Attributes
+    ----------
+    statistic : float
+        The Cramer-von Mises statistic ``C^2_M`` of the pooled
+        conditionally-uniform transforms of the event times.
+    p_value : float
+        Parametric-bootstrap p-value: the proportion of statistics from
+        data simulated (and refitted) under the fitted model that are at
+        least as large as the observed one.
+    n_boot : int
+        The number of successful bootstrap replicates behind ``p_value``.
+    n_events : int
+        The number of (transformed) event times in the statistic.
+    n_systems : int
+        The number of systems (items) in the data.
+    """
+
+    def __init__(self, statistic, p_value, n_boot, n_events, n_systems):
+        self.statistic = statistic
+        self.p_value = p_value
+        self.n_boot = n_boot
+        self.n_events = n_events
+        self.n_systems = n_systems
+
+    def __repr__(self):
+        title = "Cramer-von Mises Goodness-of-Fit Test"
+        return "\n".join(
+            [
+                title,
+                "=" * len(title),
+                "Null hypothesis  : events follow the fitted intensity",
+                "Statistic        : {s:.6g}".format(s=self.statistic),
+                "p-value          : {p:.6g} ({n} bootstrap samples)".format(
+                    p=self.p_value, n=self.n_boot
+                ),
+            ]
+        )
+
+
+def _conditional_uniforms(data, cif):
+    """
+    The conditionally-uniform transforms behind the Cramer-von Mises
+    statistic, pooled across items. For a time-truncated item every event
+    contributes ``[cif(t) - cif(entry)] / [cif(close) - cif(entry)]``; for
+    a failure-truncated item the last event is the (random) window close,
+    so the remaining events are normalised by the transform at that last
+    event and it is itself excluded (Crow's ``M = N - 1`` convention).
+    """
+    u = []
+    n_systems = 0
+    for events, entry, close, explicit_close in _per_item_windows(data):
+        n_systems += 1
+        used = events if explicit_close else events[:-1]
+        if used.size == 0:
+            continue
+        span = float(cif(close) - cif(entry))
+        if span <= 0:
+            continue
+        u.append((cif(used) - cif(entry)) / span)
+    if not u:
+        raise ValueError(
+            "No usable event times for the Cramer-von Mises statistic."
+        )
+    return np.concatenate(u), n_systems
+
+
+def cvm_statistic(u):
+    """
+    The Cramer-von Mises statistic ``1/(12M) + sum_j (u_(j) -
+    (2j - 1)/(2M))^2`` of a sample ``u`` against the standard uniform.
+    """
+    u = np.sort(np.asarray(u, dtype=float))
+    m = u.size
+    j = np.arange(1, m + 1)
+    return float(1.0 / (12.0 * m) + np.sum((u - (2 * j - 1) / (2 * m)) ** 2))
+
+
+def cramer_von_mises(model, n_boot=200, seed=None):
+    """
+    Cramer-von Mises goodness-of-fit test of a fitted parametric recurrent
+    model; see :meth:`ParametricRecurrenceModel.cramer_von_mises` for the
+    user-facing documentation.
+    """
+    from surpyval.utils.recurrent_event_data import RecurrentEventData
+
+    data = model.data
+    _validate_diagnostic_data(data, "The Cramer-von Mises test")
+    if not hasattr(model.dist, "inv_cif"):
+        raise ValueError(
+            "The Cramer-von Mises test requires an invertible CIF; {} does "
+            "not define inv_cif.".format(model.dist.name)
+        )
+
+    u, n_systems = _conditional_uniforms(data, model.cif)
+    observed = cvm_statistic(u)
+
+    # Parametric bootstrap: simulate each item's window from the fitted
+    # model (conditional on the fitted intensity the event count in a
+    # window is Poisson and the times are iid with density proportional to
+    # the intensity), refit, and recompute the statistic -- so the p-value
+    # accounts for the parameters having been estimated. Failure-truncated
+    # items are approximated by a window fixed at their last observed
+    # event.
+    rng = np.random.default_rng(seed)
+    windows = _per_item_windows(data)
+    statistics = []
+    failures = 0
+    while len(statistics) < n_boot and failures < 2 * n_boot:
+        x_b, i_b, c_b, tl_b = [], [], [], []
+        for item_id, (_, entry, close, _) in enumerate(windows):
+            span = float(model.cif(close) - model.cif(entry))
+            count = rng.poisson(span) if span > 0 else 0
+            times = np.sort(
+                model.inv_cif(
+                    model.cif(entry) + span * rng.uniform(size=count)
+                )
+            )
+            x_b.extend([*times, close])
+            i_b.extend([item_id] * (count + 1))
+            c_b.extend([0] * count + [1])
+            tl_b.extend([entry] * (count + 1))
+        if (np.asarray(c_b) == 0).sum() < 2:
+            failures += 1
+            continue
+        sim_data = RecurrentEventData(
+            np.asarray(x_b, dtype=float),
+            np.asarray(i_b),
+            np.asarray(c_b),
+            np.ones(len(x_b), dtype=int),
+            tl=np.asarray(tl_b, dtype=float),
+        )
+        try:
+            # The optimiser explores extreme parameter values on its way to
+            # the optimum; the resulting numerical warnings are routine, and
+            # over hundreds of refits they would swamp the console.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", RuntimeWarning)
+                refit = model.dist.fit_from_recurrent_data(sim_data)
+                u_b, _ = _conditional_uniforms(sim_data, refit.cif)
+        except (ValueError, RuntimeError, np.linalg.LinAlgError):
+            failures += 1
+            continue
+        statistics.append(cvm_statistic(u_b))
+
+    if not statistics:
+        raise ValueError(
+            "All bootstrap refits failed; cannot compute a p-value."
+        )
+    if failures:
+        warnings.warn(
+            "{} bootstrap replicate(s) failed and were resampled or "
+            "dropped.".format(failures)
+        )
+
+    statistics = np.asarray(statistics)
+    p_value = float(
+        (1.0 + np.sum(statistics >= observed)) / (statistics.size + 1.0)
+    )
+    return GoodnessOfFitResult(
+        statistic=observed,
+        p_value=p_value,
+        n_boot=int(statistics.size),
+        n_events=int(u.size),
+        n_systems=n_systems,
+    )

--- a/surpyval/recurrent/inference.py
+++ b/surpyval/recurrent/inference.py
@@ -1,6 +1,7 @@
 import warnings
 
 import numpy as np
+from scipy.stats import norm
 
 
 def numerical_hessian(func, x):
@@ -29,6 +30,68 @@ def numerical_hessian(func, x):
                 + func(x - ei - ej)
             ) / (4.0 * step[i] * step[j])
     return H
+
+
+def delta_method_std_errors(func, mle, cov):
+    """
+    Standard errors of the (possibly vector-valued) function ``func`` of the
+    parameters, evaluated at the MLE, via the delta method with a
+    central-difference Jacobian: ``se_i = sqrt(J_i' cov J_i)``.
+    """
+    mle = np.asarray(mle, dtype=float)
+    step = (np.finfo(float).eps ** (1.0 / 3.0)) * np.maximum(np.abs(mle), 1e-2)
+    cols = []
+    for i in range(mle.size):
+        ei = np.zeros(mle.size)
+        ei[i] = step[i]
+        cols.append(
+            (
+                np.asarray(func(mle + ei), dtype=float)
+                - np.asarray(func(mle - ei), dtype=float)
+            )
+            / (2.0 * step[i])
+        )
+    J = np.stack(cols, axis=-1)
+    var = np.einsum("...i,ij,...j->...", J, cov, J)
+    with np.errstate(invalid="ignore"):
+        return np.sqrt(var)
+
+
+def _bound_signs(alpha_ci, bound):
+    """
+    The one-sided tail probability and the signs of the normal quantile for
+    each requested bound: ``[-1, 1]`` (lower, upper) for two-sided bounds,
+    a single sign otherwise.
+    """
+    if bound == "two-sided":
+        return alpha_ci / 2.0, np.array([-1.0, 1.0])
+    elif bound == "lower":
+        return alpha_ci, np.array([-1.0])
+    elif bound == "upper":
+        return alpha_ci, np.array([1.0])
+    raise ValueError("`bound` must be 'two-sided', 'lower' or 'upper'")
+
+
+def log_transformed_cb(estimate, se, alpha_ci=0.05, bound="two-sided"):
+    """
+    Log-transformed normal confidence bounds ``est * exp(+/- z * se / est)``
+    for a positive curve (the same construction as the exponential Greenwood
+    bounds on the nonparametric MCF). Where the estimate is zero (e.g. a CIF
+    at ``x = 0``) both bounds are zero.
+
+    For two-sided bounds the last axis holds ``[lower, upper]``; one-sided
+    bounds are returned with the shape of ``estimate``.
+    """
+    estimate = np.asarray(estimate, dtype=float)
+    se = np.asarray(se, dtype=float)
+    alpha, signs = _bound_signs(alpha_ci, bound)
+    z = norm.ppf(1.0 - alpha)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratio = np.where(estimate > 0, se / estimate, 0.0)
+    cb = estimate[..., None] * np.exp(signs * z * ratio[..., None])
+    if bound == "two-sided":
+        return cb
+    return cb[..., 0]
 
 
 class LikelihoodInferenceMixin:
@@ -131,3 +194,71 @@ class LikelihoodInferenceMixin:
                 "be at a boundary); their standard errors are NaN."
             )
         return se
+
+    def _parameter_bounds(self):
+        """
+        Natural-space ``(lower, upper)`` bounds for each entry of ``_mle``,
+        ordered to match :attr:`parameter_names`. Subclasses override this so
+        :meth:`param_cb` can pick a transform that keeps the confidence bounds
+        inside the parameter's support; the default is unbounded.
+        """
+        return [(None, None)] * self._mle.size
+
+    def param_cb(self, name, alpha_ci=0.05, bound="two-sided"):
+        """
+        Confidence bound(s) on a fitted parameter, mirroring the univariate
+        ``Parametric.param_cb`` API.
+
+        Wald bounds from the observed information, computed on a transformed
+        scale chosen from the parameter's bounds so the result respects its
+        support: log scale for one-sided-bounded parameters (e.g. a positive
+        rate), logit scale for interval-bounded parameters (e.g. a repair
+        efficiency in ``(0, 1)``), and the natural scale for unbounded ones.
+
+        Parameters
+        ----------
+
+        name : str
+            The parameter to bound; one of :attr:`parameter_names`.
+        alpha_ci : float, optional
+            The total tail probability of the bound(s). Default is 0.05.
+        bound : {'two-sided', 'lower', 'upper'}, optional
+            Two-sided bounds are returned as ``[lower, upper]``.
+
+        Returns
+        -------
+
+        numpy array
+            The confidence bound(s) on the parameter.
+        """
+        self._check_fitted()
+        names = self.parameter_names
+        if name not in names:
+            raise ValueError(
+                "Unknown parameter {!r}; expected one of {}".format(
+                    name, names
+                )
+            )
+        idx = names.index(name)
+        p_hat = float(self._mle[idx])
+        var = float(self.covariance()[idx, idx])
+        lower, upper = self._parameter_bounds()[idx]
+
+        alpha, signs = _bound_signs(alpha_ci, bound)
+        offsets = signs * norm.ppf(1.0 - alpha) * np.sqrt(var)
+
+        if lower is not None and upper is not None:
+            # Bounds on the generalised logit keep the result in (lower,
+            # upper).
+            width = upper - lower
+            frac = (p_hat - lower) / width
+            u_hat = np.log(frac / (1.0 - frac))
+            du = offsets / (width * frac * (1.0 - frac))
+            return lower + width / (1.0 + np.exp(-(u_hat + du)))
+        elif lower is not None:
+            # Bounds on log(p - lower) keep the result above ``lower``.
+            return lower + (p_hat - lower) * np.exp(offsets / (p_hat - lower))
+        elif upper is not None:
+            # Bounds on log(upper - p) keep the result below ``upper``.
+            return upper - (upper - p_hat) * np.exp(-offsets / (upper - p_hat))
+        return p_hat + offsets

--- a/surpyval/recurrent/parametric/cox_lewis.py
+++ b/surpyval/recurrent/parametric/cox_lewis.py
@@ -71,4 +71,11 @@ class CoxLewis(NHPPFitter):
     def inv_cif(self, N, *params):
         alpha = params[0]
         beta = params[1]
-        return np.log(1.0 + N * beta * np.exp(-alpha)) / beta
+        # For an improving system (beta < 0) the cumulative intensity is
+        # bounded above by exp(alpha) / -beta, so counts at or beyond that
+        # asymptote are never reached: return inf rather than log of a
+        # non-positive number.
+        arg = 1.0 + np.asarray(N, dtype=float) * beta * np.exp(-alpha)
+        reached = arg > 0.0
+        safe_arg = np.where(reached, arg, 1.0)
+        return np.where(reached, np.log(safe_arg) / beta, np.inf)

--- a/surpyval/recurrent/parametric/nhpp_fitter.py
+++ b/surpyval/recurrent/parametric/nhpp_fitter.py
@@ -49,9 +49,9 @@ class NHPPFitter(IntensityModel):
         n_i = n[c == 2] if has_interval_censoring else np.array([])
 
         # Right window-close: for items with a finite right-truncation time
-        # ``tr`` the intensity is integrated out to ``tr`` rather than merely to
-        # the last observed event / censoring row. These arrays are empty for
-        # untruncated data, so the term adds nothing in that case.
+        # ``tr`` the intensity is integrated out to ``tr`` rather than
+        # merely to the last observed event / censoring row. These arrays are
+        # empty for untruncated data, so the term adds nothing in that case.
         x_close_last, x_close_tr, _ = data.get_right_truncation_close()
 
         # Using the empty arrays avoids the need for if statements in the
@@ -95,8 +95,7 @@ class NHPPFitter(IntensityModel):
             # right-truncation time tr (zero when tr is infinite or already
             # coincides with a right-censoring row)
             ll += (
-                self.cif(x_close_last, *params)
-                - self.cif(x_close_tr, *params)
+                self.cif(x_close_last, *params) - self.cif(x_close_tr, *params)
             ).sum()
 
             return -ll

--- a/surpyval/recurrent/parametric/parametric_recurrence.py
+++ b/surpyval/recurrent/parametric/parametric_recurrence.py
@@ -1,7 +1,11 @@
 import numpy as np
 from matplotlib import pyplot as plt
 
-from surpyval.recurrent.inference import LikelihoodInferenceMixin
+from surpyval.recurrent.inference import (
+    LikelihoodInferenceMixin,
+    delta_method_std_errors,
+    log_transformed_cb,
+)
 from surpyval.recurrent.simulation import RecurrenceSimulationMixin
 
 
@@ -32,6 +36,9 @@ class ParametricRecurrenceModel(
 
     def _parameter_names(self):
         return list(self.dist.param_names)
+
+    def _parameter_bounds(self):
+        return list(self.dist.bounds)
 
     def __repr__(self):
         param_string = "\n".join(
@@ -136,10 +143,48 @@ class ParametricRecurrenceModel(
                 "Inverse cif undefined for {}".format(self.dist.name)
             )
 
-    def plot(self, ax=None):
+    def cif_cb(self, x, alpha_ci=0.05, bound="two-sided"):
         """
-        Compute the inverse of the cumulative incidence function (CIF) based
-        on the fitted model, if it's defined for the distribution.
+        Confidence bounds on the fitted CIF at ``x``, from the delta method.
+
+        The variance of the fitted CIF is propagated from the parameter
+        covariance (the inverse observed information) through the CIF's
+        gradient, and the bounds are computed on the log scale -- the same
+        construction as the exponential Greenwood bounds on the nonparametric
+        MCF -- so they cannot go negative.
+
+        Parameters
+        ----------
+
+        x: array_like
+            Values at which to compute the confidence bounds.
+        alpha_ci: float, optional
+            The total tail probability of the bound(s). Default is 0.05.
+        bound: {'two-sided', 'lower', 'upper'}, optional
+            Two-sided bounds are returned as an ``(len(x), 2)`` array with
+            columns ``[lower, upper]``; one-sided bounds have the shape of
+            ``x``.
+
+        Returns
+        -------
+
+        numpy array
+            The confidence bounds on the CIF.
+        """
+        self._check_fitted()
+        x = np.atleast_1d(np.asarray(x, dtype=float))
+        se = delta_method_std_errors(
+            lambda params: self.dist.cif(x, *params),
+            self._mle,
+            self.covariance(),
+        )
+        return log_transformed_cb(self.cif(x), se, alpha_ci, bound)
+
+    def plot(self, ax=None, plot_bounds=True, confidence=0.95):
+        """
+        Plot the fitted CIF over the nonparametric MCF of the data used to
+        fit it, with a delta-method confidence band around the fitted curve
+        when the model carries a likelihood.
 
         Parameters
         ----------
@@ -147,6 +192,12 @@ class ParametricRecurrenceModel(
         ax: matplotlib axes, optional
             An axes object to draw the plot on. Creates a new one if not
             provided.
+        plot_bounds: bool, optional
+            Whether to draw the confidence band around the fitted CIF.
+            Ignored for models with no likelihood (``how="MSE"`` fits and
+            ``from_params`` models). Default is True.
+        confidence: float, optional
+            The confidence level of the band. Default is 0.95.
 
         Returns
         -------
@@ -162,4 +213,14 @@ class ParametricRecurrenceModel(
 
         ax.step(x, (d / r).cumsum(), color="r", where="post")
         ax.plot(x_plot, self.cif(x_plot), color="b")
+        if plot_bounds and hasattr(self, "_neg_ll"):
+            cb = self.cif_cb(x_plot, alpha_ci=1.0 - confidence)
+            ax.fill_between(
+                x_plot,
+                cb[:, 0],
+                cb[:, 1],
+                color="b",
+                alpha=0.2,
+                label=f"{confidence * 100}% Confidence Band",
+            )
         return ax

--- a/surpyval/recurrent/parametric/parametric_recurrence.py
+++ b/surpyval/recurrent/parametric/parametric_recurrence.py
@@ -1,12 +1,14 @@
 import numpy as np
 from matplotlib import pyplot as plt
 
+from surpyval.recurrent import diagnostics
 from surpyval.recurrent.inference import (
     LikelihoodInferenceMixin,
     delta_method_std_errors,
     log_transformed_cb,
 )
 from surpyval.recurrent.simulation import RecurrenceSimulationMixin
+from surpyval.recurrent.tests import laplace, mil_hdbk_189c
 
 
 class ParametricRecurrenceModel(
@@ -142,6 +144,141 @@ class ParametricRecurrenceModel(
             raise ValueError(
                 "Inverse cif undefined for {}".format(self.dist.name)
             )
+
+    def _check_has_data(self, what):
+        if not hasattr(self, "data"):
+            raise ValueError(
+                "{} requires a model fitted from data; fit_from_parameters "
+                "models carry no data.".format(what)
+            )
+
+    def residuals(self, kind="cumulative_hazard"):
+        """
+        Residual diagnostics for the fitted model, from the time-rescaling
+        theorem.
+
+        Parameters
+        ----------
+
+        kind: {'cumulative_hazard', 'pit', 'martingale'}, optional
+            ``'cumulative_hazard'`` returns the rescaled interarrival times
+            ``cif(t_k) - cif(t_{k-1})`` of every observed event (pooled
+            across items), which are iid Exp(1) under the fitted model.
+            ``'pit'`` applies the probability integral transform
+            ``1 - exp(-e)`` to those residuals, giving iid U(0, 1) values.
+            ``'martingale'`` returns one residual per (sorted-unique) item:
+            its observed event count minus the count the model expects over
+            its observation window; positive values mean the item saw more
+            events than predicted.
+
+        Returns
+        -------
+
+        numpy array
+            The residuals.
+        """
+        self._check_has_data("residuals")
+        if kind in ("cumulative_hazard", "pit"):
+            e = diagnostics.cumulative_hazard_residuals(self.data, self.cif)
+            if kind == "pit":
+                return 1.0 - np.exp(-e)
+            return e
+        elif kind == "martingale":
+            return diagnostics.martingale_residuals(self.data, self.cif)
+        raise ValueError(
+            "`kind` must be 'cumulative_hazard', 'pit' or 'martingale'; "
+            "got {!r}".format(kind)
+        )
+
+    def trend_test(self, test="laplace", alternative="two-sided"):
+        """
+        Run a trend test on the data this model was fitted to.
+
+        This is a convenience wrapper around the standalone tests in
+        ``surpyval.recurrent.tests`` -- the null hypothesis is that the
+        events follow a *homogeneous* Poisson process (no trend), so it
+        checks whether the data warranted a time-varying intensity at all.
+        The model's parameters play no part in the statistic.
+
+        Parameters
+        ----------
+
+        test: {'laplace', 'mil_hdbk_189c'}, optional
+            The trend test to run. Default is 'laplace'.
+        alternative: {'two-sided', 'increasing', 'decreasing'}, optional
+            The alternative hypothesis. Default is 'two-sided'.
+
+        Returns
+        -------
+
+        TrendTestResult
+            The test result, carrying the statistic, p-value and suggested
+            trend direction.
+        """
+        self._check_has_data("trend_test")
+        data = self.data
+        diagnostics._validate_diagnostic_data(data, "trend_test")
+        tests = {"laplace": laplace, "mil_hdbk_189c": mil_hdbk_189c}
+        if test not in tests:
+            raise ValueError(
+                "`test` must be one of {}; got {!r}".format(
+                    sorted(tests), test
+                )
+            )
+
+        # The trend tests assume every system is observed from time 0.
+        x, i, T = [], [], {}
+        for item_id, (events, entry, close, explicit_close) in enumerate(
+            diagnostics._per_item_windows(data)
+        ):
+            if entry != 0.0:
+                raise ValueError(
+                    "trend tests assume observation from time 0; this data "
+                    "has delayed entry (left truncation)."
+                )
+            if not explicit_close:
+                # Failure-truncated: the last event is the truncation point,
+                # exactly as the standalone tests treat T=None data.
+                events = events[:-1]
+            x.extend(events)
+            i.extend([item_id] * events.size)
+            T[item_id] = close
+        return tests[test](x, i=i, T=T, alternative=alternative)
+
+    def cramer_von_mises(self, n_boot=200, seed=None):
+        """
+        Cramer-von Mises goodness-of-fit test of the fitted intensity.
+
+        Conditional on the number of events an item shows in its
+        observation window, the transformed times ``[cif(t) - cif(entry)] /
+        [cif(close) - cif(entry)]`` are iid U(0, 1) when the fitted
+        intensity is the true one; the Cramer-von Mises statistic measures
+        their departure from uniformity (for the power-law process this is
+        the construction behind Crow's goodness-of-fit test). Because the
+        parameters were estimated from the same data, the p-value is
+        computed by a parametric bootstrap: data is simulated from the
+        fitted model over the same observation windows, refitted, and the
+        statistic recomputed. Failure-truncated items (no explicit window
+        close) are approximated in the bootstrap by a window fixed at their
+        last observed event.
+
+        Parameters
+        ----------
+
+        n_boot: int, optional
+            Number of bootstrap replicates for the p-value. Default is 200.
+        seed: int or numpy.random.Generator, optional
+            Seed for a reproducible p-value.
+
+        Returns
+        -------
+
+        GoodnessOfFitResult
+            The observed statistic and its bootstrap p-value.
+        """
+        self._check_fitted()
+        self._check_has_data("cramer_von_mises")
+        return diagnostics.cramer_von_mises(self, n_boot=n_boot, seed=seed)
 
     def cif_cb(self, x, alpha_ci=0.05, bound="two-sided"):
         """

--- a/surpyval/recurrent/regression/hpp_proportional_intensity.py
+++ b/surpyval/recurrent/regression/hpp_proportional_intensity.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 import numpy as np
 from scipy.optimize import minimize
 from scipy.special import gammaln
@@ -56,14 +54,18 @@ class ProportionalIntensityHPP:
     <BLANKLINE>
     """
 
+    # Display name of the (constant) baseline hazard rate model, used by
+    # ``ProportionalIntensityModel``'s repr via ``dist.name``.
+    name = "Constant"
+
     def iif(self, x, rate):
-        return np.ones_like(x) * rate
+        return np.ones_like(np.asarray(x, dtype=float)) * rate
 
     def cif(self, x, rate):
-        return rate * x
+        return rate * np.asarray(x, dtype=float)
 
     def inv_cif(self, cif, rate):
-        return cif / rate
+        return np.asarray(cif, dtype=float) / rate
 
     def create_negll_func(self, data):
         x, c, n = data.x, data.c, data.n
@@ -277,9 +279,9 @@ class ProportionalIntensityHPP:
         out._neg_ll = lambda p: neg_ll(np.concatenate([[np.log(p[0])], p[1:]]))
         out._mle = np.concatenate([out.params, out.coeffs])
         out._n_obs = len(data.x)
-        # The baseline rate is constant, so there is no fitted intensity
-        # distribution; expose a lightweight stand-in carrying just the name
-        # used by ``ProportionalIntensityModel``'s repr.
-        out.dist = SimpleNamespace(name="Constant")
+        # The baseline hazard is this fitter's own constant-rate model, so the
+        # fitted model's ``cif``/``iif``/``inv_cif`` (and everything built on
+        # them: simulation, ``cif_cb``, ``plot``) delegate back to it.
+        out.dist = self
 
         return out

--- a/surpyval/recurrent/regression/nhpp_proportional_intensity.py
+++ b/surpyval/recurrent/regression/nhpp_proportional_intensity.py
@@ -129,9 +129,7 @@ class ProportionalIntensityNHPP:
         # Right window-close: for items with a finite right-truncation time
         # ``tr`` the baseline intensity is integrated out to ``tr`` (scaled by
         # the item's proportional factor). Empty for untruncated data.
-        x_close_last, x_close_tr, close_idx = (
-            data.get_right_truncation_close()
-        )
+        x_close_last, x_close_tr, close_idx = data.get_right_truncation_close()
         Z_close = Z[close_idx]
 
         # Using the empty arrays avoids the need for if statements in the
@@ -147,7 +145,6 @@ class ProportionalIntensityNHPP:
             delta_cif_o = dist.cif(x_o_prev, *dist_params) - dist.cif(
                 x_o, *dist_params
             )
-            # TODO: Implement log_iif functions
             ll = (
                 dist.log_iif(x_o, *dist_params)
                 + phi_exponents_observed

--- a/surpyval/recurrent/regression/proportional_intensity.py
+++ b/surpyval/recurrent/regression/proportional_intensity.py
@@ -1,7 +1,11 @@
 import numpy as np
 from matplotlib import pyplot as plt
 
-from surpyval.recurrent.inference import LikelihoodInferenceMixin
+from surpyval.recurrent.inference import (
+    LikelihoodInferenceMixin,
+    delta_method_std_errors,
+    log_transformed_cb,
+)
 from surpyval.recurrent.simulation import RecurrenceSimulationMixin
 
 
@@ -98,14 +102,58 @@ class ProportionalIntensityModel(
                 "Inverse cif undefined for {}".format(self.dist.name)
             )
 
-    def plot(self, ax=None):
+    def cif_cb(self, x, Z, alpha_ci=0.05, bound="two-sided"):
+        """
+        Confidence bounds on the fitted CIF at ``x`` for covariates ``Z``,
+        from the delta method.
+
+        The variance of the fitted CIF is propagated from the joint
+        covariance of the base-rate parameters and covariate coefficients
+        (the inverse observed information) through the CIF's gradient, and
+        the bounds are computed on the log scale so they cannot go negative.
+
+        Parameters
+        ----------
+
+        x : array_like
+            Values at which to compute the confidence bounds.
+        Z : array_like
+            The covariates for the item.
+        alpha_ci : float, optional
+            The total tail probability of the bound(s). Default is 0.05.
+        bound : {'two-sided', 'lower', 'upper'}, optional
+            Two-sided bounds are returned as an ``(len(x), 2)`` array with
+            columns ``[lower, upper]``; one-sided bounds have the shape of
+            ``x``.
+
+        Returns
+        -------
+
+        numpy array
+            The confidence bounds on the CIF.
+        """
+        self._check_fitted()
+        x = np.atleast_1d(np.asarray(x, dtype=float))
+        Z = np.asarray(Z, dtype=float)
+        n_dist_params = len(self.params)
+
+        def cif_at(theta):
+            return self.dist.cif(x, *theta[:n_dist_params]) * np.exp(
+                Z @ theta[n_dist_params:]
+            )
+
+        se = delta_method_std_errors(cif_at, self._mle, self.covariance())
+        return log_transformed_cb(self.cif(x, Z), se, alpha_ci, bound)
+
+    def plot(self, ax=None, plot_bounds=True, confidence=0.95):
         """
         PLots the CIF of the model against the data used to fit it.
 
         To do this, the plot method takes the average of the covariates, and
         uses them to calculate the CIF of the model. This is then plotted
         against the non-parametric MCF of the raw data. That is, the raw
-        MCF is created without considering the covariates.
+        MCF is created without considering the covariates. A delta-method
+        confidence band is drawn around the fitted CIF.
 
         Parameters
         ----------
@@ -113,6 +161,11 @@ class ProportionalIntensityModel(
         ax : matplotlib.axes.Axes, optional
             The axes to plot the data on. If None, the current axes will be
             used.
+        plot_bounds : bool, optional
+            Whether to draw the confidence band around the fitted CIF.
+            Default is True.
+        confidence : float, optional
+            The confidence level of the band. Default is 0.95.
 
         Returns
         -------
@@ -130,6 +183,16 @@ class ProportionalIntensityModel(
 
         ax.step(x, (d / r).cumsum(), color="r", where="post")
         ax.plot(x_plot, self.cif(x_plot, Z_0), color="b")
+        if plot_bounds and hasattr(self, "_neg_ll"):
+            cb = self.cif_cb(x_plot, Z_0, alpha_ci=1.0 - confidence)
+            ax.fill_between(
+                x_plot,
+                cb[:, 0],
+                cb[:, 1],
+                color="b",
+                alpha=0.2,
+                label=f"{confidence * 100}% Confidence Band",
+            )
         return ax
 
     def _parameter_names(self):
@@ -139,6 +202,13 @@ class ProportionalIntensityModel(
             *self.param_names,
             *["beta_{}".format(i) for i in range(len(self.coeffs))],
         ]
+
+    def _parameter_bounds(self):
+        # The base-rate bounds come from the intensity model (PI-HPP stores
+        # them on the fitted model directly; PI-NHPP's live on ``dist``); the
+        # covariate coefficients are unbounded.
+        dist_bounds = getattr(self, "bounds", None) or self.dist.bounds
+        return [*dist_bounds, *[(None, None)] * len(self.coeffs)]
 
     def _new_sequence_sampler(self):
         # The shared simulation driver requests one of these per item; the

--- a/surpyval/recurrent/renewal/ara.py
+++ b/surpyval/recurrent/renewal/ara.py
@@ -115,6 +115,7 @@ class ARA(RenewalFitMixin):
             "Repair Efficiency",
             "ARA Renewal",
             self._build_sampler,
+            restoration_bounds=(0, 1),
         )
         out.m = m
         return out

--- a/surpyval/recurrent/renewal/ari.py
+++ b/surpyval/recurrent/renewal/ari.py
@@ -115,6 +115,7 @@ class ARI(RenewalFitMixin):
             "ARI Recurrence",
             self._build_sampler,
             dist_label="Baseline Intensity",
+            restoration_bounds=(0, 1),
         )
         out.m = m
         return out

--- a/surpyval/recurrent/renewal/generalized_one_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_one_renewal.py
@@ -85,6 +85,7 @@ class GeneralizedOneRenewal(RenewalFitMixin):
             "Restoration Factor",
             "G1 Renewal",
             self._build_sampler,
+            restoration_bounds=(-1, None),
         )
 
     def create_negll_func(self, x, i, c, n, dist):

--- a/surpyval/recurrent/renewal/generalized_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_renewal.py
@@ -108,6 +108,7 @@ class GeneralizedRenewal(RenewalFitMixin):
             "Restoration Factor",
             "Generalized Renewal",
             self._build_sampler,
+            restoration_bounds=(0, None),
         )
         out.kijima_type = kijima_type
         out._virtual_age_function = self._resolve_virtual_age_function(

--- a/surpyval/recurrent/renewal/renewal_model.py
+++ b/surpyval/recurrent/renewal/renewal_model.py
@@ -37,6 +37,10 @@ class RenewalModel(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
     sampler_factory : callable
         ``sampler_factory(model) -> sample`` returning a fresh per-sequence
         sampler ``sample(ui) -> interarrival`` for simulation.
+    restoration_bounds : tuple, optional
+        Natural-space ``(lower, upper)`` bounds of the restoration parameter
+        (e.g. ``(0, 1)`` for ARA/ARI's ``rho``), used by ``param_cb`` to pick
+        a transform that keeps its confidence bounds inside the support.
     """
 
     def __init__(
@@ -48,11 +52,13 @@ class RenewalModel(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
         kind,
         sampler_factory,
         dist_label="Distribution",
+        restoration_bounds=(None, None),
     ):
         self.model = model
         self.restoration = restoration
         self._restoration_param_name = restoration_name
         self._restoration_label = restoration_label
+        self._restoration_bounds = restoration_bounds
         self._dist_label = dist_label
         self.kind = kind
         self._sampler_factory = sampler_factory
@@ -67,6 +73,9 @@ class RenewalModel(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
         # The restoration parameter (``q``/``rho``) leads ``_mle``, followed by
         # the underlying lifetime/intensity model's parameters.
         return [self._restoration_param_name, *self.model.dist.param_names]
+
+    def _parameter_bounds(self):
+        return [self._restoration_bounds, *self.model.dist.bounds]
 
     def __repr__(self):
         title = f"{self.kind} SurPyval Model"

--- a/surpyval/tests/multivariate/test_copula_censoring.py
+++ b/surpyval/tests/multivariate/test_copula_censoring.py
@@ -32,7 +32,7 @@ def test_interval_censoring_matches_brute_force_integral():
     gy = np.linspace(a2, b2, 400)
     GX, GY = np.meshgrid(gx, gy)
     pdf = m.pdf(np.column_stack([GX.ravel(), GY.ravel()])).reshape(GX.shape)
-    integral = np.trapz(np.trapz(pdf, gy, axis=0), gx)
+    integral = np.trapezoid(np.trapezoid(pdf, gy, axis=0), gx)
 
     assert np.isclose(L, integral, rtol=1e-3)
 

--- a/surpyval/tests/recurrent/test_cox_lewis.py
+++ b/surpyval/tests/recurrent/test_cox_lewis.py
@@ -37,6 +37,35 @@ def test_inv_cif_inverts_cif(alpha, beta):
     assert np.allclose(CoxLewis.cif(x, alpha, beta), N)
 
 
+def test_inv_cif_beyond_asymptote_is_inf():
+    # For an improving system (beta < 0) the cumulative intensity is bounded
+    # above by exp(alpha) / -beta; counts at or beyond that asymptote are
+    # never reached, so their inverse must be inf -- not NaN or a negative
+    # time.
+    alpha, beta = 0.0, -0.5
+    asymptote = np.exp(alpha) / -beta  # = 2 expected events, ever
+    N = np.array([1.0, asymptote, asymptote + 1.0])
+    x = CoxLewis.inv_cif(N, alpha, beta)
+    assert np.isfinite(x[0]) and x[0] > 0
+    assert np.isinf(x[1]) and np.isinf(x[2])
+    assert not np.isnan(x).any()
+
+
+def test_time_terminated_simulation_with_improving_system():
+    # An improving system generates finitely many events; simulation must
+    # right-censor each sequence at T with valid (finite, non-NaN) event
+    # times instead of spinning out NaNs.
+    model = CoxLewis.fit(np.array([0.5, 1.0, 2.0, 4.0]), tl=0, tr=10)
+    model.params = np.array([0.0, -0.5])
+    data = model.time_terminated_simulation_data(T=100.0, items=5, seed=1)
+    assert np.isfinite(data.x).all()
+    assert (data.x >= 0).all()
+    assert (data.x <= 100.0).all()
+    # every sequence ends right-censored at the window close
+    for item in np.unique(data.i):
+        assert data.c[data.i == item][-1] == 1
+
+
 def test_fit_recovers_log_linear_intensity():
     # Events simulated from a known log-linear intensity should recover the
     # generating parameters (alpha, beta) via the intensity, not an offset

--- a/surpyval/tests/recurrent/test_diagnostics.py
+++ b/surpyval/tests/recurrent/test_diagnostics.py
@@ -1,0 +1,177 @@
+"""Residual diagnostics, trend-test delegation and the Cramer-von Mises
+goodness-of-fit test on fitted parametric recurrent models."""
+
+import numpy as np
+import pytest
+
+from surpyval import Exponential
+from surpyval.recurrent import HPP, CoxLewis, CrowAMSAA, laplace, mil_hdbk_189c
+from surpyval.recurrent.diagnostics import cvm_statistic
+
+
+def _events():
+    np.random.seed(1)
+    return Exponential.random(40, 1e-2).cumsum()
+
+
+def _multi_item_data():
+    # Item 1 closes with an explicit censoring row; items 2 and 3 are
+    # failure-truncated (observed to their last event).
+    x = [5, 9, 13, 16, 18, 20, 6, 10, 13, 15, 17, 12, 15, 19]
+    i = [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3]
+    c = [0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
+    return x, i, c
+
+
+def test_hpp_cumulative_hazard_residuals_are_rescaled_gaps():
+    # For an HPP the time-rescaling transform is linear, so the residuals
+    # are exactly lambda times the interarrival gaps.
+    x = _events()
+    model = HPP.fit(x)
+    gaps = np.diff(np.concatenate([[0.0], x]))
+    assert np.allclose(model.residuals(), model.params[0] * gaps)
+
+
+def test_pit_residuals_transform_of_cumulative_hazard():
+    model = HPP.fit(_events())
+    e = model.residuals()
+    pit = model.residuals(kind="pit")
+    assert np.allclose(pit, 1.0 - np.exp(-e))
+    assert np.all((pit >= 0) & (pit <= 1))
+
+
+def test_martingale_residuals_sum_to_zero_at_hpp_mle():
+    # The HPP MLE is total events / total exposure, which forces the summed
+    # observed-minus-expected counts to zero exactly.
+    x, i, c = _multi_item_data()
+    model = HPP.fit(x, i=i, c=c)
+    mart = model.residuals(kind="martingale")
+    assert mart.shape == (3,)
+    assert np.isclose(mart.sum(), 0.0, atol=1e-8)
+
+
+def test_residuals_with_delayed_entry():
+    # With left truncation the first interval starts at the entry time, so
+    # residuals use cif differences from tl, not from 0.
+    model = CrowAMSAA.fit([12, 15, 19, 21], i=[1] * 4, c=[0, 0, 0, 1], tl=10.0)
+    e = model.residuals()
+    x = np.array([12.0, 15.0, 19.0])
+    expected = np.diff(model.cif(np.concatenate([[10.0], x])))
+    assert np.allclose(e, expected)
+
+
+def test_residuals_validation():
+    model = HPP.fit(_events())
+    with pytest.raises(ValueError, match="kind"):
+        model.residuals(kind="nope")
+    no_data = CrowAMSAA.from_params([1000.0, 1.2])
+    with pytest.raises(ValueError, match="fitted from data"):
+        no_data.residuals()
+    interval = CrowAMSAA.fit(
+        [[0, 5], [5, 10], [10, 15]], c=[2, 2, 2], n=[3, 2, 2]
+    )
+    with pytest.raises(ValueError, match="exact event times"):
+        interval.residuals()
+
+
+def test_trend_test_matches_standalone_failure_truncated():
+    # A failure-truncated single system: the model method must reproduce
+    # the standalone test's statistic exactly.
+    x = _events()
+    model = HPP.fit(x)
+    for name, func in (("laplace", laplace), ("mil_hdbk_189c", mil_hdbk_189c)):
+        res = model.trend_test(test=name)
+        direct = func(x)
+        assert np.isclose(res.statistic, direct.statistic)
+        assert res.p_value == direct.p_value
+
+
+def test_trend_test_matches_standalone_mixed_windows():
+    # Mixed truncation: item 1 is time-truncated at its censoring row while
+    # items 2 and 3 are failure-truncated. The model method must agree with
+    # a hand-built standalone call using the same windows.
+    x, i, c = _multi_item_data()
+    model = CrowAMSAA.fit(x, i=i, c=c)
+    res = model.trend_test()
+    direct = laplace(
+        [5, 9, 13, 16, 18, 6, 10, 13, 15, 12, 15],
+        i=[1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3],
+        T={1: 20.0, 2: 17.0, 3: 19.0},
+    )
+    assert np.isclose(res.statistic, direct.statistic)
+    assert res.n_events == direct.n_events
+    assert res.n_systems == direct.n_systems
+
+
+def test_trend_test_validation():
+    model = HPP.fit(_events())
+    with pytest.raises(ValueError, match="`test` must be"):
+        model.trend_test(test="nope")
+    truncated = CrowAMSAA.fit(
+        [12, 15, 19, 21], i=[1] * 4, c=[0, 0, 0, 1], tl=10.0
+    )
+    with pytest.raises(ValueError, match="observation from time 0"):
+        truncated.trend_test()
+
+
+def test_cvm_statistic_minimum_at_uniform_quantiles():
+    # The statistic attains its floor 1/(12M) when the sample sits exactly
+    # on the uniform plotting positions.
+    m = 10
+    u = (2 * np.arange(1, m + 1) - 1) / (2 * m)
+    assert np.isclose(cvm_statistic(u), 1.0 / (12 * m))
+    # Any other sample is strictly larger.
+    assert cvm_statistic(np.linspace(0.8, 0.99, m)) > 1.0 / (12 * m)
+
+
+def test_cramer_von_mises_reproducible_and_calibrated():
+    # A correctly-specified HPP should not be rejected, and the same seed
+    # must reproduce the same p-value.
+    model = HPP.fit(_events())
+    gof = model.cramer_von_mises(n_boot=50, seed=1)
+    gof2 = model.cramer_von_mises(n_boot=50, seed=1)
+    assert gof.p_value == gof2.p_value
+    assert 0 < gof.p_value <= 1
+    assert gof.p_value > 0.05
+    assert gof.n_boot == 50
+    assert gof.n_systems == 1
+    assert "p-value" in repr(gof)
+
+
+def test_cramer_von_mises_rejects_misspecified_model():
+    # Events from a strongly increasing intensity, fitted with a constant
+    # one: the test must reject at its bootstrap resolution floor.
+    t = np.linspace(1, 40, 40)
+    x = (t / 40) ** (1.0 / 3.0) * 4000.0
+    model = HPP.fit(x)
+    gof = model.cramer_von_mises(n_boot=50, seed=1)
+    assert gof.p_value <= 0.02
+
+
+def test_cramer_von_mises_multi_item_and_cox_lewis():
+    x, i, c = _multi_item_data()
+    model = CrowAMSAA.fit(x, i=i, c=c)
+    gof = model.cramer_von_mises(n_boot=30, seed=0)
+    # Failure-truncated items drop their final event from the statistic.
+    assert gof.n_events == 11
+    assert gof.n_systems == 3
+    assert 0 < gof.p_value <= 1
+
+    rng = np.random.default_rng(0)
+    T = 20.0
+    lam_max = np.exp(0.3 * T)
+    cand = np.sort(rng.uniform(0, T, rng.poisson(lam_max * T)))
+    keep = rng.uniform(0, 1, cand.size) < np.exp(0.3 * cand) / lam_max
+    cox = CoxLewis.fit(cand[keep], tl=0.0, tr=T)
+    gof = cox.cramer_von_mises(n_boot=30, seed=1)
+    assert gof.p_value > 0.05
+
+
+def test_cramer_von_mises_requires_likelihood_fit():
+    x = _events()
+    mse = CrowAMSAA.fit(x, how="MSE")
+    with pytest.raises(ValueError, match="fitted from data"):
+        mse.cramer_von_mises()
+    no_data = CrowAMSAA.from_params([1000.0, 1.2])
+    with pytest.raises(ValueError, match="fitted from data"):
+        no_data.cramer_von_mises()

--- a/surpyval/tests/recurrent/test_parametric_inference.py
+++ b/surpyval/tests/recurrent/test_parametric_inference.py
@@ -1,16 +1,23 @@
-"""Likelihood inference (AIC/BIC/SE) for the parametric and regression
-recurrent models -- the behaviour added when these fitters started setting
-``_neg_ll``/``_mle``/``_n_obs`` and inheriting ``LikelihoodInferenceMixin``."""
+"""Likelihood inference (AIC/BIC/SE/confidence bounds) for the parametric,
+regression and renewal recurrent models -- the behaviour provided by
+``LikelihoodInferenceMixin`` from ``_neg_ll``/``_mle``/``_n_obs``."""
 
+import matplotlib
 import numpy as np
 import pytest
+from scipy.stats import norm
 
-from surpyval import Exponential
-from surpyval.recurrent import (
+matplotlib.use("Agg")
+
+from matplotlib import pyplot as plt  # noqa: E402
+
+from surpyval import Exponential, Weibull  # noqa: E402
+from surpyval.recurrent import (  # noqa: E402
     HPP,
     CoxLewis,
     CrowAMSAA,
     Duane,
+    GeneralizedRenewal,
     ProportionalIntensityHPP,
     ProportionalIntensityNHPP,
 )
@@ -111,3 +118,164 @@ def test_hpp_regression_information_criteria():
     assert model.parameter_names == ["lambda", "beta_0"]
     assert np.isfinite(model.aic) and np.isfinite(model.bic)
     assert np.all(np.isfinite(model.standard_errors()))
+
+
+def test_hpp_param_cb_matches_analytic():
+    # For an HPP with n events observed to the last event, the observed
+    # information gives se = lambda / sqrt(n), so the log-Wald bounds are
+    # exactly lambda * exp(+/- z / sqrt(n)).
+    x = _intensity_events()
+    model = HPP.fit(x)
+    lam, n = model.params[0], len(x)
+    z = norm.ppf(0.975)
+    expected = lam * np.exp(np.array([-1.0, 1.0]) * z / np.sqrt(n))
+    assert np.allclose(model.param_cb("lambda"), expected, rtol=1e-4)
+
+
+@pytest.mark.parametrize("dist", [HPP, CrowAMSAA, Duane])
+def test_param_cb_brackets_mle_and_respects_support(dist):
+    x = _intensity_events()
+    model = dist.fit(x)
+    for name, (lo, hi), p_hat in zip(
+        model.parameter_names, model._parameter_bounds(), model._mle
+    ):
+        lower, upper = model.param_cb(name)
+        assert lower < p_hat < upper
+        if lo is not None:
+            assert lower > lo
+        if hi is not None:
+            assert upper < hi
+        # One-sided bounds are single values on the matching side of the MLE,
+        # and less extreme than the two-sided ones at the same alpha_ci.
+        (lower_1s,) = model.param_cb(name, bound="lower")
+        (upper_1s,) = model.param_cb(name, bound="upper")
+        assert lower < lower_1s < p_hat < upper_1s < upper
+
+
+def test_param_cb_unknown_name_raises():
+    model = CrowAMSAA.fit(_intensity_events())
+    with pytest.raises(ValueError, match="Unknown parameter"):
+        model.param_cb("nope")
+
+
+def test_param_cb_requires_likelihood():
+    model = CrowAMSAA.from_params([1000.0, 1.2])
+    with pytest.raises(ValueError, match="fitted from data"):
+        model.param_cb("alpha")
+
+
+def test_hpp_cif_cb_matches_analytic():
+    # cif = lambda * x, so the delta-method se is x * se(lambda) and the
+    # log-transformed band is cif * exp(+/- z * se(lambda) / lambda) -- the
+    # relative width is constant in x.
+    x = _intensity_events()
+    model = HPP.fit(x)
+    lam, n = model.params[0], len(x)
+    z = norm.ppf(0.975)
+    t = np.array([100.0, 500.0])
+    expected = (lam * t)[:, None] * np.exp(
+        np.array([-1.0, 1.0]) * z / np.sqrt(n)
+    )
+    assert np.allclose(model.cif_cb(t), expected, rtol=1e-4)
+
+
+@pytest.mark.parametrize("dist", [HPP, CrowAMSAA, Duane])
+def test_cif_cb_brackets_cif(dist):
+    x = _intensity_events()
+    model = dist.fit(x)
+    t = np.linspace(0.0, x.max(), 25)
+    cb = model.cif_cb(t)
+    cif = model.cif(t)
+    assert cb.shape == (t.size, 2)
+    # The band starts as a point at the origin (cif(0) == 0) and brackets
+    # the fitted curve everywhere else.
+    assert np.all(cb[0] == 0.0)
+    assert np.all(cb[1:, 0] < cif[1:])
+    assert np.all(cb[1:, 1] > cif[1:])
+    assert np.all(cb >= 0.0)
+    # One-sided bounds match the corresponding side's shape.
+    assert model.cif_cb(t, bound="lower").shape == t.shape
+    assert model.cif_cb(t, bound="upper").shape == t.shape
+
+
+def test_cif_cb_requires_likelihood():
+    model = CrowAMSAA.fit(_intensity_events(), how="MSE")
+    with pytest.raises(ValueError, match="fitted from data"):
+        model.cif_cb([1.0, 2.0])
+
+
+def test_plot_confidence_band():
+    model = CrowAMSAA.fit(_intensity_events())
+    # The band is drawn as a fill_between collection for MLE fits...
+    ax = model.plot()
+    assert len(ax.collections) == 1
+    plt.close("all")
+    # ...can be turned off...
+    ax = model.plot(plot_bounds=False)
+    assert len(ax.collections) == 0
+    plt.close("all")
+    # ...and is skipped (not an error) for MSE fits with no likelihood.
+    mse_model = CrowAMSAA.fit(_intensity_events(), how="MSE")
+    ax = mse_model.plot()
+    assert len(ax.collections) == 0
+    plt.close("all")
+
+
+def test_regression_param_cb():
+    x, i, c, Z = _regression_data()
+    model = ProportionalIntensityNHPP.fit(x, Z, i=i, c=c, dist=CrowAMSAA)
+    # Positive base-rate parameter: log-Wald bounds stay positive.
+    lower, upper = model.param_cb("alpha")
+    assert 0 < lower < model.params[0] < upper
+    # Unbounded coefficient: plain Wald bounds are symmetric about the MLE.
+    cb = model.param_cb("beta_0")
+    assert np.isclose(cb.mean(), model.coeffs[0])
+    assert cb[0] < model.coeffs[0] < cb[1]
+
+
+def test_regression_cif_cb_brackets_cif():
+    x, i, c, Z = _regression_data()
+    Z_0 = np.array([0.5])
+    t = np.array([5.0, 10.0, 20.0])
+    for model in (
+        ProportionalIntensityHPP.fit(x, Z, i=i, c=c),
+        ProportionalIntensityNHPP.fit(x, Z, i=i, c=c, dist=CrowAMSAA),
+    ):
+        cb = model.cif_cb(t, Z_0)
+        cif = model.cif(t, Z_0)
+        assert cb.shape == (t.size, 2)
+        assert np.all(cb[:, 0] < cif) and np.all(cif < cb[:, 1])
+        assert np.all(cb > 0)
+        ax = model.plot()
+        assert len(ax.collections) == 1
+        plt.close("all")
+
+
+def test_pi_hpp_model_functions_delegate_to_constant_baseline():
+    # The PI-HPP fitted model's dist used to be a bare namespace with only a
+    # name, so cif/iif/inv_cif (and anything built on them) raised.
+    x, i, c, Z = _regression_data()
+    model = ProportionalIntensityHPP.fit(x, Z, i=i, c=c)
+    Z_0 = np.array([0.5])
+    lam = model.params[0]
+    phi = np.exp(model.coeffs @ Z_0)
+    assert np.allclose(
+        model.cif([2.0, 4.0], Z_0), lam * phi * np.array([2.0, 4.0])
+    )
+    assert np.allclose(model.iif([2.0, 4.0], Z_0), lam * phi)
+    assert np.allclose(model.inv_cif(model.cif([3.0], Z_0), Z_0), [3.0])
+    assert model.dist.name == "Constant"
+
+
+def test_renewal_param_cb():
+    # The renewal models share the same mixin; the restoration parameter's
+    # bounds flow through so its confidence bounds respect the support.
+    true = GeneralizedRenewal.fit_from_parameters([10, 2.5], 0.3, dist=Weibull)
+    data = true.count_terminated_simulation_data(10, items=6, seed=3)
+    model = GeneralizedRenewal.fit_from_recurrent_data(data)
+    assert model.parameter_names == ["q", "alpha", "beta"]
+    assert model._parameter_bounds() == [(0, None), (0, None), (0, None)]
+    lower, upper = model.param_cb("q")
+    assert 0 < lower < model.q < upper
+    lower, upper = model.param_cb("alpha")
+    assert 0 < lower < model.model.params[0] < upper

--- a/surpyval/tests/recurrent/test_truncation.py
+++ b/surpyval/tests/recurrent/test_truncation.py
@@ -4,9 +4,9 @@ import pytest
 from surpyval.recurrent import (
     ARA,
     ARI,
+    HPP,
     CrowAMSAA,
     GeneralizedRenewal,
-    HPP,
     ProportionalIntensityHPP,
     ProportionalIntensityNHPP,
 )

--- a/surpyval/univariate/regression/accelerated_life/general_log_linear.py
+++ b/surpyval/univariate/regression/accelerated_life/general_log_linear.py
@@ -16,8 +16,7 @@ class GeneralLogLinear_(LifeModel):
         return np.exp(np.dot(Z, np.array(params)))
 
     def phi_init(self, life: float, Z: ndarray) -> list[float]:
-        # return np.zeros(Z.shape[1])
-        return 1.0 / Z.mean(axis=0)
+        return (1.0 / Z.mean(axis=0)).tolist()
 
 
 GeneralLogLinear = GeneralLogLinear_()


### PR DESCRIPTION
Works through the remaining DEVELOPMENT.md section 2 high-priority items, verifying each claimed gap against the code first (several were already fixed and are cleared from the doc).

## 1. Bug verification and CoxLewis fix (`8f77322`)

The three "confirmed bugs" in DEVELOPMENT.md §2 were already fixed (`has_left_censoring` typo, `log_iif` implementations, the `inv_cif` CIF inversion). One residual edge remained: for an improving system (β < 0) the Cox-Lewis CIF is bounded at `exp(α)/(−β)`, and inverting a count beyond that asymptote took `log` of a non-positive number — NaN interarrival times that the time-terminated simulation loop could never exit on. `inv_cif` now returns `inf` for unreachable counts so simulation right-censors cleanly at `T`. Also fixes a pre-existing `np.trapz` → `np.trapezoid` failure on NumPy 2.x and an E501 lint break.

## 2. Parameter and CIF confidence bounds (`1aec42a`)

`standard_errors()`/`covariance()`/AIC/BIC already existed via `LikelihoodInferenceMixin`; this adds what was missing:

- **`param_cb(name, alpha_ci, bound)`** on the shared mixin — Wald bounds on a transformed scale respecting each parameter's support (log for positive parameters, generalised logit for interval-bounded ones like ARA/ARI's `rho`), mirroring the univariate `Parametric.param_cb` API. Restoration-parameter bounds flow through `RenewalModel` from each fitter.
- **`cif_cb()`** on `ParametricRecurrenceModel` and `ProportionalIntensityModel` — delta-method bounds on the fitted CIF, computed on the log scale (exponential-Greenwood construction) so the band stays positive. Both `plot()` methods draw the band; skipped for MSE/`from_params` models.
- **Bug fix found on the way:** the PI-HPP fitted model's `dist` was a bare `SimpleNamespace`, so `cif`/`iif`/`inv_cif`/simulation/`plot` all raised `AttributeError`. The fitter's own constant-rate functions now back the fitted model.

## 3. Model validation diagnostics (`49a7a32`)

New `surpyval/recurrent/diagnostics.py`, built on the time-rescaling theorem, exposed on `ParametricRecurrenceModel`:

- **`residuals(kind=...)`** — `'cumulative_hazard'` (rescaled interarrival times, iid Exp(1) under the model, delayed entry handled), `'pit'` (iid U(0,1)), `'martingale'` (per-item observed − expected counts).
- **`trend_test(test, alternative)`** — runs the standalone Laplace / MIL-HDBK-189C tests directly on the fitted data, resolving each item's window from `tr`, its censoring row, or its last event.
- **`cramer_von_mises(n_boot, seed)`** — GOF test of the fitted intensity via the conditional-uniform transform (Crow's construction generalised to any fitted intensity, `M = N − 1` for failure-truncated items), with a parametric-bootstrap p-value that accounts for parameter estimation.

## Verification

- HPP cases anchored analytically: SE = λ/√n to 7 digits, `param_cb` = λ·exp(±z/√n), residuals = λ·gaps exactly, martingale residuals sum to 0 at the MLE.
- Trend-test delegation reproduces the standalone statistics exactly on mixed failure-/time-truncated windows.
- CvM keeps correctly-specified models (p ≈ 0.1–0.8) and rejects an HPP fitted to strongly trending data (p ≤ 0.02).
- Full suite: 879 passed, 1 skipped; flake8/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_