### PR TITLE
Nonparametric: monotone cubic interpolation, seedable random(), serialization

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -114,34 +114,6 @@ Extract a shared helper. The `count_terminated_simulation` methods are similarly
 
 The following engineering debt in `surpyval/univariate/nonparametric/` remains.
 
-### `random()` uses the legacy global RNG
-**File:** `nonparametric.py` (`NonParametric.random`, ~line 454)
-
-`random()` calls `np.random.choice`, drawing on the legacy global
-random state, so it cannot be seeded locally and is inconsistent with
-the `bootstrap_cb`/`band` methods that already accept a
-`random_state`. Add a `random_state` argument and route through
-`np.random.default_rng`, matching the parametric side.
-
-### No serialization
-Parametric models expose `to_dict`/`to_json`; `NonParametric` has
-nothing. A fitted non-parametric model (its `x`, `R`, `r`, `d`,
-`greenwood`, and estimator metadata) cannot be persisted or
-round-tripped. Add `to_dict`/`from_dict` (and the JSON wrappers) and
-fold the result into the empty `test_to_dict.py` once the general
-parametric path is also covered.
-
-### `interp='cubic'` can violate monotonicity
-**File:** `nonparametric.py` (`interp_function`)
-
-The survival function is monotone non-increasing, but `interp1d(...,
-kind='cubic')` can overshoot and produce a non-monotone — even
-out-of-`[0, 1]` — interpolated curve, which then propagates into `Hf`,
-`hf`, and the interpolated confidence bounds. Switch the smooth
-interpolation to a shape-preserving monotone scheme
-(`scipy.interpolate.PchipInterpolator`) so interpolated curves remain
-valid survival functions.
-
 ### `dist='t'` confidence-bound heuristic
 **File:** `nonparametric.py` (`R_cb`)
 

