### PR TITLE
Finish nonparametric section: remove dist='t' heuristic, cover untested paths

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -110,23 +110,19 @@ Extract a shared helper. The `count_terminated_simulation` methods are similarly
 
 ---
 
-## 4. Univariate Non-Parametric Module — Remaining Work
+## 4. Univariate Non-Parametric Module — Complete
 
-The following engineering debt in `surpyval/univariate/nonparametric/` remains.
+The tracked engineering debt in `surpyval/univariate/nonparametric/` is
+cleared: monotone (PCHIP) smooth interpolation, seedable `random()`, and
+`to_dict`/`from_dict`/JSON serialization are done; the unjustified
+`dist='t'` confidence-bound heuristic has been removed (`R_cb`/`cb` now
+accept only `dist='z'`, raising an informative error for `'t'` that
+points to `bootstrap_cb`/`band`); and the previously-untested `from_xrd`,
+`set_lower_limit`, and non-step `plot()` paths now have direct tests.
 
-### `dist='t'` confidence-bound heuristic
-**File:** `nonparametric.py` (`R_cb`)
-
-The `dist='t'` option is documented as an unfounded conservative
-heuristic (degrees of freedom from the at-risk count, undefined at the
-last point). It is retained only for backward compatibility; decide
-whether to formally deprecate and remove it, or keep it and accept the
-maintenance of a statistically unjustified path.
-
-### Residual test gaps
-`plot()` with non-step `interp`, the `set_lower_limit` path in
-`NonParametricFitter.fit`, and the `from_xrd` entry point still have
-no direct tests.
+Note (out of scope here, tracked under §2): `NonParametricCounting.mcf_cb`
+in the recurrent module carries the same `dist='t'` heuristic and could be
+removed for consistency.
 
 ---
 

--- a/surpyval/tests/univariate/nonparametric/test_confidence_bounds.py
+++ b/surpyval/tests/univariate/nonparametric/test_confidence_bounds.py
@@ -148,6 +148,20 @@ def test_cb_invalid_bound_type_raises():
         model.cb([2.0], bound_type="regular")
 
 
