### PR TITLE
Consolidate recurrent simulation sampler and post-processing into the shared mixin

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -100,13 +100,15 @@ policy: either render with `np.float64(...)` reprs and run doctests in
 CI, or keep the readable plain-float style and accept that examples
 are unchecked.
 
-### Duplicated simulation block
-The same "simulate timelines to `T`" loop appears twice:
-
-- `surpyval/recurrent/parametric/parametric_recurrence.py` (`time_terminated_simulation`)
-- `surpyval/recurrent/regression/proportional_intensity.py` (`time_terminated_simulation`)
-
-Extract a shared helper. The `count_terminated_simulation` methods are similarly duplicated.
+### Duplicated simulation block (done)
+The count/time-terminated simulation loops and their public drivers live once
+in `RecurrenceSimulationMixin` (`surpyval/recurrent/simulation.py`), shared by
+the parametric, proportional-intensity and renewal models. The residual
+per-family duplication has also been removed: the conditional inverse-CIF
+`_new_sequence_sampler` and the CoxLewis `_postprocess_simulated_model` now
+live in the mixin, and subclasses only declare the extra `cif`/`inv_cif`
+arguments via `_cif_args` (empty for unconditional models; the covariate
+vector for proportional-intensity models).
 
 ---
 

--- a/surpyval/recurrent/parametric/parametric_recurrence.py
+++ b/surpyval/recurrent/parametric/parametric_recurrence.py
@@ -58,22 +58,9 @@ class ParametricRecurrenceModel(
             + param_string
         )
 
-    def _new_sequence_sampler(self):
-        x_prev = 0.0
-
-        def sample(ui):
-            nonlocal x_prev
-            u_adj = ui * np.exp(-self.cif(x_prev))
-            xi = self.inv_cif(-np.log(u_adj)) - x_prev
-            x_prev += xi
-            return xi
-
-        return sample
-
-    def _postprocess_simulated_model(self, model):
-        if self.dist.name == "CoxLewis":
-            model.mcf_hat += np.exp(self.params[0])
-        return model
+    # Simulation uses the shared conditional inverse-CIF sampler and the
+    # CoxLewis post-processing from RecurrenceSimulationMixin; this model is
+    # unconditional, so it needs no extra cif args (_cif_args defaults to ()).
 
     def cif(self, x):
         """

--- a/surpyval/recurrent/regression/proportional_intensity.py
+++ b/surpyval/recurrent/regression/proportional_intensity.py
@@ -210,26 +210,12 @@ class ProportionalIntensityModel(
         dist_bounds = getattr(self, "bounds", None) or self.dist.bounds
         return [*dist_bounds, *[(None, None)] * len(self.coeffs)]
 
-    def _new_sequence_sampler(self):
-        # The shared simulation driver requests one of these per item; the
+    def _cif_args(self):
+        # The shared inverse-CIF sampler threads these into cif/inv_cif; the
         # covariate vector for the run is stashed on ``_sim_Z`` by the public
-        # simulation entry points below.
-        Z = self._sim_Z
-        x_prev = 0.0
-
-        def sample(ui):
-            nonlocal x_prev
-            u_adj = ui * np.exp(-self.cif(x_prev, Z))
-            xi = self.inv_cif(-np.log(u_adj), Z) - x_prev
-            x_prev += xi
-            return xi
-
-        return sample
-
-    def _postprocess_simulated_model(self, model):
-        if self.dist.name == "CoxLewis":
-            model.mcf_hat += np.exp(self.params[0])
-        return model
+        # simulation entry points below. (CoxLewis post-processing is handled
+        # by the shared mixin.)
+        return (self._sim_Z,)
 
     def count_terminated_simulation(self, events, Z, items=1, seed=None):
         """

