### PR TITLE
Competing-risks regression: Fine-Gray, Efron inference fix, regression confidence bounds, and a rename

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -48,15 +48,22 @@ forest).
   thinly tested, and its shared Breslow `baseline()` (all-cause event counts
   with a Fine-Gray-style risk set) should be reviewed for the cause-specific
   CIF before it is relied on.
-- **Cox PH tie-handling and Efron inference.** `cox_ph.py` implements only
-  Breslow and Efron ties — no exact or Kalbfleisch-Prentice. The Efron branch
-  computes but discards its Hessian ("something remains incorrect"), so p-values
-  are available only under Breslow. Fixing the Efron Hessian (or documenting the
-  limitation) and adding exact/K&P tie methods are the outstanding items. Note:
-  the `# TODO: Incorporate left-truncation... somehow` comments at
-  `cox_ph.py:175/307` are **stale** — left-truncation via `tl` is already wired
-  through both Breslow and Efron; only right/interval truncation is missing (see
-  §6). Clean the comments up.
+- **Cox PH exact / Kalbfleisch-Prentice tie methods.** `cox_ph.py` now supports
+  Breslow and Efron ties, both with analytic-Hessian standard errors and
+  p-values (the Efron Hessian, previously computed with an inner product in
+  place of the outer product `a a'` and then discarded, is fixed and validated
+  against finite differences). Two lower-value tie methods remain unimplemented
+  (`# TODO: Cox-Exact` / `# TODO: K&P` at `cox_ph.py:460-461`):
+  - **Exact partial likelihood** — averages over all orderings of tied events;
+    combinatorially expensive and only meaningfully different from Efron under
+    heavy ties. Niche.
+  - **Kalbfleisch-Prentice** — the discrete-time (grouped) proportional-hazards
+    likelihood for tied data. Also niche; Breslow + Efron already match what
+    R's `survival` and lifelines offer by default.
+
+  Neither is a common need, so both are deferred. Also: only right-censoring
+  and left-truncation (`tl`) are wired; right/interval truncation is missing
+  (see §6).
 - **`Beta` MPP guard.** `Beta` does not set `supports_mpp = False`, so
   `Beta.fit(how="MPP")` passes the support check and hits a raw
   `NotImplementedError` (`beta.py:404`) instead of the clean `ValueError` other

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,8 +23,10 @@ Two genuine blockers, both process rather than code:
   no `0.11.1` entry and nothing for the large body of work since (parametric
   additive hazards, recurrent parameter-uncertainty + diagnostics, discrete
   lifetime distributions, `handle_xicn` validation, copula and degradation
-  features, the simulation/`dist='t'` cleanups). Write real per-version entries
-  before tagging.
+  features, the simulation/`dist='t'` cleanups, the Fine-Gray regression
+  implementation, the Efron-Hessian fix, and delta-method confidence bounds
+  (`cb`/`param_cb`/`covariance`) on the parametric regression models). Write
+  real per-version entries before tagging.
 - **Add a publish workflow.** `.github/workflows/actions.yml` is CI-only (lint +
   pytest matrix + coverage, `on: [push]`). There is no tag-triggered
   `pypa/gh-action-pypi-publish` step, so releasing to PyPI is fully manual. Add

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -39,18 +39,15 @@ forest).
 
 ## 2. Correctness — broken or fragile public API (high priority)
 
-- **Fine-Gray competing-risks regression is broken.**
-  `univariate/competing_risks/regression/fine_gray.py` — `FineGray.fit()` raises
-  `NotImplementedError` (its log-likelihood/jacobian/hessian are commented out),
-  and it is **publicly exported** (`surpyval.univariate.competing_risks.FineGray`).
-  `CompetingRiskProportionalHazard.fit(how="Fine-Gray")` calls into it and so
-  raises too. Either finish the sub-distribution-hazard likelihood or mark the
-  Fine-Gray path clearly experimental / remove it from the public surface until
-  it works. The **cause-specific** path (`CRPH.fit(how="Cox")`, the default —
-  one Cox PH per event type) is fully functional, as are the predictors
-  (`hf`/`Hf`/`sf`/`ff`/`df`/`cif`).
 - **`CRPH.fit_from_df` is unimplemented** (`raise NotImplementedError("Not
-  yet...")`). Add the DataFrame entry point once the Fine-Gray path is sorted.
+  yet...")`). Add the DataFrame entry point for both the Cox and Fine-Gray
+  competing-risks paths.
+- **Competing-risks regression needs test coverage and Cox-path review.** The
+  Fine-Gray path is now implemented (IPCW subdistribution model, with tests);
+  the cause-specific Cox path (`CRPH.fit(how="Cox")`) fits and predicts but is
+  thinly tested, and its shared Breslow `baseline()` (all-cause event counts
+  with a Fine-Gray-style risk set) should be reviewed for the cause-specific
+  CIF before it is relied on.
 - **Cox PH tie-handling and Efron inference.** `cox_ph.py` implements only
   Breslow and Efron ties — no exact or Kalbfleisch-Prentice. The Efron branch
   computes but discards its Hessian ("something remains incorrect"), so p-values

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,15 +41,15 @@ forest).
 
 ## 2. Correctness — broken or fragile public API (high priority)
 
-- **`CRPH.fit_from_df` is unimplemented** (`raise NotImplementedError("Not
-  yet...")`). Add the DataFrame entry point for both the Cox and Fine-Gray
-  competing-risks paths.
+- **`CompetingRisksProportionalHazards.fit_from_df` is unimplemented** (`raise
+  NotImplementedError("Not yet...")`). Add the DataFrame entry point for both
+  the Cox and Fine-Gray competing-risks paths.
 - **Competing-risks regression needs test coverage and Cox-path review.** The
   Fine-Gray path is now implemented (IPCW subdistribution model, with tests);
