### PR TITLE
Input validation for handle_xicn, parametric additive hazards, discrete-distribution docs, and a reserved-attribute fix

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -128,11 +128,21 @@ removed for consistency.
 
 ## 5. Semi-Parametric Regression — Future Work
 
-`AdditiveHazards` (Lin & Ying 1994) is now implemented: the closed-form
-semi-parametric additive-hazards estimator `h(x|Z) = h₀(x) + β'Z`, with
-the sandwich covariance, p-values, a Breslow-type baseline, `sf`/`ff`/
-`hf`/`Hf`/`df` prediction and `fit_from_df`. Three candidates remain, in
-priority order:
+Additive hazards is implemented on both scales, completing the symmetry
+with proportional hazards (semi-parametric `CoxPH` + parametric
+`WeibullPH` etc.):
+
+- **Semi-parametric** `AdditiveHazards` (Lin & Ying 1994) — the closed-form
+  estimator `h(x|Z) = h₀(x) + β'Z` with an unspecified baseline, sandwich
+  covariance, p-values, a Breslow-type baseline, `sf`/`ff`/`hf`/`Hf`/`df`
+  prediction and `fit_from_df`.
+- **Parametric** `AH(dist)` factory + pre-built `WeibullAH`,
+  `ExponentialAH`, … — `h(x|Z) = h₀(x; θ) + β'Z` with a parametric
+  baseline, fit by plain MLE. Positivity is not enforced: the fit finds
+  the best positive-hazard solution and raises (pointing at PH) only if
+  the optimum genuinely needs a negative hazard.
+
+Three candidates remain, in priority order:
 
 ### Buckley-James (semi-parametric AFT) — High priority
 The semi-parametric counterpart to Cox PH. Fits `log(T) = β'Z + ε` without assuming a parametric baseline distribution. Uses an iterative censoring-imputation (Buckley-James) algorithm. Completes the semi-parametric trio alongside `CoxPH`. Supported in R's `survival::survreg` with no baseline assumption.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,8 +56,8 @@ which is a genuinely different construction.
 **Left-truncation support (partial)**
 `handle_xicn` takes the surpyval `t`/`tl`/`tr` truncation fields, and the calendar-time NHPP models (`HPP`, `CrowAMSAA`, `Duane`, `CoxLewis`) integrate each item's likelihood from its entry time `tl`, so delayed-entry (warranty-from-first-sale) data is analysed correctly there. The virtual-age / history-dependent models (Kijima/G1/ARA/ARI) reject `tl > 0` with an explanatory error, since the virtual age at entry is undefined without the pre-entry history. Still to do: multi-window (gapped) observation per item.
 
-**No input validation**
-Negative times, NaN/inf values, and empty arrays all pass silently into the optimiser. Add a validation step in `handle_xicn()` with informative `ValueError`s.
+**Input validation (done)**
+`handle_xicn()` now validates its input up front with informative `ValueError`s: empty arrays, non-finite (NaN/inf) event times, invalid censoring codes (outside `{-1, 0, 1, 2}`), non-positive or non-finite counts, NaN truncation bounds, and non-finite covariates are all rejected. Event times are checked against each item's integration origin — its left-truncation bound when finite, otherwise the fallback origin `0` — so untruncated negative times are rejected while a genuine (possibly negative) left-truncation window still admits negative times.
 
 ---
 

--- a/docs/Parametric SurPyval Modelling.rst
+++ b/docs/Parametric SurPyval Modelling.rst
@@ -707,6 +707,91 @@ To showcase the SurPyval API again, and to demonstrate the flexibility, it is tr
 
 Using a ``LogNormal`` distribution we were able to easily capture the DS/LFP and ZI behaviour of the data.
 
+Discrete Distributions
+----------------------
+
+Every distribution used so far is *continuous* -- a failure time can be any positive real number. But many reliability problems are naturally *discrete*: an item does not fail after "3.7 cycles", it fails **on** the 4th cycle. A switch is toggled until it breaks, a component absorbs shocks until it fractures, a system is inspected once per period until a defect appears. When the lifetime is a count -- a positive integer -- a discrete distribution is the honest model, and reaching for a continuous one can bias the answer.
+
+*SurPyval* provides three discrete lifetime distributions, all supported on the positive integers :math:`\{1, 2, 3, \dots\}`:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Distribution
+     - Continuous analogue
+     - Discrete hazard
+   * - ``Geometric``
+     - Exponential
+     - constant (memoryless)
+   * - ``DiscreteWeibull``
+     - Weibull
+     - increasing, constant, or decreasing
+   * - ``NegativeBinomial``
+     - Gamma
+     - cycles until the ``r``-th shock
+
+They are used exactly like the continuous distributions -- the same ``fit()`` call, the same ``sf``, ``ff``, ``hf``, ``Hf`` and ``df`` methods, and the same support for censoring, truncation, and counts.
+
+The ``Geometric`` distribution is the discrete analogue of the ``Exponential``: each cycle fails independently with a constant probability ``p``, so it is *memoryless*. It models the number of cycles until the first failure.
+
+.. jupyter-execute::
+
+    import surpyval as surv
+    import numpy as np
+
+    np.random.seed(1)
+    # 200 items; each cycle fails with probability 0.15
+    x = surv.Geometric.random(200, 0.15)
+    surv.Geometric.fit(x)
+
+The ``DiscreteWeibull`` distribution (the Nakagawa-Osaki Type I) is the discrete analogue of the ``Weibull``, and like it has a flexible hazard: ``beta`` controls the shape, with ``beta < 1`` a decreasing (infant-mortality) hazard, ``beta = 1`` the constant-hazard Geometric, and ``beta > 1`` an increasing (wear-out) hazard.
+
+.. jupyter-execute::
+
+    np.random.seed(2)
+    # beta = 2 -> a wearing-out item
+    x = surv.DiscreteWeibull.random(200, 0.95, 2.0)
+    model = surv.DiscreteWeibull.fit(x)
+    model
+
+Because ``beta > 1`` here, the discrete hazard rises with each cycle -- the chance of failing on the next cycle grows as the item wears:
+
+.. jupyter-execute::
+
+    model.hf([1, 5, 10, 15])
+
+The ``NegativeBinomial`` distribution models the number of cycles until an item accumulates enough shocks to fail: with ``T = 1 + Y`` where ``Y`` is the number of failures before the ``r``-th success. It is overdispersed relative to a Poisson count and reduces to the ``Geometric`` when ``r = 1``.
+
+.. jupyter-execute::
+
+    np.random.seed(3)
+    x = surv.NegativeBinomial.random(1000, 3.0, 0.4)
+    surv.NegativeBinomial.fit(x)
+
+Since ``r`` and ``p`` trade off against each other, the negative binomial usually needs more data than the single-parameter Geometric to pin both down.
+
+The full ``fit()`` API carries over. Censored and truncated discrete data are handled exactly as for the continuous distributions -- here every item still running after 10 cycles is right censored:
+
+.. jupyter-execute::
+
+    np.random.seed(4)
+    x = surv.DiscreteWeibull.random(200, 0.95, 2.0)
+    c = np.zeros_like(x)
+    c[x > 10] = 1
+    x[x > 10] = 10
+    surv.DiscreteWeibull.fit(x, c=c)
+
+Because the support is :math:`\{1, 2, 3, \dots\}`, the value ``0`` is left free to carry a **zero-inflation** mass -- the "dead on arrival" units from the previous section. Fitting with ``zi=True`` recovers both the lifetime parameters and the structural-zero fraction:
+
+.. jupyter-execute::
+
+    np.random.seed(5)
+    x = surv.Geometric.random(200, 0.2)
+    x = np.concatenate([x, np.zeros(40)])  # 40 dead-on-arrival units
+    surv.Geometric.fit(x, zi=True)
+
+A note on estimation: probability plotting (MPP) is not defined for these discrete lifetimes, so they are fit by maximum likelihood (the default) and calling ``plot()`` on a discrete model raises. All the other model methods -- ``sf``, ``ff``, ``hf``, ``Hf``, ``df``, ``mean``, ``moment``, ``random`` and the confidence bounds ``cb`` -- work as usual.
+
 Confidence Intervals
 --------------------
 

