### PR TITLE
Turnbull: O(N+M) memory rewrite, truncation fix, and correct confidence intervals

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Notes
 
-This document tracks known issues, technical debt, and improvement priorities for surpyval. Issues are grouped by theme and ordered by severity within each section. Implemented items are removed; this reflects the state of the codebase as of 2026-07-12. The full test suite passes on Python 3.11+ with numpy 2.x / scipy 1.17 / pandas 3.x.
+This document tracks known issues, technical debt, and improvement priorities for surpyval. Issues are grouped by theme and ordered by severity within each section. Implemented items are removed; this reflects the state of the codebase as of 2026-07-13. The full test suite passes on Python 3.11+ with numpy 2.x / scipy 1.17 / pandas 3.x.
 
 ---
 
@@ -113,20 +113,6 @@ Extract a shared helper. The `count_terminated_simulation` methods are similarly
 ## 4. Univariate Non-Parametric Module — Remaining Work
 
 The following engineering debt in `surpyval/univariate/nonparametric/` remains.
-
-### Turnbull EM performance and convergence control
-**File:** `surpyval/univariate/nonparametric/turnbull.py`
-
-The EM loop builds `dok_matrix` sparse matrices and iterates over
-`.keys()`/`.values()` in Python, which dominates runtime (the bootstrap
-and any simulation involving Turnbull are noticeably slow). The
-convergence criterion is hardcoded — `np.allclose(p, p_prev,
-rtol=1e-30, atol=1e-30)` with a silent `iters < 1000` cap — so a
-non-converged fit is returned without warning, and callers cannot
-trade accuracy for speed. Expose `tol` and `max_iter` as `fit`
-parameters, emit a `warnings.warn` when the cap is hit without
-convergence, and act on the existing in-file TODO to do row-wise
-iteration on the sparse matrices.
 
 ### `random()` uses the legacy global RNG
 **File:** `nonparametric.py` (`NonParametric.random`, ~line 454)

--- a/surpyval/tests/univariate/nonparametric/test_turnbull.py
+++ b/surpyval/tests/univariate/nonparametric/test_turnbull.py
@@ -138,6 +138,40 @@ def test_turnbull_against_lifelines_npmle_reference():
     assert np.allclose(model.sf(probe), reference, atol=1e-3)
 
 
+def test_turnbull_estimator_options_on_fractional_ladder():
+    # The Kaplan-Meier / Nelson-Aalen / Fleming-Harrington choice is
+    # applied to the EM's expected-count ladder inside every iteration,
+    # so the three options must produce distinct, correctly ordered
+    # survival curves (NA >= FH >= KM), each fitted on fractional
+    # (partial) event counts.
+    xl = [2.0, 4.0, 5.0, 3.0, 1.0, 4.0, 2.0, 6.0, 7.0, 2.5, 3.6, 5.5]
+    xr = [2.0, 4.0, 5.0, 3.0, 1.0, 6.0, 5.0, 6.0, 7.0, 2.5, 8.0, 9.0]
+    c = np.array([0, 0, 1, -1, 0, 2, 2, 1, 0, 0, 2, 2])
+    n = np.array([1, 2, 1, 1, 1, 1, 1, 2, 1, 1, 3, 1])
+    models = {
+        est: surpyval.Turnbull.fit(
+            xl=xl, xr=xr, c=c, n=n, turnbull_estimator=est
+        )
+        for est in ("Kaplan-Meier", "Nelson-Aalen", "Fleming-Harrington")
+    }
+    # The EM distributes events across intervals, so the death ladder
+    # must contain genuinely fractional counts.
+    d = models["Kaplan-Meier"].d
+    fractional = d[(d > 1e-9) & (np.abs(d - np.round(d)) > 1e-6)]
+    assert fractional.size > 0
+
+    grid = [2.6, 4.1, 6.5]
+    km = models["Kaplan-Meier"].sf(grid)
+    na = models["Nelson-Aalen"].sf(grid)
+    fh = models["Fleming-Harrington"].sf(grid)
+    assert not np.allclose(km, na)
+    assert np.all(na >= km - 1e-12)
+    assert np.all((fh >= km - 1e-12) & (fh <= na + 1e-12))
+    # Each model carries the variance for its own estimator.
+    for model in models.values():
+        assert np.isfinite(model.greenwood).any()
+
+
 def test_turnbull_docstring_example_unchanged():
     # The rewrite must reproduce the long-standing example output.
     x = np.array([[1, 5], [2, 3], [3, 6], [1, 8], [9, 10]])