-  the cause-specific Cox path (`CRPH.fit(how="Cox")`) fits and predicts but is
-  thinly tested, and its shared Breslow `baseline()` (all-cause event counts
-  with a Fine-Gray-style risk set) should be reviewed for the cause-specific
-  CIF before it is relied on.
+  the cause-specific Cox path (`CompetingRisksProportionalHazards.fit(
+  how="Cox")`) fits and predicts but is thinly tested, and its shared Breslow
+  `baseline()` (all-cause event counts with a Fine-Gray-style risk set) should
+  be reviewed for the cause-specific CIF before it is relied on.
 - **Cox PH exact / Kalbfleisch-Prentice tie methods.** `cox_ph.py` now supports
   Breslow and Efron ties, both with analytic-Hessian standard errors and
   p-values (the Efron Hessian, previously computed with an inner product in

--- a/docs/Competing Risks SurPyval Modelling.rst
+++ b/docs/Competing Risks SurPyval Modelling.rst
@@ -5,14 +5,12 @@ Competing Risks SurPyval Modelling
 This page shows how to use SurPyval's competing risks classes. For the
 theoretical background see :doc:`Competing Risks Analysis`.
 
-.. warning::
+.. note::
 
     The competing risks subsystem is under active development. The
-    ``CompetingRisks`` examples on this page are executed when the
-    documentation is built and work as shown. The ``FineGray`` and
-    ``CompetingRiskProportionalHazard`` fitters, however, currently crash on
-    first call; their sections below show the intended API only. These
-    issues are tracked in ``DEVELOPMENT.md``.
+    ``CompetingRisks`` example on this page is executed when the documentation
+    is built; the ``FineGray`` and ``CompetingRisksProportionalHazards``
+    snippets show the (working) regression API.
 
 Standard imports used throughout this page:
 
@@ -66,31 +64,37 @@ Once fitted, you can query the CIF for each cause:
     plt.title('Competing Risks CIF by Cause')
 
 
-Fine-Gray Sub-distribution Hazards (Planned)
----------------------------------------------
+Fine-Gray Sub-distribution Hazards
+----------------------------------
 
 The Fine-Gray model estimates the effect of covariates directly on the
-cumulative incidence function. The intended API mirrors the single-event
-regression fitters:
+cumulative incidence function of a chosen cause, using an
+inverse-probability-of-censoring-weighted subdistribution risk set. ``e`` is
+the per-observation cause label (``None`` for a censored row) and ``cause``
+selects the cause of interest:
 
 .. code-block:: python
 
-    # Planned API — not yet working (see DEVELOPMENT.md)
     from surpyval.univariate.competing_risks import FineGray
 
-    model = FineGray.fit(x=x, c=c, Z=Z, cause=cause, cause_of_interest=0)
-    print(model.summary())
+    # x times, Z covariates, e cause labels, c censoring flags
+    model = FineGray.fit(x, Z, e, c=c, cause=0)
+    print(model)                 # coefficients, standard errors, p-values
+    model.cif(t, Z=[0.5, 1.2])   # cumulative incidence of cause 0
 
-Cause-Specific Proportional Hazards (Planned)
-----------------------------------------------
+Cause-Specific Proportional Hazards
+-----------------------------------
 
-Fit a separate proportional hazards model per cause, censoring all other
-events:
+``CompetingRisksProportionalHazards`` fits a proportional-hazards model per
+cause. With ``how="Cox"`` (the default) each cause is a Cox model with the
+other causes treated as censored; ``how="Fine-Gray"`` fits the subdistribution
+model above for every cause:
 
 .. code-block:: python
 
-    # Planned API — not yet working (see DEVELOPMENT.md)
-    from surpyval.univariate.competing_risks import CompetingRiskProportionalHazard
+    from surpyval.univariate.competing_risks import (
+        CompetingRisksProportionalHazards,
+    )
 
-    model = CompetingRiskProportionalHazard.fit(x=x, c=c, Z=Z, cause=cause)
-    print(model.summary())
+    model = CompetingRisksProportionalHazards.fit(x, Z, e, c=c, how="Cox")
+    model.cif(t, Z=[0.5, 1.2], event=0)

--- a/surpyval/tests/univariate/competing_risks/test_fine_gray.py
+++ b/surpyval/tests/univariate/competing_risks/test_fine_gray.py
@@ -1,0 +1,184 @@
+"""Fine-Gray subdistribution-hazard regression.
+
+The model targets the cumulative incidence of a cause directly:
+``F_k(t|Z) = 1 - exp(-Lambda0(t) exp(beta'Z))``. Independent right-censoring
+is handled by inverse-probability-of-censoring weighting (IPCW), so these
+tests exercise parameter recovery *under censoring* -- the regime where a
+naive (unweighted) subdistribution risk set would be biased.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval.univariate.competing_risks import CRPH, FineGray
+
+
+def _simulate_fine_gray(N, seed, beta=(0.7, -0.4), p=0.5, cens_scale=3.0):
+    """
+    Simulate two-cause competing-risks data whose cause-1 cumulative incidence
+    follows a Fine-Gray model with coefficients ``beta`` (Fine & Gray 1999
+    construction): ``F_1(t|Z) = 1 - (1 - p(1 - e^{-t}))^{exp(beta'Z)}``.
+    Cause 2 mops up the rest; exponential right-censoring is applied.
+    """
+    rng = np.random.default_rng(seed)
+    beta = np.asarray(beta, dtype=float)
+    Z = rng.uniform(-1, 1, size=(N, beta.size))
+    phi = np.exp(Z @ beta)
+
+    p1 = 1 - (1 - p) ** phi  # P(cause = 1 | Z)
+    is1 = rng.uniform(size=N) < p1
+
+    x = np.empty(N)
+    e = np.empty(N, dtype=object)
+
+    # Invert the conditional cause-1 CIF for the cause-1 event times.
+    v = rng.uniform(size=N)
+    w = 1 - (1 - v * p1) ** (1 / phi)  # = p (1 - e^{-t})
+    t1 = -np.log(np.clip(1 - w / p, 1e-12, 1.0))
+    x[is1] = t1[is1]
+    e[is1] = 1
+
+    # Cause-2 times are exponential.
+    t2 = rng.exponential(1.0, size=N)
+    x[~is1] = t2[~is1]
+    e[~is1] = 2
+
+    # Independent right-censoring.
+    cens = rng.exponential(cens_scale, size=N)
+    c = (x > cens).astype(int)
+    x = np.minimum(x, cens)
+    e[c == 1] = None
+    return x, Z, e, c
+
+
+# --- standalone FineGray --------------------------------------------------
+
+
+def test_recovers_parameters_under_censoring():
+    x, Z, e, c = _simulate_fine_gray(8000, 0)
+    m = FineGray.fit(x, Z, e, c=c, cause=1)
+    assert np.allclose(m.beta, [0.7, -0.4], atol=0.07)
+    # Roughly a quarter of observations are censored in this design.
+    assert 0.15 < c.mean() < 0.35
+
+
+def test_baseline_cif_matches_theory_at_Z_zero():
+    # At Z = 0 the model reduces to the baseline CIF p(1 - e^{-t}).
+    x, Z, e, c = _simulate_fine_gray(8000, 1)
+    m = FineGray.fit(x, Z, e, c=c, cause=1)
+    t = np.array([0.5, 1.0, 2.0])
+    expected = 0.5 * (1 - np.exp(-t))
+    assert np.allclose(m.cif(t, [0.0, 0.0]), expected, atol=0.03)
+
+
+def test_cif_is_monotone_and_bounded():
+    x, Z, e, c = _simulate_fine_gray(4000, 2)
+    m = FineGray.fit(x, Z, e, c=c, cause=1)
+    t = np.linspace(0.0, 5.0, 50)
+    cif = m.cif(t, [0.3, -0.2])
+    assert np.all(cif >= 0) and np.all(cif <= 1)
+    assert np.all(np.diff(cif) >= -1e-12)
+
+
+def test_sf_and_hf_identities():
+    x, Z, e, c = _simulate_fine_gray(4000, 3)
+    m = FineGray.fit(x, Z, e, c=c, cause=1)
+    t = np.array([0.5, 1.0, 2.0])
+    Z0 = [0.1, -0.1]
+    assert np.allclose(m.sf(t, Z0), 1 - m.cif(t, Z0))
+
+
+def test_positive_coefficient_is_significant():
+    # The strong cause-1 covariate should be clearly significant; all p-values
+    # are well-defined probabilities.
+    x, Z, e, c = _simulate_fine_gray(6000, 4)
+    m = FineGray.fit(x, Z, e, c=c, cause=1)
+    assert np.all(np.isfinite(m.p_values))
+    assert np.all((m.p_values >= 0) & (m.p_values <= 1))
+    assert m.p_values[0] < 0.01  # beta_0 = 0.7
+
+
+def test_counts_equivalent_to_repeated_rows():
+    x, Z, e, c = _simulate_fine_gray(1500, 5)
+    m_rep = FineGray.fit(
+        np.repeat(x, 2),
+        np.repeat(Z, 2, axis=0),
+        np.repeat(e, 2),
+        c=np.repeat(c, 2),
+        cause=1,
+    )
+    m_cnt = FineGray.fit(x, Z, e, c=c, n=np.full(x.size, 2), cause=1)
+    assert np.allclose(m_rep.beta, m_cnt.beta, atol=1e-4)
+
+
+def test_ipcw_matters_versus_naive_no_censoring():
+    # With no censoring the IPCW weights are all 1, so the fit is the plain
+    # subdistribution model and still recovers the truth.
+    x, Z, e, c = _simulate_fine_gray(8000, 6, cens_scale=1e6)
+    assert c.mean() == 0.0
+    m = FineGray.fit(x, Z, e, c=c, cause=1)
+    assert np.allclose(m.beta, [0.7, -0.4], atol=0.07)
+
+
+# --- input handling -------------------------------------------------------
+
+
+def test_cause_required_when_multiple_event_types():
+    x, Z, e, c = _simulate_fine_gray(500, 7)
+    with pytest.raises(ValueError, match="specify `cause`"):
+        FineGray.fit(x, Z, e, c=c)
+
+
+def test_unknown_cause_rejected():
+    x, Z, e, c = _simulate_fine_gray(500, 8)
+    with pytest.raises(ValueError, match="not observed"):
+        FineGray.fit(x, Z, e, c=c, cause=99)
+
+
+# --- CRPH integration -----------------------------------------------------
+
+
+def test_crph_fine_gray_matches_standalone():
+    x, Z, e, c = _simulate_fine_gray(5000, 9)
+    crph = CRPH.fit(x, Z, e, c=c, how="Fine-Gray")
+    standalone = FineGray.fit(x, Z, e, c=c, cause=1)
+    i1 = crph.event_idx_map[1]
+    assert np.allclose(crph.betas[i1], standalone.beta, atol=1e-6)
+    t = np.array([0.5, 1.0, 2.0])
+    assert np.allclose(
+        crph.cif(t, [0.2, -0.1], 1), standalone.cif(t, [0.2, -0.1])
+    )
+
+
+def test_crph_fine_gray_cif_identities():
+    x, Z, e, c = _simulate_fine_gray(4000, 10)
+    crph = CRPH.fit(x, Z, e, c=c, how="Fine-Gray")
+    t = np.array([0.5, 1.0, 2.0])
+    Z0 = [0.1, 0.1]
+    assert np.allclose(crph.sf(t, Z0, 1) + crph.cif(t, Z0, 1), 1.0)
+    assert np.allclose(crph.Hf(t, Z0, 1), -np.log(crph.sf(t, Z0, 1)))
+
+
+def test_crph_fine_gray_hf_df_raise():
+    x, Z, e, c = _simulate_fine_gray(2000, 11)
+    crph = CRPH.fit(x, Z, e, c=c, how="Fine-Gray")
+    with pytest.raises(ValueError, match="no pointwise"):
+        crph.hf([1.0], [0.0, 0.0], 1)
+    with pytest.raises(ValueError, match="no pointwise"):
+        crph.df([1.0], [0.0, 0.0], 1)
+
+
+def test_crph_fine_gray_requires_event():
+    x, Z, e, c = _simulate_fine_gray(2000, 12)
+    crph = CRPH.fit(x, Z, e, c=c, how="Fine-Gray")
+    with pytest.raises(ValueError, match="pass `event`"):
+        crph.sf([1.0], [0.0, 0.0])
+
+
+def test_crph_cox_path_still_runs():
+    # Regression guard: the cause-specific Cox path (a sibling of the same
+    # public entry point) fits and predicts.
+    x, Z, e, c = _simulate_fine_gray(3000, 13)
+    crph = CRPH.fit(x, Z, e, c=c, how="Cox")
+    cif = crph.cif(np.array([0.5, 1.0, 2.0]), [0.1, -0.1], 1)
+    assert np.all(np.isfinite(cif))

--- a/surpyval/tests/univariate/competing_risks/test_fine_gray.py
+++ b/surpyval/tests/univariate/competing_risks/test_fine_gray.py
@@ -10,7 +10,10 @@ naive (unweighted) subdistribution risk set would be biased.
 import numpy as np
 import pytest
 
-from surpyval.univariate.competing_risks import CRPH, FineGray
+from surpyval.univariate.competing_risks import (
+    CompetingRisksProportionalHazards,
+    FineGray,
+)
 
 
 def _simulate_fine_gray(N, seed, beta=(0.7, -0.4), p=0.5, cens_scale=3.0):
@@ -135,12 +138,12 @@ def test_unknown_cause_rejected():
         FineGray.fit(x, Z, e, c=c, cause=99)
 
 
-# --- CRPH integration -----------------------------------------------------
+# --- CompetingRisksProportionalHazards integration -----------------------
 
 
 def test_crph_fine_gray_matches_standalone():
     x, Z, e, c = _simulate_fine_gray(5000, 9)
-    crph = CRPH.fit(x, Z, e, c=c, how="Fine-Gray")
+    crph = CompetingRisksProportionalHazards.fit(x, Z, e, c=c, how="Fine-Gray")
     standalone = FineGray.fit(x, Z, e, c=c, cause=1)
     i1 = crph.event_idx_map[1]
     assert np.allclose(crph.betas[i1], standalone.beta, atol=1e-6)
@@ -152,7 +155,7 @@ def test_crph_fine_gray_matches_standalone():
 
 def test_crph_fine_gray_cif_identities():
     x, Z, e, c = _simulate_fine_gray(4000, 10)
-    crph = CRPH.fit(x, Z, e, c=c, how="Fine-Gray")
+    crph = CompetingRisksProportionalHazards.fit(x, Z, e, c=c, how="Fine-Gray")
     t = np.array([0.5, 1.0, 2.0])
     Z0 = [0.1, 0.1]
     assert np.allclose(crph.sf(t, Z0, 1) + crph.cif(t, Z0, 1), 1.0)
@@ -161,7 +164,7 @@ def test_crph_fine_gray_cif_identities():
 
 def test_crph_fine_gray_hf_df_raise():
     x, Z, e, c = _simulate_fine_gray(2000, 11)
-    crph = CRPH.fit(x, Z, e, c=c, how="Fine-Gray")
+    crph = CompetingRisksProportionalHazards.fit(x, Z, e, c=c, how="Fine-Gray")
     with pytest.raises(ValueError, match="no pointwise"):
         crph.hf([1.0], [0.0, 0.0], 1)
     with pytest.raises(ValueError, match="no pointwise"):
@@ -170,7 +173,7 @@ def test_crph_fine_gray_hf_df_raise():
 
 def test_crph_fine_gray_requires_event():
     x, Z, e, c = _simulate_fine_gray(2000, 12)
-    crph = CRPH.fit(x, Z, e, c=c, how="Fine-Gray")
+    crph = CompetingRisksProportionalHazards.fit(x, Z, e, c=c, how="Fine-Gray")
     with pytest.raises(ValueError, match="pass `event`"):
         crph.sf([1.0], [0.0, 0.0])
 
@@ -179,6 +182,6 @@ def test_crph_cox_path_still_runs():
     # Regression guard: the cause-specific Cox path (a sibling of the same
     # public entry point) fits and predicts.
     x, Z, e, c = _simulate_fine_gray(3000, 13)
-    crph = CRPH.fit(x, Z, e, c=c, how="Cox")
+    crph = CompetingRisksProportionalHazards.fit(x, Z, e, c=c, how="Cox")
     cif = crph.cif(np.array([0.5, 1.0, 2.0]), [0.1, -0.1], 1)
     assert np.all(np.isfinite(cif))

--- a/surpyval/tests/univariate/regression/test_confidence_bounds.py
+++ b/surpyval/tests/univariate/regression/test_confidence_bounds.py
@@ -1,0 +1,194 @@
+"""Delta-method confidence bounds for the parametric regression models.
+
+Every parametric regression fitter (AFT, PH, PO, additive hazards,
+accelerated life) produces a ``ParametricRegressionModel``, so the bounds are
+tested once on that shared surface across a few representative families. The
+checks are structural (bounds bracket the point estimate, stay in range, nest
+with the confidence level, respect parameter support) plus one coverage check
+that the interval width is calibrated, not just ordered.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from surpyval import (
+    ExponentialPH,
+    WeibullAFT,
+    WeibullAH,
+    WeibullPH,
+    WeibullPO,
+)
+
+ALL_FAMILIES = [WeibullPH, WeibullAFT, WeibullAH, WeibullPO, ExponentialPH]
+
+
+def _data(seed, N=800, beta=(0.6, -0.3)):
+    rng = np.random.default_rng(seed)
+    Z = rng.uniform(-1, 1, size=(N, len(beta)))
+    scale = 10.0 * np.exp(-(Z @ np.asarray(beta)) / 2.0)
+    x = scale * rng.weibull(2.0, size=N)
+    c = (rng.uniform(size=N) < 0.2).astype(int)
+    return x, Z, c
+
+
+@pytest.mark.parametrize("F", ALL_FAMILIES)
+def test_parameter_names_and_covariance_shape(F):
+    x, Z, c = _data(0)
+    m = F.fit(x=x, Z=Z, c=c)
+    names = m.parameter_names()
+    # distribution params first, then one coefficient per covariate.
+    assert names[-2:] == ["beta_0", "beta_1"]
+    k = len(names)
+    assert m.covariance().shape == (k, k)
+    se = m.standard_errors()
+    assert se.shape == (k,)
+    assert np.all(np.isfinite(se)) and np.all(se > 0)
+
+
+@pytest.mark.parametrize("F", ALL_FAMILIES)
+def test_sf_bounds_bracket_and_bounded(F):
+    x, Z, c = _data(1)
+    m = F.fit(x=x, Z=Z, c=c)
+    xs = np.array([2.0, 5.0, 10.0])
+    Z0 = np.array([0.2, -0.1])
+    sf = m.sf(xs, Z0)
+    cb = m.cb(xs, Z0, on="sf")
+    assert cb.shape == (3, 2)
+    lo, hi = cb[:, 0], cb[:, 1]
+    assert np.all(lo <= sf) and np.all(sf <= hi)
+    assert np.all(lo >= 0) and np.all(hi <= 1)
+    assert np.all(lo <= hi)
+
+
+@pytest.mark.parametrize("on", ["sf", "ff", "Hf", "hf", "df"])
+def test_all_functions_bracket_estimate(on):
+    x, Z, c = _data(2)
+    m = WeibullAFT.fit(x=x, Z=Z, c=c)
+    xs = np.array([3.0, 8.0])
+    Z0 = np.array([0.1, -0.2])
+    est = getattr(m, on)(xs, Z0)
+    cb = m.cb(xs, Z0, on=on)
+    assert np.all(cb[:, 0] <= est) and np.all(est <= cb[:, 1])
+    # ff/sf are probabilities.
+    if on in ("sf", "ff"):
+        assert np.all(cb >= 0) and np.all(cb <= 1)
+    # hf/df/Hf are non-negative.
+    if on in ("hf", "df", "Hf"):
+        assert np.all(cb >= 0)
+
+
+def test_one_sided_bounds_ordered():
+    x, Z, c = _data(3)
+    m = WeibullPH.fit(x=x, Z=Z, c=c)
+    xs = np.array([2.0, 6.0])
+    Z0 = np.array([0.3, 0.0])
+    for on in ["sf", "ff", "Hf", "hf", "df"]:
+        est = getattr(m, on)(xs, Z0)
+        lower = m.cb(xs, Z0, on=on, bound="lower")
+        upper = m.cb(xs, Z0, on=on, bound="upper")
+        assert np.all(lower <= est) and np.all(est <= upper)
+
+
+def test_tighter_confidence_gives_wider_bounds():
+    # A smaller alpha_ci (higher confidence) must widen the interval.
+    x, Z, c = _data(4)
+    m = WeibullAFT.fit(x=x, Z=Z, c=c)
+    xs = np.array([2.0, 5.0, 9.0])
+    Z0 = np.array([0.2, -0.2])
+    cb95 = m.cb(xs, Z0, on="sf", alpha_ci=0.05)
+    cb90 = m.cb(xs, Z0, on="sf", alpha_ci=0.10)
+    assert np.all(cb95[:, 0] <= cb90[:, 0])  # 95% lower is below 90% lower
+    assert np.all(cb90[:, 1] <= cb95[:, 1])  # 95% upper is above 90% upper
+
+
+def test_param_cb_brackets_and_respects_support():
+    x, Z, c = _data(5)
+    m = WeibullPH.fit(x=x, Z=Z, c=c)
+    names = m.parameter_names()
+    for nm in names:
+        idx = names.index(nm)
+        lo, hi = m.param_cb(nm)
+        assert lo <= m.params[idx] <= hi
+        assert lo <= hi
+    # Weibull scale/shape are strictly positive; their lower bound must be too.
+    assert m.param_cb("alpha")[0] > 0
+    assert m.param_cb("beta")[0] > 0
+
+
+def test_param_cb_one_sided():
+    x, Z, c = _data(6)
+    m = WeibullAFT.fit(x=x, Z=Z, c=c)
+    # One-sided bounds return a single value (as a length-1 array, matching
+    # the two-sided [lower, upper] convention).
+    lower = np.ravel(m.param_cb("beta_0", bound="lower"))[0]
+    upper = np.ravel(m.param_cb("beta_0", bound="upper"))[0]
+    beta0 = m.params[m.parameter_names().index("beta_0")]
+    assert lower <= beta0 <= upper
+
+
+def test_fixed_parameter_has_zero_variance():
+    x, Z, c = _data(7)
+    m = WeibullAFT.fit(x=x, Z=Z, c=c, fixed={"beta_1": 0.0})
+    names = m.parameter_names()
+    j = names.index("beta_1")
+    cov = m.covariance()
+    assert np.allclose(cov[j, :], 0.0) and np.allclose(cov[:, j], 0.0)
+    # The free parameters still have positive variance.
+    assert m.standard_errors()[names.index("beta_0")] > 0
+
+
+def test_coverage_of_coefficient_interval():
+    # The 95% Wald interval for a coefficient should cover the truth close to
+    # 95% of the time -- a check that the covariance magnitude is calibrated,
+    # not merely that the interval is ordered.
+    true_beta0 = 0.5
+    covered = 0
+    reps = 120
+    for s in range(reps):
+        rng = np.random.default_rng(1000 + s)
+        N = 500
+        Z = rng.uniform(-1, 1, size=(N, 2))
+        phi = np.exp(Z @ [true_beta0, -0.4])
+        x = 10.0 * rng.weibull(2.0, size=N) / phi
+        c = (rng.uniform(size=N) < 0.15).astype(int)
+        m = WeibullAFT.fit(x=x, Z=Z, c=c)
+        lo, hi = m.param_cb("beta_0")
+        covered += lo <= true_beta0 <= hi
+    # Allow Monte-Carlo slack (finite-sample Wald slightly under-covers).
+    assert 0.88 <= covered / reps <= 1.0
+
+
+def test_cb_accepts_dataframe_covariates():
+    x, Z, c = _data(8)
+    df = pd.DataFrame({"t": x, "c": c, "age": Z[:, 0], "dose": Z[:, 1]})
+    m = WeibullAFT.fit_from_df(
+        df, x_col="t", Z_cols=["age", "dose"], c_col="c"
+    )
+    row = df[["age", "dose"]].iloc[[0]]
+    cb = m.cb([1.0, 2.0], row, on="sf")
+    assert cb.shape == (2, 2)
+    assert np.all(cb >= 0) and np.all(cb <= 1)
+
+
+def test_cb_rejects_bad_arguments():
+    x, Z, c = _data(9)
+    m = WeibullPH.fit(x=x, Z=Z, c=c)
+    with pytest.raises(ValueError, match="`on` must be one of"):
+        m.cb([1.0], [0.0, 0.0], on="nonsense")
+    with pytest.raises(ValueError, match="`bound` must be"):
+        m.cb([1.0], [0.0, 0.0], bound="sideways")
+    with pytest.raises(ValueError, match="Unknown parameter"):
+        m.param_cb("beta_99")
+
+
+def test_plot_with_bounds_returns_axes():
+    import matplotlib
+
+    matplotlib.use("Agg")
+    x, Z, c = _data(10)
+    m = WeibullPH.fit(x=x, Z=Z, c=c)
+    ax = m.plot(plot_bounds=True)
+    assert ax is not None
+    # A band (fill_between) adds a PolyCollection to the axes.
+    assert len(ax.collections) >= 1

--- a/surpyval/tests/univariate/regression/test_proportional_hazards.py
+++ b/surpyval/tests/univariate/regression/test_proportional_hazards.py
@@ -194,15 +194,68 @@ def test_count_weights_equivalent_to_repeated():
     assert np.allclose(m_rep.beta, m_cnt.beta, atol=1e-6)
 
 
-def test_efron_p_values_is_none():
-    # Efron root-finding does not return a Hessian, so p_values should be None.
+def test_efron_returns_p_values():
+    # Efron now returns its (corrected) analytic Hessian, so p_values are
+    # produced -- finite probabilities in [0, 1], one per covariate.
     x = [1.0, 2.0, 3.0, 4.0, 5.0]
     Z = [[0.1], [0.5], [0.3], [0.8], [0.2]]
     c = [0, 0, 0, 0, 0]
 
     model = CoxPH.fit(x=x, Z=Z, c=c, method="efron")
 
-    assert model.p_values is None
+    assert model.p_values is not None
+    assert model.p_values.shape == (1,)
+    assert np.all(np.isfinite(model.p_values))
+    assert np.all((model.p_values >= 0) & (model.p_values <= 1))
+
+
+def test_efron_hessian_matches_finite_difference():
+    # The analytic Efron information (returned as the root-finding Jacobian)
+    # must match a central-difference Jacobian of the score, including the
+    # off-diagonal terms that the old inner-product bug corrupted. Uses a
+    # multi-covariate design with tied event times.
+    from surpyval.utils import validate_coxph
+
+    rng = np.random.default_rng(0)
+    N, p = 300, 3
+    Z = rng.normal(size=(N, p))
+    eta = np.exp(Z @ [0.5, 0.0, -0.4])
+    t = np.round(-np.log(rng.uniform(size=N)) / eta, 1)
+    c = (rng.uniform(size=N) < 0.25).astype(int)
+
+    x, cc, nn, tl, ZZ = validate_coxph(t, c, np.ones(N), Z, None, "efron")
+    _, jac_hess, has_hess = CoxPH.create_efron_ll_jac_hess(x, ZZ, cc, nn, tl)
+    assert has_hess
+
+    beta = np.array([0.1, -0.1, 0.2])
+    H = jac_hess(beta)[1]
+    eps = 1e-6
+    H_num = np.zeros((p, p))
+    for k in range(p):
+        bp, bm = beta.copy(), beta.copy()
+        bp[k] += eps
+        bm[k] -= eps
+        H_num[:, k] = (jac_hess(bp)[0] - jac_hess(bm)[0]) / (2 * eps)
+
+    assert np.allclose(H, H_num, atol=1e-5)
+    assert np.allclose(H, H.T)  # symmetric
+    assert np.all(np.linalg.eigvalsh(H) > 0)  # positive definite
+
+
+def test_efron_and_breslow_p_values_agree_without_ties():
+    # With no tied event times Efron and Breslow reduce to the same partial
+    # likelihood, so their standard errors (hence p-values) should agree.
+    rng = np.random.default_rng(1)
+    N = 2000
+    Z = rng.normal(size=(N, 2))
+    x = -np.log(rng.uniform(size=N)) / np.exp(Z @ [0.7, -0.5])
+    c = (rng.uniform(size=N) < 0.2).astype(int)
+
+    m_ef = CoxPH.fit(x=x, Z=Z, c=c, method="efron")
+    m_br = CoxPH.fit(x=x, Z=Z, c=c, method="breslow")
+
+    assert np.allclose(m_ef.beta, m_br.beta, atol=1e-3)
+    assert np.allclose(m_ef.p_values, m_br.p_values, atol=1e-2)
 
 
 def test_baseline_hazard_properties():

--- a/surpyval/univariate/competing_risks/__init__.py
+++ b/surpyval/univariate/competing_risks/__init__.py
@@ -1,2 +1,8 @@
 from .nonparametric import CompetingRisks
-from .regression import CRPH, CompetingRiskProportionalHazard, FineGray
+from .regression import CompetingRisksProportionalHazards, FineGray
+
+__all__ = [
+    "CompetingRisks",
+    "CompetingRisksProportionalHazards",
+    "FineGray",
+]

--- a/surpyval/univariate/competing_risks/regression/__init__.py
+++ b/surpyval/univariate/competing_risks/regression/__init__.py
@@ -1,5 +1,6 @@
 from .competing_risks_proportional_hazard import (
-    CRPH,
-    CompetingRiskProportionalHazard,
+    CompetingRisksProportionalHazards,
 )
 from .fine_gray import FineGray
+
+__all__ = ["CompetingRisksProportionalHazards", "FineGray"]

--- a/surpyval/univariate/competing_risks/regression/competing_risks_proportional_hazard.py
+++ b/surpyval/univariate/competing_risks/regression/competing_risks_proportional_hazard.py
@@ -15,10 +15,17 @@ from surpyval.utils import _get_idx, _scale, validate_fine_gray_inputs
 from .fine_gray import FineGray, _step
 
 
-class CompetingRiskProportionalHazard:
+class CompetingRisksProportionalHazards:
     """
+    Competing-risks proportional-hazards regression.
+
+    Fits either a cause-specific proportional-hazards model (``how="Cox"``,
+    one Cox model per cause with the other causes treated as censored) or a
+    Fine-Gray subdistribution-hazards model (``how="Fine-Gray"``). The naming
+    follows the package convention (compare ``CompetingRisks`` and
+    ``ProportionalHazards``).
+
     TODO: Time-Varying Implementation
-    TODO: Change this to SemiParametricCompetingRiskProportionalHazard ??
     """
 
     def _fg_model(self, event):
@@ -203,13 +210,15 @@ class CompetingRiskProportionalHazard:
         Returns
         -------
 
-        model : CompetingRiskProportionalHazard
-            A Competing Risk Proportional Hazard model with fitted params
+        model : CompetingRisksProportionalHazards
+            A competing-risks proportional-hazards model with fitted params
             and helper methods using the fitted params.
 
         Examples
         --------
-        >>> from surpyval.univariate.competing_risks import CRPH
+        >>> from surpyval.univariate.competing_risks import (
+        ...     CompetingRisksProportionalHazards,
+        ... )
 
         """
         x, Z, e, c, n = validate_fine_gray_inputs(x, Z, e, c, n)
@@ -277,6 +286,3 @@ class CompetingRiskProportionalHazard:
         model.H0_e = baselines.cumsum(axis=1)
         model.x = unique_x
         return model
-
-
-CRPH = CompetingRiskProportionalHazard

--- a/surpyval/univariate/competing_risks/regression/competing_risks_proportional_hazard.py
+++ b/surpyval/univariate/competing_risks/regression/competing_risks_proportional_hazard.py
@@ -12,7 +12,7 @@ import numpy as np
 from surpyval.univariate.regression import CoxPH
 from surpyval.utils import _get_idx, _scale, validate_fine_gray_inputs
 
-from .fine_gray import FineGray
+from .fine_gray import FineGray, _step
 
 
 class CompetingRiskProportionalHazard:
@@ -20,6 +20,17 @@ class CompetingRiskProportionalHazard:
     TODO: Time-Varying Implementation
     TODO: Change this to SemiParametricCompetingRiskProportionalHazard ??
     """
+
+    def _fg_model(self, event):
+        # Resolve the per-cause Fine-Gray subdistribution model, requiring an
+        # explicit cause (the Fine-Gray CIF is defined one cause at a time).
+        if event is None:
+            raise ValueError(
+                "A Fine-Gray model predicts one cause at a time; pass `event`."
+            )
+        if event not in self._fg_models:
+            raise ValueError("Unrecognised event type for this model")
+        return self._fg_models[event]
 
     def _f(self, arr, x, Z, event=None, interp="step"):
         idx, rev = _get_idx(self.x, x)
@@ -34,28 +45,48 @@ class CompetingRiskProportionalHazard:
             return (arr[e_i, idx] * self.phi_e(Z, e_i))[rev]
 
     def hf(self, x, Z, event=None, interp="step"):
+        if self.how == "Fine-Gray":
+            raise ValueError(
+                "The Fine-Gray subdistribution hazard has no pointwise "
+                "density from the step baseline; use `cif` or `Hf`."
+            )
         return self._f(self.h0_e, x, Z, event=event, interp=interp)
 
     def Hf(self, x, Z, event=None, interp="step"):
+        if self.how == "Fine-Gray":
+            # Cumulative subdistribution hazard H0_k(x) * exp(beta'Z) = -log S.
+            return -np.log(self.sf(x, Z, event=event))
         return self._f(self.H0_e, x, Z, event=event, interp=interp)
 
     def sf(self, x, Z, event=None, interp="step"):
+        if self.how == "Fine-Gray":
+            return self._fg_model(event).sf(x, Z)
         return np.exp(-self.Hf(x, Z, event=event, interp=interp))
 
     def ff(self, x, Z, event=None, interp="step"):
+        if self.how == "Fine-Gray":
+            return self.cif(x, Z, event)
         return 1 - self.sf(x, Z, event=event, interp=interp)
 
     def df(self, x, Z, event=None, interp="step"):
+        if self.how == "Fine-Gray":
+            raise ValueError(
+                "The Fine-Gray subdistribution density has no pointwise form "
+                "from the step baseline; use `cif`."
+            )
         return self.hf(x, Z, event=event, interp=interp) * self.sf(
             x, Z, event=event, interp=interp
         )
 
     def cif(self, x, Z, event):
-        # Index and reverse index
-        # in case x is not in order.
+        if self.how == "Fine-Gray":
+            # Direct subdistribution CIF: 1 - exp(-H0_k(x) exp(beta'Z)).
+            return self._fg_model(event).cif(x, Z)
+
+        # Cause-specific CIF: integrate this cause's hazard against the
+        # all-cause survival. Index and reverse index in case x is unordered.
         idx, rev = _get_idx(self.x, x)
 
-        # CIF
         lambda_e = self.hf(self.x, Z, event)
         S = self.sf(self.x, Z)
         # iif = instantaneous incidence function
@@ -210,21 +241,30 @@ class CompetingRiskProportionalHazard:
             for i, event in enumerate(unique_e):
                 c_e = np.where(e == event, 0, 1)
 
-                res = CoxPH.fit(
-                    x, Z, c_e, n, method=tie_method, with_hess=False
-                ).res
+                res = CoxPH.fit(x, Z, c_e, n, method=tie_method).res
 
                 results.append(res)
                 betas[i, :] = res.x
                 baselines[i, :] = cls.baseline(res.x, x, c, n, Z, e, event)
 
         elif how == "Fine-Gray":
-            results, unique_e = FineGray.fit(x, Z, e, c, n)
-            for i, res in enumerate(results):
-                betas[i, :] = res.x
-                baselines[i, :] = cls.baseline(
-                    res.x, x, c, n, Z, e, unique_e[i]
-                )
+            # Delegate to the IPCW Fine-Gray fitter, one subdistribution model
+            # per cause. The authoritative predictions come from these models
+            # (see ``_fg_models`` and the ``cif``/``sf`` branches below); the
+            # ``baselines`` grid is filled with each cause's cumulative
+            # subdistribution hazard for a coherent ``H0_e``.
+            fg_models = {}
+            results = []
+            for i, event in enumerate(unique_e):
+                fg = FineGray.fit(x, Z, e, c=c, n=n, cause=event)
+                fg_models[event] = fg
+                results.append(fg.res)
+                betas[i, :] = fg.beta
+                # Store increments so the shared ``H0_e = baselines.cumsum``
+                # equals this cause's cumulative subdistribution hazard.
+                H_grid = _step(fg._times, fg._cumhaz, unique_x, before=0.0)
+                baselines[i, :] = np.diff(H_grid, prepend=0.0)
+            model._fg_models = fg_models
         else:
             raise ValueError("`how` must be either 'Cox' or 'Fine-Gray")
 

--- a/surpyval/univariate/competing_risks/regression/fine_gray.py
+++ b/surpyval/univariate/competing_risks/regression/fine_gray.py
@@ -67,9 +67,7 @@ def _step(times, values, query, before):
     first time.
     """
     idx = np.searchsorted(times, query, side="right") - 1
-    out = np.where(
-        idx < 0, before, values[np.clip(idx, 0, len(values) - 1)]
-    )
+    out = np.where(idx < 0, before, values[np.clip(idx, 0, len(values) - 1)])
     return out
 
 
@@ -116,9 +114,7 @@ def _fit_cause(x, Z, e, c, n, cause):
         weighted_exp = n * anp.exp(eta)
         denom = anp.dot(W, weighted_exp)
         eta_event = anp.dot(Z_event, beta)
-        ll = anp.sum(n_event * eta_event) - anp.sum(
-            n_event * anp.log(denom)
-        )
+        ll = anp.sum(n_event * eta_event) - anp.sum(n_event * anp.log(denom))
         return -ll
 
     beta0 = np.zeros(Z.shape[1])
@@ -209,12 +205,8 @@ class FineGrayModel:
             f"Cause of interest   : {self.cause}",
             "Coefficients (beta'Z acts on the subdistribution hazard):",
         ]
-        for i, (b, s, p) in enumerate(
-            zip(self.beta, self.se, self.p_values)
-        ):
-            lines.append(
-                f"   beta_{i}  :  {b: .6f}  (se {s:.6f}, p {p:.4f})"
-            )
+        for i, (b, s, p) in enumerate(zip(self.beta, self.se, self.p_values)):
+            lines.append(f"   beta_{i}  :  {b: .6f}  (se {s:.6f}, p {p:.4f})")
         return "\n".join(lines)
 
 

--- a/surpyval/univariate/competing_risks/regression/fine_gray.py
+++ b/surpyval/univariate/competing_risks/regression/fine_gray.py
@@ -5,125 +5,264 @@ and waives any and all liability in connection therewith. Your use of the
 code constitutes acceptance of these terms.
 
 Copyright 2022 Cartiga LLC
+
+Fine-Gray subdistribution-hazard regression for competing risks.
+
+Where cause-specific proportional hazards models the hazard of each cause
+after removing subjects who fail from a competing cause, the Fine-Gray model
+(Fine & Gray, 1999) keeps those subjects in a modified ("subdistribution")
+risk set so that a single coefficient vector acts directly on the cumulative
+incidence function (CIF) of the cause of interest,
+
+.. math::
+    F_k(t \\mid Z) = 1 - \\exp\\{-\\Lambda_{k0}(t)\\,\\exp(\\beta' Z)\\},
+
+with :math:`\\Lambda_{k0}` a baseline cumulative subdistribution hazard. This
+makes :math:`\\beta` interpretable as a (log) subdistribution hazard ratio: a
+positive coefficient raises the incidence of cause :math:`k`.
+
+Independent right-censoring is handled by inverse-probability-of-censoring
+weighting (IPCW): a subject who has already failed from a competing cause
+stays in the subdistribution risk set with a time-varying weight
+:math:`G(t)/G(x_i)`, where :math:`G` is the Kaplan-Meier estimate of the
+censoring-time survival function. Subjects who are censored, or who have
+already had the event of interest, leave the risk set. The partial likelihood
+is the Breslow form of this weighted risk set.
 """
 
-# from numba import njit
-# from scipy.optimize import root
+import numpy as np
+from autograd import grad, hessian
+from autograd import numpy as anp
+from scipy.optimize import minimize
+from scipy.stats import norm
 
-# TODO: Improve this so that it uses root and the jac and hess.
-# TODO: Implement it with time-varying covariates
+from surpyval.utils import validate_fine_gray_inputs
+
+
+def _censoring_survival(x, c, n):
+    """
+    Kaplan-Meier estimate of the censoring survival ``G(t) = P(C > t)``.
+
+    The roles are reversed relative to an ordinary survival fit: right-censored
+    rows (``c == 1``) are the "events" for the censoring distribution and
+    observed events (``c == 0``) are treated as censored. Returns the sorted
+    unique times and the right-continuous ``G`` evaluated at each.
+    """
+    times = np.unique(x)
+    G = np.ones(times.shape[0])
+    surv = 1.0
+    for k, t in enumerate(times):
+        at_risk = n[x >= t].sum()
+        censored = n[(x == t) & (c == 1)].sum()
+        if at_risk > 0:
+            surv = surv * (1.0 - censored / at_risk)
+        G[k] = surv
+    return times, G
+
+
+def _step(times, values, query, before):
+    """
+    Right-continuous step function: the value carried by the largest ``times``
+    entry ``<= query``; ``before`` is returned where ``query`` precedes the
+    first time.
+    """
+    idx = np.searchsorted(times, query, side="right") - 1
+    out = np.where(
+        idx < 0, before, values[np.clip(idx, 0, len(values) - 1)]
+    )
+    return out
+
+
+def _fit_cause(x, Z, e, c, n, cause):
+    """
+    Fit the Fine-Gray subdistribution-hazard model for a single ``cause``.
+
+    Returns a dict with the fitted coefficients, their standard errors and
+    p-values, the baseline cumulative subdistribution hazard (as sorted event
+    times and the cumulative hazard at each), and the optimiser result.
+    """
+    is_event = (c == 0) & (e == cause)
+    if not is_event.any():
+        raise ValueError(f"No observed events for cause {cause!r}")
+    is_competing = (c == 0) & (e != cause)
+
+    # Censoring-survival for the IPCW weights.
+    g_times, g_vals = _censoring_survival(x, c, n)
+    # G is >= its last positive value; guard the ratio against division by a
+    # zero tail (times beyond the last censoring-KM step).
+    g_floor = g_vals[g_vals > 0].min() if np.any(g_vals > 0) else 1.0
+    G_x = np.maximum(_step(g_times, g_vals, x, before=1.0), g_floor)
+
+    event_times = x[is_event]
+    G_t = _step(g_times, g_vals, event_times, before=1.0)
+
+    # Subdistribution risk-set weight matrix W (n_events x N), independent of
+    # beta: 1 for the ordinary risk set (x_i >= t_j); G(t_j)/G(x_i) for a
+    # subject who already failed from a competing cause (x_i < t_j); 0 for a
+    # censored subject or one that already had the event of interest.
+    at_risk = x[None, :] >= event_times[:, None]
+    already_competing = is_competing[None, :] & (
+        x[None, :] < event_times[:, None]
+    )
+    W = at_risk.astype(float) + already_competing * (
+        G_t[:, None] / G_x[None, :]
+    )
+
+    n_event = n[is_event]
+    Z_event = Z[is_event]
+
+    def neg_ll(beta):
+        eta = anp.dot(Z, beta)
+        weighted_exp = n * anp.exp(eta)
+        denom = anp.dot(W, weighted_exp)
+        eta_event = anp.dot(Z_event, beta)
+        ll = anp.sum(n_event * eta_event) - anp.sum(
+            n_event * anp.log(denom)
+        )
+        return -ll
+
+    beta0 = np.zeros(Z.shape[1])
+    res = minimize(neg_ll, beta0, jac=grad(neg_ll), method="BFGS")
+    beta = res.x
+
+    # Standard errors from the inverse observed information.
+    H = hessian(neg_ll)(beta)
+    try:
+        cov = np.linalg.inv(H)
+    except np.linalg.LinAlgError:
+        cov = np.linalg.pinv(H)
+    var = np.diag(cov)
+    with np.errstate(invalid="ignore"):
+        se = np.sqrt(np.where(var > 0, var, np.nan))
+        z_score = beta / se
+    p_values = 2.0 * (1.0 - norm.cdf(np.abs(z_score)))
+
+    # Breslow baseline cumulative subdistribution hazard: at each event-of-
+    # interest time, dLambda0 = (events there) / (weighted risk set there).
+    denom = W @ (n * np.exp(Z @ beta))
+    order = np.argsort(event_times, kind="mergesort")
+    t_sorted = event_times[order]
+    d_over_r = (n_event / denom)[order]
+    uniq_t, inv = np.unique(t_sorted, return_inverse=True)
+    dL = np.zeros(uniq_t.shape[0])
+    np.add.at(dL, inv, d_over_r)
+    baseline_cumhaz = np.cumsum(dL)
+
+    return {
+        "cause": cause,
+        "beta": beta,
+        "se": se,
+        "p_values": p_values,
+        "cov": cov,
+        "baseline_times": uniq_t,
+        "baseline_cumhaz": baseline_cumhaz,
+        "neg_ll": float(res.fun),
+        "res": res,
+    }
+
+
+class FineGrayModel:
+    """
+    A fitted Fine-Gray subdistribution-hazard model for one cause of interest.
+
+    The natural prediction is the cumulative incidence function :meth:`cif`;
+    ``coefficients``/``se``/``p_values`` describe the (log) subdistribution
+    hazard ratios.
+    """
+
+    def __init__(self, fit):
+        self.cause = fit["cause"]
+        self.coefficients = fit["beta"]
+        self.beta = fit["beta"]
+        self.se = fit["se"]
+        self.p_values = fit["p_values"]
+        self.cov = fit["cov"]
+        self._times = fit["baseline_times"]
+        self._cumhaz = fit["baseline_cumhaz"]
+        self._neg_ll = fit["neg_ll"]
+        self.res = fit["res"]
+
+    def phi(self, Z):
+        return np.exp(np.asarray(Z, dtype=float) @ self.beta)
+
+    def cif(self, x, Z):
+        """
+        Cumulative incidence of the cause of interest at times ``x`` for a
+        single covariate vector ``Z``: ``1 - exp(-Lambda0(x) * exp(beta'Z))``.
+        The CIF is flat before the first event time and after the last (the
+        baseline is a step function estimated only on the observed range).
+        """
+        x = np.atleast_1d(np.asarray(x, dtype=float))
+        Z = np.asarray(Z, dtype=float).ravel()
+        H0 = _step(self._times, self._cumhaz, x, before=0.0)
+        return 1.0 - np.exp(-H0 * np.exp(Z @ self.beta))
+
+    def sf(self, x, Z):
+        """One minus the cumulative incidence (the cause-of-interest-free
+        probability under the subdistribution)."""
+        return 1.0 - self.cif(x, Z)
+
+    def __repr__(self):
+        lines = [
+            "Fine-Gray Subdistribution Hazard Model",
+            "======================================",
+            f"Cause of interest   : {self.cause}",
+            "Coefficients (beta'Z acts on the subdistribution hazard):",
+        ]
+        for i, (b, s, p) in enumerate(
+            zip(self.beta, self.se, self.p_values)
+        ):
+            lines.append(
+                f"   beta_{i}  :  {b: .6f}  (se {s:.6f}, p {p:.4f})"
+            )
+        return "\n".join(lines)
 
 
 class FineGray_:
-    # def create_breslow_ll_jac_hess(
-    #     self, x, Z, c, n, e, mask, with_jac=True, with_hess=True
-    # ):
-    #     """
-    #     The reference used to compute the jacobian and hessian
-    #     was https://mathweb.ucsd.edu/~rxu/math284/slect5.pdf
-    #     """
-    #     # TODO: Incorporate left-truncation... somehow.
-    #     #left truncation allows for implementation of time-varying covariates
+    def fit(self, x, Z, e, c=None, n=None, cause=None):
+        """
+        Fit the Fine-Gray model for a cause of interest.
 
-    #     x_e, c_e, n_e = (arr[mask] for arr in (x, c, n))
-    #     Z_e = Z[mask, :]
+        Parameters
+        ----------
+        x : array_like
+            Observed times.
+        Z : ndarray
+            Covariate matrix, one row per observation.
+        e : array_like
+            Event-type (cause) labels; ``None`` for a censored observation.
+        c : array_like, optional
+            Censoring flags (0 observed, 1 right-censored). Defaults to all
+            observed. Left/interval censoring is not supported.
+        n : array_like, optional
+            Counts per observation. Defaults to 1.
+        cause : optional
+            The cause of interest. May be omitted only when the data contains a
+            single event type.
 
-    #     x_fg, c_fg, n_fg = (arr[~mask] for arr in (x, c, n))
-    #     Z_fg = Z[~mask, :]
+        Returns
+        -------
+        FineGrayModel
+            The fitted model, with :meth:`~FineGrayModel.cif` prediction.
+        """
+        x, Z, e, c, n = validate_fine_gray_inputs(x, Z, e, c, n)
 
-    #     gb_x = npi.group_by(x_e)
-
-    #     n_d_x = np.where(c_e == 0, n_e, 0)
-    #     x_e_unique, n_d = gb_x.sum(n_d_x)
-    #     n_d = n_d.reshape(-1, 1)
-    #     n_e = n_e.reshape(-1, 1)
-
-    #     # Create the log_like function for the data
-    #     def log_like(beta):
-    #         beta_z = Z_e @ beta
-    #         di_beta_z = gb_x.sum(n_d_x * beta_z)[1].reshape(-1, 1)
-
-    #         e_beta_z = np.exp(beta_z).reshape(-1, 1)
-    #         Ri = gb_x.sum(n_e * e_beta_z)[1]
-    #         Ri = Ri[::-1].cumsum()[::-1].reshape(-1, 1)
-    #         # Add fine gray risk set
-    #         Ri_e = n_fg * np.exp(Z_fg @ beta)
-
-    #         Ri += Ri_e.sum()
-    #         Ri = np.log(Ri)
-
-    #         Ri = n_d * Ri
-
-    #         like = di_beta_z - Ri
-
-    #         return -like.sum()
-
-    #     if with_jac:
-    #         S_d = gb_x.sum(n_d_x.reshape(-1, 1) * Z)[1]
-
-    #         def jac(beta):
-    #             e_beta_z = np.exp(Z @ beta).reshape(-1, 1)
-    #             z_e_beta_z = Z * e_beta_z
-
-    #             Ri = gb_x.sum(n * e_beta_z)[1]
-    #             Ri = Ri[::-1].cumsum(axis=0)[::-1]
-    #             Ri += Ri_e
-
-    #             ZRi = gb_x.sum(n * z_e_beta_z)[1]
-    #             ZRi = ZRi[::-1].cumsum(axis=0)[::-1]
-    #             ZRi += ZRi_e
-
-    #             EZ = ZRi / Ri
-
-    #             EZ = n_d * EZ
-
-    #             out = S_d - EZ
-    #             return -out.sum(axis=0)
-
-    #     else:
-    #         jac = None
-
-    #     if with_hess:
-
-    #         def hess(beta):
-    #             # denominator for both terms
-    #             e_beta_z = np.exp(Z @ beta).reshape(-1, 1)
-    #             denom = at_risk_beta_Z(e_beta_z, n, gb_x)
-
-    #             # calc term 1
-    #             Z2 = np.einsum("ij, ik-> ijk", Z, Z)
-
-    #             term_1 = np.einsum(
-    #                 "ijk,ij->ijk", Z2, n.reshape(-1, 1) * e_beta_z
-    #             )
-    #             term_1 = gb_x.sum(term_1)[1]
-    #             term_1 = term_1[::-1].cumsum(axis=0)[::-1]
-    #             term_1 = np.einsum("ijk,ij->ijk", term_1, 1.0 / denom)
-
-    #             # calc term 2
-    #             z_beta_z = Z * e_beta_z
-    #             term_2 = at_risk_beta_Z(z_beta_z, n, gb_x)
-    #             term_2 = term_2 / denom
-    #             term_2 = np.einsum("ij, ik-> ijk", term_2, term_2)
-
-    #             # Compute the Hessian matrix
-    #             hess_matrix = term_1 - term_2
-    #             hess_matrix = np.einsum(
-    #                 "ijk,i->ijk", hess_matrix, n_d.flatten()
-    #             )
-    #             hess_matrix = hess_matrix.sum(axis=0)
-    #             return hess_matrix
-
-    #     else:
-    #         hess = None
-
-    #     return log_like, jac, hess
-
-    def fit(self, x, Z, e, c=None, n=None):
-        raise NotImplementedError(
-            "FineGray.fit() is not yet implemented. "
-            "The log-likelihood computation is incomplete."
+        causes = sorted(
+            {ei for ei in e if ei is not None}, key=lambda v: str(v)
         )
+        if cause is None:
+            if len(causes) != 1:
+                raise ValueError(
+                    "Data has multiple event types "
+                    f"({causes}); specify `cause`."
+                )
+            cause = causes[0]
+        elif cause not in causes:
+            raise ValueError(
+                f"Cause {cause!r} not observed; causes are {causes}."
+            )
+
+        return FineGrayModel(_fit_cause(x, Z, e, c, n, cause))
 
 
 FineGray = FineGray_()

--- a/surpyval/univariate/regression/_bounds.py
+++ b/surpyval/univariate/regression/_bounds.py
@@ -1,0 +1,116 @@
+"""
+Delta-method confidence bounds for the parametric regression models.
+
+Every parametric regression fitter (AFT, parametric PH, PO, additive hazards,
+accelerated life) produces a :class:`ParametricRegressionModel` fitted by
+maximum likelihood, so its parameter uncertainty is the inverse of the
+observed information (the Hessian of the negative log-likelihood at the MLE).
+These helpers turn that covariance into
+
+* Wald bounds on individual parameters (on a support-respecting scale), and
+* delta-method bounds on the predicted ``sf``/``ff``/``Hf``/``hf``/``df`` at a
+  covariate vector ``Z``.
+
+The functions here are deliberately self-contained (numpy + scipy only) so the
+regression package does not depend on any other fitted-model machinery.
+"""
+
+import numpy as np
+from scipy.stats import norm
+
+
+def numerical_hessian(func, x):
+    """
+    Central finite-difference Hessian of a scalar ``func`` at ``x``. Used to
+    approximate the observed Fisher information from the negative
+    log-likelihood, which the regression fitters minimise with a derivative
+    -free optimiser.
+    """
+    x = np.asarray(x, dtype=float)
+    n = x.size
+    step = (np.finfo(float).eps ** (1.0 / 3.0)) * np.maximum(np.abs(x), 1e-2)
+    H = np.zeros((n, n))
+    for i in range(n):
+        for j in range(i, n):
+            ei = np.zeros(n)
+            ei[i] = step[i]
+            ej = np.zeros(n)
+            ej[j] = step[j]
+            H[i, j] = H[j, i] = (
+                func(x + ei + ej)
+                - func(x + ei - ej)
+                - func(x - ei + ej)
+                + func(x - ei - ej)
+            ) / (4.0 * step[i] * step[j])
+    return H
+
+
+def delta_method_se(func, mle, cov):
+    """
+    Standard errors of the (vector-valued) ``func`` of the parameters at the
+    MLE via the delta method with a central-difference Jacobian:
+    ``se_i = sqrt(J_i' cov J_i)``.
+    """
+    mle = np.asarray(mle, dtype=float)
+    step = (np.finfo(float).eps ** (1.0 / 3.0)) * np.maximum(np.abs(mle), 1e-2)
+    cols = []
+    for i in range(mle.size):
+        ei = np.zeros(mle.size)
+        ei[i] = step[i]
+        cols.append(
+            (
+                np.asarray(func(mle + ei), dtype=float)
+                - np.asarray(func(mle - ei), dtype=float)
+            )
+            / (2.0 * step[i])
+        )
+    J = np.stack(cols, axis=-1)
+    var = np.einsum("...i,ij,...j->...", J, cov, J)
+    with np.errstate(invalid="ignore"):
+        return np.sqrt(var)
+
+
+def bound_signs(alpha_ci, bound):
+    """
+    The per-bound one-sided tail probability and normal-quantile signs:
+    ``[-1, 1]`` (lower, upper) for two-sided bounds, a single sign otherwise.
+    """
+    if bound == "two-sided":
+        return alpha_ci / 2.0, np.array([-1.0, 1.0])
+    elif bound == "lower":
+        return alpha_ci, np.array([-1.0])
+    elif bound == "upper":
+        return alpha_ci, np.array([1.0])
+    raise ValueError("`bound` must be 'two-sided', 'lower' or 'upper'")
+
+
+def log_transformed_cb(estimate, se, alpha_ci=0.05, bound="two-sided"):
+    """
+    Log-transformed normal bounds ``est * exp(+/- z se / est)`` for a positive
+    quantity (used for ``hf`` and ``df``). Two-sided bounds put ``[lower,
+    upper]`` on the last axis; one-sided bounds keep the shape of ``estimate``.
+    """
+    estimate = np.asarray(estimate, dtype=float)
+    se = np.asarray(se, dtype=float)
+    alpha, signs = bound_signs(alpha_ci, bound)
+    z = norm.ppf(1.0 - alpha)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratio = np.where(estimate > 0, se / estimate, 0.0)
+    cb = estimate[..., None] * np.exp(signs * z * ratio[..., None])
+    if bound == "two-sided":
+        return cb
+    return cb[..., 0]
+
+
+def logit_sf_bound(sf_hat, se, sign, alpha_tail):
+    """
+    A single survival-function confidence bound on the logit scale, which keeps
+    it inside ``(0, 1)``: ``expit(logit(sf) + sign z se/(sf(1-sf)))``. ``sign``
+    is ``-1`` for the lower bound and ``+1`` for the upper.
+    """
+    z = norm.ppf(1.0 - alpha_tail)
+    est = np.clip(np.asarray(sf_hat, dtype=float), 1e-15, 1.0 - 1e-15)
+    logit = np.log(est / (1.0 - est))
+    with np.errstate(divide="ignore", invalid="ignore"):
+        se_logit = np.asarray(se, dtype=float) / (est * (1.0 - est))
+    return 1.0 / (1.0 + np.exp(-(logit + sign * z * se_logit)))

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -3,10 +3,17 @@ from typing import TYPE_CHECKING, Any
 import autograd.numpy as np
 import numpy.typing as npt
 from matplotlib import pyplot as plt
-from scipy.stats import uniform
+from scipy.stats import norm, uniform
 
 from surpyval.utils import fsli_to_xcnt
 
+from ._bounds import (
+    bound_signs,
+    delta_method_se,
+    log_transformed_cb,
+    logit_sf_bound,
+    numerical_hessian,
+)
 from .regression_data import prepare_Z
 
 if TYPE_CHECKING:
@@ -550,13 +557,232 @@ class ParametricRegressionModel:
             self._aic_c = self.aic() + (2 * k**2 + 2 * k) / (n - k - 1)
             return self._aic_c
 
-    def plot(self, ax: "Axes | None" = None) -> "Axes":
+    # -- confidence bounds -------------------------------------------------
+
+    def _check_inference(self) -> None:
+        if not hasattr(self, "data") or getattr(self, "res", None) is None:
+            raise ValueError(
+                "Confidence bounds are only available for models fit from "
+                "data; from_params models carry no likelihood."
+            )
+
+    def parameter_names(self) -> list[str]:
+        """
+        Names of the fitted parameters in ``.params`` order: the distribution's
+        parameters followed by the covariate coefficients.
+        """
+        dist_names = list(self.distribution.param_names)
+        phi_map = self.reg_model.phi_param_map
+        phi_names = [
+            k for k, _ in sorted(phi_map.items(), key=lambda kv: kv[1])
+        ]
+        return dist_names + phi_names
+
+    def covariance(self) -> npt.NDArray:
+        """
+        Approximate covariance matrix of the fitted parameters, ordered to
+        match :meth:`parameter_names`. Computed as the inverse of the numerical
+        Hessian of the negative log-likelihood at the MLE (the observed
+        information). Fixed parameters get a zero row/column.
+
+        A parameter driven to a boundary breaks the Wald approximation; the
+        covariance is then returned filled with ``nan`` (with a warning).
+        """
+        self._check_inference()
+        names = self.parameter_names()
+        p_hat = np.asarray(self.params, dtype=float)
+        free = [i for i, nm in enumerate(names) if nm not in self.fixed]
+        n = len(names)
+        cov = np.zeros((n, n))
+        if not free:
+            return cov
+
+        def neg_ll_free(free_vals: npt.NDArray) -> float:
+            full = p_hat.copy()
+            full[free] = free_vals
+            return self.model.neg_ll(self.data, *full)
+
+        H = numerical_hessian(neg_ll_free, p_hat[free])
+        bad = not np.all(np.isfinite(H))
+        if not bad:
+            try:
+                cov_free = np.linalg.inv(H)
+            except np.linalg.LinAlgError:
+                bad = True
+        if bad:
+            import warnings
+
+            warnings.warn(
+                "The information matrix could not be inverted (the optimum "
+                "may be at a parameter boundary); covariance is unavailable."
+            )
+            return np.full((n, n), np.nan)
+        cov[np.ix_(free, free)] = cov_free
+        return cov
+
+    def standard_errors(self) -> npt.NDArray:
+        """
+        Standard errors of the fitted parameters (square roots of the diagonal
+        of :meth:`covariance`), ordered to match :meth:`parameter_names`.
+        """
+        with np.errstate(invalid="ignore"):
+            return np.sqrt(np.diag(self.covariance()))
+
+    def param_cb(
+        self,
+        name: str,
+        alpha_ci: float = 0.05,
+        bound: str = "two-sided",
+    ) -> npt.NDArray:
+        """
+        Confidence bound(s) on a single fitted parameter.
+
+        Wald bounds from the observed information, computed on a scale chosen
+        from the parameter's support so the result stays inside it: log for a
+        one-sided-bounded distribution parameter (e.g. a positive scale), the
+        natural scale for the unbounded covariate coefficients.
+
+        Parameters
+        ----------
+        name : str
+            The parameter to bound; one of :meth:`parameter_names`.
+        alpha_ci : float, optional
+            Total tail probability of the bound(s). Default 0.05.
+        bound : {'two-sided', 'lower', 'upper'}, optional
+            Two-sided bounds are returned as ``[lower, upper]``.
+        """
+        self._check_inference()
+        names = self.parameter_names()
+        if name not in names:
+            raise ValueError(
+                "Unknown parameter {!r}; expected one of {}".format(
+                    name, names
+                )
+            )
+        idx = names.index(name)
+        p_hat = float(self.params[idx])
+        var = float(self.covariance()[idx, idx])
+
+        # Distribution parameters carry the distribution's support bounds; the
+        # covariate coefficients are unbounded.
+        dist_bounds = list(self.distribution.bounds)
+        n_phi = len(names) - self.k_dist
+        all_bounds = dist_bounds + [(None, None)] * n_phi
+        lower, upper = all_bounds[idx]
+
+        alpha, signs = bound_signs(alpha_ci, bound)
+        offsets = signs * norm.ppf(1.0 - alpha) * np.sqrt(var)
+
+        if lower is not None and upper is not None:
+            width = upper - lower
+            frac = (p_hat - lower) / width
+            u_hat = np.log(frac / (1.0 - frac))
+            du = offsets / (width * frac * (1.0 - frac))
+            return lower + width / (1.0 + np.exp(-(u_hat + du)))
+        elif lower is not None:
+            return lower + (p_hat - lower) * np.exp(offsets / (p_hat - lower))
+        elif upper is not None:
+            return upper - (upper - p_hat) * np.exp(-offsets / (upper - p_hat))
+        return p_hat + offsets
+
+    def cb(
+        self,
+        x: npt.ArrayLike,
+        Z: "npt.ArrayLike | pd.DataFrame",
+        on: str = "sf",
+        alpha_ci: float = 0.05,
+        bound: str = "two-sided",
+    ) -> npt.NDArray:
+        r"""
+        Confidence bounds on a predicted function at covariate vector ``Z``.
+
+        The bounds propagate the fitted parameter covariance through the
+        requested function by the delta method. ``sf``/``ff``/``Hf`` are
+        derived from a survival-function bound taken on the logit scale (so it
+        stays in ``(0, 1)``); ``hf``/``df`` use a log-scale bound (so they stay
+        positive).
+
+        Parameters
+        ----------
+        x : array like or scalar
+            Times at which to evaluate the bound(s).
+        Z : array like
+            A single covariate vector.
+        on : {'sf', 'ff', 'Hf', 'hf', 'df'}, optional
+            The function to bound. Default ``'sf'``.
+        alpha_ci : float, optional
+            Total tail probability of the bound(s). Default 0.05.
+        bound : {'two-sided', 'lower', 'upper'}, optional
+            Two-sided bounds put ``[lower, upper]`` on the last axis.
+
+        Returns
+        -------
+        numpy array
+            The confidence bound(s) on ``on`` at each ``x``.
+        """
+        self._check_inference()
+        valid = ("sf", "R", "ff", "F", "Hf", "hf", "df")
+        if on not in valid:
+            raise ValueError("`on` must be one of {}".format(valid))
+        if bound not in ("two-sided", "lower", "upper"):
+            raise ValueError("`bound` must be 'two-sided', 'lower' or 'upper'")
+        x = np.atleast_1d(np.asarray(x, dtype=float))
+        Zp = self._prepare_Z(Z)
+        params = np.asarray(self.params, dtype=float)
+        cov = self.covariance()
+
+        if on in ("hf", "df"):
+            fn = self.model.hf if on == "hf" else self.model.df
+            est = np.asarray(fn(x, Zp, *params), dtype=float)
+            se = delta_method_se(lambda p: fn(x, Zp, *p), params, cov)
+            return log_transformed_cb(est, se, alpha_ci, bound)
+
+        # sf, ff and Hf all derive from a survival-function bound.
+        sf_hat = np.asarray(self.model.sf(x, Zp, *params), dtype=float)
+        se = delta_method_se(lambda p: self.model.sf(x, Zp, *p), params, cov)
+
+        if bound == "two-sided":
+            sf_lo = logit_sf_bound(sf_hat, se, -1.0, alpha_ci / 2.0)
+            sf_hi = logit_sf_bound(sf_hat, se, +1.0, alpha_ci / 2.0)
+            if on in ("sf", "R"):
+                return np.stack([sf_lo, sf_hi], axis=-1)
+            elif on in ("ff", "F"):
+                return np.stack([1.0 - sf_hi, 1.0 - sf_lo], axis=-1)
+            else:  # Hf: -log(sf) is decreasing in sf
+                return np.stack([-np.log(sf_hi), -np.log(sf_lo)], axis=-1)
+
+        # One-sided. ff and Hf decrease in sf, so their bound uses the
+        # opposite survival-function tail.
+        if on in ("sf", "R"):
+            sign = -1.0 if bound == "lower" else 1.0
+            return logit_sf_bound(sf_hat, se, sign, alpha_ci)
+        sign = 1.0 if bound == "lower" else -1.0
+        sf_b = logit_sf_bound(sf_hat, se, sign, alpha_ci)
+        if on in ("ff", "F"):
+            return 1.0 - sf_b
+        return -np.log(sf_b)
+
+    def plot(
+        self,
+        ax: "Axes | None" = None,
+        plot_bounds: bool = True,
+        alpha_ci: float = 0.05,
+    ) -> "Axes":
         r"""
 
-        A method to plot the survival function, cumulative hazard function,
-        hazard function and density function of the distribution using the
-        parameters found in the ``.params`` attribute.
+        A method to plot the survival function of the distribution at the mean
+        covariate vector against the empirical (Kaplan-Meier) survival of the
+        fitted data, with a delta-method confidence band.
 
+        Parameters
+        ----------
+        ax : matplotlib axes, optional
+            Axes to draw on; a new one is created if not provided.
+        plot_bounds : bool, optional
+            Whether to draw the confidence band around the fitted survival
+            curve. Default True.
+        alpha_ci : float, optional
+            Total tail probability of the band. Default 0.05.
         """
 
         if ax is None:
@@ -565,7 +791,18 @@ class ParametricRegressionModel:
         x, r, d = self.data.to_xrd()
         x_plot = np.linspace(self.data.x.min(), self.data.x.max(), 1000)
 
+        Z_mean = self.data.Z.mean(axis=0)
         ax.step(x, np.exp(-(d / r).cumsum()), color="r", where="post")
-        sf = self.sf(x_plot, self.data.Z.mean(axis=0))
+        sf = self.sf(x_plot, Z_mean)
         ax.plot(x_plot, sf, color="b")
+        if plot_bounds:
+            cb = self.cb(x_plot, Z_mean, on="sf", alpha_ci=alpha_ci)
+            ax.fill_between(
+                x_plot,
+                cb[:, 0],
+                cb[:, 1],
+                color="b",
+                alpha=0.2,
+                label=f"{(1 - alpha_ci) * 100:g}% Confidence Band",
+            )
         return ax

--- a/surpyval/univariate/regression/proportional_hazards/cox_ph.py
+++ b/surpyval/univariate/regression/proportional_hazards/cox_ph.py
@@ -109,8 +109,16 @@ def efron_jac(n_d, Ri, ZRi, Di, ZDi, masked_array):
 
 
 def efron_hess_jit(n_d, Ri, ZRi, Z2Ri, Di, ZDi, Z2Di, out):
-    # TODO: Vectorised implementation like for the jacobian above
-    # Not sure my brain can handle that many dimensions.
+    # Per-tied-time contribution to the observed information (the Hessian of
+    # the negative Efron partial log-likelihood). For each of the ``n_d[i]``
+    # tied deaths the Efron correction shrinks the risk set by ``c * D``:
+    #
+    #     sum_j (Z2R - c Z2D) / (R - c D) - a a' / (R - c D)^2,
+    #
+    # with ``a = ZR - c ZD``. The second term is the *outer* product ``a a'``
+    # (a p x p matrix), which is where this previously went wrong -- an inner
+    # product collapses it to a scalar and silently corrupts the off-diagonal
+    # information for any model with more than one covariate.
     for i in range(len(n_d)):
         val = np.zeros(out.shape[1:])
         if n_d[i] == 0:
@@ -119,18 +127,8 @@ def efron_hess_jit(n_d, Ri, ZRi, Z2Ri, Di, ZDi, Z2Di, out):
             c = j / n_d[i]
             dRD = Ri[i] - c * Di[i]
             a = ZRi[i] - c * ZDi[i]
-            # If einsum ever supported by numba, remove this
-            if a.shape == (1,):
-                a2 = a * a
-            else:
-                a2 = a @ a.reshape(-1, 1)
-            val += (
-                +dRD * (Z2Ri[i] - c * Z2Di[i])
-                # Einsum not supported by numba
-                # Change if this ever is the case.
-                # - np.einsum('i, j -> ij', a, a)
-                - a2
-            ) / dRD**2
+            a2 = np.outer(a, a)
+            val += (dRD * (Z2Ri[i] - c * Z2Di[i]) - a2) / dRD**2
         out[i] = val
     return out
 
@@ -172,12 +170,8 @@ class CoxPH_:
     ):
         # The reference used to compute the jacobian and hessian
         # was https://mathweb.ucsd.edu/~rxu/math284/slect5.pdf
-        # TODO: Incorporate left-truncation... somehow.
-        # left truncation allows for implementation of time-varying covariates
-
-        # To do left truncation. All one needs to do is to adjust the risk set.
-        # I am aiming to implement this by:
-        # Ri - TRi.. that's it!
+        # Left-truncation is handled by subtracting the pre-entry risk set
+        # (``Ri - TRi``) below, so delayed-entry data is fitted correctly.
 
         # Groupby object for repeated use
         gb_x = _GroupBy(x)
@@ -286,26 +280,29 @@ class CoxPH_:
             diff = S_d - expected_S_d
             jacobian = -diff.sum(axis=0)
 
-            # Something remains incorrect with the Hessian
+            # Observed information (Hessian of the negative log-likelihood),
+            # accumulated per tied time then summed. Same positive-definite
+            # convention as the Breslow branch, so ``inv(hess)`` gives the
+            # parameter covariance directly.
             Z2Di = np.einsum("ijk, ij -> ijk", Z2, n_d_x * e_beta_z)
             Z2Di = gb_x.sum(Z2Di)[1]
 
-            hess_matrix = np.zeros_like(Z2)
+            n_params = Z.shape[1]
+            hess_matrix = np.zeros((len(n_d), n_params, n_params))
             hess_matrix = efron_hess_jit(
                 n_d, Ri, ZRi, Z2Ri, Di, ZDi, Z2Di, hess_matrix
             )
-            hess_matrix = -hess_matrix.sum(axis=0)
+            hess_matrix = hess_matrix.sum(axis=0)
 
-            return jacobian  # , hess_matrix
+            return jacobian, hess_matrix
 
-        return log_like, jac_hess, False
+        return log_like, jac_hess, True
 
     def create_breslow_ll_jac_hess(self, x, Z, c, n, tl):
         # The reference used to compute the jacobian and hessian
         # was https://mathweb.ucsd.edu/~rxu/math284/slect5.pdf
-
-        # TODO: Incorporate left-truncation... somehow.
-        # left truncation allows for implementation of time-varying covariates
+        # Left-truncation is handled by subtracting the pre-entry risk set
+        # (``Ri - TRi``) below, so delayed-entry data is fitted correctly.
 
         gb_x = _GroupBy(x)
         gb_tl = _GroupBy(tl)


### PR DESCRIPTION
## Summary

Four related pieces of competing-risks / regression work.

### Fine-Gray subdistribution-hazard regression (IPCW)
`FineGray.fit()` previously raised `NotImplementedError` (its likelihood was commented out), so the publicly-exported `FineGray` and the competing-risks-PH Fine-Gray path both failed. Implemented properly: the model targets the cumulative incidence directly (`F_k(t│Z) = 1 − exp(−Λ₀(t)·exp(β'Z))`) via the Breslow partial likelihood of the subdistribution risk set, with **inverse-probability-of-censoring weighting** so it is correct under independent censoring (not just complete data). Coefficients, inverse-Hessian SEs and p-values, a Breslow baseline, and a `cif()`/`sf()` predictor. Validated by parameter recovery under ~25% censoring and the baseline CIF matching the analytic curve.

### Efron tie-handling Hessian fix
CoxPH's Efron branch computed its observed information but discarded it, so Efron fits had no p-values. Two bugs: an inner product where the Hessian needs the outer product `a aᵀ` (corrupting off-diagonals for ≥2 covariates), and a sign flip. Fixed, validated against finite differences to ~1e-8 (symmetric PD, p=1,2,3), and Efron p-values now match Breslow with no ties. Efron is `fit_from_df`'s default and the tie method the competing-risks Cox path uses, so this unblocks inference under the preferred tie handler.

### Confidence bounds for the parametric regression models
Added `covariance()`, `standard_errors()`, `param_cb()`, and `cb(x, Z, on=…)` to `ParametricRegressionModel`, covering AFT / PH / PO / additive-hazards / accelerated-life at once. Delta-method bounds from the observed information, on support-respecting scales (logit for sf/ff/Hf, log for hf/df). `plot()` now draws a confidence band. Coefficient-interval coverage checked by simulation (~93% at nominal 95%).

### Rename `CRPH` → `CompetingRisksProportionalHazards`
The acronym (and its singular spelling) didn't match the package convention (`CompetingRisks`, `ProportionalHazards`, `AdditiveHazards`). Renamed and dropped the alias; updated exports, tests, DEVELOPMENT.md, and the competing-risks docs page (which also still claimed these fitters "crash" — now corrected to the working API).

## Testing
Full suite **1033 passed, 1 skipped**. flake8/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_