--- a/surpyval/tests/univariate/nonparametric/test_np_improvements.py
+++ b/surpyval/tests/univariate/nonparametric/test_np_improvements.py
@@ -1,0 +1,152 @@
+"""Monotone (PCHIP) smooth interpolation, seedable random(), and
+to_dict/from_dict/JSON serialization for NonParametric models."""
+
+import json
+
+import numpy as np
+import pytest
+
+import surpyval
+
+# --- interp='cubic' must stay a valid survival function (PCHIP) -----------
+
+
+def _overshooting_data():
+    # A sharp drop followed by a long flat tail makes an ordinary cubic
+    # spline overshoot below zero.
+    return np.array([1.0, 2.0, 3.0, 3.2, 3.4, 8.0, 12.0, 20.0])
+
+
+def test_cubic_interpolation_is_monotone_and_bounded():
+    model = surpyval.KaplanMeier.fit(_overshooting_data())
+    grid = np.linspace(model.x.min(), model.x.max(), 500)
+    sf = model.sf(grid, interp="cubic")
+    finite = sf[np.isfinite(sf)]
+    # Non-increasing and inside [0, 1] -- a plain cubic spline breaks both.
+    assert np.all(np.diff(finite) <= 1e-12)
+    assert finite.min() >= 0.0 and finite.max() <= 1.0
+
+
+def test_cubic_interpolation_passes_through_estimates():
+    # A shape-preserving interpolant must still interpolate: at the
+    # observed times it returns the fitted survival exactly.
+    model = surpyval.KaplanMeier.fit(_overshooting_data())
+    assert np.allclose(model.sf(model.x, interp="cubic"), model.R, atol=1e-9)
+
+
+def test_cubic_interpolation_does_not_poison_hazard():
+    # A negative interpolated survival used to make Hf = -log(sf) NaN in
+    # the interior. With a monotone interpolant Hf is instead a valid,
+    # non-decreasing cumulative hazard (with +inf only where the survival
+    # estimate legitimately reaches 0 at the last uncensored point).
+    model = surpyval.KaplanMeier.fit(_overshooting_data())
+    grid = np.linspace(model.x.min(), model.x.max(), 200)
+    Hf = model.Hf(grid, interp="cubic")
+    assert not np.any(np.isnan(Hf))
+    finite = Hf[np.isfinite(Hf)]
+    assert np.all(np.diff(finite) >= -1e-9)
+
+
+def test_cubic_interpolation_with_turnbull_zero_width_bounds():
+    # Turnbull's ``x`` carries duplicated (zero-width) bounds at exact
+    # times; PCHIP requires strictly increasing abscissae, so the fix must
+    # collapse them rather than raise.
+    x = np.array([[1, 5], [2, 3], [3, 6], [1, 8], [9, 10.0]])
+    model = surpyval.Turnbull.fit(x, turnbull_estimator="Kaplan-Meier")
+    grid = np.linspace(1.0, 10.0, 200)
+    sf = model.sf(grid, interp="cubic")
+    finite = sf[np.isfinite(sf)]
+    assert np.all(np.diff(finite) <= 1e-9)
+    assert finite.min() >= -1e-9 and finite.max() <= 1 + 1e-9
+
+
+# --- random() is seedable --------------------------------------------------
+
+
+def test_random_is_reproducible_with_seed():
+    model = surpyval.KaplanMeier.fit(_overshooting_data())
+    a = model.random(500, random_state=42)
+    b = model.random(500, random_state=42)
+    c = model.random(500, random_state=7)
+    assert np.array_equal(a, b)
+    assert not np.array_equal(a, c)
+
+
+def test_random_draws_from_observed_values():
+    model = surpyval.KaplanMeier.fit(_overshooting_data())
+    draws = model.random(1000, random_state=1)
+    assert set(np.unique(draws)).issubset(set(model.x))
+    assert draws.size == 1000
+
+
+# --- serialization ---------------------------------------------------------
+
+
+def _models():
+    x = _overshooting_data()
+    c = (np.arange(x.size) % 3 == 0).astype(int)
+    interval = np.array([[1, 5], [2, 3], [3, 6], [1, 8], [9, 10.0]])
+    return {
+        "kaplan_meier": surpyval.KaplanMeier.fit(x, c=c),
+        "nelson_aalen": surpyval.NelsonAalen.fit(x),
+        "fleming_harrington": surpyval.FlemingHarrington.fit(x, c=c),
+        "turnbull": surpyval.Turnbull.fit(
+            interval, turnbull_estimator="Kaplan-Meier"
+        ),
+    }
+
+
+@pytest.mark.parametrize("name", list(_models()))
+def test_to_dict_from_dict_round_trip(name):
+    model = _models()[name]
+    restored = surpyval.NonParametric.from_dict(model.to_dict(with_data=True))
+    grid = np.linspace(1.5, 9.0, 40)
+    assert np.allclose(model.sf(grid), restored.sf(grid), equal_nan=True)
+    assert np.allclose(model.cb(grid), restored.cb(grid), equal_nan=True)
+    assert np.allclose(model.R, restored.R, equal_nan=True)
+    assert restored.model == model.model
+
+
+def test_to_dict_is_json_serializable_and_round_trips(tmp_path):
+    model = surpyval.KaplanMeier.fit(
+        _overshooting_data(), c=np.array([0, 0, 1, 0, 0, 1, 0, 0])
+    )
+    # The plain dict must be JSON-encodable...
+    encoded = json.dumps(model.to_dict())
+    assert isinstance(encoded, str)
+    # ...and the file round-trip must reproduce the survival estimate.
+    path = tmp_path / "model.json"
+    model.to_json(path)
+    restored = surpyval.NonParametric.from_json(path)
+    grid = np.linspace(1.5, 9.0, 40)
+    assert np.allclose(model.sf(grid), restored.sf(grid), equal_nan=True)
+
+
+def test_serialized_turnbull_keeps_estimator_and_bootstrap():
+    model = surpyval.Turnbull.fit(
+        np.array([[1, 5], [2, 3], [3, 6], [1, 8], [9, 10.0]]),
+        turnbull_estimator="Kaplan-Meier",
+    )
+    restored = surpyval.NonParametric.from_dict(model.to_dict(with_data=True))
+    assert restored.data["estimator"] == "Kaplan-Meier"
+    # The stored data lets the restored model still bootstrap.
+    cb = restored.bootstrap_cb([2.0, 4.0, 6.0], B=20, random_state=0)
+    assert cb.shape == (3, 2)
+
+
+def test_from_dict_rejects_wrong_parameterization():
+    with pytest.raises(ValueError, match="non-parametric"):
+        surpyval.NonParametric.from_dict({"parameterization": "parametric"})
+
+
+def test_fit_from_ecdf_serialization_preserves_missing_variance():
+    # No r/d/greenwood -> confidence bounds must stay unavailable after a
+    # round trip.
+    model = surpyval.NonParametric.fit_from_ecdf(
+        np.array([1.0, 2.0, 3.0]), np.array([0.9, 0.6, 0.3])
+    )
+    restored = surpyval.NonParametric.from_dict(model.to_dict())
+    assert restored.greenwood is None
+    assert np.allclose(model.sf([1.5, 2.5]), restored.sf([1.5, 2.5]))
+    with pytest.raises(ValueError, match="no variance estimate"):
+        restored.cb([1.5])