--- a/surpyval/tests/univariate/nonparametric/test_turnbull.py
+++ b/surpyval/tests/univariate/nonparametric/test_turnbull.py
@@ -1,0 +1,105 @@
+"""Turnbull estimator: truncation correctness, convergence controls and
+memory-efficient EM (the interval-censoring results against R's icenReg
+live in test_np.py)."""
+
+import numpy as np
+import pytest
+
+import surpyval
+
+
+def _left_truncated_sample(n=800, seed=5):
+    np.random.seed(seed)
+    x = surpyval.Weibull.random(n, 10, 2)
+    tl = surpyval.Uniform.random(n, 0, 8)
+    keep = x > tl
+    return x[keep], tl[keep]
+
+
+def test_turnbull_left_truncation_matches_kaplan_meier():
+    # For exactly observed, left-truncated data the Turnbull NPMLE is the
+    # Kaplan-Meier estimator with delayed entry, which surpyval's KM
+    # already handles through the risk set. Before the ghost step was
+    # fixed, Turnbull silently ignored truncation entirely and returned
+    # the (biased) untruncated estimate here.
+    x, tl = _left_truncated_sample()
+    km = surpyval.KaplanMeier.fit(x, tl=tl)
+    tb = surpyval.Turnbull.fit(
+        x, tl=tl, turnbull_estimator="Kaplan-Meier", max_iter=20_000
+    )
+    grid = np.array([4.0, 6.0, 8.0, 10.0, 12.0])
+    assert np.allclose(tb.sf(grid), km.sf(grid), atol=5e-3)
+
+    # And the biased no-truncation estimate is measurably different, so
+    # the assertion above genuinely discriminates.
+    untruncated = surpyval.KaplanMeier.fit(x)
+    assert np.max(np.abs(untruncated.sf(grid) - km.sf(grid))) > 0.02
+
+
+def test_turnbull_right_truncation_recovers_cdf_shape():
+    # Right-truncated data identifies F up to a scale, so compare the
+    # fitted CDF's shape against the true Weibull CDF conditioned on the
+    # truncation horizon.
+    np.random.seed(7)
+    x = surpyval.Weibull.random(4000, 10, 2)
+    keep = x < 14.0
+    tb = surpyval.Turnbull.fit(
+        x[keep], tr=14.0, turnbull_estimator="Kaplan-Meier"
+    )
+    grid = np.array([4.0, 6.0, 8.0, 10.0, 12.0])
+    F_true = 1 - np.exp(-((grid / 10.0) ** 2))
+    ratio_hat = tb.ff(grid) / tb.ff(12.0)
+    ratio_true = F_true / F_true[-1]
+    assert np.allclose(ratio_hat, ratio_true, atol=0.05)
+
+
+def test_turnbull_interval_censored_with_left_truncation():
+    # Interval censoring and truncation together must run and produce a
+    # monotone survival curve over positive masses.
+    np.random.seed(11)
+    x = surpyval.Weibull.random(500, 10, 2)
+    tl = surpyval.Uniform.random(500, 0, 6)
+    keep = np.floor(x) > tl
+    xl = np.floor(x[keep])
+    xr = xl + 1.0
+    model = surpyval.Turnbull.fit(xl=xl, xr=xr, tl=tl[keep])
+    R = model.R[np.isfinite(model.R)]
+    assert np.all(np.diff(R) <= 1e-12)
+    assert R[0] <= 1.0 + 1e-12 and R[-1] >= -1e-12
+
+
+def test_turnbull_max_iter_warns_and_reports():
+    x, tl = _left_truncated_sample()
+    with pytest.warns(UserWarning, match="did not converge"):
+        model = surpyval.Turnbull.fit(x, tl=tl, max_iter=5)
+    assert model.converged is False
+    assert model.iters == 5
+
+
+def test_turnbull_tol_controls_iterations():
+    # A looser tolerance must converge in no more iterations than a tight
+    # one, without warning on well-behaved data.
+    x = np.array([[1, 5], [2, 3], [3, 6], [1, 8], [9, 10]])
+    loose = surpyval.Turnbull.fit(x, tol=1e-4)
+    tight = surpyval.Turnbull.fit(x, tol=1e-12, max_iter=10_000)
+    assert loose.converged and tight.converged
+    assert loose.iters <= tight.iters
+    # Both agree to well within the loose tolerance's practical effect.
+    assert np.allclose(loose.R, tight.R, atol=1e-3, equal_nan=True)
+
+
+def test_turnbull_docstring_example_unchanged():
+    # The rewrite must reproduce the long-standing example output.
+    x = np.array([[1, 5], [2, 3], [3, 6], [1, 8], [9, 10]])
+    model = surpyval.Turnbull.fit(x)
+    expected = [
+        1.0,
+        1.0,
+        0.63472351,
+        0.29479882,
+        0.2631432,
+        0.2631432,
+        0.2631432,
+        0.09680497,
+    ]
+    assert np.allclose(model.R, expected, atol=1e-6)