+def test_cb_dist_t_removed():
+    # The unjustified Student-t heuristic was removed; only the normal ('z')
+    # statistic is supported, and 't' now raises an informative error
+    # pointing to the principled alternatives.
+    model = surpyval.KaplanMeier.fit(np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
+    with pytest.raises(ValueError, match="bootstrap_cb"):
+        model.cb([2.0, 3.0], dist="t")
+    with pytest.raises(ValueError, match="'dist' must be 'z'"):
+        model.R_cb([2.0, 3.0], dist="t")
+    # 'z' (the default) is unaffected.
+    assert model.cb([2.0, 3.0], dist="z").shape == (2, 2)
+    assert np.allclose(model.cb([2.0, 3.0]), model.cb([2.0, 3.0], dist="z"))
+
+
 def test_cb_turnbull_uses_selected_estimator_variance():
     left = np.array([1, 8, 8, 7, 7, 17, 37, 46, 46, 45.0])
     right = np.array([7, 8, 10, 16, 14, np.inf, 44, np.inf, np.inf, np.inf])

--- a/surpyval/tests/univariate/nonparametric/test_np_coverage.py
+++ b/surpyval/tests/univariate/nonparametric/test_np_coverage.py
@@ -1,0 +1,98 @@
+"""Direct tests for the previously-untested NonParametric entry points:
+``from_xrd``, the ``set_lower_limit`` fit option, and ``plot`` with the
+non-step interpolation schemes."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+import surpyval  # noqa: E402
+
+# --- from_xrd -------------------------------------------------------------
+
+
+def test_from_xrd_nelson_aalen_matches_formula():
+    x = [1, 2, 3, 4, 5, 6]
+    r = [10, 8, 6, 4, 3, 2]
+    d = [2, 1, 1, 1, 1, 1]
+    model = surpyval.NelsonAalen.from_xrd(x, r, d)
+    expected = np.exp(-np.cumsum(np.array(d) / np.array(r)))
+    assert np.allclose(model.x, x)
+    assert np.allclose(model.R, expected)
+
+
+def test_from_xrd_kaplan_meier_matches_formula():
+    x = [1, 2, 3, 4, 5, 6]
+    r = [10, 8, 6, 4, 3, 2]
+    d = [2, 1, 1, 1, 1, 1]
+    model = surpyval.KaplanMeier.from_xrd(x, r, d)
+    expected = np.cumprod(1 - np.array(d) / np.array(r))
+    assert np.allclose(model.R, expected)
+
+
+def test_from_xrd_supports_confidence_bounds_but_not_bootstrap():
+    # from_xrd carries r and d, so the Greenwood variance (and cb) is
+    # available, but it stores no raw data so the bootstrap cannot run.
+    model = surpyval.NelsonAalen.from_xrd(
+        [1, 2, 3, 4, 5], [10, 8, 6, 4, 2], [2, 2, 2, 2, 2]
+    )
+    assert model.greenwood is not None
+    assert model.cb([2.0, 3.0]).shape == (2, 2)
+    with pytest.raises(ValueError, match="Bootstrap requires the data"):
+        model.bootstrap_cb([2.0, 3.0])
+
+
+def test_from_xrd_rejected_for_turnbull():
+    with pytest.raises(ValueError, match="from_xrd with Turnbull"):
+        surpyval.Turnbull.from_xrd([1, 2, 3], [3, 2, 1], [1, 1, 1])
+
+
+# --- set_lower_limit ------------------------------------------------------
+
+
+def test_set_lower_limit_anchors_curve():
+    x = np.array([2.0, 3.0, 4.0, 5.0, 6.0])
+    model = surpyval.KaplanMeier.fit(x, set_lower_limit=0.0)
+    baseline = surpyval.KaplanMeier.fit(x)
+    # A leading point is inserted at the lower limit with no deaths, so the
+    # survival there is 1 and the rest of the ladder is unchanged.
+    assert model.x[0] == 0.0
+    assert model.d[0] == 0
+    assert model.R[0] == 1.0
+    assert model.x.size == baseline.x.size + 1
+    assert np.allclose(model.R[1:], baseline.R)
+
+
+def test_set_lower_limit_shifts_survival_evaluation():
+    x = np.array([2.0, 3.0, 4.0, 5.0])
+    model = surpyval.KaplanMeier.fit(x, set_lower_limit=0.5)
+    # Between the lower limit and the first event the survival is 1.
+    assert np.allclose(model.sf([0.6, 1.0, 1.9]), 1.0)
+
+
+# --- plot with non-step interpolation -------------------------------------
+
+
+@pytest.mark.parametrize("interp", ["linear", "cubic"])
+def test_plot_with_non_step_interp(interp):
+    model = surpyval.KaplanMeier.fit(np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))
+    ax = plt.figure().gca()
+    returned = model.plot(ax=ax, interp=interp)
+    # A curve is drawn (as a line, not a step) and the confidence band as a
+    # filled region.
+    assert returned is ax
+    assert len(ax.lines) >= 1
+    assert len(ax.collections) >= 1
+    plt.close("all")
+
+
+def test_plot_non_step_interp_without_bounds():
+    model = surpyval.KaplanMeier.fit(np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
+    ax = plt.figure().gca()
+    model.plot(ax=ax, interp="linear", plot_bounds=False)
+    assert len(ax.collections) == 0
+    plt.close("all")

--- a/surpyval/univariate/nonparametric/nonparametric.py
+++ b/surpyval/univariate/nonparametric/nonparametric.py
@@ -7,7 +7,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 from scipy.interpolate import PchipInterpolator, interp1d
-from scipy.stats import norm, t
+from scipy.stats import norm
 
 from surpyval.distribution import NonParametricDistribution
 
@@ -314,14 +314,11 @@ class NonParametric(NonParametricDistribution):
             undercover in small samples. Defaults to 'exp' (the
             log(-log) transformed interval) as this ensures the bounds
             are within 0 and 1 and has better coverage.
-        dist : ('t', 'z'), str, optional
-            The statistic to use in calculating the bounds (student-t or
-            normal). Defaults to the normal (z). The 't' option is a
-            conservative heuristic which uses the at risk count minus one
-            at each point as the degrees of freedom; it is not supported
-            by asymptotic theory, widens (overcovers) as the at risk
-            count falls, and is undefined when only one item remains at
-            risk.
+        dist : ('z',), str, optional
+            The statistic used for the bounds. Only the normal ('z') is
+            supported, which is what the asymptotic theory of the estimator
+            justifies. For small-sample or Turnbull bounds use
+            ``bootstrap_cb``; for a simultaneous band use ``band``.
 
         Returns
         -------
@@ -409,8 +406,15 @@ class NonParametric(NonParametricDistribution):
     ) -> npt.NDArray:
         if bound_type not in ["exp", "normal"]:
             raise ValueError("'bound_type' must be in ['exp', 'normal']")
-        if dist not in ["t", "z"]:
-            raise ValueError("'dist' must be in ['t', 'z']")
+        if dist != "z":
+            raise ValueError(
+                "'dist' must be 'z'. The 't' option (Student-t with the "
+                "at-risk count as degrees of freedom) has been removed: it "
+                "had no asymptotic justification, was undefined at the last "
+                "event, and widened bounds arbitrarily as the risk set "
+                "shrank. For small-sample or Turnbull confidence bounds use "
+                "`bootstrap_cb`, and for a simultaneous band use `band`."
+            )
         if getattr(self, "greenwood", None) is None:
             raise ValueError(
                 "Model has no variance estimate so confidence bounds "
@@ -425,17 +429,11 @@ class NonParametric(NonParametricDistribution):
 
         x = np.atleast_1d(x)
         if bound in ["upper", "lower"]:
-            if dist == "t":
-                stat = t.ppf(1 - confidence, self.r - 1)
-            else:
-                stat = norm.ppf(1 - confidence, 0, 1)
+            stat = norm.ppf(1 - confidence, 0, 1)
             if bound == "upper":
                 stat = -stat
         elif bound == "two-sided":
-            if dist == "t":
-                stat = t.ppf((1 - confidence) / 2, self.r - 1)
-            else:
-                stat = norm.ppf((1 - confidence) / 2, 0, 1)
+            stat = norm.ppf((1 - confidence) / 2, 0, 1)
             stat = np.array([-1, 1]).reshape(2, 1) * stat
 
         if bound_type == "exp":
@@ -593,9 +591,9 @@ class NonParametric(NonParametricDistribution):
             computed. Defaults to 0.05.
         bound_type : ('exp', 'normal'), str, optional
             The method for the underlying survival function bounds.
-        dist : ('t', 'z'), str, optional
+        dist : ('z',), str, optional
             The statistic used in the underlying survival function
-            bounds.
+            bounds. Only the normal ('z') is supported.
 
         Returns
         -------


### PR DESCRIPTION
Completes DEVELOPMENT.md §4 (univariate non-parametric module).

## Remove the `dist='t'` confidence-bound heuristic

`NonParametric.R_cb`/`cb` offered a Student-t critical value with `df = (at-risk count) − 1`. It was a well-intentioned small-sample analogy with no statistical basis:

- **No theory** — the Kaplan-Meier / Nelson-Aalen estimators are asymptotically *normal* (martingale CLT); nothing derives a t-distribution for these bounds.
- **Breaks where it should help** — at the last event (r=1) the t-quantile is undefined (df=0), and at r=2 it inflated the interval **6.5×** with no principled meaning.
- **Inconsistent** — identical estimate + variance gave different bounds purely from the at-risk count.

`dist` now accepts only `'z'`; passing `'t'` raises an informative error pointing to the principled alternatives already in the class — `bootstrap_cb` (small-sample / Turnbull bounds) and `band` (simultaneous bands). The default (`'z'`) is unaffected. The unused `scipy.stats.t` import and the `cb`/`R_cb`/`quantile_cb` docstrings are updated.

This is a deliberate breaking change for anyone passing `dist='t'`; they now get an explanatory error rather than silently unjustified numbers.

## Cover the three previously-untested entry points

- **`from_xrd`** — NA/KM survival checked against the closed forms; confidence bounds available but `bootstrap_cb` correctly rejected (no stored data); Turnbull rejected.
- **`set_lower_limit`** — leading anchor point inserted at R=1 with no deaths, rest of the ladder unchanged; survival is 1 between the limit and the first event.
- **`plot()` with non-step `interp`** — linear and cubic draw a line curve plus a filled confidence band, and honour `plot_bounds=False`.

## Note

The recurrent `NonParametricCounting.mcf_cb` carries the same `dist='t'` heuristic. Left as-is here (it's §2 scope) and flagged in the doc as a consistent follow-up.

Full suite: 924 passed, 1 skipped; flake8/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_