### PR TITLE
Competing-risks Cox fix + fit_from_df, Buckley-James AFT, and two-stage degradation confidence bounds

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,8 +26,9 @@ Two genuine blockers, both process rather than code:
   features, the simulation/`dist='t'` cleanups, the Fine-Gray regression
   implementation, the Efron-Hessian fix, delta-method confidence bounds
   (`cb`/`param_cb`/`covariance`) on the parametric regression models, and the
-  cause-specific Cox competing-risks CIF fix plus `fit_from_df`, and the
-  Buckley-James semi-parametric AFT model). Write real per-version entries
+  cause-specific Cox competing-risks CIF fix plus `fit_from_df`, the
+  Buckley-James semi-parametric AFT model, and two-stage degradation
+  confidence bounds (`DegradationModel.cb`)). Write real per-version entries
   before tagging.
 - **Add a publish workflow.** `.github/workflows/actions.yml` is CI-only (lint +
   pytest matrix + coverage, `on: [push]`). There is no tag-triggered
@@ -175,13 +176,12 @@ into `SurpyvalData`, and `ProportionalHazardsFitter` handles left-truncation via
 fits over 9 forms with `path="best"` AICc selection, extrapolation to a
 threshold, lifetime fit to the pseudo failure times), a two-stage
 noise-corrected population path-parameter distribution (moment and REML
-variants), and `predict_rul` shrinkage RUL predictions. Natural extensions,
-roughly in priority order:
+variants), `predict_rul` shrinkage RUL predictions, and `DegradationModel.cb`
+two-stage confidence bounds on the reliability (an analytic delta-method /
+generated-regressor correction that folds the first-stage path-fit and
+extrapolation uncertainty into the life-model covariance, plus a `method=
+"bootstrap"` cross-check). Natural extensions, roughly in priority order:
 
-- **Uncertainty propagation for the life model.** The two-stage method treats
-  pseudo failure times as exact, so life-model confidence bounds understate the
-  true uncertainty. A bootstrap over units (refit paths + life model per
-  resample) is the cheap fix; expose it as a `cb`/`bootstrap` option.
 - **Induced failure-time distribution.** With `(μ, Σ, σ²)` fitted (especially by
   REML), derive the population failure-time distribution from the path model
   directly (Monte Carlo over `θ ~ MVN` through `inv_path`) instead of via noisy

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,8 +26,9 @@ Two genuine blockers, both process rather than code:
   features, the simulation/`dist='t'` cleanups, the Fine-Gray regression
   implementation, the Efron-Hessian fix, delta-method confidence bounds
   (`cb`/`param_cb`/`covariance`) on the parametric regression models, and the
-  cause-specific Cox competing-risks CIF fix plus `fit_from_df`). Write real
-  per-version entries before tagging.
+  cause-specific Cox competing-risks CIF fix plus `fit_from_df`, and the
+  Buckley-James semi-parametric AFT model). Write real per-version entries
+  before tagging.
 - **Add a publish workflow.** `.github/workflows/actions.yml` is CI-only (lint +
   pytest matrix + coverage, `on: [push]`). There is no tag-triggered
   `pypa/gh-action-pypi-publish` step, so releasing to PyPI is fully manual. Add
@@ -125,13 +126,14 @@ remains:
 
 ## 5. Semi-Parametric Regression — future work
 
-Proportional hazards (`CoxPH` + parametric `WeibullPH` …) and additive hazards
-(semi-parametric `AdditiveHazards` + parametric `AH(dist)`) are both complete.
-Three candidates remain, in priority order:
+The semi-parametric trio is complete: proportional hazards (`CoxPH`), additive
+hazards (`AdditiveHazards`), and now accelerated failure time (`BuckleyJames` —
+`log T = β'Z + ε` with an unspecified error distribution, fit by the
+Buckley-James imputation iteration with an Efron-corrected residual KM,
+two-cycle handling, bootstrap CIs, and `fit_from_df`; coefficients follow the
+package's accelerated-failure sign convention). Two lower-priority candidates
+remain:
 
-- **Buckley-James (semi-parametric AFT) — high.** The semi-parametric
-  counterpart to Cox PH: fits `log(T) = β'Z + ε` with no parametric baseline via
-  iterative censoring imputation. Completes the semi-parametric trio.
 - **Semi-parametric proportional odds — low.** `O(x|Z) = O₀(x)·exp(β'Z)` with a
   non-parametric baseline odds step function; needs joint NPMLE of `(β, Λ₀)`
   (profile likelihood with an isotonic inner loop). Much harder than Cox PH;

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,9 +24,10 @@ Two genuine blockers, both process rather than code:
   additive hazards, recurrent parameter-uncertainty + diagnostics, discrete
   lifetime distributions, `handle_xicn` validation, copula and degradation
   features, the simulation/`dist='t'` cleanups, the Fine-Gray regression
-  implementation, the Efron-Hessian fix, and delta-method confidence bounds
-  (`cb`/`param_cb`/`covariance`) on the parametric regression models). Write
-  real per-version entries before tagging.
+  implementation, the Efron-Hessian fix, delta-method confidence bounds
+  (`cb`/`param_cb`/`covariance`) on the parametric regression models, and the
+  cause-specific Cox competing-risks CIF fix plus `fit_from_df`). Write real
+  per-version entries before tagging.
 - **Add a publish workflow.** `.github/workflows/actions.yml` is CI-only (lint +
   pytest matrix + coverage, `on: [push]`). There is no tag-triggered
   `pypa/gh-action-pypi-publish` step, so releasing to PyPI is fully manual. Add
@@ -41,15 +42,6 @@ forest).
 
 ## 2. Correctness — broken or fragile public API (high priority)
 