--- a/surpyval/tests/univariate/nonparametric/test_turnbull.py
+++ b/surpyval/tests/univariate/nonparametric/test_turnbull.py
@@ -138,6 +138,27 @@ def test_turnbull_against_lifelines_npmle_reference():
     assert np.allclose(model.sf(probe), reference, atol=1e-3)
 
 
+def test_turnbull_truncated_confidence_bounds_match_kaplan_meier():
+    # The estimation ladder's ghost events make the truncated *estimate*
+    # correct, but they are not observations: a variance computed from
+    # the ghost-inflated risk set was up to ~33% too narrow. The variance
+    # now comes from an observed-information ladder that reduces to the
+    # Kaplan-Meier delayed-entry risk set for exactly observed
+    # left-truncated data, so the bounds must match KM's.
+    x, tl = _left_truncated_sample()
+    km = surpyval.KaplanMeier.fit(x, tl=tl)
+    tb = surpyval.Turnbull.fit(
+        x, tl=tl, turnbull_estimator="Kaplan-Meier", max_iter=20_000
+    )
+    grid = np.array([6.0, 8.0, 10.0, 12.0])
+    assert np.allclose(tb.R_cb(grid), km.R_cb(grid), atol=2e-3)
+
+    # Untruncated fits keep using the estimation ladder for the variance
+    # (no separate attributes appear).
+    plain = surpyval.Turnbull.fit(x)
+    assert not hasattr(plain, "var_r") and not hasattr(plain, "var_d")
+
+
 def test_turnbull_estimator_options_on_fractional_ladder():
     # The Kaplan-Meier / Nelson-Aalen / Fleming-Harrington choice is
     # applied to the EM's expected-count ladder inside every iteration,

--- a/surpyval/tests/univariate/nonparametric/test_turnbull.py
+++ b/surpyval/tests/univariate/nonparametric/test_turnbull.py
@@ -88,6 +88,56 @@ def test_turnbull_tol_controls_iterations():
     assert np.allclose(loose.R, tight.R, atol=1e-3, equal_nan=True)
 
 
+def test_turnbull_equals_kaplan_meier_with_right_censoring():
+    # Classical identity: on exactly observed + right-censored data the
+    # Turnbull NPMLE *is* the Kaplan-Meier estimator. This exercises the
+    # zero-width Turnbull intervals (every exact time is a duplicated
+    # bound carrying a point mass) against surpyval's R-validated KM.
+    np.random.seed(3)
+    x = np.round(surpyval.Weibull.random(300, 10, 2), 2)
+    c = (np.random.uniform(size=300) < 0.3).astype(int)
+    km = surpyval.KaplanMeier.fit(x, c=c)
+    tb = surpyval.Turnbull.fit(x, c=c, turnbull_estimator="Kaplan-Meier")
+    grid = np.quantile(x, [0.1, 0.3, 0.5, 0.7, 0.9])
+    assert np.allclose(tb.sf(grid), km.sf(grid), atol=1e-12)
+
+
+def test_turnbull_all_censoring_types_together():
+    # Exact (0), right (1), left (-1) and interval (2) censoring in one
+    # dataset: the fit must run, keep the duplicated zero-width bounds
+    # for every exact time, and return a monotone survival curve.
+    xl = [2.0, 4.0, 5.0, 3.0, 1.0, 4.0, 2.0, 6.0, 7.0, 2.5]
+    xr = [2.0, 4.0, 5.0, 3.0, 1.0, 6.0, 5.0, 6.0, 7.0, 2.5]
+    c = np.array([0, 0, 1, -1, 0, 2, 2, 1, 0, 0])
+    n = np.array([1, 2, 1, 1, 1, 1, 1, 2, 1, 1])
+    model = surpyval.Turnbull.fit(xl=xl, xr=xr, c=c, n=n)
+    for v in (1.0, 2.0, 2.5, 4.0, 7.0):
+        assert (model.bounds == v).sum() == 2
+    R = model.R[np.isfinite(model.R)]
+    assert np.all(np.diff(R) <= 1e-12)
+
+
+def test_turnbull_against_lifelines_npmle_reference():
+    # Overlapping intervals whose endpoints are all distinct, so the
+    # NPMLE does not depend on open/closed interval conventions (which
+    # differ between packages: surpyval uses [l, r), icenReg (l, r],
+    # lifelines [l, r]). Reference survival values computed with
+    # lifelines 0.30.3 ``KaplanMeierFitter.fit_interval_censoring``
+    # (its residual ~1e-4 unconverged mass is inside the tolerance).
+    left = [0.5, 1.2, 2.1, 1.8, 3.4, 4.2, 5.1, 4.8, 6.3, 7.2, 2.7, 8.4]
+    right = [2.4, 3.1, 4.5, 6.1, 5.6, 6.8, 7.9, 9.2, 8.8, 9.9, 10.4, 11.3]
+    model = surpyval.Turnbull.fit(
+        xl=left,
+        xr=right,
+        turnbull_estimator="Kaplan-Meier",
+        tol=1e-12,
+        max_iter=100_000,
+    )
+    probe = [2.5, 3.2, 4.6, 5.7, 6.9, 8.0]
+    reference = [0.714780, 0.714780, 0.714622, 0.326064, 0.326064, 0.325946]
+    assert np.allclose(model.sf(probe), reference, atol=1e-3)
+
+
 def test_turnbull_docstring_example_unchanged():
     # The rewrite must reproduce the long-standing example output.
     x = np.array([[1, 5], [2, 3], [3, 6], [1, 8], [9, 10]])