--- a/surpyval/univariate/nonparametric/nonparametric.py
+++ b/surpyval/univariate/nonparametric/nonparametric.py
@@ -1,10 +1,12 @@
+import json
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-from scipy.interpolate import interp1d
+from scipy.interpolate import PchipInterpolator, interp1d
 from scipy.stats import norm, t
 
 from surpyval.distribution import NonParametricDistribution
@@ -16,6 +18,20 @@ if TYPE_CHECKING:
 def interp_function(
     x: npt.ArrayLike, y: npt.ArrayLike, kind: str
 ) -> Callable[[npt.ArrayLike], npt.NDArray]:
+    if kind == "cubic":
+        # A plain cubic spline can overshoot and produce a non-monotone
+        # (even out-of-[0, 1]) survival curve, which then propagates into
+        # ``Hf``, ``hf`` and the interpolated confidence bounds. PCHIP is a
+        # shape-preserving piecewise-cubic Hermite interpolant, so it stays
+        # monotone wherever the data are monotone. It requires strictly
+        # increasing abscissae, so collapse any duplicated ``x`` (e.g. the
+        # zero-width Turnbull bounds at exactly observed times) to the last
+        # value there, which is where the step function has settled.
+        x = np.asarray(x, dtype=float)
+        y = np.asarray(y, dtype=float)
+        keep = np.append(np.diff(x) > 0, True)
+        pchip = PchipInterpolator(x[keep], y[keep], extrapolate=False)
+        return lambda q: pchip(np.asarray(q, dtype=float))
     return interp1d(x, y, kind=kind, bounds_error=False, fill_value=np.nan)
 
 
@@ -474,7 +490,9 @@ class NonParametric(NonParametricDistribution):
 
         return R_out
 
-    def random(self, size: int) -> npt.NDArray:
+    def random(
+        self, size: int, random_state: int | None = None
+    ) -> npt.NDArray:
         r"""
         Draws random samples from the fitted distribution. Each observed
         value x is drawn with the probability mass the estimated survival
@@ -482,12 +500,28 @@ class NonParametric(NonParametricDistribution):
         due to right censoring) the remaining mass is distributed over the
         observed values, i.e. sampling is conditional on an event occurring
         at one of the observed values.
+
+        Parameters
+        ----------
+
+        size : int
+            The number of random samples to draw.
+        random_state : int or numpy.random.Generator, optional
+            Seed or generator for reproducible sampling. Matches the
+            ``random_state`` argument of ``bootstrap_cb`` and ``band``.
+
+        Returns
+        -------
+
+        random : numpy array
+            The random samples drawn from the observed values.
         """
         with np.errstate(all="ignore"):
             p = -np.diff(np.hstack([[1.0], self.R]))
         p = np.where(np.isfinite(p), p, 0)
         p = p / p.sum()