-- **`CompetingRisksProportionalHazards.fit_from_df` is unimplemented** (`raise
-  NotImplementedError("Not yet...")`). Add the DataFrame entry point for both
-  the Cox and Fine-Gray competing-risks paths.
-- **Competing-risks regression needs test coverage and Cox-path review.** The
-  Fine-Gray path is now implemented (IPCW subdistribution model, with tests);
-  the cause-specific Cox path (`CompetingRisksProportionalHazards.fit(
-  how="Cox")`) fits and predicts but is thinly tested, and its shared Breslow
-  `baseline()` (all-cause event counts with a Fine-Gray-style risk set) should
-  be reviewed for the cause-specific CIF before it is relied on.
 - **Cox PH exact / Kalbfleisch-Prentice tie methods.** `cox_ph.py` now supports
   Breslow and Efron ties, both with analytic-Hessian standard errors and
   p-values (the Efron Hessian, previously computed with an inner product in

--- a/surpyval/degradation/_bounds.py
+++ b/surpyval/degradation/_bounds.py
@@ -1,0 +1,320 @@
+"""
+Confidence bounds for the pseudo-failure-time degradation model.
+
+The classic degradation analysis is a *two-stage* estimator: a path is fitted
+to each unit and extrapolated to the threshold to give a pseudo failure time,
+then a lifetime distribution is fitted to those pseudo failure times. The
+life-model MLE covariance (what ``life_model.cb`` returns) treats the pseudo
+failure times as exact data, so it captures only the between-unit scatter and
+misses the *first-stage* uncertainty -- the measurement noise and extrapolation
+error baked into each pseudo failure time. Its intervals are therefore too
+narrow.
+
+Two ways to fix this are provided:
+
+* **analytic** (default) -- a delta-method / generated-regressor correction.
+  Each pseudo failure time ``t_i`` carries a variance ``v_i`` propagated from
+  the per-unit path-fit covariance through ``inv_path``. Perturbing ``t_i``
+  moves the life-model MLE by ``dphi/dt_i = H^{-1} d(score)/dt_i`` (implicit
+  function theorem; ``H`` is the life-model observed information). The
+  corrected parameter covariance is
+
+      Cov(phi) = H^{-1}  +  sum_i v_i (dphi/dt_i)(dphi/dt_i)',
+
+  i.e. the usual MLE covariance plus the first-stage contribution. Fast (a few
+  numerical derivatives, no refitting) and composes to any predicted quantity
+  by one more delta step.
+
+* **bootstrap** -- resample units with replacement, rerun the whole pipeline,
+  and take percentiles. Slower but assumption-light; a good robustness check on
+  the analytic bounds, especially with few units or heavy extrapolation where
+  the first-order approximation is weakest.
+"""
+
+import numpy as np
+from scipy.stats import norm
+
+# -- small delta-method helpers (self-contained) --------------------------
+
+
+def _num_hessian(func, x):
+    x = np.asarray(x, dtype=float)
+    n = x.size
+    step = (np.finfo(float).eps ** (1.0 / 3.0)) * np.maximum(np.abs(x), 1e-2)
+    H = np.zeros((n, n))
+    for i in range(n):
+        for j in range(i, n):
+            ei = np.zeros(n)
+            ei[i] = step[i]
+            ej = np.zeros(n)
+            ej[j] = step[j]
+            H[i, j] = H[j, i] = (
+                func(x + ei + ej)
+                - func(x + ei - ej)
+                - func(x - ei + ej)
+                + func(x - ei - ej)
+            ) / (4.0 * step[i] * step[j])
+    return H
+
+
+def _delta_se(func, mle, cov):
+    mle = np.asarray(mle, dtype=float)
+    step = (np.finfo(float).eps ** (1.0 / 3.0)) * np.maximum(np.abs(mle), 1e-2)
+    cols = []
+    for i in range(mle.size):
+        ei = np.zeros(mle.size)
+        ei[i] = step[i]
+        cols.append(
+            (
+                np.asarray(func(mle + ei), dtype=float)
+                - np.asarray(func(mle - ei), dtype=float)
+            )
+            / (2.0 * step[i])
+        )
+    J = np.stack(cols, axis=-1)
+    var = np.einsum("...i,ij,...j->...", J, cov, J)
+    with np.errstate(invalid="ignore"):
+        return np.sqrt(var)
+
+
+def _bound_signs(alpha_ci, bound):
+    if bound == "two-sided":
+        return alpha_ci / 2.0, np.array([-1.0, 1.0])
+    elif bound == "lower":
+        return alpha_ci, np.array([-1.0])
+    elif bound == "upper":
+        return alpha_ci, np.array([1.0])
+    raise ValueError("`bound` must be 'two-sided', 'lower' or 'upper'")
+
+
+def _logit_bound(p_hat, se, alpha_ci, bound):
+    """Confidence bounds for a probability, taken on the logit scale so they
+    stay in ``(0, 1)``. Two-sided puts ``[lower, upper]`` on the last axis."""
+    p_hat = np.clip(np.asarray(p_hat, dtype=float), 1e-15, 1.0 - 1e-15)
+    alpha, signs = _bound_signs(alpha_ci, bound)
+    z = norm.ppf(1.0 - alpha)
+    logit = np.log(p_hat / (1.0 - p_hat))
+    with np.errstate(divide="ignore", invalid="ignore"):
+        se_logit = np.asarray(se, dtype=float) / (p_hat * (1.0 - p_hat))
+    lb = logit[..., None] + signs * z * se_logit[..., None]
+    cb = 1.0 / (1.0 + np.exp(-lb))
+    return cb if bound == "two-sided" else cb[..., 0]
+
+
+# -- first stage: per-unit pseudo-failure-time variances ------------------
+
+
+def _inv_path_grad(path_model, threshold, theta):
+    """Gradient of ``inv_path(threshold; theta)`` w.r.t. the path parameters,
+    by central differences."""
+    theta = np.asarray(theta, dtype=float)
+    g = np.zeros(theta.size)
+    for j in range(theta.size):
+        h = 1e-6 * max(abs(theta[j]), 1.0)
+        up, dn = theta.copy(), theta.copy()
+        up[j] += h
+        dn[j] -= h
+        t_up = float(path_model.inv_path(threshold, *up))
+        t_dn = float(path_model.inv_path(threshold, *dn))
+        g[j] = (t_up - t_dn) / (2.0 * h)
+    return g
+
+
+def pseudo_time_variances(model):
+    """
+    Variance of each unit's pseudo failure time from the first stage.
+
+    For unit ``i`` the least-squares path covariance is
+    ``sigma^2 (J_i' J_i)^{-1}`` (``sigma^2`` the pooled measurement variance,
+    ``J_i`` the path Jacobian at the fitted parameters), and the pseudo failure
+    time ``t_i = inv_path(threshold; theta_i)`` has variance
+    ``grad' Cov(theta_i) grad`` by the delta method. Censored units (whose
+    "pseudo failure time" is an observed censoring time, not an extrapolation)
+    get zero.
+    """
+    v = np.zeros(len(model.units))
+    sigma2 = float(model.measurement_var)
+    if not sigma2 > 0:
+        return v  # exact path fits: no first-stage uncertainty
+    for idx, unit in enumerate(model.units):
+        if model.c[idx] == 1:
+            continue
+        theta = model.path_params[idx]
+        x_unit = model.x[model.i == unit]
+        J = np.atleast_2d(model.path_model.jacobian(x_unit, *theta))
+        try:
+            cov_theta = sigma2 * np.linalg.inv(J.T @ J)
+        except np.linalg.LinAlgError:
+            cov_theta = sigma2 * np.linalg.pinv(J.T @ J)
+        g = _inv_path_grad(model.path_model, model.threshold, theta)
+        v[idx] = float(g @ cov_theta @ g)
+    return v
+
+
+# -- second stage: corrected life-model covariance ------------------------
+
+
+def _life_loglik(model, phi, t):
+    """Life-model log-likelihood at parameters ``phi`` and pseudo failure
+    times ``t`` (events use the density, censored units the survival)."""
+    lm = model.life_model
+    gamma = float(getattr(lm, "gamma", 0.0) or 0.0)
+    xt = np.asarray(t, dtype=float) - gamma
+    tiny = 1e-300
+    with np.errstate(divide="ignore", invalid="ignore"):
+        logf = np.log(np.clip(lm.dist.df(xt, *phi), tiny, None))
+        logs = np.log(np.clip(lm.dist.sf(xt, *phi), tiny, None))
+    contrib = np.where(model.c == 0, logf, logs)
+    return float(np.sum(contrib))
+
+
+def life_parameter_covariance(model, method="analytic"):
+    """
+    Covariance of the fitted life-model parameters.
+
+    ``method='analytic'`` returns the two-stage-corrected covariance
+    ``H^{-1} + sum_i v_i (dphi/dt_i)(dphi/dt_i)'``; the first term alone is the
+    ordinary MLE covariance that treats the pseudo failure times as exact.
+    """
+    if method != "analytic":
+        raise ValueError(
+            "life_parameter_covariance supports method='analytic'"
+        )
+    lm = model.life_model
+    if getattr(lm, "p", 1.0) != 1.0 or getattr(lm, "f0", 0.0) != 0.0:
+        raise ValueError(
+            "The analytic correction is implemented for a plain life model "
+            "(no limited-failure-population or zero-inflation component); use "
+            "method='bootstrap'."
+        )
+    phi = np.asarray(lm.params, dtype=float)
+    t = np.asarray(model.pseudo_failure_times, dtype=float)
+
+    H = -_num_hessian(lambda p: _life_loglik(model, p, t), phi)
+    try:
+        Hinv = np.linalg.inv(H)
+    except np.linalg.LinAlgError:
+        Hinv = np.linalg.pinv(H)
+
+    v = pseudo_time_variances(model)
+    events = np.where((model.c == 0) & (v > 0))[0]
+    cov = Hinv.copy()
+    if events.size:
+        k = phi.size
+        hphi = (np.finfo(float).eps ** (1.0 / 3.0)) * np.maximum(
+            np.abs(phi), 1e-2
+        )
+        # Mixed partials d2 loglik / d phi_a d t_i for each event unit.
+        S = np.zeros((k, events.size))
+        for col, i in enumerate(events):
+            ht = (np.finfo(float).eps ** (1.0 / 3.0)) * max(abs(t[i]), 1e-2)
+            for a in range(k):
+                pp, pm = phi.copy(), phi.copy()
+                pp[a] += hphi[a]
+                pm[a] -= hphi[a]
+                tp, tm = t.copy(), t.copy()
+                tp[i] += ht
+                tm[i] -= ht
+                d2 = (
+                    _life_loglik(model, pp, tp)
+                    - _life_loglik(model, pp, tm)
+                    - _life_loglik(model, pm, tp)
+                    + _life_loglik(model, pm, tm)
+                ) / (4.0 * hphi[a] * ht)
+                S[a, col] = d2
+        # dphi/dt_i = H^{-1} d(score)/dt_i, weighted by v_i.
+        dphi = Hinv @ S
+        cov = cov + (dphi * v[events]) @ dphi.T
+    return cov
+
+
+# -- public confidence-bound entry points ---------------------------------
+
+
+def _target(model, x, on):
+    lm = model.life_model
+    gamma = float(getattr(lm, "gamma", 0.0) or 0.0)
+    x = np.atleast_1d(np.asarray(x, dtype=float))
+
+    def sf_of(phi):
+        return lm.dist.sf(x - gamma, *phi)
+
+    return x, sf_of
+
+
+def analytic_cb(model, x, on, alpha_ci, bound):
+    cov = life_parameter_covariance(model, method="analytic")
+    phi = np.asarray(model.life_model.params, dtype=float)
+    x, sf_of = _target(model, x, on)
+    sf_hat = np.asarray(sf_of(phi), dtype=float)
+    se = _delta_se(sf_of, phi, cov)
+
+    if bound == "two-sided":
+        sf_lo = _logit_bound(sf_hat, se, alpha_ci, "lower")
+        sf_hi = _logit_bound(sf_hat, se, alpha_ci, "upper")
+        if on in ("sf", "R"):
+            return np.stack([sf_lo, sf_hi], axis=-1)
+        elif on in ("ff", "F"):
+            return np.stack([1.0 - sf_hi, 1.0 - sf_lo], axis=-1)
+        else:  # Hf
+            return np.stack([-np.log(sf_hi), -np.log(sf_lo)], axis=-1)
+
+    # one-sided: ff and Hf decrease in sf, so flip the tail
+    if on in ("sf", "R"):
+        return _logit_bound(sf_hat, se, alpha_ci, bound)
+    flip = "upper" if bound == "lower" else "lower"
+    sf_b = _logit_bound(sf_hat, se, alpha_ci, flip)
+    return (1.0 - sf_b) if on in ("ff", "F") else -np.log(sf_b)
+
+
+def bootstrap_cb(model, x, on, alpha_ci, bound, n_boot, seed):
+    import warnings
+
+    from .degradation_analysis import DegradationAnalysis
+
+    x = np.atleast_1d(np.asarray(x, dtype=float))
+    rng = np.random.default_rng(seed)
+    curves = []
+    # Each resampled fit may emit the usual small-sample path-covariance
+    # warnings; silence them here so a single bootstrap call does not surface
+    # hundreds of duplicates.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for _ in range(n_boot):
+            picks = rng.choice(len(model.units), size=len(model.units))
+            xs, ys, ids = [], [], []
+            for new_id, idx in enumerate(picks):
+                mask = model.i == model.units[idx]
+                xs.append(model.x[mask])
+                ys.append(model.y[mask])
+                ids.append(np.full(int(mask.sum()), new_id))
+            try:
+                m = DegradationAnalysis.fit(
+                    np.concatenate(xs),
+                    np.concatenate(ys),
+                    np.concatenate(ids),
+                    threshold=model.threshold,
+                    path=model.path_model,
+                    distribution=model._distribution,
+                    how=model._how,
+                )
+                curves.append(np.asarray(getattr(m, _on_method(on))(x)))
+            except Exception:
+                continue
+    if len(curves) < 2:
+        raise RuntimeError(
+            "The degradation bootstrap produced too few successful refits to "
+            "form a confidence bound."
+        )
+    curves = np.asarray(curves)
+    alpha, _ = _bound_signs(alpha_ci, bound)
+    if bound == "two-sided":
+        lo = np.quantile(curves, alpha_ci / 2.0, axis=0)
+        hi = np.quantile(curves, 1.0 - alpha_ci / 2.0, axis=0)
+        return np.stack([lo, hi], axis=-1)
+    q = alpha_ci if bound == "lower" else 1.0 - alpha_ci
+    return np.quantile(curves, q, axis=0)
+
+
+def _on_method(on):
+    return {"sf": "sf", "R": "sf", "ff": "ff", "F": "ff", "Hf": "Hf"}[on]

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -13,6 +13,7 @@ observed time.
 import warnings
 from dataclasses import dataclass, field
 from numbers import Number
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -22,6 +23,7 @@ import pandas as pd
 from surpyval.univariate.parametric import Weibull
 from surpyval.univariate.parametric.parametric import Parametric
 
+from ._bounds import analytic_cb, bootstrap_cb, life_parameter_covariance
 from .path_models import PATH_MODELS, PathModel, get_path_model
 from .population import reml_estimate
 
@@ -181,6 +183,9 @@ class DegradationModel:
     path_param_sample_cov: npt.NDArray
     population_method: str
     path_selection: "dict[str, float] | None"
+    # Recorded after construction so the bootstrap bounds can rerun the fit.
+    _distribution: Any
+    _how: str
 
     def __init__(
         self,
@@ -505,6 +510,74 @@ class DegradationModel:
         """Random pseudo failure times from the fitted life model."""
         return self.life_model.random(size)
 
+    def life_parameter_covariance(
+        self, method: str = "analytic"
+    ) -> npt.NDArray:
+        """
+        Covariance of the fitted life-model parameters, corrected for the
+        first-stage (path-fit and extrapolation) uncertainty that the plain
+        life-model MLE ignores.
+
+        See :meth:`cb` for the two-stage rationale; ``method='analytic'`` is
+        the delta-method / generated-regressor correction
+        ``H^{-1} + sum_i v_i (dphi/dt_i)(dphi/dt_i)'``.
+        """
+        return life_parameter_covariance(self, method=method)
+
+    def cb(
+        self,
+        x: npt.ArrayLike,
+        on: str = "sf",
+        alpha_ci: float = 0.05,
+        bound: str = "two-sided",
+        method: str = "analytic",
+        n_boot: int = 200,
+        seed=None,
+    ) -> npt.NDArray:
+        r"""
+        Confidence bounds on the reliability of the fitted life model that
+        account for the degradation analysis being a *two-stage* estimator.
+
+        The pseudo failure times are extrapolated per-unit path fits, not
+        observed failures, so ``life_model.cb`` -- which treats them as
+        exact -- gives intervals that are too narrow. These bounds fold the
+        first-stage (measurement + extrapolation) uncertainty back in.
+
+        Parameters
+        ----------
+        x : array like
+            Times at which to evaluate the bound(s).
+        on : {'sf', 'ff', 'Hf'}, optional
+            The function to bound. Default ``'sf'``.
+        alpha_ci : float, optional
+            Total tail probability of the bound(s). Default 0.05.
+        bound : {'two-sided', 'lower', 'upper'}, optional
+            Two-sided bounds put ``[lower, upper]`` on the last axis.
+        method : {'analytic', 'bootstrap'}, optional
+            ``'analytic'`` (default) is a fast delta-method correction;
+            ``'bootstrap'`` resamples units and reruns the whole pipeline (a
+            slower, assumption-light cross-check).
+        n_boot : int, optional
+            Bootstrap resamples (``method='bootstrap'`` only). Default 200.
+        seed : optional
+            Seed for the bootstrap resampling.
+
+        Returns
+        -------
+        numpy array
+            The confidence bound(s) on ``on`` at each ``x``.
+        """
+        valid = ("sf", "R", "ff", "F", "Hf")
+        if on not in valid:
+            raise ValueError("`on` must be one of {}".format(valid))
+        if bound not in ("two-sided", "lower", "upper"):
+            raise ValueError("`bound` must be 'two-sided', 'lower' or 'upper'")
+        if method == "analytic":
+            return analytic_cb(self, x, on, alpha_ci, bound)
+        elif method == "bootstrap":
+            return bootstrap_cb(self, x, on, alpha_ci, bound, n_boot, seed)
+        raise ValueError("`method` must be 'analytic' or 'bootstrap'")
+
     def plot(self, ax=None):
         """
         Plot the degradation data, the fitted per-unit paths (extended
@@ -812,7 +885,7 @@ class DegradationAnalysis_:
 
         life_model = distribution.fit(x=pseudo_failure_times, c=c, how=how)
 
-        return DegradationModel(
+        model = DegradationModel(
             x=x_arr,
             y=y_arr,
             i=i_arr,
@@ -830,6 +903,11 @@ class DegradationAnalysis_:
             population_method=population_method,
             path_selection=path_selection,
         )
+        # Recorded so the bootstrap confidence bounds can rerun the pipeline
+        # (with the selected path model held fixed) on resampled units.
+        model._distribution = distribution
+        model._how = how
+        return model
 
     @staticmethod
     def _select_path_model(

--- a/surpyval/tests/degradation/test_degradation_bounds.py
+++ b/surpyval/tests/degradation/test_degradation_bounds.py
@@ -1,0 +1,225 @@
+"""Confidence bounds for the pseudo-failure-time degradation model.
+
+The degradation analysis is a two-stage estimator (per-unit path fit ->
+extrapolate to threshold -> fit a life model to the pseudo failure times), so
+the plain life-model MLE covariance -- which treats the pseudo failure times as
+exact -- gives intervals that are too narrow. These tests pin the analytic
+delta-method correction (and its bootstrap cross-check): that it *widens* the
+bounds via the first-stage uncertainty, that it agrees with the bootstrap, and
+that it restores coverage of the true reliability the MLE-only bounds lose.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+from surpyval import Weibull
+from surpyval.degradation import DegradationAnalysis
+from surpyval.degradation._bounds import (
+    _delta_se,
+    _life_loglik,
+    _logit_bound,
+    _num_hessian,
+)
+
+
+def _linear_degradation(seed, n_units=20, noise=2.0, n_points=5, t_max=8.0):
+    """Units with linear degradation crossing a threshold of 100 at a
+    Weibull-distributed true time, measured only out to ``t_max`` (so the
+    threshold is reached by extrapolation)."""
+    rng = np.random.default_rng(seed)
+    alpha, beta, thr = 50.0, 3.0, 100.0
+    T = alpha * rng.weibull(beta, n_units)
+    t_meas = np.linspace(1.0, t_max, n_points)
+    xs, ys, ids = [], [], []
+    for u, Tu in enumerate(T):
+        slope = thr / Tu
+        y = slope * t_meas + rng.normal(0.0, noise, t_meas.size)
+        xs.append(t_meas)
+        ys.append(y)
+        ids.append(np.full(t_meas.size, u))
+    return (
+        np.concatenate(xs),
+        np.concatenate(ys),
+        np.concatenate(ids),
+        thr,
+        (alpha, beta),
+    )
+
+
+def _fit(seed, **kw):
+    x, y, i, thr, truth = _linear_degradation(seed, **kw)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        m = DegradationAnalysis.fit(
+            x, y, i, threshold=thr, path="linear", distribution=Weibull
+        )
+    return m, truth
+
+
+def _mle_only_se(model, x):
+    # The life-model MLE covariance alone (H^{-1}), i.e. the bound the current
+    # life_model.cb would use, treating pseudo failure times as exact.
+    phi = np.asarray(model.life_model.params, dtype=float)
+    t = model.pseudo_failure_times
+    cov = np.linalg.inv(
+        -_num_hessian(lambda p: _life_loglik(model, p, t), phi)
+    )
+    x = np.atleast_1d(np.asarray(x, dtype=float))
+    return _delta_se(lambda p: model.life_model.dist.sf(x, *p), phi, cov)
+
+
+# --- the mechanism: the correction widens the covariance ------------------
+
+
+def test_analytic_covariance_is_wider_than_mle():
+    m, _ = _fit(0)
+    cov_corr = m.life_parameter_covariance("analytic")
+    phi = np.asarray(m.life_model.params, dtype=float)
+    t = m.pseudo_failure_times
+    cov_mle = np.linalg.inv(
+        -_num_hessian(lambda p: _life_loglik(m, p, t), phi)
+    )
+    se_corr = np.sqrt(np.diag(cov_corr))
+    se_mle = np.sqrt(np.diag(cov_mle))
+    # Every parameter's standard error grows once the first-stage uncertainty
+    # is folded in.
+    assert np.all(se_corr > se_mle)
+
+
+def test_exact_fits_give_no_correction():
+    # Two points per unit and no measurement noise => each path fits exactly,
+    # measurement_var is 0, so there is no first-stage uncertainty and the
+    # analytic covariance reduces to the plain MLE covariance.
+    rng = np.random.default_rng(1)
+    thr = 100.0
+    xs, ys, ids = [], [], []
+    for u in range(15):
+        slope = rng.uniform(2.0, 6.0)
+        t = np.array([1.0, 3.0])
+        xs.append(t)
+        ys.append(slope * t)  # exact line, no noise
+        ids.append(np.full(2, u))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        m = DegradationAnalysis.fit(
+            np.concatenate(xs),
+            np.concatenate(ys),
+            np.concatenate(ids),
+            threshold=thr,
+            path="linear",
+            distribution=Weibull,
+        )
+    assert m.measurement_var == 0.0
+    cov_corr = m.life_parameter_covariance("analytic")
+    phi = np.asarray(m.life_model.params, dtype=float)
+    t = m.pseudo_failure_times
+    cov_mle = np.linalg.inv(
+        -_num_hessian(lambda p: _life_loglik(m, p, t), phi)
+    )
+    assert np.allclose(cov_corr, cov_mle)
+
+
+# --- shape / range / direction of the bounds ------------------------------
+
+
+def test_cb_brackets_and_bounded():
+    m, _ = _fit(2)
+    x = np.array([20.0, 35.0, 50.0])
+    cb = m.cb(x, on="sf")
+    assert cb.shape == (3, 2)
+    sf = m.sf(x)
+    assert np.all(cb[:, 0] <= sf) and np.all(sf <= cb[:, 1])
+    assert np.all(cb >= 0) and np.all(cb <= 1)
+    assert np.all(cb[:, 0] <= cb[:, 1])
+
+
+@pytest.mark.parametrize("on", ["sf", "ff", "Hf"])
+def test_cb_on_variants_bracket(on):
+    m, _ = _fit(3)
+    x = np.array([25.0, 45.0])
+    est = getattr(m, on)(x)
+    cb = m.cb(x, on=on)
+    assert np.all(cb[:, 0] <= est) and np.all(est <= cb[:, 1])
+    if on in ("sf", "ff"):
+        assert np.all(cb >= 0) and np.all(cb <= 1)
+    else:
+        assert np.all(cb >= 0)
+
+
+def test_one_sided_bounds_ordered():
+    m, _ = _fit(4)
+    x = np.array([30.0, 45.0])
+    for on in ("sf", "ff", "Hf"):
+        est = getattr(m, on)(x)
+        lower = m.cb(x, on=on, bound="lower")
+        upper = m.cb(x, on=on, bound="upper")
+        assert np.all(lower <= est) and np.all(est <= upper)
+
+
+# --- analytic vs bootstrap ------------------------------------------------
+
+
+def test_analytic_and_bootstrap_agree():
+    m, _ = _fit(5)
+    x = np.array([25.0, 40.0])
+    an = m.cb(x, on="sf", method="analytic")
+    bs = m.cb(x, on="sf", method="bootstrap", n_boot=150, seed=7)
+    # Same ballpark: the two 95% intervals overlap substantially at each point.
+    for a, b in zip(an, bs):
+        lo = max(a[0], b[0])
+        hi = min(a[1], b[1])
+        overlap = max(0.0, hi - lo)
+        assert overlap > 0.4 * (a[1] - a[0])
+
+
+# --- coverage: the correction restores what the MLE-only bound loses ------
+
+
+def test_coverage_improves_over_mle_only():
+    # In a heavy-extrapolation regime (few noisy points, threshold far beyond
+    # the measurement window) the MLE-only bound under-covers the true
+    # reliability; the analytic bound folds the first-stage error back in and
+    # covers at least as well, close to nominal.
+    t0 = 45.0
+    true_sf = float(Weibull.from_params([50.0, 3.0]).sf(t0))
+    an_hits, mle_hits = 0, 0
+    reps = 80
+    for s in range(reps):
+        m, _ = _fit(1000 + s, n_units=18, noise=3.0, n_points=3, t_max=4.0)
+        an = m.cb([t0], on="sf", method="analytic")[0]
+        se = _mle_only_se(m, [t0])
+        sf_hat = m.sf([t0])
+        mlo = _logit_bound(sf_hat, se, 0.05, "lower")[0]
+        mhi = _logit_bound(sf_hat, se, 0.05, "upper")[0]
+        an_hits += an[0] <= true_sf <= an[1]
+        mle_hits += mlo <= true_sf <= mhi
+    an_cov = an_hits / reps
+    mle_cov = mle_hits / reps
+    # Analytic reaches (at least) nominal coverage and never covers worse than
+    # the uncorrected bound.
+    assert an_cov >= 0.90
+    assert mle_cov <= an_cov
+
+
+# --- guards ---------------------------------------------------------------
+
+
+def test_cb_rejects_bad_arguments():
+    m, _ = _fit(6)
+    with pytest.raises(ValueError, match="`on` must be one of"):
+        m.cb([10.0], on="nonsense")
+    with pytest.raises(ValueError, match="`bound` must be"):
+        m.cb([10.0], bound="sideways")
+    with pytest.raises(ValueError, match="`method` must be"):
+        m.cb([10.0], method="magic")
+
+
+def test_analytic_rejects_lfp_life_model():
+    # The analytic correction is only implemented for a plain life model; a
+    # limited-failure-population component must route to the bootstrap.
+    m, _ = _fit(7)
+    m.life_model.p = 0.8  # pretend an LFP was fitted
+    with pytest.raises(ValueError, match="limited-failure-population"):
+        m.cb([10.0], on="sf", method="analytic")

--- a/surpyval/tests/univariate/competing_risks/test_cause_specific_cox.py
+++ b/surpyval/tests/univariate/competing_risks/test_cause_specific_cox.py
@@ -1,0 +1,173 @@
+"""Cause-specific proportional-hazards competing-risks regression.
+
+``CompetingRisksProportionalHazards.fit(how="Cox")`` fits one Cox model per
+cause (other causes censored) and combines them into a cumulative-incidence
+prediction. These tests pin the correctness of that combination against a
+known analytic truth and exercise the DataFrame entry point.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from surpyval.univariate.competing_risks import (
+    CompetingRisksProportionalHazards as CRPH,
+)
+
+
+def _exponential_cr_data(N, seed, lam=(0.5, 0.3), beta=None, cens=6.0):
+    """
+    Two-cause data with constant (exponential) cause-specific hazards
+    ``h_e(t|Z) = lam_e exp(beta_e'Z)`` and *different* covariate effects per
+    cause. The analytic cumulative incidence is
+
+        F_e(t|Z) = lam_e(Z)/lam_tot(Z) * (1 - exp(-lam_tot(Z) t)).
+    """
+    if beta is None:
+        beta = np.array([[0.8, -0.2], [-0.3, 0.6]])
+    rng = np.random.default_rng(seed)
+    lam = np.asarray(lam)
+    Z = rng.uniform(-1, 1, size=(N, beta.shape[1]))
+    rate = lam[None, :] * np.exp(Z @ beta.T)
+    T = rng.exponential(1.0 / rate)
+    x = T.min(axis=1)
+    cause = T.argmin(axis=1) + 1
+    C = rng.exponential(cens, size=N)
+    c = (x > C).astype(int)
+    x = np.minimum(x, C)
+    e = np.array(
+        [None if ci == 1 else int(ce) for ci, ce in zip(c, cause)],
+        dtype=object,
+    )
+    return x, Z, e, c, lam, beta
+
+
+def _analytic_cif(t, Z0, lam, beta, event):
+    lz = lam * np.exp(Z0 @ beta.T)
+    tot = lz.sum()
+    return lz[event - 1] / tot * (1 - np.exp(-tot * t))
+
+
+def test_cox_cif_matches_analytic_with_differing_covariate_effects():
+    # The key correctness test: with different coefficients per cause, the
+    # all-cause survival must combine each cause with its own coefficients
+    # (not a summed coefficient), and the baseline must be cause-specific.
+    x, Z, e, c, lam, beta = _exponential_cr_data(20000, 0)
+    m = CRPH.fit(x, Z, e, c=c, how="Cox")
+    Z0 = np.array([0.5, -0.3])
+    ts = np.array([0.5, 1.0, 2.0, 4.0])
+    for event in (1, 2):
+        fitted = m.cif(ts, Z0, event)
+        truth = _analytic_cif(ts, Z0, lam, beta, event)
+        assert np.allclose(fitted, truth, atol=0.02)
+
+
+def test_cox_recovers_per_cause_coefficients():
+    x, Z, e, c, lam, beta = _exponential_cr_data(20000, 1)
+    m = CRPH.fit(x, Z, e, c=c, how="Cox")
+    assert np.allclose(m.betas[m.event_idx_map[1]], beta[0], atol=0.05)
+    assert np.allclose(m.betas[m.event_idx_map[2]], beta[1], atol=0.05)
+
+
+def test_cif_is_monotone_and_bounded():
+    x, Z, e, c, lam, beta = _exponential_cr_data(4000, 2)
+    m = CRPH.fit(x, Z, e, c=c, how="Cox")
+    t = np.linspace(0.01, 8.0, 60)
+    cif = m.cif(t, [0.2, -0.1], 1)
+    assert np.all(cif >= 0) and np.all(cif <= 1)
+    assert np.all(np.diff(cif) >= -1e-9)
+
+
+def test_cifs_sum_below_one():
+    # The competing CIFs plus the overall survival must sum to one.
+    x, Z, e, c, lam, beta = _exponential_cr_data(6000, 3)
+    m = CRPH.fit(x, Z, e, c=c, how="Cox")
+    t = np.array([0.5, 1.0, 3.0])
+    Z0 = [0.1, 0.2]
+    total = m.cif(t, Z0, 1) + m.cif(t, Z0, 2) + m.sf(t, Z0)
+    assert np.allclose(total, 1.0, atol=0.02)
+
+
+def test_baseline_uses_cause_specific_events_only():
+    # A cause with very few events must have a much smaller cumulative
+    # incidence than a common cause -- a direct probe that the baseline is
+    # built from cause-specific (not all-cause) event counts.
+    rng = np.random.default_rng(4)
+    N = 8000
+    Z = rng.uniform(-1, 1, size=(N, 1))
+    # Cause 1 is ~9x more frequent than cause 2.
+    rate = np.array([0.9, 0.1])[None, :] * np.exp(
+        Z @ np.array([[0.0], [0.0]]).T
+    )
+    T = rng.exponential(1.0 / rate)
+    x = T.min(axis=1)
+    cause = T.argmin(axis=1) + 1
+    e = np.array([int(ce) for ce in cause], dtype=object)
+    c = np.zeros(N, dtype=int)
+    m = CRPH.fit(x, Z, e, c=c, how="Cox")
+    f1 = m.cif([5.0], [0.0], 1)[0]
+    f2 = m.cif([5.0], [0.0], 2)[0]
+    assert f1 > 5 * f2  # cause 1 dominates, as its ~0.9 share implies
+
+
+# --- fit_from_df ----------------------------------------------------------
+
+
+def _frame(x, Z, e, c):
+    return pd.DataFrame(
+        {
+            "t": x,
+            "c": c,
+            "cause": pd.array(e, dtype=object),
+            "age": Z[:, 0],
+            "dose": Z[:, 1],
+        }
+    )
+
+
+@pytest.mark.parametrize("how", ["Cox", "Fine-Gray"])
+def test_fit_from_df_matches_array_fit(how):
+    x, Z, e, c, lam, beta = _exponential_cr_data(4000, 5)
+    df = _frame(x, Z, e, c)
+    m_df = CRPH.fit_from_df(
+        df,
+        x_col="t",
+        e_col="cause",
+        Z_cols=["age", "dose"],
+        c_col="c",
+        how=how,
+    )
+    m_arr = CRPH.fit(x, Z, e, c=c, how=how)
+    assert m_df.feature_names == ["age", "dose"]
+    t = np.array([0.5, 1.0, 2.0])
+    assert np.allclose(
+        m_df.cif(t, [0.2, -0.1], 1), m_arr.cif(t, [0.2, -0.1], 1)
+    )
+
+
+def test_fit_from_df_accepts_nan_cause_for_censored():
+    # A blank/NaN cause cell is treated as a censored observation.
+    x, Z, e, c, lam, beta = _exponential_cr_data(3000, 6)
+    df = _frame(x, Z, e, c)
+    df_nan = df.copy()
+    df_nan.loc[df_nan.c == 1, "cause"] = np.nan
+    m_nan = CRPH.fit_from_df(
+        df_nan, x_col="t", e_col="cause", Z_cols=["age", "dose"], c_col="c"
+    )
+    m_ref = CRPH.fit_from_df(
+        df, x_col="t", e_col="cause", Z_cols=["age", "dose"], c_col="c"
+    )
+    t = np.array([1.0, 2.0])
+    assert np.allclose(
+        m_nan.cif(t, [0.1, 0.1], 1), m_ref.cif(t, [0.1, 0.1], 1)
+    )
+
+
+def test_fit_from_df_formula():
+    x, Z, e, c, lam, beta = _exponential_cr_data(3000, 7)
+    df = _frame(x, Z, e, c)
+    m = CRPH.fit_from_df(
+        df, x_col="t", e_col="cause", formula="age + dose", c_col="c"
+    )
+    assert "age" in m.feature_names and "dose" in m.feature_names
+    assert np.all(np.isfinite(m.cif([1.0, 2.0], [0.2, -0.1], 1)))

--- a/surpyval/tests/univariate/regression/test_buckley_james.py
+++ b/surpyval/tests/univariate/regression/test_buckley_james.py
@@ -1,0 +1,155 @@
+"""Buckley-James semi-parametric AFT regression.
+
+The model is ``log T = gamma'Z + eps`` with an unspecified error distribution,
+fit under right-censoring by the Buckley-James imputation iteration.
+Coefficients are reported in surpyval's accelerated-failure convention (the
+negative of the textbook ``gamma``), so a positive coefficient shortens life --
+matching ``WeibullAFT``/``LogNormalAFT``.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from surpyval import BuckleyJames, LogNormalAFT
+
+
+def _aft_data(N, seed, gamma=(0.8, -0.5), mu=1.5, sigma=0.6, cens_mu=2.2):
+    """``log T = mu + gamma'Z + eps`` with normal errors and independent
+    right-censoring. Returns the surpyval-convention coefficients ``-gamma``.
+    """
+    rng = np.random.default_rng(seed)
+    gamma = np.asarray(gamma, dtype=float)
+    Z = rng.uniform(-1, 1, size=(N, gamma.size))
+    Y = mu + Z @ gamma + rng.normal(0, sigma, N)
+    T = np.exp(Y)
+    C = np.exp(rng.normal(cens_mu, 0.8, N))
+    c = (T > C).astype(int)
+    x = np.minimum(T, C)
+    return x, Z, c, -gamma
+
+
+def test_no_censoring_equals_ols():
+    # With no censoring the imputation is a no-op, so BJ is exactly the
+    # least-squares slope of log(x) on Z (negated for the AFT sign).
+    rng = np.random.default_rng(0)
+    N = 500
+    Z = rng.uniform(-1, 1, size=(N, 2))
+    Y = 2.0 + Z @ [0.7, -0.4] + rng.normal(0, 0.5, N)
+    x = np.exp(Y)
+    m = BuckleyJames.fit(x, Z)
+    X = np.column_stack([np.ones(N), Z])
+    ols_slope = np.linalg.lstsq(X, Y, rcond=None)[0][1:]
+    assert np.allclose(m.beta, -ols_slope, atol=1e-6)
+    assert m.converged and m.n_iter == 1
+
+
+def test_recovers_coefficients_under_censoring():
+    x, Z, c, beta = _aft_data(6000, 1)
+    m = BuckleyJames.fit(x, Z, c=c)
+    assert m.converged
+    assert np.allclose(m.beta, beta, atol=0.06)
+
+
+def test_agrees_with_lognormal_aft():
+    # For normal errors the semi-parametric BJ should track the parametric
+    # LogNormal AFT in both sign and magnitude.
+    x, Z, c, beta = _aft_data(6000, 2)
+    bj = BuckleyJames.fit(x, Z, c=c)
+    la = LogNormalAFT.fit(x=x, Z=Z, c=c)
+    la_beta = la.params[la.k_dist :]
+    assert np.allclose(bj.beta, la_beta, atol=0.06)
+
+
+def test_positive_coefficient_shortens_life():
+    # Direct convention check: a larger positive coefficient must lower
+    # survival at fixed time (accelerated failure).
+    x, Z, c, beta = _aft_data(4000, 3)
+    m = BuckleyJames.fit(x, Z, c=c)
+    # beta[0] is negative here (gamma[0] positive), so raising covariate 0
+    # should *raise* survival. Compare two covariate vectors.
+    t = np.array([5.0])
+    hi_cov = m.sf(t, [1.0, 0.0])
+    lo_cov = m.sf(t, [-1.0, 0.0])
+    # sign of the effect follows sign of beta[0]
+    if m.beta[0] < 0:
+        assert hi_cov > lo_cov
+    else:
+        assert hi_cov < lo_cov
+
+
+def test_sf_is_monotone_and_bounded():
+    x, Z, c, beta = _aft_data(3000, 4)
+    m = BuckleyJames.fit(x, Z, c=c)
+    t = np.linspace(0.5, 60.0, 80)
+    sf = m.sf(t, [0.3, -0.2])
+    assert np.all(sf >= 0) and np.all(sf <= 1)
+    assert np.all(np.diff(sf) <= 1e-12)
+    assert np.allclose(m.ff(t, [0.3, -0.2]), 1 - sf)
+
+
+def test_counts_equivalent_to_repeated_rows():
+    x, Z, c, beta = _aft_data(1200, 5)
+    m_rep = BuckleyJames.fit(
+        np.repeat(x, 2), np.repeat(Z, 2, axis=0), c=np.repeat(c, 2)
+    )
+    m_cnt = BuckleyJames.fit(x, Z, c=c, n=np.full(x.size, 2))
+    assert np.allclose(m_rep.beta, m_cnt.beta, atol=1e-4)
+
+
+def test_single_covariate():
+    x, Z, c, beta = _aft_data(2000, 6, gamma=(0.7,))
+    m = BuckleyJames.fit(x, Z[:, 0], c=c)
+    assert m.beta.shape == (1,)
+    assert np.allclose(m.beta, beta, atol=0.08)
+
+
+def test_bootstrap_ci_brackets_estimate():
+    x, Z, c, beta = _aft_data(2000, 7)
+    m = BuckleyJames.fit(x, Z, c=c)
+    ci = m.bootstrap_ci(n_boot=120, seed=0)
+    assert ci.shape == (2, 2)
+    assert np.all(ci[:, 0] <= m.beta) and np.all(m.beta <= ci[:, 1])
+    assert np.all(ci[:, 0] <= ci[:, 1])
+
+
+def test_rejects_non_right_censoring():
+    x, Z, c, beta = _aft_data(200, 8)
+    bad = c.copy()
+    bad[:3] = -1  # left-censored
+    with pytest.raises(ValueError, match="only observed"):
+        BuckleyJames.fit(x, Z, c=bad)
+
+
+def test_rejects_non_positive_times():
+    rng = np.random.default_rng(9)
+    Z = rng.uniform(-1, 1, size=(50, 2))
+    x = rng.uniform(-1, 1, size=50)  # some non-positive
+    with pytest.raises(ValueError, match="must be positive"):
+        BuckleyJames.fit(x, Z)
+
+
+# --- fit_from_df ----------------------------------------------------------
+
+
+def test_fit_from_df_matches_array_fit():
+    x, Z, c, beta = _aft_data(3000, 10)
+    df = pd.DataFrame({"t": x, "c": c, "age": Z[:, 0], "dose": Z[:, 1]})
+    m_df = BuckleyJames.fit_from_df(
+        df, x_col="t", Z_cols=["age", "dose"], c_col="c"
+    )
+    m_arr = BuckleyJames.fit(x, Z, c=c)
+    assert m_df.feature_names == ["age", "dose"]
+    assert np.allclose(m_df.beta, m_arr.beta)
+    pred = m_df.sf([2.0, 5.0], df[["age", "dose"]].iloc[[0]])
+    assert pred.shape == (2,)
+
+
+def test_fit_from_df_formula():
+    x, Z, c, beta = _aft_data(3000, 11)
+    df = pd.DataFrame({"t": x, "c": c, "age": Z[:, 0], "dose": Z[:, 1]})
+    m = BuckleyJames.fit_from_df(
+        df, x_col="t", formula="age + dose", c_col="c"
+    )
+    assert "age" in m.feature_names and "dose" in m.feature_names
+    assert np.allclose(m.beta, beta, atol=0.08)

--- a/surpyval/tests/univariate/regression/test_proportional_hazards.py
+++ b/surpyval/tests/univariate/regression/test_proportional_hazards.py
@@ -52,8 +52,10 @@ def test_cox_ph_sim():
     """
     Generates samples randomly and tests convergence.
     """
-    # Instantiate random number generator
-    rng = np.random.default_rng()
+    # Instantiate random number generator. Seeded so the tight
+    # parameter-recovery tolerance below cannot flake (a bare default_rng()
+    # ignores the module seed fixture and was non-deterministic).
+    rng = np.random.default_rng(2)
 
     # Construct covariant (Z) matrix
     n_samples = 100
@@ -89,8 +91,10 @@ def test_exponential_ph_sim():
     Same as test_cox_ph_sim_example but for ExponentialPH, checking the
     baseline hazard rate is fitted correctly.
     """
-    # Instantiate random number generator
-    rng = np.random.default_rng()
+    # Instantiate random number generator. Seeded so the tight
+    # parameter-recovery tolerance below cannot flake (a bare default_rng()
+    # ignores the module seed fixture and was non-deterministic).
+    rng = np.random.default_rng(2)
 
     # Construct covariant (Z) matrix
     n_samples = 100
@@ -129,8 +133,10 @@ def test_weibull_ph_sim():
     Same as test_cox_ph_sim_example but with a Weibull baseline hazard, and
     testing WeibullPH can get the Weibull and covariant parameters correct.
     """
-    # Instantiate random number generator
-    rng = np.random.default_rng()
+    # Instantiate random number generator. Seeded so the tight
+    # parameter-recovery tolerance below cannot flake (a bare default_rng()
+    # ignores the module seed fixture and was non-deterministic).
+    rng = np.random.default_rng(2)
 
     # Construct covariant (Z) matrix
     n_samples = 100

--- a/surpyval/univariate/competing_risks/regression/competing_risks_proportional_hazard.py
+++ b/surpyval/univariate/competing_risks/regression/competing_risks_proportional_hazard.py
@@ -10,7 +10,11 @@ Copyright 2022 Cartiga LLC
 import numpy as np
 
 from surpyval.univariate.regression import CoxPH
-from surpyval.utils import _get_idx, _scale, validate_fine_gray_inputs
+from surpyval.utils import (
+    _get_idx,
+    validate_fine_gray_inputs,
+    wrangle_and_check_form_and_Z_cols,
+)
 
 from .fine_gray import FineGray, _step
 
@@ -42,14 +46,20 @@ class CompetingRisksProportionalHazards:
     def _f(self, arr, x, Z, event=None, interp="step"):
         idx, rev = _get_idx(self.x, x)
 
-        if event is not None and event not in self.event_idx_map:
-            raise ValueError("Unrecognised event type for this model")
-
-        if event is None:
-            return (arr.sum(axis=0)[idx] * self.phi(Z))[rev]
-        else:
-            e_i = self.event_idx_map.get(event, None)
+        if event is not None:
+            if event not in self.event_idx_map:
+                raise ValueError("Unrecognised event type for this model")
+            e_i = self.event_idx_map[event]
             return (arr[e_i, idx] * self.phi_e(Z, e_i))[rev]
+
+        # All causes combined: each cause contributes with its OWN
+        # coefficients, so the all-cause (cumulative) hazard is the sum of
+        # H0_e(t) * exp(beta_e'Z), not a single summed-coefficient term.
+        total = sum(
+            arr[e_i, idx] * self.phi_e(Z, e_i)
+            for e_i in self.event_idx_map.values()
+        )
+        return total[rev]
 
     def hf(self, x, Z, event=None, interp="step"):
         if self.how == "Fine-Gray":
@@ -103,72 +113,71 @@ class CompetingRisksProportionalHazards:
         return cif[idx][rev]
 
     @classmethod
-    def cox_risk_set_indices(cls, x_i, e_i, x, e):
-        return x >= x_i
-
-    @classmethod
-    def fine_gray_risk_set_indices(cls, x_i, e_i, x, e):
-        return (x >= x_i) | (e != e_i)
-
-    @classmethod
-    def partial_log_like(
-        cls, beta, x, c, n, Z, e, event, how="Cox", scale=False
+    def fit_from_df(
+        cls,
+        df,
+        x_col,
+        e_col,
+        Z_cols=None,
+        c_col=None,
+        n_col=None,
+        formula=None,
+        how="Cox",
+        tie_method="efron",
     ):
         """
-        This is the Breslow implementation
-        TODO:
-        - Efron, and
-        - Kalbfleisch and Prentice (This is what we need!)
+        Fit a competing-risks proportional-hazards model from a pandas
+        DataFrame.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            The data.
+        x_col : str
+            Column of observed times.
+        e_col : str
+            Column of event-type (cause) labels. Use ``None`` (or a blank/NaN
+            cell) for a censored observation.
+        Z_cols : str or list of str, optional
+            Covariate columns. Either ``Z_cols`` or ``formula`` must be given.
+        c_col : str, optional
+            Column of censoring flags (0 observed, 1 right-censored).
+        n_col : str, optional
+            Column of counts per row.
+        formula : str, optional
+            A patsy/formulaic formula for the covariates, as an alternative to
+            ``Z_cols``.
+        how : {'Cox', 'Fine-Gray'}, optional
+            Cause-specific proportional hazards or Fine-Gray subdistribution
+            hazards. Default 'Cox'.
+        tie_method : {'efron', 'breslow'}, optional
+            Tie handling for the ``how='Cox'`` path. Default 'efron'.
+
+        Returns
+        -------
+        CompetingRisksProportionalHazards
+            The fitted model. Predictions still take a covariate array ``Z``.
         """
-        # print(beta)
-        if how == "Cox":
-            risk_set_indices = cls.cox_risk_set_indices
-        elif how == "Fine-Gray":
-            risk_set_indices = cls.fine_gray_risk_set_indices
-        N = len(x)
+        import pandas as pd
 
-        ll = np.zeros_like(x)
-        idx = np.array(range(N))
+        Z, mask, form, feature_names, model_spec = (
+            wrangle_and_check_form_and_Z_cols(Z_cols, formula, df)
+        )
+        sub = df.loc[mask]
+        x = sub[x_col].values
+        # A censored row's cause is ``None``; accept a blank/NaN cell for it.
+        e = np.array(
+            [None if pd.isna(v) else v for v in sub[e_col].values],
+            dtype=object,
+        )
+        c = sub[c_col].values if c_col is not None else None
+        n = sub[n_col].values if n_col is not None else None
 
-        for i, x_i in enumerate(x):
-            if c[i] == 1:
-                continue
-            elif e[i] != event:
-                continue
-            # This is the key insight:
-            # all non e failures are still at risk!
-            at_risk = risk_set_indices(x_i, event, x, e)
-            Z_ri = Z[at_risk, :]
-            # Sum of 'Z's is sometimes also called 'S'
-            # e.g. see https://myweb.uiowa.edu/pbreheny/7210/f15/notes/11-5.pdf
-            Z_i = n[i] * Z[i, :]
-            # Breslow log-like
-            ll_i = (Z_i @ beta) - (n[i] * np.log(np.exp(Z_ri @ beta).sum()))
-            ll = np.where(i == idx, ll_i, ll)
-
-        return _scale(ll, n, scale)
-
-    @classmethod
-    def baseline(cls, beta, x, c, n, Z, e, event):
-        unique_x = np.unique(x)
-
-        d = np.zeros_like(unique_x)
-        r = np.zeros_like(unique_x)
-        for i, tau_i in enumerate(unique_x):
-            mask_d_i = (x == tau_i) & (c == 0)
-            d[i] = n[mask_d_i].sum()
-
-            mask_at_risk_i = (x >= tau_i) | (e != event)
-            Z_ri = Z[mask_at_risk_i, :]
-
-            r[i] = np.exp(Z_ri @ beta).sum()
-
-        return d / r
-
-    @classmethod
-    def fit_from_df(self, *args, **kwargs):
-        # TODO: Finish this
-        raise NotImplementedError("Not yet...")
+        model = cls.fit(x, Z, e, c=c, n=n, how=how, tie_method=tie_method)
+        model.formula = form
+        model.feature_names = feature_names
+        model._model_spec = model_spec
+        return model
 
     @classmethod
     def fit(cls, x, Z, e, c=None, n=None, how="Cox", tie_method="efron"):
@@ -244,17 +253,22 @@ class CompetingRisksProportionalHazards:
         model.how = how
 
         if how == "Cox":
-            # The Cox method is just assuming the other methods
-            # are right censored.
+            # Cause-specific proportional hazards: one Cox model per cause,
+            # treating every other cause (and censoring) as right-censored.
             results = []
             for i, event in enumerate(unique_e):
                 c_e = np.where(e == event, 0, 1)
+                cox_model = CoxPH.fit(x, Z, c_e, n, method=tie_method)
 
-                res = CoxPH.fit(x, Z, c_e, n, method=tie_method).res
-
-                results.append(res)
-                betas[i, :] = res.x
-                baselines[i, :] = cls.baseline(res.x, x, c, n, Z, e, event)
+                results.append(cox_model.res)
+                betas[i, :] = cox_model.res.x
+                # Cause-specific baseline hazard: reuse the fitted Cox model's
+                # own Breslow baseline, which is built from c_e (the
+                # cause-specific event indicator) and the standard risk set.
+                # Map its cumulative hazard onto the shared unique_x grid and
+                # store increments so H0_e = baselines.cumsum stays coherent.
+                H_grid = _step(cox_model.x, cox_model.H0, unique_x, before=0.0)
+                baselines[i, :] = np.diff(H_grid, prepend=0.0)
 
         elif how == "Fine-Gray":
             # Delegate to the IPCW Fine-Gray fitter, one subdistribution model

--- a/surpyval/univariate/regression/__init__.py
+++ b/surpyval/univariate/regression/__init__.py
@@ -9,6 +9,7 @@ from .accelerated_failure_time import (
     NormalAFT,
     WeibullAFT,
 )
+from .buckley_james import BuckleyJames, BuckleyJamesModel
 from .accelerated_life import (
     AcceleratedLife,
     DualExponential,
@@ -62,6 +63,9 @@ from .proportional_odds import (
 )
 
 __all__ = [
+    # Buckley-James semi-parametric AFT
+    "BuckleyJames",
+    "BuckleyJamesModel",
     # Additive hazards — semi-parametric (Lin-Ying) and parametric
     "AH",
     "AdditiveHazards",

--- a/surpyval/univariate/regression/buckley_james/__init__.py
+++ b/surpyval/univariate/regression/buckley_james/__init__.py
@@ -1,0 +1,3 @@
+from .buckley_james import BuckleyJames, BuckleyJamesModel
+
+__all__ = ["BuckleyJames", "BuckleyJamesModel"]

--- a/surpyval/univariate/regression/buckley_james/buckley_james.py
+++ b/surpyval/univariate/regression/buckley_james/buckley_james.py
@@ -1,0 +1,343 @@
+"""
+Buckley-James semi-parametric accelerated-failure-time regression.
+
+The accelerated-failure-time model writes the (log) lifetime as a linear
+function of the covariates plus an error term with an *unspecified*
+distribution,
+
+.. math::
+    \\log T = \\beta' Z + \\varepsilon ,
+
+so it is the accelerated-time counterpart of Cox proportional hazards (which
+leaves the baseline *hazard* unspecified). Buckley & James (1979) fit it under
+right-censoring by iterating two steps until the coefficients stop moving:
+
+1. **Impute.** Replace each censored log-time by its conditional expectation
+   given that it exceeds the censoring time, estimated from the Kaplan-Meier
+   distribution of the current residuals ``e_i = log T_i - beta'Z_i``.
+2. **Re-fit.** Update ``beta`` by (weighted) least squares of the imputed
+   responses on the covariates.
+
+Only the slope is identified from the least-squares step; the location of the
+errors is carried by the residual distribution, so predictions use the
+residual Kaplan-Meier directly. Coefficients are reported in surpyval's
+accelerated-failure sign convention -- a *positive* coefficient accelerates
+failure (shortens life), matching ``WeibullAFT`` and the proportional-hazards
+models -- which is the negative of the textbook ``log T = gamma'Z + eps``
+slope. Prediction is therefore ``S(t | Z) = S_eps(log t + beta'Z)``.
+
+The residual Kaplan-Meier is given an Efron tail-correction (its largest
+residual is treated as an event) so it is a proper distribution and the
+conditional means in step 1 are always finite. The iteration can settle into a
+two-point cycle rather than a fixed point -- a known feature of the estimator
+-- which is detected and resolved by averaging the cycle.
+"""
+
+import warnings
+
+import numpy as np
+
+from surpyval.utils import (
+    wrangle_and_check_form_and_Z_cols,
+    wrangle_Z,
+    xcnt_handler,
+)
+
+
+def _residual_km(e, delta, w):
+    """
+    Weighted Kaplan-Meier of the residuals with an Efron tail-correction.
+
+    Returns the sorted unique residual values, the (right-continuous) survival
+    at each, and the probability mass (jump) the estimator places at each.
+    Forcing the largest residual to be an event makes the estimator proper, so
+    the jumps sum to one and conditional expectations above any point are
+    finite.
+    """
+    order = np.argsort(e, kind="mergesort")
+    e = e[order]
+    delta = delta[order].astype(float).copy()
+    w = w[order].astype(float)
+
+    # Efron tail-correction: the largest residual(s) act as an event.
+    delta[e == e[-1]] = 1.0
+
+    uniq, first_idx = np.unique(e, return_index=True)
+    w_cum = np.concatenate([[0.0], np.cumsum(w)])
+    total = w_cum[-1]
+    # At-risk weight for each unique time (residuals >= that time).
+    r = total - w_cum[first_idx]
+
+    d = np.zeros(uniq.shape[0])
+    grp = np.searchsorted(uniq, e)
+    np.add.at(d, grp, np.where(delta == 1.0, w, 0.0))
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        surv = np.cumprod(1.0 - d / r)
+    surv = np.clip(surv, 0.0, 1.0)
+    s_prev = np.concatenate([[1.0], surv[:-1]])
+    jumps = s_prev - surv
+    return uniq, surv, jumps
+
+
+def _impute(Y, delta, Zbeta, w):
+    """
+    Buckley-James imputed responses. Observed (``delta == 1``) rows keep their
+    value; each censored row is replaced by ``Zbeta_i + E[e | e > e_i]``, the
+    conditional mean of the residual above its censored value under the
+    residual Kaplan-Meier. Where nothing lies above (the largest residual) the
+    censored value is kept.
+    """
+    e = Y - Zbeta
+    uniq, surv, jumps = _residual_km(e, delta, w)
+
+    # Reverse cumulative sum of the jump-weighted residual values: at index j,
+    # sum_{k > j} jumps[k] * uniq[k].
+    contrib = (jumps * uniq)[::-1]
+    tail_above = np.concatenate([np.cumsum(contrib)[::-1][1:], [0.0]])
+
+    idx = np.searchsorted(uniq, e)
+    s_at = surv[idx]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        cond_mean = np.where(s_at > 0, tail_above[idx] / s_at, np.nan)
+
+    imputed = Zbeta + cond_mean
+    # Observed rows, and censored rows with no mass above, keep the raw value.
+    keep = (delta == 1.0) | ~np.isfinite(imputed)
+    return np.where(keep, Y, imputed)
+
+
+def _wls_slope(Z, Y, w):
+    """Weighted least-squares slope of ``Y`` on ``Z`` with the intercept
+    profiled out by centring (the location stays in the residuals)."""
+    wsum = w.sum()
+    Zbar = (w[:, None] * Z).sum(axis=0) / wsum
+    Ybar = (w * Y).sum() / wsum
+    Zc = Z - Zbar
+    A = (w[:, None] * Zc).T @ Zc
+    b = (w * (Y - Ybar))[None, :] @ Zc
+    return np.linalg.solve(A, b.ravel())
+
+
+def _fit_beta(Y, delta, Z, w, tol, max_iter):
+    """Run the Buckley-James iteration and return
+    ``(beta, n_iter, converged)``. A two-point cycle is resolved by averaging
+    the cycle."""
+    beta = _wls_slope(Z, Y, w)  # least squares ignoring censoring, as a start
+    history = [beta]
+    converged = False
+    for it in range(1, max_iter + 1):
+        imputed = _impute(Y, delta, Z @ beta, w)
+        beta_new = _wls_slope(Z, imputed, w)
+        if np.linalg.norm(beta_new - beta) < tol:
+            beta = beta_new
+            converged = True
+            break
+        # Two-cycle detection: the new iterate matches the one before last.
+        if len(history) >= 2 and np.linalg.norm(beta_new - history[-2]) < tol:
+            beta = 0.5 * (beta_new + beta)
+            converged = True
+            break
+        history.append(beta_new)
+        beta = beta_new
+    return beta, it, converged
+
+
+class BuckleyJamesModel:
+    """
+    A fitted Buckley-James accelerated-failure-time model.
+
+    Predictions use the residual Kaplan-Meier: ``sf(t | Z) = S_eps(log t +
+    beta'Z)``. ``coef`` are the covariate coefficients in surpyval's
+    accelerated-failure convention: a positive coefficient accelerates failure
+    (shortens life), matching ``WeibullAFT`` and the PH models.
+    """
+
+    feature_names = None
+    formula = None
+    _model_spec = None
+
+    def __init__(self, beta, resid, resid_surv, n_iter, converged, data):
+        self.beta = np.asarray(beta, dtype=float)
+        self.params = self.beta
+        self.coef = self.beta
+        self._resid = resid
+        self._resid_surv = resid_surv
+        self.n_iter = n_iter
+        self.converged = converged
+        self._data = data  # (Y, delta, Z, w) for the bootstrap
+
+    def _prepare_Z(self, Z):
+        from ..regression_data import prepare_Z
+
+        return prepare_Z(Z, self.feature_names, self._model_spec)
+
+    def _resid_sf(self, r):
+        # Right-continuous residual survival at query points ``r``.
+        idx = np.searchsorted(self._resid, r, side="right") - 1
+        out = np.where(
+            idx < 0,
+            1.0,
+            self._resid_surv[np.clip(idx, 0, len(self._resid_surv) - 1)],
+        )
+        return out
+
+    def sf(self, x, Z):
+        """Survival ``P(T > x | Z) = S_eps(log x - beta'Z)`` for a single
+        covariate vector ``Z``."""
+        x = np.atleast_1d(np.asarray(x, dtype=float))
+        Z = self._prepare_Z(Z)
+        Z = np.asarray(Z, dtype=float).ravel()
+        # beta is the accelerated-failure (negated) slope, so the residual
+        # r = log t - gamma'Z = log t + beta'Z.
+        r = np.log(x) + Z @ self.beta
+        return self._resid_sf(r)
+
+    def ff(self, x, Z):
+        return 1.0 - self.sf(x, Z)
+
+    def Hf(self, x, Z):
+        with np.errstate(divide="ignore"):
+            return -np.log(self.sf(x, Z))
+
+    def bootstrap_ci(self, alpha_ci=0.05, n_boot=200, seed=None):
+        """
+        Percentile bootstrap confidence intervals for the coefficients.
+
+        Buckley-James has no simple closed-form standard error, so uncertainty
+        is obtained by resampling observations with replacement, refitting, and
+        taking percentiles of the coefficient distribution. Returns an
+        ``(n_coef, 2)`` array of ``[lower, upper]`` bounds.
+        """
+        Y, delta, Z, w = self._data
+        rng = np.random.default_rng(seed)
+        n = Y.shape[0]
+        boot = []
+        for _ in range(n_boot):
+            idx = rng.integers(0, n, size=n)
+            try:
+                g, _, _ = _fit_beta(
+                    Y[idx], delta[idx], Z[idx], w[idx], 1e-5, 100
+                )
+                boot.append(-g)  # report in the accelerated-failure sign
+            except np.linalg.LinAlgError:
+                continue
+        boot = np.asarray(boot)
+        lo = np.quantile(boot, alpha_ci / 2.0, axis=0)
+        hi = np.quantile(boot, 1.0 - alpha_ci / 2.0, axis=0)
+        return np.stack([lo, hi], axis=-1)
+
+    def __repr__(self):
+        lines = [
+            "Buckley-James AFT SurPyval Model",
+            "================================",
+            "Kind                : Semi-Parametric AFT",
+            f"Converged           : {self.converged} ({self.n_iter} iters)",
+            "Coefficients (positive => accelerates failure):",
+        ]
+        names = self.feature_names or [
+            f"beta_{i}" for i in range(self.beta.size)
+        ]
+        for nm, b in zip(names, self.beta):
+            lines.append(f"   {nm:>10}  :  {b: .6f}")
+        return "\n".join(lines)
+
+
+class BuckleyJames_:
+    def fit(
+        self,
+        x,
+        Z,
+        c=None,
+        n=None,
+        tol=1e-5,
+        max_iter=100,
+    ):
+        """
+        Fit the Buckley-James AFT model.
+
+        Parameters
+        ----------
+        x : array_like
+            Observed (positive) times.
+        Z : array_like
+            Covariate matrix, one row per observation.
+        c : array_like, optional
+            Censoring flags: 0 observed, 1 right-censored. Left and interval
+            censoring are not supported. Defaults to all observed.
+        n : array_like, optional
+            Counts per row (case weights). Defaults to 1.
+        tol : float, optional
+            Convergence tolerance on the coefficient step. Default 1e-5.
+        max_iter : int, optional
+            Maximum Buckley-James iterations. Default 100.
+
+        Returns
+        -------
+        BuckleyJamesModel
+            The fitted model.
+        """
+        x, c, n, _ = xcnt_handler(x, c, n, group_and_sort=False)
+        Z, mask = wrangle_Z(Z)
+        x, c, n = x[mask], c[mask], n[mask]
+        x, c, n, Z = (a.astype(float) for a in (x, c, n, Z))
+
+        if np.any((c != 0) & (c != 1)):
+            raise ValueError(
+                "Buckley-James supports only observed (c=0) and "
+                "right-censored (c=1) data."
+            )
+        if np.any(x <= 0):
+            raise ValueError(
+                "Buckley-James models log(time); all times must be positive."
+            )
+
+        Y = np.log(x)
+        delta = (c == 0).astype(float)
+        # gamma is the textbook ``log T = gamma'Z + eps`` slope; report its
+        # negative so a positive coefficient accelerates failure.
+        gamma, n_iter, converged = _fit_beta(Y, delta, Z, n, tol, max_iter)
+        if not converged:
+            warnings.warn(
+                "Buckley-James did not converge in {} iterations; returning "
+                "the last iterate.".format(max_iter)
+            )
+
+        # Final residual distribution used for prediction.
+        resid, resid_surv, _ = _residual_km(Y - Z @ gamma, delta, n)
+
+        return BuckleyJamesModel(
+            -gamma, resid, resid_surv, n_iter, converged, (Y, delta, Z, n)
+        )
+
+    def fit_from_df(
+        self,
+        df,
+        x_col,
+        Z_cols=None,
+        c_col=None,
+        n_col=None,
+        formula=None,
+        tol=1e-5,
+        max_iter=100,
+    ):
+        """
+        Fit a Buckley-James model from a pandas DataFrame. See :meth:`fit` for
+        the estimator; ``Z_cols`` or ``formula`` selects the covariates.
+        """
+        Z, mask, form, feature_names, model_spec = (
+            wrangle_and_check_form_and_Z_cols(Z_cols, formula, df)
+        )
+        sub = df.loc[mask]
+        x = sub[x_col].values
+        c = sub[c_col].values if c_col is not None else None
+        n = sub[n_col].values if n_col is not None else None
+
+        model = self.fit(x, Z, c=c, n=n, tol=tol, max_iter=max_iter)
+        model.formula = form
+        model.feature_names = feature_names
+        model._model_spec = model_spec
+        return model
+
+
+BuckleyJames = BuckleyJames_()


### PR DESCRIPTION
## Summary

Three feature/correctness pieces plus a flaky-test fix.

### Cause-specific Cox competing-risks CIF fix + `fit_from_df`
Reviewing the shared `baseline()` turned up two bugs in the `how="Cox"` path: (1) the per-cause baseline was built from *all-cause* event counts and a Fine-Gray-style risk set instead of cause-specific events and the standard risk set — fixed by reusing the fitted `CoxPH` model's own (correct) baseline; (2) the all-cause survival in the CIF combined the per-cause cumulative hazards with a *single summed* coefficient instead of each cause's own — fixed to combine per-cause. Validated against the analytic competing-risks CIF for exponential cause-specific hazards with *differing* per-cause coefficients. Also implemented `CompetingRisksProportionalHazards.fit_from_df` for both paths, and removed the now-dead `partial_log_like`/`baseline`/risk-set classmethods.

### Buckley-James semi-parametric AFT (`BuckleyJames`)
Completes the semi-parametric trio (Cox PH, additive hazards, AFT). Fits `log T = γ'Z + ε` with an unspecified error distribution by the Buckley-James imputation iteration (Efron-corrected residual KM; two-cycle handling). Coefficients follow surpyval's accelerated-failure sign convention. `fit_from_df`, percentile-bootstrap CIs, `sf`/`ff`/`Hf` prediction. Validated: with no censoring BJ equals the OLS slope exactly; under censoring it matches `LogNormalAFT` in sign and magnitude.

### Two-stage degradation confidence bounds (`DegradationModel.cb`)
The pseudo-failure-time analysis is a two-stage estimator; the life-model MLE covariance ignores the first-stage (path-fit + extrapolation) uncertainty, so its bounds are too narrow. Adds an analytic delta-method / generated-regressor correction (`Cov(φ) = H⁻¹ + Σ vᵢ (dφ/dtᵢ)(dφ/dtᵢ)'`) as the default, plus a `method="bootstrap"` cross-check. Validated by coverage simulation: the MLE-only bound under-covers the true reliability in a heavy-extrapolation regime while the analytic bound restores coverage.

### Flaky-test fix
Seeded three `WeibullPH`/`CoxPH` `*_sim` recovery tests that used a bare `default_rng()` (ignoring the module seed fixture) with tight tolerances.

## Testing
Full suite green (one pre-existing flaky sim test, now seeded). flake8/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_