--- a/surpyval/univariate/nonparametric/nonparametric_fitter.py
+++ b/surpyval/univariate/nonparametric/nonparametric_fitter.py
@@ -58,6 +58,8 @@ class NonParametricFitter:
         tr: npt.ArrayLike | Number | None = None,
         turnbull_estimator: str = "Fleming-Harrington",
         set_lower_limit: float | None = None,
+        tol: float = 1e-10,
+        max_iter: int = 1000,
     ) -> NonParametric:
         r"""
 
@@ -115,6 +117,14 @@ class NonParametricFitter:
             KM, NA, or FH estimator with the Turnbull estimates of r, and d.
             Defaults to FH.
 
+        tol : float, optional
+            Turnbull only. The EM stops once the largest change in any
+            interval's probability mass falls below this. Defaults to 1e-10.
+
+        max_iter : int, optional
+            Turnbull only. Cap on EM iterations; a warning is raised if it
+            is reached before ``tol`` is. Defaults to 1000.
+
         Returns
         -------
 
@@ -151,7 +161,7 @@ class NonParametricFitter:
         if self.how == "Turnbull":
             data["estimator"] = turnbull_estimator
             out = NonParametric()
-            t_obj = self._fit(x, c, n, t, turnbull_estimator)
+            t_obj = self._fit(x, c, n, t, turnbull_estimator, tol, max_iter)
 
             out.greenwood = self._compute_var(
                 turnbull_estimator, t_obj["r"], t_obj["d"]

--- a/surpyval/univariate/nonparametric/nonparametric_fitter.py
+++ b/surpyval/univariate/nonparametric/nonparametric_fitter.py
@@ -163,9 +163,12 @@ class NonParametricFitter:
             out = NonParametric()
             t_obj = self._fit(x, c, n, t, turnbull_estimator, tol, max_iter)
 
-            out.greenwood = self._compute_var(
-                turnbull_estimator, t_obj["r"], t_obj["d"]
-            )
+            # Truncated fits supply a separate observed-information ladder
+            # for the variance (the estimation ladder's ghost events would
+            # understate it); untruncated fits use the estimation ladder.
+            var_r = t_obj.pop("var_r", t_obj["r"])
+            var_d = t_obj.pop("var_d", t_obj["d"])
+            out.greenwood = self._compute_var(turnbull_estimator, var_r, var_d)
             for k, v in t_obj.items():
                 setattr(out, k, v)
 

--- a/surpyval/univariate/nonparametric/turnbull.py
+++ b/surpyval/univariate/nonparametric/turnbull.py
@@ -1,5 +1,6 @@
+import warnings
+
 import numpy as np
-from scipy.sparse import dok_matrix
 
 from surpyval.univariate.nonparametric.nonparametric_fitter import (
     NonParametricFitter,
@@ -10,15 +11,28 @@ from .kaplan_meier import kaplan_meier as km
 from .nelson_aalen import nelson_aalen as na
 
 
-def turnbull(x, c, n, t, estimator="Fleming-Harrington"):
+def turnbull(
+    x, c, n, t, estimator="Fleming-Harrington", tol=1e-10, max_iter=1000
+):
+    """
+    Turnbull NPMLE via the EM (self-consistency) algorithm.
+
+    Every observation's support -- the set of Turnbull interval endpoints
+    its event could have occurred at -- is a *contiguous* run of indices
+    into the sorted ``bounds`` array, as is its truncation (observation)
+    window. The E-step therefore never needs an (N x M) matrix: the
+    per-observation support probabilities are range sums of ``p``
+    (prefix sums), and the per-interval expected event counts are sums of
+    per-observation weights over ranges (difference arrays). Each
+    iteration is O(N + M) in both time and memory.
+    """
     any_truncated = np.isfinite(t).any()
     # Find all unique bounding points
     bounds = np.unique(np.concatenate([np.unique(x), np.unique(t)]))
     # Add the times at which there was an observation again since
     # the failure occurs in a 0 bound e.g. in the [1, 1] "interval".
-    bounds = np.sort(np.concatenate([bounds, np.unique(x[c == 0])]))
-    # Total items observed
-    N = n.sum()
+    exact_times = np.unique(x[c == 0])
+    bounds = np.sort(np.concatenate([bounds, exact_times]))
 
     if x.ndim == 1:
         x_new = np.empty(shape=(x.shape[0], 2))
@@ -27,8 +41,8 @@ def turnbull(x, c, n, t, estimator="Fleming-Harrington"):
         x = x_new
 
     # Unpack x array
-    xl = x[:, 0]
-    xr = x[:, 1]
+    xl = x[:, 0].astype(float)
+    xr = x[:, 1].astype(float)
 
     # Unpack t array
     tl = t[:, 0]
@@ -43,40 +57,50 @@ def turnbull(x, c, n, t, estimator="Fleming-Harrington"):
     M = bounds.size
     N = xl.size
 
-    alpha = dok_matrix((N, M), dtype="int32")
-    beta = dok_matrix((N, M), dtype="int32")
+    # Each observation's support is the contiguous index range [lo, hi] of
+    # the bound points its event may sit on:
+    # - an exactly observed event sits on the zero-width "interval" at the
+    #   first copy of its (duplicated) time;
+    # - a right-censored event may sit on any bound strictly after the
+    #   censoring time;
+    # - an interval-censored event (including left censored, whose interval
+    #   is (-inf, xr)) may sit on any bound in [xl, xr), *except* the
+    #   zero-width exact interval at xl when xl is also an exactly observed
+    #   time -- the event is known to be after xl.
+    exact = xl == xr
+    right = ~exact & np.isinf(xr)
+    interval = ~exact & ~right
 
-    for i in range(0, N):
-        x1, x2 = xl[i], xr[i]
-        t1, t2 = tl[i], tr[i]
-        if x1 == x2:
-            # Find first index of repeated value
-            idx = np.searchsorted(bounds, x1)
-            alpha[i, idx] = n[i]
-        elif x2 == np.inf:
-            alpha[i, :] = ((bounds > x1) & (bounds <= x2)).astype(int) * n[i]
-            if x1 in x[c == 0]:
-                idx = np.searchsorted(bounds, x1)
-                alpha[i, idx] = 0
-        else:
-            alpha[i, :] = ((bounds >= x1) & (bounds < x2)).astype(int) * n[i]
-            if x1 in x[c == 0]:
-                idx = np.searchsorted(bounds, x1)
-                alpha[i, idx] = 0
-        # Find the indices of the bounds that are outside the interval
-        if any_truncated:
-            where_truncated = np.multiply((bounds < t1), (bounds >= t2))
-            # Assign a value of 1 in the sparse matrix for the intervals where
-            # the observation window is truncated
-            for j in np.where(where_truncated == x1)[0]:
-                beta[i, j] = 1
+    lo = np.empty(N, dtype=np.int64)
+    hi = np.empty(N, dtype=np.int64)
+    lo[exact] = np.searchsorted(bounds, xl[exact], side="left")
+    hi[exact] = lo[exact]
+    lo[right] = np.searchsorted(bounds, xl[right], side="right")
+    hi[right] = M - 1
+    lo[interval] = np.searchsorted(
+        bounds, xl[interval], side="left"
+    ) + np.isin(xl[interval], exact_times)
+    hi[interval] = np.searchsorted(bounds, xr[interval], side="left") - 1
 
-    n = n.reshape(-1, 1)
+    # Each observation's truncation window is likewise a contiguous index
+    # range [w_lo, w_hi]: the bound points at which an event was observable
+    # -- strictly after its left truncation time and at or before its right
+    # truncation time.
+    if any_truncated:
+        w_lo = np.where(
+            np.isfinite(tl), np.searchsorted(bounds, tl, side="right"), 0
+        )
+        w_hi = np.where(
+            np.isfinite(tr),
+            np.searchsorted(bounds, tr, side="right") - 1,
+            M - 1,
+        )
+        truncated = np.isfinite(tl) | np.isfinite(tr)
+        w_lo, w_hi = w_lo[truncated], w_hi[truncated]
+        n_truncated = n[truncated]
+
     d = np.zeros(M)
     p = np.ones(M) / M
-
-    iters = 0
-    p_prev = np.zeros_like(p)
 
     if estimator == "Kaplan-Meier":
         func = km
@@ -86,45 +110,45 @@ def turnbull(x, c, n, t, estimator="Fleming-Harrington"):
         func = fh
 
     old_err_state = np.seterr(all="ignore")
-    expected = dok_matrix(alpha.shape, dtype="float64")
 
-    while (iters < 1000) & (
-        not np.allclose(p, p_prev, rtol=1e-30, atol=1e-30)
-    ):
-        p_prev = p
-        iters += 1
-        # TODO: Change this so that it does row iterations on sparse matrices
-        # Row wise should, in the majority of cases, be more memory efficient
-        denominator = np.zeros(N)
+    converged = False
+    for iters in range(1, max_iter + 1):
+        # Prefix sums of p turn every range sum into two lookups.
+        cumulative = np.concatenate([[0.0], np.cumsum(p)])
 
-        for (i, j), v in zip(alpha.keys(), alpha.values()):
-            denominator[i] += v * p[j]
-            expected[i, j] = v**2 * p[j]
+        # E-step, observed events: each observation distributes its n
+        # events over its support in proportion to p, i.e. it adds
+        # n * p_j / P(support) to every interval j in [lo, hi]. Summing
+        # the weights n / P(support) over observations via a difference
+        # array gives all M totals in one cumsum.
+        support_p = cumulative[hi + 1] - cumulative[lo]
+        # A row whose support carries no mass (or is empty) contributes
+        # nothing, rather than propagating inf/nan through the totals.
+        weight = np.where(support_p > 0, n / support_p, 0.0)
+        delta = np.zeros(M + 1)
+        np.add.at(delta, lo, weight)
+        np.add.at(delta, hi + 1, -weight)
+        d_observed = p * np.cumsum(delta[:M])
 
-        d_observed = np.array(
-            expected.multiply(1 / denominator[:, np.newaxis]).sum(0)
-        ).ravel()
-
-        d_ghosts = np.zeros(M)
+        # E-step, ghosts: a truncated observation was only observable
+        # because its event fell inside its window, so for every one seen,
+        # unseen "ghost" events fell outside it at rate p_j / P(window).
+        # Add n / P(window) everywhere, subtract it back over the window.
         if any_truncated:
-            beta_denominator = np.zeros(N)
-            for (i, j), v in zip(beta.keys(), beta.values()):
-                beta_denominator[i] += (1 - v) * p[j]
-            beta_denominator = np.where(
-                beta_denominator == 0, 1, beta_denominator
-            )
-
-            d_ghosts = np.array(
-                beta.power(2)
-                .multiply(n * p)
-                .multiply(1 / beta_denominator[:, np.newaxis])
-                .sum(0)
-            ).ravel()
+            window_p = cumulative[w_hi + 1] - cumulative[w_lo]
+            ghost_weight = np.where(window_p > 0, n_truncated / window_p, 0.0)
+            delta = np.zeros(M + 1)
+            delta[0] = ghost_weight.sum()
+            np.add.at(delta, w_lo, -ghost_weight)
+            np.add.at(delta, w_hi + 1, ghost_weight)
+            d_ghosts = p * np.cumsum(delta[:M])
+        else:
+            d_ghosts = 0.0
 
         # Deaths/Failures/Events
         d = d_ghosts + d_observed
         # total observed and unobserved failures.
-        total_events = (d_ghosts + d_observed).sum()
+        total_events = d.sum()
         # Risk set, i.e the number of items at risk at immediately before x
         r = total_events - d.cumsum() + d
         # Find the survival function values (R) using the deaths and risk set
@@ -132,8 +156,19 @@ def turnbull(x, c, n, t, estimator="Fleming-Harrington"):
         # is to do p = (nu + mu).sum(axis=0)/(nu + mu).sum()
         R = func(r, d)
         # Calculate the probability mass in each interval
-        p = np.abs(np.diff(np.hstack([[1], R])))
-        expected.clear()
+        p_new = np.abs(np.diff(np.hstack([[1], R])))
+        if np.nanmax(np.abs(p_new - p)) < tol:
+            p = p_new
+            converged = True
+            break
+        p = p_new
+
+    if not converged:
+        warnings.warn(
+            "The Turnbull EM did not converge to within `tol` ({}) in "
+            "`max_iter` ({}) iterations; the estimate may be "
+            "inaccurate.".format(tol, max_iter)
+        )
 
     out = {}
     out["x"] = bounds[1:-1]
@@ -143,10 +178,11 @@ def turnbull(x, c, n, t, estimator="Fleming-Harrington"):
     out["F"] = 1 - R[0:-2]
     out["R_upper"] = R[0:-2]
     out["R_lower"] = R[1:-1]
-    out["alpha"] = alpha
     out["bounds"] = bounds
     out["model"] = "Turnbull"
     out["turnbull_estimator"] = estimator
+    out["iters"] = iters
+    out["converged"] = converged
 
     np.seterr(**old_err_state)
 
@@ -158,6 +194,10 @@ class Turnbull_(NonParametricFitter):
     Turnbull estimator class. Returns a `NonParametric` object from method
     :code:`fit()`. Calculates the Non-Parametric estimate of the survival
     function using the Turnbull NPMLE.
+
+    The EM iterates until the largest change in any interval's probability
+    mass falls below ``tol`` or ``max_iter`` iterations have run (with a
+    warning in the latter case); both can be passed to :code:`fit()`.
 
     Examples
     --------
@@ -173,8 +213,10 @@ class Turnbull_(NonParametricFitter):
     def __init__(self):
         self.how = "Turnbull"
 
-    def _fit(self, x, c, n, t, turnbull_estimator):
-        return turnbull(x, c, n, t, turnbull_estimator)
+    def _fit(self, x, c, n, t, turnbull_estimator, tol, max_iter):
+        return turnbull(
+            x, c, n, t, turnbull_estimator, tol=tol, max_iter=max_iter
+        )
 
 
 Turnbull = Turnbull_()

--- a/surpyval/univariate/nonparametric/turnbull.py
+++ b/surpyval/univariate/nonparametric/turnbull.py
@@ -170,10 +170,73 @@ def turnbull(
             "inaccurate.".format(tol, max_iter)
         )
 
+    if any_truncated:
+        # Variance ladder from *observed* information only. The estimation
+        # ladder above includes the ghost events -- they are what make the
+        # estimate correct under truncation -- but ghosts are not data, and
+        # a risk set inflated by them understates the variance. Instead,
+        # each observed item contributes its conditional probability of
+        # still being event-free at each bound, and only while that bound
+        # lies inside its observation window (so delayed entry removes it
+        # from the early risk sets, exactly as in the Kaplan-Meier
+        # delayed-entry risk set, to which this reduces for exactly
+        # observed left-truncated data):
+        #
+        #   r_var[j] = sum_i n_i * 1[w_lo_i <= j <= w_hi_i] * P_i(T >= j)
+        #
+        # with P_i(T >= j) equal to 1 before the item's support, the
+        # conditional tail (cum[hi+1] - cum[j]) / P(support) inside it, and
+        # 0 after it. Piece one and the constant part of piece two are
+        # range-adds; the j-dependent part is cum[j] times a range-added
+        # weight -- all still O(N + M). For untruncated data this ladder
+        # equals the estimation ladder, so it is only computed (and only
+        # used for the variance) when truncation is present.
+        cumulative = np.concatenate([[0.0], np.cumsum(p)])
+        support_p = cumulative[hi + 1] - cumulative[lo]
+        weight = np.where(support_p > 0, n / support_p, 0.0)
+        delta = np.zeros(M + 1)
+        np.add.at(delta, lo, weight)
+        np.add.at(delta, hi + 1, -weight)
+        d_var = p * np.cumsum(delta[:M])
+
+        w_lo_all = np.where(
+            np.isfinite(tl), np.searchsorted(bounds, tl, side="right"), 0
+        )
+        w_hi_all = np.where(
+            np.isfinite(tr),
+            np.searchsorted(bounds, tr, side="right") - 1,
+            M - 1,
+        )
+
+        const = np.zeros(M + 1)
+        coeff = np.zeros(M + 1)
+        # Before the support (probability 1), within the window.
+        a1 = w_lo_all
+        b1 = np.minimum(lo, w_hi_all)
+        ok = a1 <= b1
+        np.add.at(const, a1[ok], n[ok])
+        np.add.at(const, b1[ok] + 1, -n[ok])
+        # Within the support (conditional tail), within the window.
+        a2 = np.maximum(lo + 1, w_lo_all)
+        b2 = np.minimum(hi, w_hi_all)
+        ok = (a2 <= b2) & (support_p > 0)
+        tail_const = np.where(
+            support_p > 0, n * cumulative[hi + 1] / support_p, 0.0
+        )
+        np.add.at(const, a2[ok], tail_const[ok])
+        np.add.at(const, b2[ok] + 1, -tail_const[ok])
+        np.add.at(coeff, a2[ok], weight[ok])
+        np.add.at(coeff, b2[ok] + 1, -weight[ok])
+
+        r_var = np.cumsum(const[:M]) - np.cumsum(coeff[:M]) * cumulative[:M]
+
     out = {}
     out["x"] = bounds[1:-1]
     out["r"] = r[1:-1]
     out["d"] = d[1:-1]
+    if any_truncated:
+        out["var_r"] = r_var[1:-1]
+        out["var_d"] = d_var[1:-1]
     out["R"] = R[0:-2]
     out["F"] = 1 - R[0:-2]
     out["R_upper"] = R[0:-2]


### PR DESCRIPTION
Reworks the Turnbull estimator per DEVELOPMENT.md §4, with memory efficiency as the driver, and fixes two correctness issues found while verifying.

## Memory-efficient EM rewrite (`53338a1`)

Every observation's support over the sorted Turnbull bound points is a contiguous index range (as is its truncation window), so the E-step needs no (N×M) `dok_matrix` at all: support probabilities are range sums of `p` via one prefix-sum array, and per-interval expected counts are range-adds via difference arrays. Each iteration is **O(N+M) time and memory**.

- N=150: 46.1s → 0.060s (~770×), results identical to 1.2e-15
- Peak traced memory at N=300: 7.2MB → 0.1MB (76×)
- N=100,000 interval-censored observations: 1.9s / 13MB peak (unreachable before)
- The dead `alpha` dok matrix attribute is no longer kept on fitted models
- `fit()` gains `tol` (default 1e-10) and `max_iter` (default 1000), warns on non-convergence instead of silently returning, and models record `iters`/`converged`

## Truncation was silently broken (fixed in `53338a1`)

The ghost step never ran: `beta` was filled under the impossible condition `(bounds < t1) & (bounds >= t2)` compared against `x1` rather than `True`, and its denominator was always 0-forced-to-1 — so **truncated fits returned the plain untruncated estimate**. The proper Turnbull ghosts (`n·p_j/P(window)` outside each observation's window) are now implemented: left-truncated exact data matches KM with delayed entry (previously off by ~0.09 survival), and right-truncated data recovers the true conditional CDF shape.

## Correct confidence intervals under truncation (`b1140ac`)

The ghost events fix the estimate but are not observations — a Greenwood variance from the ghost-inflated risk set was 0.67–0.96× the correct width. Truncated fits now compute the variance from an observed-information ladder (each item contributes its conditional survival probability, only while inside its observation window), which reduces exactly to KM's delayed-entry risk set for exact left-truncated data and equals the estimation ladder for untruncated data (untruncated fits untouched, still O(N+M)). CI widths now within 0.1% of KM's; empirical 95% coverage: 95.7–98% (interval-censored), 93.7–96.7% (left-truncated).

## Reference tests (`6916baa`, `882c567`)

- All four censoring types together; zero-width duplicated bounds for exact times preserved (point mass lands on the zero-width interval)
- Turnbull ≡ Kaplan-Meier on exact + right-censored data (machine precision)
- Independent NPMLE cross-check against lifelines 0.30.3 on overlapping intervals with all-distinct endpoints (where open/closed-interval conventions — surpyval `[l,r)`, icenReg `(l,r]`, lifelines `[l,r]` — cannot matter); values hardcoded with provenance so CI needs no lifelines
- KM/NA/FH `turnbull_estimator` options pinned: applied inside each EM iteration on the fractional event ladder, verified against the pre-rewrite implementation for all three (max |ΔR| ≤ 1.1e-9)
- Existing icenReg reference tests unchanged and passing

Full suite: 890 passed, 1 skipped; flake8/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_