--- a/docs/Recurrent Event Modelling with SurPyval.rst
+++ b/docs/Recurrent Event Modelling with SurPyval.rst
@@ -175,6 +175,71 @@ made a poor assumption in using the HPP model. Let's try another one.
 This is clearly a much better fit. Have a look at the api documentation to see
 what other parametric models are available in SurPyval.
 
+Inference and model checking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A fitted parametric recurrence model is more than a point estimate. Every
+model fit by maximum likelihood exposes the usual likelihood quantities for
+comparing models — the log-likelihood and the ``aic`` / ``bic`` information
+criteria (these are attributes, not methods):
+
+.. jupyter-execute::
+
+    print("AIC:", model.aic, " BIC:", model.bic)
+
+It also carries the uncertainty of the fitted parameters. ``standard_errors()``
+returns the standard error of each parameter (from the observed information),
+and ``param_cb`` gives a confidence interval on a named parameter — computed on
+a transformed scale so the interval respects the parameter's support (a rate,
+for instance, cannot go negative):
+
+.. jupyter-execute::
+
+    print("parameters :", model.parameter_names)
+    print("std errors :", model.standard_errors())
+    print("alpha 95% CI:", model.param_cb("alpha"))
+
+That parameter uncertainty propagates to the fitted curve. ``plot()`` draws a
+delta-method confidence band around the cumulative intensity function, and
+``cif_cb`` returns the band directly:
+
+.. jupyter-execute::
+
+    model.plot()
+
+Having a model is not the same as having a *good* model. SurPyval provides three
+complementary checks. First, a **trend test** on the fitted data — the same
+Laplace / Military-Handbook tests used to decide whether a time-varying
+intensity was warranted in the first place:
+
+.. jupyter-execute::
+
+    result = model.trend_test()
+    print(result.trend, "trend, p-value", round(result.p_value, 3))
+
+Second, **residuals**. Via the time-rescaling theorem, the fitted model turns
+the event times into what should be a unit-rate Poisson process, so the
+cumulative-hazard residuals are (under the model) an i.i.d. Exp(1) sample with
+mean 1:
+
+.. jupyter-execute::
+
+    print(model.residuals().round(3))
+
+Third, a **goodness-of-fit test**. ``cramer_von_mises`` measures how far the
+transformed event times fall from uniformity and calibrates the statistic with
+a parametric bootstrap, so its p-value accounts for the parameters having been
+estimated. A large p-value means the fitted intensity is consistent with the
+data:
+
+.. jupyter-execute::
+
+    gof = model.cramer_von_mises(n_boot=100, seed=1)
+    print("statistic", round(gof.statistic, 3), " p-value", round(gof.p_value, 3))
+
+The same inference and diagnostic methods are available on the
+proportional-intensity regression models and the renewal models below.
+
 Renewal Modelling in SurPyval
 -----------------------------
 

--- a/docs/Regression Modelling with SurPyval.rst
+++ b/docs/Regression Modelling with SurPyval.rst
@@ -251,6 +251,16 @@ interaction term counteracts — the same story, told on the additive scale.
    model — whose exponential form keeps the hazard positive — is often the
    safer choice.
 
+Just as Cox has parametric proportional-hazards counterparts (the next
+section), there is also a *parametric* additive-hazards model — a parametric
+baseline hazard with the same additive covariate term, ``h(x|Z) = h_0(x;θ) +
+β'Z``, fit by maximum likelihood. It is available as the ``AH(distribution)``
+factory and as pre-built ``WeibullAH``, ``ExponentialAH``, … instances, and
+gives a smooth, extrapolatable version of what ``AdditiveHazards`` estimates
+non-parametrically. The positivity caveat above applies more sharply here:
+because the likelihood needs ``log(h)`` at every event, a fit whose optimum
+requires a negative hazard raises rather than returning an invalid model.
+
 
 Parametric Proportional Hazards (PH)
 --------------------------------------

--- a/docs/Regression Modelling with SurPyval.rst
+++ b/docs/Regression Modelling with SurPyval.rst
@@ -26,7 +26,7 @@ For the rest of this page we assume the following imports:
 Choosing a regression model family
 ------------------------------------
 
-There are three fundamentally different ways a covariate can affect a survival
+There are four fundamentally different ways a covariate can affect a survival
 distribution. Each gives rise to a distinct model family:
 
 **Proportional Hazards (PH)** — the covariate multiplies the *rate of dying*:
@@ -65,6 +65,21 @@ converges toward failure regardless of their covariates. When you believe the
 PH assumption ("constant hazard ratio for all time") is too strong, PO is often
 a better default.
 
+**Additive Hazards (AH)** — the covariate *adds* to the hazard instead of
+multiplying it:
+
+.. math::
+
+    h(x \mid Z) = h_0(x) + \beta' Z
+
+Here :math:`\beta_j` is a *risk difference* — the change in the absolute hazard
+per unit of covariate, constant over time — rather than a hazard *ratio*. This
+is the natural scale when you care about *how many extra failures per unit time*
+a factor causes: excess risk in epidemiology, or reliability settings where
+hazards from independent mechanisms genuinely add. Because the effect is
+additive rather than exponential it is not constrained to be positive, which is
+both its interpretive appeal and its main caveat (discussed below).
+
 **Accelerated Life (AL)** — the covariate substitutes the distribution's *life
 parameter*:
 
@@ -89,8 +104,10 @@ because the exponential guarantees :math:`\phi > 0` for any covariate value and
 any β — no parameter constraints needed. A positive β makes failure faster;
 negative makes it slower.
 
-SurPyval supports all four families, each available as pre-built instances for
-every standard distribution and as factory functions for custom combinations:
+SurPyval supports all of these families, each available as pre-built instances
+for every standard distribution and as factory functions for custom
+combinations (with additive hazards provided as a single semi-parametric
+model):
 
 .. list-table::
    :header-rows: 1
@@ -108,6 +125,9 @@ every standard distribution and as factory functions for custom combinations:
    * - Proportional Odds (PO)
      - Scales the survival odds :math:`O(x|Z) = O_0(x)\,\phi(Z)`
      - ``WeibullPO``, ``LogisticPO``, …