-        return np.random.choice(self.x, size=size, p=p)
+        rng = np.random.default_rng(random_state)
+        return rng.choice(self.x, size=size, p=p)
 
     def qf(self, p: npt.ArrayLike) -> npt.NDArray:
         r"""
@@ -1228,3 +1262,97 @@ class NonParametric(NonParametricDistribution):
         out.greenwood = None  # type: ignore[assignment]
 
         return out
+
+    # The estimator ladder and derived curves that fully describe a fitted
+    # model; everything the public methods need is a function of these.
+    _SERIALIZED_ARRAYS = ("x", "r", "d", "R", "F", "H", "greenwood")
+
+    def to_dict(self, with_data: bool = False) -> dict:
+        r"""
+        Serialize the fitted non-parametric model to a plain dictionary,
+        mirroring the parametric ``to_dict``. The estimator ladder
+        (``x``, ``r``, ``d``), the derived curves (``R``, ``F``, ``H``),
+        the variance estimate (``greenwood``) and the estimator name are
+        stored, which is everything the model's methods need to be
+        reconstructed with :meth:`from_dict`.
+
+        Parameters
+        ----------
+
+        with_data : bool, optional
+            Also store the raw ``x``/``c``/``n``/``t`` data the model was
+            fitted with (needed to reconstruct a model that can call
+            :meth:`bootstrap_cb`). Defaults to False.
+
+        Returns
+        -------
+
+        model_dict : dict
+            The serialized model.
+        """
+        out: dict[str, Any] = {"parameterization": "non-parametric"}
+        out["model"] = self.model
+        for attr in self._SERIALIZED_ARRAYS:
+            value = getattr(self, attr, None)
+            out[attr] = None if value is None else np.asarray(value).tolist()
+
+        if "estimator" in getattr(self, "data", {}):
+            out["estimator"] = self.data["estimator"]
+
+        if with_data and getattr(self, "data", None) is not None:
+            data_dict: dict[str, Any] = {}
+            for ch in ["x", "c", "n", "t"]:
+                value = self.data.get(ch, None)
+                data_dict[ch] = (
+                    None if value is None else np.asarray(value).tolist()
+                )
+            out["data"] = data_dict
+
+        return out
+
+    def to_json(self, fp: str | Path) -> None:
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "NonParametric":
+        r"""
+        Reconstruct a fitted non-parametric model from a dictionary
+        produced by :meth:`to_dict`.
+        """
+        if model_dict.get("parameterization") != "non-parametric":
+            raise ValueError(
+                "Must create a non-parametric model from a non-parametric "
+                "model dict"
+            )
+        out = cls()
+        out.model = model_dict["model"]
+        for attr in cls._SERIALIZED_ARRAYS:
+            value = model_dict.get(attr, None)
+            if value is None:
+                # ``greenwood`` is legitimately absent (no variance
+                # estimate, e.g. ``fit_from_ecdf``); leave it as None so
+                # the confidence-bound guards fire as they would on the
+                # original model.
+                if attr == "greenwood":
+                    out.greenwood = None  # type: ignore[assignment]
+            else:
+                setattr(out, attr, np.asarray(value))
+
+        if "data" in model_dict or "estimator" in model_dict:
+            data: dict[str, Any] = {}
+            raw = model_dict.get("data", {})
+            for ch in ["x", "c", "n", "t"]:
+                value = raw.get(ch, None)
+                if value is not None:
+                    data[ch] = np.asarray(value)
+            if "estimator" in model_dict:
+                data["estimator"] = model_dict["estimator"]
+            out.data = data
+
+        return out
+
+    @classmethod
+    def from_json(cls, fp: str | Path) -> "NonParametric":
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))


### PR DESCRIPTION
Three fixes to `surpyval/univariate/nonparametric/`, closing most of DEVELOPMENT.md §4.

## `interp='cubic'` is now shape-preserving (correctness fix)

`interp1d(kind='cubic')` can overshoot on a survival curve: a sharp drop followed by a flat tail produced interpolated `sf` as low as **−0.44** and non-monotone, which then made `Hf = −log(sf)` NaN in the interior (and poisoned `hf` and interpolated bounds). `interp_function` now uses scipy's `PchipInterpolator` (monotone piecewise-cubic Hermite) for the `'cubic'` path, collapsing the duplicated zero-width Turnbull bounds to satisfy its strictly-increasing-x requirement. Curves stay in `[0, 1]` and non-increasing while still interpolating the fitted estimates exactly.

## `random()` is seedable

`NonParametric.random(size, random_state=None)` now routes through `np.random.default_rng` instead of the legacy global `np.random.choice`, matching `bootstrap_cb`/`band` and making draws reproducible.

## `NonParametric` serialization

Adds `to_dict`/`from_dict` and `to_json`/`from_json`, mirroring the parametric API. The estimator ladder (`x`, `r`, `d`), derived curves (`R`, `F`, `H`), variance (`greenwood`) and estimator name round-trip so a restored model reproduces `sf`/`cb` exactly; `with_data=True` also stores raw `x`/`c`/`n`/`t` so a restored model can still bootstrap. Missing variance (`fit_from_ecdf`) is preserved as `None` so the bound guards still fire.

## Verification

New `test_np_improvements.py` (14 tests): the cubic bug reproduced-then-fixed (monotone, bounded, non-NaN hazard, passes through estimates, Turnbull zero-width bounds); seedable/observed-value `random()`; round-trip of `sf`/`cb`/`R` across KM/NA/FH/Turnbull, JSON encodability, Turnbull estimator + bootstrap survival, wrong-parameterization rejection, and `fit_from_ecdf` missing-variance preservation.

Full suite: 904 passed, 1 skipped; flake8/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_