--- a/surpyval/recurrent/simulation.py
+++ b/surpyval/recurrent/simulation.py
@@ -21,13 +21,12 @@ class RecurrenceSimulationMixin:
     """
     Shared simulation machinery for fitted recurrent-event models.
 
-    Subclasses provide the per-event sampling logic by implementing
-    ``_new_sequence_sampler``, which returns a callable mapping a uniform
-    random number to the next interarrival time and which carries its own
-    per-sequence state. Subclasses may optionally override
-    ``_postprocess_simulated_model`` to adjust the fitted
-    ``NonParametricCounting`` model (e.g. the CoxLewis offset) before it is
-    returned.
+    Every recurrence model here samples the next event by the same
+    conditional inverse-CIF construction, so that lives in
+    ``_new_sequence_sampler``. The only per-family difference is the extra
+    arguments threaded into ``cif``/``inv_cif``: unconditional models pass
+    none, proportional-intensity models pass the covariate vector. Subclasses
+    declare those via ``_cif_args`` rather than reimplementing the sampler.
     """
 
     def _set_simulation_seed(self, seed):
@@ -54,19 +53,50 @@ class RecurrenceSimulationMixin:
             self.initialize_simulation()
             return self.us.pop()
 
+    def _cif_args(self):
+        """
+        Extra positional arguments threaded into ``cif``/``inv_cif`` for each
+        simulated sequence. Empty for unconditional models; the covariate
+        vector for proportional-intensity models (which override this).
+        """
+        return ()
+
     def _new_sequence_sampler(self):
         """
         Return a callable ``sample(ui) -> xi`` that draws the next interarrival
-        time from a uniform random number, maintaining any per-sequence state
+        time from a uniform random number, maintaining per-sequence state
         internally. A fresh sampler is requested for each simulated sequence.
+
+        The next event is sampled by inverting the cumulative intensity
+        conditional on the time of the previous event: given the CIF value at
+        ``x_prev``, a uniform ``ui`` maps to the next event time via
+        ``inv_cif(-log(ui) + cif(x_prev))``. Any per-family arguments (e.g. the
+        covariate vector) come from :meth:`_cif_args`.
         """
-        raise NotImplementedError
+        cif_args = self._cif_args()
+        x_prev = 0.0
+
+        def sample(ui):
+            nonlocal x_prev
+            u_adj = ui * np.exp(-self.cif(x_prev, *cif_args))
+            xi = self.inv_cif(-np.log(u_adj), *cif_args) - x_prev
+            x_prev += xi
+            return xi
+
+        return sample
 
     def _postprocess_simulated_model(self, model):
         """
-        Hook to adjust the fitted ``NonParametricCounting`` model in place
-        before it is returned. Default is a no-op.
+        Adjust the fitted ``NonParametricCounting`` model in place before it is
+        returned. A CoxLewis (log-linear) intensity has a non-zero baseline
+        rate ``exp(alpha)`` at time zero that the simulated event counts do not
+        carry, so it is added back to the MCF here. Other intensity models --
+        and renewal models, which carry no top-level ``dist`` -- are left
+        unchanged.
         """
+        dist = getattr(self, "dist", None)
+        if dist is not None and dist.name == "CoxLewis":
+            model.mcf_hat += np.exp(self.params[0])
         return model
 
     def _simulate_count_xicn(self, events, items, seed):


### PR DESCRIPTION
## Summary

Finishes the recurrent-simulation de-duplication tracked in DEVELOPMENT.md §3. The count/time-terminated loops and their public drivers already lived once in `RecurrenceSimulationMixin`; the two smaller pieces that were still copy-pasted between the parametric and proportional-intensity models are now shared too.

## Changes

- **`_new_sequence_sampler`** — the conditional inverse-CIF per-event sampler is now concrete in the mixin. It threads any per-family `cif`/`inv_cif` arguments through a new **`_cif_args`** hook (empty by default; the covariate vector for proportional-intensity models).
- **`_postprocess_simulated_model`** — the CoxLewis MCF offset moves into the mixin default, guarded by `getattr(self, "dist", None)` so `RenewalModel` (which carries no top-level `dist` and overrides the sampler) keeps its no-op behaviour.
- `ParametricRecurrenceModel` drops both overrides; `ProportionalIntensityModel` replaces its sampler with a one-line `_cif_args` returning `(self._sim_Z,)`.

Behaviour is unchanged — same seeds, same CoxLewis offset, same renewal path.

## Testing

Full recurrent suite: **212 passed**. flake8/black clean. Verified against the simulation, Cox-Lewis, regression-simulation and parametric-inference tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_