+   * - Additive Hazards (AH)
+     - Adds to the hazard rate :math:`h(x|Z) = h_0(x) + \beta'Z`
+     - ``AdditiveHazards``
    * - Accelerated Life (AL)
      - Substitutes the life parameter with a physics-motivated function
      - ``AcceleratedLife(Weibull, Power)``, ``AcceleratedLife(Weibull, Eyring)``
@@ -182,6 +202,54 @@ mean tire against 10% above and below average:
 
 The step-function shape is the signature of the non-parametric baseline —
 the model makes no smoothness assumptions about :math:`h_0(x)`.
+
+
+Semi-Parametric — Additive Hazards
+----------------------------------
+
+The Lin & Ying additive hazards model is the additive-scale companion to Cox.
+Like Cox it leaves the baseline hazard :math:`h_0(x)` completely unspecified,
+but the covariate effect is a *risk difference* rather than a hazard *ratio*:
+
+.. math::
+
+    h(x \mid Z) = h_0(x) + \beta' Z
+
+Its practical convenience is that, unlike Cox's iterative partial likelihood,
+the coefficient estimator is *closed form* — a ratio of sums accumulated over
+the risk sets — so there is no optimisation and nothing to converge. Standard
+errors come from the Lin-Ying sandwich estimator. We can reuse the tire data
+and the significant covariates from the Cox fit above:
+
+.. jupyter-execute::
+
+    from surpyval import AdditiveHazards
+
+    model = AdditiveHazards.fit(x=x, Z=Z, c=c)
+    model
+
+.. jupyter-execute::
+
+    print(model.p_values)
+
+The coefficients read as risk differences: a one-unit change in a covariate
+shifts the absolute hazard by :math:`\beta` at every time. As in the Cox fit,
+higher gauge and peel-force values reduce the hazard (improving life) while the
+interaction term counteracts — the same story, told on the additive scale.
+
+.. note::
+
+   An additive hazard can go **negative** when :math:`\beta' Z` is sufficiently
+   negative — nothing constrains :math:`h_0(x) + \beta' Z > 0`. When that
+   happens the fitted cumulative hazard is no longer monotone and the implied
+   survival can rise above 1. SurPyval returns the raw estimate without
+   clamping; a survival above 1 is a signal that the additive model is a poor
+   description at that covariate value (or that you are outside the range where
+   it is well behaved), and is best read as a caution rather than a prediction.
+   This is an inherent property of additive-hazards models, not a defect of the
+   fit. When covariate effects are strongly protective, a proportional-hazards
+   model — whose exponential form keeps the hazard positive — is often the
+   safer choice.
 
 
 Parametric Proportional Hazards (PH)

--- a/surpyval/tests/recurrent/test_nhpp_censoring.py
+++ b/surpyval/tests/recurrent/test_nhpp_censoring.py
@@ -43,7 +43,7 @@ def test_single_interval_row_does_not_crash():
 def test_interval_censoring_respects_truncation_window():
     # An interval beginning below the left-truncation bound is rejected.
     x = np.array([[1.0, 5.0], [6.0, 9.0]])
-    with pytest.raises(ValueError, match="outside its truncation window"):
+    with pytest.raises(ValueError, match="outside its observation window"):
         HPP.fit(
             x, np.array([1, 1]), c=np.array([2, 2]), n=np.array([1, 1]), tl=3.0
         )

--- a/surpyval/tests/recurrent/test_truncation.py
+++ b/surpyval/tests/recurrent/test_truncation.py
@@ -14,18 +14,21 @@ from surpyval.utils.recurrent_utils import handle_xicn
 
 
 def test_handle_xicn_default_truncation():
-    # Without truncation the window defaults to the whole real line, so no
-    # assumption is made about the sign of x.
+    # Without truncation the window defaults to the whole real line on the
+    # right, with the fallback origin 0 on the left.
     data = handle_xicn(np.array([1.0, 2.0, 3.0]), np.array([1, 1, 1]))
     assert np.all(data.tl == -np.inf)
     assert np.all(data.tr == np.inf)
 
 
-def test_handle_xicn_allows_negative_x_when_untruncated():
-    # A variable on a native/transformed scale (e.g. a log-intensity) can be
-    # negative; the default window must not reject it.
-    data = handle_xicn(np.array([-3.0, -1.0, 2.0]), np.array([1, 1, 1]))
-    assert np.allclose(data.x, [-3.0, -1.0, 2.0])
+def test_handle_xicn_rejects_negative_x_when_untruncated():
+    # Untruncated event times are integrated from the fallback origin 0, so a
+    # negative time would give a negative interarrival. It is rejected rather
+    # than silently corrupting the likelihood. (Genuinely negative event
+    # times are admitted only with an explicit negative left-truncation
+    # window; see test_explicit_negative_left_truncation_is_used_as_origin.)
+    with pytest.raises(ValueError, match="outside its observation window"):
+        handle_xicn(np.array([-3.0, -1.0, 2.0]), np.array([1, 1, 1]))
 
 
 def test_explicit_negative_left_truncation_is_used_as_origin():
@@ -45,7 +48,7 @@ def test_handle_xicn_scalar_truncation_broadcasts():
 
 
 def test_handle_xicn_rejects_events_outside_window():
-    with pytest.raises(ValueError, match="outside its truncation window"):
+    with pytest.raises(ValueError, match="outside its observation window"):
         handle_xicn(np.array([1.0, 5.0]), np.array([1, 1]), tl=2.0)
 
 

--- a/surpyval/tests/recurrent/test_xicn_validation.py
+++ b/surpyval/tests/recurrent/test_xicn_validation.py
@@ -1,0 +1,188 @@
+"""Input validation for ``handle_xicn``.
+
+Recurrent-event data enters the fitters through ``handle_xicn``. Malformed
+input (empty arrays, NaN/inf, nonsensical counts or censoring codes, event
+times below the integration origin) previously flowed silently into the
+optimiser and produced meaningless fits. These tests pin the informative
+``ValueError``s that now guard those cases -- and, importantly, confirm the
+valid edge cases that must *not* be rejected.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval.utils.recurrent_utils import handle_xicn
+
+# --- empty / degenerate shapes -------------------------------------------
+
+
+def test_empty_x_rejected():
+    with pytest.raises(ValueError, match="cannot be empty"):
+        handle_xicn(np.array([]))
+
+
+# --- non-finite event times ----------------------------------------------
+
+
+def test_nan_x_rejected():
+    # NaN is caught upstream by coerce_xcnt_x, but the contract is asserted
+    # here so the guarantee is visible from the recurrent entry point.
+    with pytest.raises(ValueError):
+        handle_xicn(np.array([1.0, np.nan, 3.0]), np.array([1, 1, 1]))
+
+
+def test_inf_x_rejected():
+    with pytest.raises(ValueError, match="must be finite"):
+        handle_xicn(np.array([1.0, np.inf, 3.0]), np.array([1, 1, 1]))
+
+
+# --- censoring codes ------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_code", [3, -2, 0.5, 10])
+def test_invalid_censoring_code_rejected(bad_code):
+    with pytest.raises(ValueError, match="Censoring 'c' must be one of"):
+        handle_xicn(
+            np.array([1.0, 2.0, 3.0]),
+            np.array([1, 1, 1]),
+            c=np.array([0, bad_code, 1]),
+        )
+
+
+def test_nan_censoring_code_rejected():
+    with pytest.raises(ValueError, match="Censoring 'c' must be one of"):
+        handle_xicn(
+            np.array([1.0, 2.0, 3.0]),
+            np.array([1, 1, 1]),
+            c=np.array([0.0, np.nan, 1.0]),
+        )
+
+
+def test_all_valid_censoring_codes_accepted():
+    # -1 (left), 0 (observed), 1 (right) on a single item, ordered so the
+    # left-censoring is first and right-censoring last (the handler's other
+    # rules). Interval (2) is exercised with 2D x below.
+    data = handle_xicn(
+        np.array([1.0, 2.0, 3.0]),
+        np.array([1, 1, 1]),
+        c=np.array([-1, 0, 1]),
+    )
+    assert np.array_equal(np.sort(np.unique(data.c)), [-1, 0, 1])
+
+
+def test_interval_censoring_code_accepted():
+    x = np.array([[1.0, 2.0], [3.0, 4.0]])
+    data = handle_xicn(x, np.array([1, 1]), c=np.array([2, 2]))
+    assert np.all(data.c == 2)
+
+
+# --- counts ---------------------------------------------------------------
+
+
+def test_zero_count_rejected():
+    with pytest.raises(ValueError, match="strictly positive"):
+        handle_xicn(np.array([1.0, 2.0]), np.array([1, 1]), n=np.array([1, 0]))
+
+
+def test_negative_count_rejected():
+    with pytest.raises(ValueError, match="strictly positive"):
+        handle_xicn(
+            np.array([1.0, 2.0]), np.array([1, 1]), n=np.array([1, -2])
+        )
+
+
+def test_nan_count_rejected():
+    with pytest.raises(ValueError, match="Counts 'n' must be finite"):
+        handle_xicn(
+            np.array([1.0, 2.0]), np.array([1, 1]), n=np.array([1.0, np.nan])
+        )
+
+
+def test_inf_count_rejected():
+    with pytest.raises(ValueError, match="Counts 'n' must be finite"):
+        handle_xicn(
+            np.array([1.0, 2.0]), np.array([1, 1]), n=np.array([1.0, np.inf])
+        )
+
+
+# --- item identifiers -----------------------------------------------------
+
+
+def test_nan_item_id_rejected():
+    with pytest.raises(ValueError, match="Item identifiers 'i' must"):
+        handle_xicn(np.array([1.0, 2.0]), np.array([1.0, np.nan]))
+
+
+def test_string_item_ids_accepted():
+    # Item labels need not be numeric; the finiteness check must skip them.
+    data = handle_xicn(
+        np.array([1.0, 2.0, 1.0]),
+        np.array(["a", "a", "b"]),
+    )
+    assert set(np.unique(data.i)) == {"a", "b"}
+
+
+# --- truncation bounds ----------------------------------------------------
+
+
+def test_default_infinite_truncation_accepted():
+    # +/-inf is the default open window and must not be rejected.
+    data = handle_xicn(np.array([1.0, 2.0]), np.array([1, 1]))
+    assert np.all(data.tl == -np.inf) and np.all(data.tr == np.inf)
+
+
+def test_nan_truncation_rejected():
+    with pytest.raises(ValueError, match="Truncation bounds must not"):
+        handle_xicn(
+            np.array([1.0, 2.0]),
+            np.array([1, 1]),
+            tl=np.array([np.nan, np.nan]),
+            tr=np.array([5.0, 5.0]),
+        )
+
+
+# --- event times vs the integration origin --------------------------------
+
+
+def test_negative_time_untruncated_rejected():
+    with pytest.raises(ValueError, match="outside its observation window"):
+        handle_xicn(np.array([-1.0, 2.0]), np.array([1, 1]))
+
+
+def test_negative_time_with_negative_left_truncation_accepted():
+    # An explicit negative left-truncation window legitimately admits
+    # negative event times (delayed/early entry on a shifted scale).
+    data = handle_xicn(
+        np.array([-1.0, 2.0]), np.array([1, 1]), tl=-4.0, tr=5.0
+    )
+    assert np.allclose(np.sort(data.x), [-1.0, 2.0])
+
+
+def test_event_after_right_truncation_rejected():
+    with pytest.raises(ValueError, match="outside its observation window"):
+        handle_xicn(np.array([1.0, 9.0]), np.array([1, 1]), tl=0.0, tr=5.0)
+
+
+# --- covariates -----------------------------------------------------------
+
+
+def test_non_finite_covariates_rejected():
+    with pytest.raises(ValueError, match="Covariates 'Z' must be finite"):
+        handle_xicn(
+            np.array([1.0, 2.0]),
+            np.array([1, 1]),
+            Z=np.array([[0.5], [np.inf]]),
+        )
+
+
+# --- a fully valid call still works ---------------------------------------
+
+
+def test_valid_data_passes():
+    data = handle_xicn(
+        np.array([1.0, 2.0, 3.0, 1.5]),
+        i=np.array([1, 1, 1, 2]),
+        c=np.array([0, 0, 1, 0]),
+        n=np.array([1, 1, 1, 1]),
+    )
+    assert data.x.shape[0] == 4

--- a/surpyval/tests/univariate/parametric/test_discrete.py
+++ b/surpyval/tests/univariate/parametric/test_discrete.py
@@ -176,6 +176,23 @@ def test_from_params_and_prediction(dist, params):
     assert np.isfinite(fitted.aic())
 
 
+@pytest.mark.parametrize("dist,params", DISTS)
+def test_fitted_model_methods_use_uncorrupted_parameters(dist, params):
+    # Distributions whose parameter is named "p" (Geometric,
+    # NegativeBinomial) must not overwrite the reserved limited-failure
+    # proportion ``model.p`` when the fitted parameters are exposed by
+    # name, or the survival functions silently compute against the wrong
+    # mixing. Fit (not from_params, which took a different path) and check
+    # the model's sf/mean match the distribution evaluated at the fitted
+    # parameters directly.
+    x = dist.random(3000, *params)
+    model = dist.fit(x)
+    assert model.p == 1.0  # no limited-failure component was requested
+    k = np.array([1.0, 2.0, 3.0, 5.0])
+    assert np.allclose(model.sf(k), dist.sf(k, *model.params))
+    assert np.isclose(model.mean(), dist.mean(*model.params))
+
+
 def test_supports_mpp_is_false():
     # Probability plotting is not defined for these discrete lifetimes, so
     # the MPP method must be rejected rather than silently misbehave.

--- a/surpyval/tests/univariate/regression/test_additive_hazards_parametric.py
+++ b/surpyval/tests/univariate/regression/test_additive_hazards_parametric.py
@@ -1,0 +1,156 @@
+"""Parametric additive hazards regression (AH factory + WeibullAH etc.).
+
+The model is h(x|Z) = h_0(x; theta) + beta'Z, fit by plain maximum
+likelihood. The additive hazard is not constrained positive: the fit finds
+the best positive-hazard solution and raises if the optimum genuinely
+requires a negative hazard.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from surpyval import (
+    AH,
+    Exponential,
+    ExponentialAH,
+    ExponentialPH,
+    Weibull,
+    WeibullAH,
+)
+
+
+def _exp_ah_data(N, seed, lam=0.5, beta=(0.30, -0.15), tau=6.0):
+    # For an Exponential baseline the additive hazard lam + beta'Z is
+    # constant in time, so survival is Exp(lam + beta'Z). Recovering
+    # (lam, beta) validates the estimator against a known truth.
+    rng = np.random.default_rng(seed)
+    beta = np.asarray(beta)
+    Z = rng.uniform(-1, 1, size=(N, beta.size))
+    rate = lam + Z @ beta
+    Z, rate = Z[rate > 0], rate[rate > 0]
+    x = rng.exponential(1.0 / rate)
+    c = (x > tau).astype(int)
+    x = np.minimum(x, tau)
+    return x, c, Z
+
+
+def test_factory_and_prebuilt_names():
+    assert AH(Weibull).name == "WeibullAH"
+    assert AH(Exponential).name == "ExponentialAH"
+    assert WeibullAH.name == "WeibullAH"
+
+
+def test_exponential_ah_recovers_parameters():
+    x, c, Z = _exp_ah_data(20000, 0)
+    model = ExponentialAH.fit(x=x, Z=Z, c=c)
+    # params are [baseline rate, beta_0, beta_1].
+    assert np.isclose(model.params[0], 0.5, atol=0.03)
+    assert np.allclose(model.params[1:], [0.30, -0.15], atol=0.03)
+
+
+def test_hazard_is_additive():
+    x, c, Z = _exp_ah_data(5000, 1)
+    model = ExponentialAH.fit(x=x, Z=Z, c=c)
+    Z0 = np.array([[0.2, -0.1]])
+    rate, beta = model.params[0], model.params[1:]
+    # For the exponential baseline the hazard is constant: rate + beta'Z0.
+    expected = rate + Z0 @ beta
+    assert np.allclose(model.hf([1.0, 2.0, 3.0], Z0), expected)
+
+
+def test_cumulative_hazard_additive_linear_term():
+    # H(x|Z) - H(x|0) = x * beta'Z (the additive covariate contribution
+    # integrates linearly in time).
+    x, c, Z = _exp_ah_data(5000, 2)
+    model = WeibullAH.fit(x=x, Z=Z, c=c)
+    t = np.array([1.0, 2.0, 4.0])
+    Z1 = np.array([[0.3, -0.2]])
+    Z0 = np.array([[0.0, 0.0]])
+    beta = model.params[-2:]
+    diff = model.Hf(t, Z1) - model.Hf(t, Z0)
+    assert np.allclose(diff, t * (Z1 @ beta), atol=1e-6)
+
+
+def test_prediction_identities():
+    x, c, Z = _exp_ah_data(4000, 3)
+    model = ExponentialAH.fit(x=x, Z=Z, c=c)
+    t = np.array([0.5, 1.0, 2.0])
+    Z0 = np.array([[0.1, -0.1]])
+    assert np.allclose(model.ff(t, Z0), 1 - model.sf(t, Z0))
+    assert np.allclose(model.df(t, Z0), model.hf(t, Z0) * model.sf(t, Z0))
+
+
+def test_baseline_reduces_to_distribution_when_Z_zero():
+    # With Z = 0 the additive term vanishes and the survival must equal the
+    # plain baseline distribution's survival at the fitted parameters.
+    x, c, Z = _exp_ah_data(8000, 4)
+    model = ExponentialAH.fit(x=x, Z=Z, c=c)
+    t = np.array([0.5, 1.0, 2.0, 3.0])
+    Z0 = np.array([[0.0, 0.0]])
+    assert np.allclose(
+        model.sf(t, Z0), Exponential.sf(t, model.params[0]), atol=1e-9
+    )
+
+
+def test_weibull_ah_on_exponential_data_has_unit_shape():
+    # A Weibull baseline fit to exponentially-distributed inter-event times
+    # should recover a shape parameter near 1 and the same covariate betas.
+    x, c, Z = _exp_ah_data(20000, 5)
+    model = WeibullAH.fit(x=x, Z=Z, c=c)
+    # Weibull params are (alpha, beta_shape); shape ~ 1 for exponential data.
+    assert np.isclose(model.params[1], 1.0, atol=0.1)
+    assert np.allclose(model.params[-2:], [0.30, -0.15], atol=0.04)
+
+
+def test_information_criteria_available():
+    x, c, Z = _exp_ah_data(4000, 6)
+    model = ExponentialAH.fit(x=x, Z=Z, c=c)
+    assert np.isfinite(model.aic())
+    assert np.isfinite(model.bic())
+    assert "Additive Hazard" in repr(model)
+
+
+def test_fit_from_df_retains_feature_names():
+    x, c, Z = _exp_ah_data(3000, 7)
+    df = pd.DataFrame({"t": x, "c": c, "age": Z[:, 0], "dose": Z[:, 1]})
+    model = ExponentialAH.fit_from_df(
+        df, x_col="t", Z_cols=["age", "dose"], c_col="c"
+    )
+    assert model.feature_names == ["age", "dose"]
+    pred = model.sf([1.0, 2.0], df[["age", "dose"]].iloc[[0]])
+    assert pred.shape == (2,)
+
+
+def test_fit_fails_when_hazard_forced_negative():
+    # Forcing a large negative coefficient makes h_0(x) + beta'Z < 0 at
+    # observed times, so no finite-likelihood fit exists and the fit raises
+    # with a message pointing at proportional hazards.
+    rng = np.random.default_rng(8)
+    Z = rng.uniform(0, 1, size=(500, 1))
+    x = rng.exponential(2.0, size=500)
+    with pytest.raises(ValueError, match="positive"):
+        ExponentialAH.fit(x=x, Z=Z, fixed={"beta_0": -5.0})
+    # The same data fits fine without the pathological constraint.
+    model = ExponentialAH.fit(x=x, Z=Z)
+    assert np.all(model.hf(x, Z) > 0)
+
+
+def test_counts_equivalent_to_repeated_rows():
+    x = np.array([1.0, 2.0, 2.0, 3.0, 5.0])
+    c = np.array([0, 0, 1, 0, 0])
+    Z = np.array([[0.4], [0.7], [0.7], [-0.2], [0.9]])
+    m_rep = ExponentialAH.fit(
+        x=np.repeat(x, 2), Z=np.repeat(Z, 2, axis=0), c=np.repeat(c, 2)
+    )
+    m_cnt = ExponentialAH.fit(x=x, Z=Z, c=c, n=np.full(5, 2))
+    assert np.allclose(m_rep.params, m_cnt.params, atol=1e-3)
+
+
+def test_agrees_with_ph_on_direction_of_effect():
+    # AH and PH are different scales, but a covariate that raises the hazard
+    # should have the same sign of effect under both.
+    x, c, Z = _exp_ah_data(20000, 9)
+    ah = ExponentialAH.fit(x=x, Z=Z, c=c)
+    ph = ExponentialPH.fit(x=x, Z=Z, c=c)
+    assert np.all(np.sign(ah.params[-2:]) == np.sign(ph.params[-2:]))

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -1025,8 +1025,16 @@ class ParametricFitter:
         for k, v in results.items():
             setattr(model, k, v)
 
+        # Expose each fitted parameter by name (e.g. ``model.alpha``), but
+        # never overwrite the reserved offset / limited-failure /
+        # zero-inflation attributes, which the survival functions rely on.
+        # A distribution may legitimately name a parameter ``p`` (e.g.
+        # ``Geometric``, ``NegativeBinomial``); those remain available via
+        # ``model.params``.
+        reserved = {"gamma", "p", "f0"}
         for k, v in zip(self.param_names, model.params):
-            setattr(model, k, v)
+            if k not in reserved:
+                setattr(model, k, v)
 
         self._set_support(model, offset)
 

--- a/surpyval/univariate/regression/__init__.py
+++ b/surpyval/univariate/regression/__init__.py
@@ -24,7 +24,19 @@ from .accelerated_life import (
     Power,
     PowerExponential,
 )
-from .additive_hazards import AdditiveHazards, AdditiveHazardsModel
+from .additive_hazards import (
+    AH,
+    AdditiveHazards,
+    AdditiveHazardsFitter,
+    AdditiveHazardsModel,
+    ExponentialAH,
+    GammaAH,
+    GumbelAH,
+    LogisticAH,
+    LogNormalAH,
+    NormalAH,
+    WeibullAH,
+)
 from .proportional_hazards import (
     PH,
     CoxPH,
@@ -50,9 +62,18 @@ from .proportional_odds import (
 )
 
 __all__ = [
-    # Additive hazards (Lin-Ying semi-parametric)
+    # Additive hazards — semi-parametric (Lin-Ying) and parametric
+    "AH",
     "AdditiveHazards",
+    "AdditiveHazardsFitter",
     "AdditiveHazardsModel",
+    "ExponentialAH",
+    "GammaAH",
+    "GumbelAH",
+    "LogisticAH",
+    "LogNormalAH",
+    "NormalAH",
+    "WeibullAH",
     # Accelerated life (parameter-substitution life models)
     "AcceleratedLife",
     "DualExponential",

--- a/surpyval/univariate/regression/additive_hazards/__init__.py
+++ b/surpyval/univariate/regression/additive_hazards/__init__.py
@@ -1,3 +1,64 @@
-from .additive_hazards import AdditiveHazards, AdditiveHazardsModel
+from surpyval.univariate.parametric import (
+    Exponential,
+    Gamma,
+    Gumbel,
+    Logistic,
+    LogNormal,
+    Normal,
+    Weibull,
+)
 
-__all__ = ["AdditiveHazards", "AdditiveHazardsModel"]
+from .additive_hazards import AdditiveHazards, AdditiveHazardsModel
+from .additive_hazards_fitter import AdditiveHazardsFitter
+
+
+def AH(distribution):
+    """
+    Create a parametric Additive Hazards fitter for the given distribution.
+
+    Fits ``h(x | Z) = h_0(x) + beta'Z`` -- the covariate is a risk difference
+    added to a parametric baseline hazard, rather than a multiplier as in the
+    proportional hazards models.
+
+    Parameters
+    ----------
+    distribution : ParametricFitter
+        A surpyval parametric distribution (e.g. ``Weibull``, ``Exponential``).
+
+    Returns
+    -------
+    AdditiveHazardsFitter
+        A configured fitter with a ``.fit(x, Z, ...)`` method.
+
+    Examples
+    --------
+    >>> from surpyval import Weibull, AH
+    >>> model = AH(Weibull).fit(x, Z=covariates, c=c)
+    """
+    return AdditiveHazardsFitter.create(distribution)
+
+
+_create = AdditiveHazardsFitter.create
+
+# Pre-built parametric additive hazards instances -- one per distribution.
+ExponentialAH = _create(Exponential)
+NormalAH = _create(Normal)
+WeibullAH = _create(Weibull)
+GumbelAH = _create(Gumbel)
+LogisticAH = _create(Logistic)
+LogNormalAH = _create(LogNormal)
+GammaAH = _create(Gamma)
+
+__all__ = [
+    "AH",
+    "AdditiveHazards",
+    "AdditiveHazardsFitter",
+    "AdditiveHazardsModel",
+    "ExponentialAH",
+    "GammaAH",
+    "GumbelAH",
+    "LogisticAH",
+    "LogNormalAH",
+    "NormalAH",
+    "WeibullAH",
+]

--- a/surpyval/univariate/regression/additive_hazards/additive_hazards_fitter.py
+++ b/surpyval/univariate/regression/additive_hazards/additive_hazards_fitter.py
@@ -1,0 +1,294 @@
+"""
+Parametric additive hazards regression.
+
+Where the semi-parametric ``AdditiveHazards`` (Lin & Ying) leaves the baseline
+hazard unspecified, this fits a fully *parametric* additive hazards model,
+
+.. math::
+    h(x \\mid Z) = h_0(x;\\,\\theta) + \\beta' Z
+
+with a parametric baseline hazard :math:`h_0(x;\\theta)` (Weibull,
+Exponential, ...) estimated jointly with the risk-difference coefficients
+:math:`\\beta` by maximum likelihood. Because the covariate effect is additive
+(a constant integrates to :math:`x\\,\\beta'Z`), the cumulative hazard is
+
+.. math::
+    H(x \\mid Z) = H_0(x;\\,\\theta) + x\\,\\beta' Z .
+
+This is the additive-scale companion to the parametric proportional hazards
+models (``WeibullPH`` and friends), and gives a smooth, extrapolatable
+version of what the semi-parametric ``AdditiveHazards`` estimates.
+
+A caveat inherent to additive hazards: nothing constrains
+:math:`h_0(x;\\theta) + \\beta' Z > 0`. The likelihood needs :math:`\\log h`
+for every observed event, so if the fitted hazard is driven non-positive at
+an observed time the log-likelihood becomes ``nan`` and the fit fails rather
+than returning a silently invalid model. This is deliberate: an additive
+hazards model that cannot keep the hazard positive over the data is not a
+valid description of it. When covariate effects are strongly protective a
+proportional hazards model, whose exponential form keeps the hazard positive
+by construction, is the safer choice.
+"""
+
+import autograd.numpy as np
+import numpy.typing as npt
+from scipy.optimize import minimize
+
+from surpyval.univariate.parametric.fitters import bounds_convert
+from surpyval.utils.surpyval_data import SurpyvalData
+
+from .._likelihood import regression_neg_ll
+from ..parametric_regression_model import ParametricRegressionModel
+from ..regression_data import DataFrameRegressionMixin
+
+
+class _AdditiveReg:
+    # Lightweight namespace for the fitted model's ``reg_model`` attribute;
+    # the model repr reads ``.name``.
+    name: str
+    phi_param_map: object
+
+
+class AdditiveHazardsFitter(DataFrameRegressionMixin):
+    def __init__(self, name, dist):
+        self.name = name
+        self.dist = dist
+        self.k_dist = len(dist.param_names)
+        self.bounds = dist.bounds
+        self.support = dist.support
+        self.param_names = dist.param_names
+        self.param_map = {v: i for i, v in enumerate(dist.param_names)}
+        self.Hf_dist = dist.Hf
+        self.hf_dist = dist.hf
+
+    # -- covariate-aware distribution functions (x, Z, *params) -----------
+
+    def _beta_Z(self, Z, beta):
+        return np.dot(Z, np.array(beta))
+
+    def hf(self, x, Z, *params):
+        dist_params = np.array(params[: self.k_dist])
+        beta = params[self.k_dist :]
+        return self.hf_dist(x, *dist_params) + self._beta_Z(Z, beta)
+
+    def Hf(self, x, Z, *params):
+        # H(x | Z) = H_0(x) + integral_0^x beta'Z ds = H_0(x) + x * beta'Z.
+        dist_params = np.array(params[: self.k_dist])
+        beta = params[self.k_dist :]
+        return self.Hf_dist(x, *dist_params) + x * self._beta_Z(Z, beta)
+
+    def sf(self, x, Z, *params):
+        return np.exp(-self.Hf(x, Z, *params))
+
+    def ff(self, x, Z, *params):
+        return 1 - np.exp(-self.Hf(x, Z, *params))
+
+    def df(self, x, Z, *params):
+        return self.hf(x, Z, *params) * np.exp(-self.Hf(x, Z, *params))
+
+    def log_df(self, x, Z, *params):
+        # log h - H. When the additive hazard is driven non-positive the log
+        # is nan; the optimiser then rejects that point (the fit fails rather
+        # than returning an invalid model).
+        return np.log(self.hf(x, Z, *params)) - self.Hf(x, Z, *params)
+
+    def log_sf(self, x, Z, *params):
+        return -self.Hf(x, Z, *params)
+
+    def log_ff(self, x, Z, *params):
+        return np.log(self.ff(x, Z, *params))
+
+    # mpp transforms are the identity (probability plotting is not used for
+    # these models, but the interface is kept consistent with the other
+    # regression fitters).
+    def mpp_x_transform(self, x, gamma=0):
+        return x - gamma
+
+    def mpp_y_transform(self, y, *params):
+        return y
+
+    def mpp_inv_y_transform(self, y, *params):
+        return y
+
+    def neg_ll(self, data, *params):
+        return regression_neg_ll(self, data, *params)
+
+    def random(self, size, Z, *params):
+        """
+        Draw ``size`` samples for a single covariate vector ``Z`` by
+        numerically inverting the (monotone) cumulative hazard. Requires the
+        additive hazard to stay positive over the sampled range.
+        """
+        dist_params = np.array(params[: self.k_dist])
+        beta = np.array(params[self.k_dist :])
+        Z = np.asarray(Z, dtype=float).ravel()
+        bz = float(np.dot(Z, beta))
+        target = -np.log(np.random.uniform(0, 1, size))
+
+        def cum_haz(xv):
+            return self.Hf_dist(xv, *dist_params) + xv * bz
+
+        lo = np.zeros(size)
+        hi = np.ones(size)
+        for _ in range(200):
+            below = cum_haz(hi) < target
+            if not np.any(below):
+                break
+            hi = np.where(below, hi * 2.0, hi)
+        for _ in range(64):
+            mid = 0.5 * (lo + hi)
+            below = cum_haz(mid) < target
+            lo = np.where(below, mid, lo)
+            hi = np.where(below, hi, mid)
+        x = 0.5 * (lo + hi)
+        Z_out = np.ones_like(x)[:, None] * Z
+        return x.flatten(), Z_out.flatten()
+
+    # -- factory ----------------------------------------------------------
+
+    @staticmethod
+    def create(distribution):
+        """
+        Create a parametric additive hazards fitter for the given
+        distribution.
+
+        Parameters
+        ----------
+        distribution : ParametricFitter
+            A surpyval parametric distribution (e.g. ``Weibull``,
+            ``Exponential``).
+
+        Returns
+        -------
+        AdditiveHazardsFitter
+            A configured fitter with a ``.fit(x, Z, ...)`` method.
+        """
+        return AdditiveHazardsFitter(f"{distribution.name}AH", distribution)
+
+    # -- fitting ----------------------------------------------------------
+
+    def fit(
+        self,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        c: npt.ArrayLike | None = None,
+        n: npt.ArrayLike | None = None,
+        t: npt.ArrayLike | None = None,
+        init: npt.ArrayLike | None = None,
+        fixed: dict[str, float] | None = None,
+    ) -> ParametricRegressionModel:
+        """
+        Fit the parametric additive hazards model by maximum likelihood.
+
+        Parameters
+        ----------
+
+        x : array_like
+            The observed event times.
+        Z : array_like
+            The covariate matrix (one row per observation).
+        c : array_like, optional
+            The censoring indicators (0 observed, 1 right, -1 left, 2
+            interval).
+        n : array_like, optional
+            The count of observations at each time.
+        t : array_like, optional
+            The truncation matrix.
+        init : array_like, optional
+            Initial parameter values (baseline parameters followed by the
+            covariate coefficients).
+        fixed : dict, optional
+            Parameters to hold fixed, by name.
+
+        Returns
+        -------
+
+        ParametricRegressionModel
+            The fitted model. Raises if the additive hazard cannot be kept
+            positive over the data (the log-likelihood is then non-finite).
+
+        Examples
+        --------
+
+        >>> from surpyval import WeibullAH
+        >>> model = WeibullAH.fit(x=x, Z=Z, c=c)
+        """
+        data = SurpyvalData(x, c, n, t, group_and_sort=False)
+        data.add_covariates(Z)
+
+        if fixed is None:
+            fixed = {}
+
+        assert data.Z is not None  # set by add_covariates above
+        n_cov = data.Z.shape[1]
+        beta_param_map = {
+            "beta_" + str(i): self.k_dist + i for i in range(n_cov)
+        }
+        param_map = {**self.param_map, **beta_param_map}
+        bounds = (*self.bounds, *(((None, None),) * n_cov))
+
+        if init is None or len(init) == 0:  # type: ignore[arg-type]
+            ps = self.dist.fit_from_surpyval_data(data).params
+            init = np.array([*ps, *np.zeros(n_cov)])
+        else:
+            init = np.array(init)
+
+        transform, inv_trans, const, fixed_idx, not_fixed = bounds_convert(
+            x, bounds, fixed, param_map
+        )
+        init = transform(init)[not_fixed]
+
+        with np.errstate(all="ignore"):
+
+            def true_neg_ll(params):
+                return self.neg_ll(data, *inv_trans(const(params)))
+
+            def fun(params):
+                # Where the additive hazard goes non-positive the log-
+                # likelihood is genuinely -inf; return a large finite penalty
+                # (not a solver constraint) so the derivative-free optimiser
+                # stays in the region where the model is valid rather than
+                # stalling on nan gradients. The initial guess (beta = 0) has
+                # the strictly-positive baseline hazard, so it is valid.
+                val = true_neg_ll(params)
+                return val if np.isfinite(val) else 1e15
+
+            res = minimize(fun, init, method="Nelder-Mead")
+            res = minimize(fun, res.x, method="TNC")
+
+            params = inv_trans(const(res.x))
+
+            # The penalty above can leave the optimiser at the edge of the
+            # valid region; recompute the unpenalised likelihood and fail if
+            # it is not finite (the additive hazard could not be kept
+            # positive at the optimum).
+            final_neg_ll = float(true_neg_ll(res.x))
+        if not np.isfinite(final_neg_ll):
+            raise ValueError(
+                "The additive hazards fit could not keep the hazard "
+                "h_0(x) + beta'Z positive at every observed time. A "
+                "proportional hazards model (e.g. {}PH) keeps the hazard "
+                "positive by construction and may be more appropriate for "
+                "this data.".format(self.dist.name)
+            )
+
+        reg_model = _AdditiveReg()
+        reg_model.name = "Additive [beta'Z]"
+        reg_model.phi_param_map = beta_param_map
+
+        model = ParametricRegressionModel()
+        model.distribution_param_map = self.param_map
+        model.phi_param_map = beta_param_map
+        model.model = self
+        model.reg_model = reg_model
+        model.kind = "Additive Hazard"
+        model.distribution = self.dist
+        model.params = np.array(params)
+        model.res = res
+        model._neg_ll = final_neg_ll
+        model.fixed = fixed
+        model.k_dist = self.k_dist
+        model.k = len(bounds)
+        model.data = data
+
+        return model

--- a/surpyval/utils/recurrent_utils.py
+++ b/surpyval/utils/recurrent_utils.py
@@ -102,6 +102,9 @@ def handle_xicn(
 ):
     x = coerce_xcnt_x(x)
 
+    if x.shape[0] == 0:
+        raise ValueError("'x' cannot be empty")
+
     if i is None:
         i = np.ones(x.shape[0])
     else:
@@ -118,10 +121,12 @@ def handle_xicn(
         c = np.array(c)
 
     # Truncation follows surpyval's xcnt convention (shared with the univariate
-    # handler): the default window is the whole real line, so no assumption is
-    # made about the sign of ``x`` (e.g. a log-intensity model can take
-    # negative values); the integration origin for untruncated NHPP data falls
-    # back to 0 in ``get_previous_x``.
+    # handler): the default window is the whole real line. No global sign
+    # assumption is made about ``x`` here -- each item is instead validated
+    # against its own observation window below. An item with an explicit
+    # (possibly negative) left-truncation bound legitimately admits negative
+    # event times; an untruncated item is integrated from the fallback origin
+    # 0 (see ``get_previous_x``) and so must have non-negative event times.
     truncation = format_truncation(t, tl, tr, x.shape[0])
     tl_arr = truncation[:, 0]
     tr_arr = truncation[:, 1]
@@ -145,6 +150,44 @@ def handle_xicn(
     if Z_arr is not None:
         if x.shape[0] != Z_arr.shape[0]:
             raise ValueError("x and Z must have the same length")
+
+    # --- Value validation ------------------------------------------------
+    # Reject malformed input with informative errors rather than letting
+    # NaN/inf or nonsensical counts and codes flow silently into the
+    # optimiser. NaN in ``x`` is already rejected by ``coerce_xcnt_x``; here
+    # the remaining degenerate values are caught.
+    if not np.isfinite(x).all():
+        raise ValueError("Event times 'x' must be finite (no inf values)")
+
+    if np.issubdtype(i.dtype, np.number) and not np.isfinite(i).all():
+        raise ValueError("Item identifiers 'i' must be finite (no NaN or inf)")
+
+    # Censoring codes: -1 left, 0 observed, 1 right, 2 interval. ``np.isin``
+    # also flags NaN, which is never a valid code.
+    valid_c = np.isin(c, [-1, 0, 1, 2])
+    if not valid_c.all():
+        bad = np.unique(c[~valid_c]).tolist()
+        raise ValueError(
+            "Censoring 'c' must be one of -1 (left), 0 (observed), "
+            f"1 (right), or 2 (interval); got {bad}"
+        )
+
+    if not np.isfinite(n).all():
+        raise ValueError("Counts 'n' must be finite")
+    if np.any(n <= 0):
+        raise ValueError("Counts 'n' must be strictly positive")
+
+    # Truncation bounds may be +/-inf (the default open window) but a NaN
+    # bound is meaningless.
+    if np.isnan(tl_arr).any() or np.isnan(tr_arr).any():
+        raise ValueError("Truncation bounds must not contain NaN")
+
+    if (
+        Z_arr is not None
+        and np.issubdtype(Z_arr.dtype, np.number)
+        and not np.isfinite(Z_arr).all()
+    ):
+        raise ValueError("Covariates 'Z' must be finite (no NaN or inf)")
 
     if np.any((n > 1) & ((c == 0) | (c == 1))):
         raise ValueError(
@@ -213,10 +256,18 @@ def handle_xicn(
             )
         if tl_i[0] > tr_i[0]:
             raise ValueError(f"Item {ii} has left truncation beyond right")
-        if (xl_i < tl_i[0]).any() or (xu_i > tr_i[0]).any():
+        # The item's first interval is integrated from its entry time: the
+        # left-truncation bound when finite, otherwise the fallback origin 0
+        # (see RecurrentEventData.get_previous_x). Events below that origin
+        # would give negative interarrival times, so they are rejected. This
+        # is why untruncated event times must be non-negative while an
+        # explicit (possibly negative) left-truncation window admits negative
+        # times.
+        lower = tl_i[0] if np.isfinite(tl_i[0]) else 0.0
+        if (xl_i < lower).any() or (xu_i > tr_i[0]).any():
             raise ValueError(
-                f"Item {ii} has events outside its truncation window "
-                f"[{tl_i[0]}, {tr_i[0]}]"
+                f"Item {ii} has events outside its observation window "
+                f"[{lower}, {tr_i[0]}]"
             )
 
     if as_recurrent_data:


### PR DESCRIPTION
## Summary

This branch bundles several pieces of hardening/finishing work from the development roadmap.

### `handle_xicn` input validation (§2)
Recurrent-event data entering `handle_xicn` was accepted unvalidated — empty arrays, NaN/inf event times, nonsensical counts and censoring codes, and event times below the integration origin all flowed silently into the optimiser and produced meaningless fits. Now validated up front with informative `ValueError`s:
- empty `x`; non-finite (inf) event times (NaN already caught by `coerce_xcnt_x`)
- censoring codes outside `{-1, 0, 1, 2}` (also catches NaN)
- non-positive or non-finite counts `n`
- NaN truncation bounds (±inf remain the valid default window)
- non-finite numeric item ids and covariates `Z`

Event times are checked against each item's **integration origin** — its left-truncation bound when finite, otherwise the fallback origin `0` used by `RecurrentEventData.get_previous_x`. This reconciles the two prior intents: untruncated negative times (which would give a negative interarrival from origin 0) are rejected, while a genuine negative left-truncation window still admits negative event times (delayed entry on a shifted scale).

### Parametric additive hazards regression
`h(x | Z) = h_0(x; θ) + β'Z` with a parametric baseline, fit by plain MLE (`AH` factory plus `WeibullAH`, `ExponentialAH`, etc.). No constrained optimisation: the fit finds the best positive-hazard solution and raises with a message pointing at proportional hazards if the optimum genuinely requires a negative hazard.

### Reserved-attribute fix
Fitted parameters named `p`/`f0`/`gamma` (e.g. Geometric's `p`) were clobbering the reserved `Parametric` attributes used for LFP proportion, zero-inflation, and offset, silently corrupting `sf`/`mean`. The param-name setattr loop now skips reserved names.

### Docs
- Discrete Distributions section in *Parametric SurPyval Modelling*.
- Additive hazards and recurrent inference/diagnostics documentation.

## Testing
Full suite: **991 passed, 1 skipped**. New `test_xicn_validation.py` pins every rejection and the valid edge cases that must not be rejected. flake8/black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_