### PR TITLE
Add Stage-1 accelerated degradation testing (ADT) covariates

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,9 +27,10 @@ Two genuine blockers, both process rather than code:
   implementation, the Efron-Hessian fix, delta-method confidence bounds
   (`cb`/`param_cb`/`covariance`) on the parametric regression models, and the
   cause-specific Cox competing-risks CIF fix plus `fit_from_df`, the
-  Buckley-James semi-parametric AFT model, and two-stage degradation
-  confidence bounds (`DegradationModel.cb`)). Write real per-version entries
-  before tagging.
+  Buckley-James semi-parametric AFT model, two-stage degradation
+  confidence bounds (`DegradationModel.cb`), and Stage-1 accelerated
+  degradation testing covariates (`DegradationAnalysis.fit(..., Z=...)`)).
+  Write real per-version entries before tagging.
 - **Add a publish workflow.** `.github/workflows/actions.yml` is CI-only (lint +
   pytest matrix + coverage, `on: [push]`). There is no tag-triggered
   `pypa/gh-action-pypi-publish` step, so releasing to PyPI is fully manual. Add
@@ -205,18 +206,28 @@ Covariates (accelerating stresses such as temperature/voltage/humidity, or
 observational factors such as lot/supplier/load) can enter at two different
 stages, and they are genuinely different features:
 
-**Stage 1 — covariates on the life fit (classic ADT; build first).** Keep the
-per-unit path fits unchanged; each unit carries a constant covariate vector
-`Z_i`. Instead of fitting a plain distribution to the pseudo failure times, feed
-`(pseudo_failure_time_i, c_i, Z_i)` into the *existing* univariate regression
-fitters (AFT / PH / parameter-substitution life-stress models). API sketch:
-`DegradationAnalysis.fit(x, y, i, Z=..., distribution=<regression fitter>)`, with
-`Z` forwarded through the delegated lifetime functions so life at use conditions
-is one call. Censored units flow through since the regression fitters take `c`.
-Mostly plumbing. Theoretical justification: for a linear path with stress acting
-on the rate, `T = (y_t − a)/b(Z)`, so `log T = log(y_t − a) − log b(Z)` — exactly
-an AFT model. Open design point: interaction with `path="best"` (default: select
-on pooled data, since the path stage stays per-unit).
+**Stage 1 — covariates on the life fit (classic ADT).** *Shipped.* The
+per-unit path fits are unchanged; each unit carries a constant covariate vector
+`Z_i`. Passing `Z` to `DegradationAnalysis.fit(x, y, i, Z=..., distribution=...)`
+feeds `(pseudo_failure_time_i, c_i, Z_i)` into the univariate regression fitters
+instead of a plain distribution — a plain `distribution` (e.g. `Weibull`) is
+auto-wrapped in `AFT(distribution)`, while an explicit regression fitter (e.g.
+`AFT(LogNormal)`, `WeibullPH`, `CoxPH`) is used directly. `Z` is aligned to the
+measurement arrays and validated constant within each unit, then reduced to one
+row per unit. The delegated lifetime functions (`sf`/`ff`/`df`/`hf`/`Hf`/`qf`/
+`mean`/`random`) take the stress vector `Z` at which to evaluate life, so life at
+use conditions is one call; `qf`/`mean` come from inverting/integrating the
+regression survival function (the fitters expose no closed `qf`/`mean`), and
+`random` uses inverse-transform sampling. First-stage regression confidence
+bounds are available via `life_model.cb(x, Z, ...)`; the two-stage
+`DegradationModel.cb` / `life_parameter_covariance` raise `NotImplementedError`
+for covariate models (the generated-regressor correction is not yet derived for
+the regression life fit). `fit_from_df` gains `Z_cols`. Theoretical
+justification: for a linear path with stress acting on the rate, `T = (y_t −
+a)/b(Z)`, so `log T = log(y_t − a) − log b(Z)` — exactly an AFT model, and the
+fitted AFT coefficient recovers the simulated stress coefficient. Remaining open
+point: two-stage bounds for the covariate life fit, and interaction with
+`path="best"` (path stage stays per-unit, selected on pooled data).
 
 **Stage 2 — covariates on the path parameters (mechanistic).** Model the
 degradation rate itself: `θ_i = Γ z_i + u_i` (e.g. Arrhenius when a rate is

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -10,10 +10,11 @@ reaches the threshold are treated as right censored at their last
 observed time.
 """
 
+import inspect
 import warnings
 from dataclasses import dataclass, field
 from numbers import Number
-from typing import Any
+from typing import Any, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -22,10 +23,24 @@ import pandas as pd
 
 from surpyval.univariate.parametric import Weibull
 from surpyval.univariate.parametric.parametric import Parametric
+from surpyval.univariate.regression import AFT
+from surpyval.univariate.regression.parametric_regression_model import (
+    ParametricRegressionModel,
+)
 
 from ._bounds import analytic_cb, bootstrap_cb, life_parameter_covariance
 from .path_models import PATH_MODELS, PathModel, get_path_model
 from .population import reml_estimate
+
+
+def _is_regression_fitter(fitter) -> bool:
+    """True if ``fitter.fit`` takes a covariate matrix ``Z`` (i.e. it is one of
+    the regression fitters -- AFT, PH, PO, additive hazards, accelerated
+    life)."""
+    try:
+        return "Z" in inspect.signature(fitter.fit).parameters
+    except (TypeError, ValueError):
+        return False
 
 
 def _clip_psd(matrix: npt.NDArray) -> tuple[npt.NDArray, bool]:
@@ -183,6 +198,9 @@ class DegradationModel:
     path_param_sample_cov: npt.NDArray
     population_method: str
     path_selection: "dict[str, float] | None"
+    #: Per-unit covariates when fitted as an accelerated-degradation model
+    #: (``Z`` given to :meth:`DegradationAnalysis.fit`); ``None`` otherwise.
+    Z: "npt.NDArray | None"
     # Recorded after construction so the bootstrap bounds can rerun the fit.
     _distribution: Any
     _how: str
@@ -205,6 +223,7 @@ class DegradationModel:
         path_param_sample_cov,
         population_method,
         path_selection=None,
+        Z=None,
     ):
         self.x = x
         self.y = y
@@ -222,7 +241,36 @@ class DegradationModel:
         self.path_param_sample_cov = path_param_sample_cov
         self.population_method = population_method
         self.path_selection = path_selection
+        self.Z = Z
         self._unit_index = {unit: idx for idx, unit in enumerate(units)}
+
+    @property
+    def is_accelerated(self) -> bool:
+        """True when the life model is a covariate (ADT) regression model."""
+        return isinstance(self.life_model, ParametricRegressionModel)
+
+    @property
+    def _reg(self) -> ParametricRegressionModel:
+        """The life model viewed as a regression model (accelerated only)."""
+        return cast(ParametricRegressionModel, self.life_model)
+
+    def _predict_Z(self, Z):
+        """Validate the covariate argument for the prediction methods: an
+        accelerated model needs a stress vector ``Z``; a plain model rejects
+        one."""
+        if self.is_accelerated:
+            if Z is None:
+                raise ValueError(
+                    "This is an accelerated-degradation (covariate) model; "
+                    "pass the covariate vector Z (the stress conditions) to "
+                    "predict life."
+                )
+            return Z
+        if Z is not None:
+            raise ValueError(
+                "This degradation model has no covariates; do not pass Z."
+            )
+        return None
 
     def path(self, x: npt.ArrayLike, unit) -> npt.NDArray:
         """Evaluate the fitted degradation path of ``unit`` at ``x``."""
@@ -478,37 +526,149 @@ class DegradationModel:
             )
         return x, y
 
-    def sf(self, x: npt.ArrayLike) -> npt.NDArray:
-        """Survival function of the fitted life model."""
+    def sf(self, x: npt.ArrayLike, Z=None) -> npt.NDArray:
+        """
+        Survival function of the fitted life model.
+
+        For an accelerated-degradation model (fitted with covariates) the
+        stress vector ``Z`` at which to evaluate life is required.
+        """
+        Z = self._predict_Z(Z)
+        if self.is_accelerated:
+            return self._reg.sf(x, Z)
         return self.life_model.sf(x)
 
-    def ff(self, x: npt.ArrayLike) -> npt.NDArray:
-        """CDF of the fitted life model."""
+    def ff(self, x: npt.ArrayLike, Z=None) -> npt.NDArray:
+        """CDF of the fitted life model (pass ``Z`` for accelerated models)."""
+        Z = self._predict_Z(Z)
+        if self.is_accelerated:
+            return self._reg.ff(x, Z)
         return self.life_model.ff(x)
 
-    def df(self, x: npt.ArrayLike) -> npt.NDArray:
-        """Density of the fitted life model."""
+    def df(self, x: npt.ArrayLike, Z=None) -> npt.NDArray:
+        """Density of the fitted life model (``Z`` for accelerated models)."""
+        Z = self._predict_Z(Z)
+        if self.is_accelerated:
+            return self._reg.df(x, Z)
         return self.life_model.df(x)
 
-    def hf(self, x: npt.ArrayLike) -> npt.NDArray:
-        """Hazard rate of the fitted life model."""
+    def hf(self, x: npt.ArrayLike, Z=None) -> npt.NDArray:
+        """Hazard rate of the fitted life model (``Z`` for accelerated)."""
+        Z = self._predict_Z(Z)
+        if self.is_accelerated:
+            return self._reg.hf(x, Z)
         return self.life_model.hf(x)
 
-    def Hf(self, x: npt.ArrayLike) -> npt.NDArray:
-        """Cumulative hazard of the fitted life model."""
+    def Hf(self, x: npt.ArrayLike, Z=None) -> npt.NDArray:
+        """Cumulative hazard of the life model (``Z`` for accelerated)."""
+        Z = self._predict_Z(Z)
+        if self.is_accelerated:
+            return self._reg.Hf(x, Z)
         return self.life_model.Hf(x)
 
-    def qf(self, p: npt.ArrayLike) -> npt.NDArray:
-        """Quantile function of the fitted life model."""
+    def qf(self, p: npt.ArrayLike, Z=None) -> npt.NDArray:
+        """
+        Quantile function of the fitted life model.
+
+        Plain life models expose their own ``qf``; accelerated regression
+        models do not, so the quantile at stress ``Z`` is obtained by
+        numerically inverting the survival function.
+        """
+        Z = self._predict_Z(Z)
+        if self.is_accelerated:
+            return self._reg_qf(p, Z)
         return self.life_model.qf(p)
 
-    def mean(self) -> float:
-        """Mean of the fitted life model."""
+    def mean(self, Z=None) -> float:
+        """
+        Mean of the fitted life model.
+
+        For an accelerated model the mean life at stress ``Z`` is obtained by
+        integrating the survival function (the regression model has no closed
+        ``mean``).
+        """
+        Z = self._predict_Z(Z)
+        if self.is_accelerated:
+            return self._reg_mean(Z)
         return self.life_model.mean()
 
-    def random(self, size: int) -> npt.NDArray:
-        """Random pseudo failure times from the fitted life model."""
+    def random(self, size: int, Z=None, random_state=None) -> npt.NDArray:
+        """
+        Random pseudo failure times from the fitted life model.
+
+        For an accelerated model, ``size`` samples are drawn at stress ``Z`` by
+        inverse-transform sampling of the fitted survival function (the
+        regression models do not all expose ``random`` directly).
+        """
+        Z = self._predict_Z(Z)
+        if self.is_accelerated:
+            rng = np.random.default_rng(random_state)
+            u = rng.uniform(size=size)
+            return self._reg_qf(u, Z)
         return self.life_model.random(size)
+
+    def _reg_qf(self, p: npt.ArrayLike, Z) -> npt.NDArray:
+        """
+        Quantile function of an accelerated life model by bisection.
+
+        Inverts the (monotone decreasing) survival function ``sf(t | Z) = 1 -
+        p`` for each requested probability. Brackets are grown geometrically
+        from the fitted pseudo-failure-time scale until they straddle the
+        target, then bisected.
+        """
+        p_arr = np.atleast_1d(np.asarray(p, dtype=float))
+        if np.any((p_arr < 0) | (p_arr > 1)):
+            raise ValueError("qf probabilities must lie in [0, 1]")
+        scale = float(np.median(self.pseudo_failure_times))
+        if not (np.isfinite(scale) and scale > 0):
+            scale = 1.0
+
+        def target_sf(t):
+            return float(self._reg.sf(np.array([t]), Z).ravel()[0])
+
+        out = np.empty_like(p_arr)
+        for k, pk in enumerate(p_arr):
+            if pk <= 0.0:
+                out[k] = 0.0
+                continue
+            if pk >= 1.0:
+                out[k] = np.inf
+                continue
+            want = 1.0 - pk  # survival at the quantile
+            lo, hi = 0.0, scale
+            # grow the upper bracket until sf(hi) drops below the target
+            for _ in range(200):
+                if target_sf(hi) <= want:
+                    break
+                lo = hi
+                hi *= 2.0
+            else:
+                out[k] = np.inf
+                continue
+            for _ in range(200):
+                mid = 0.5 * (lo + hi)
+                if target_sf(mid) > want:
+                    lo = mid
+                else:
+                    hi = mid
+                if hi - lo <= 1e-10 * max(hi, 1.0):
+                    break
+            out[k] = 0.5 * (lo + hi)
+        return out
+
+    def _reg_mean(self, Z) -> float:
+        """
+        Mean life of an accelerated model at stress ``Z``.
+
+        ``E[T] = \\int_0^\\infty S(t | Z) dt`` by numerical integration over a
+        grid that extends to a high survival quantile.
+        """
+        upper = float(np.ravel(self._reg_qf(0.999, Z))[0])
+        if not np.isfinite(upper):
+            upper = float(np.max(self.pseudo_failure_times)) * 100.0
+        grid = np.linspace(0.0, upper, 4000)
+        sf = np.asarray(self._reg.sf(grid, Z), dtype=float).ravel()
+        return float(np.trapezoid(sf, grid))
 
     def life_parameter_covariance(
         self, method: str = "analytic"
@@ -522,6 +682,13 @@ class DegradationModel:
         the delta-method / generated-regressor correction
         ``H^{-1} + sum_i v_i (dphi/dt_i)(dphi/dt_i)'``.
         """
+        if self.is_accelerated:
+            raise NotImplementedError(
+                "The two-stage life-parameter covariance is not implemented "
+                "for accelerated-degradation (covariate) models; use "
+                "life_model.covariance() for the (first-stage-only) "
+                "regression parameter covariance."
+            )
         return life_parameter_covariance(self, method=method)
 
     def cb(
@@ -567,6 +734,13 @@ class DegradationModel:
         numpy array
             The confidence bound(s) on ``on`` at each ``x``.
         """
+        if self.is_accelerated:
+            raise NotImplementedError(
+                "Two-stage confidence bounds are not implemented for "
+                "accelerated-degradation (covariate) models; call "
+                "life_model.cb(x, Z, on=...) for the (first-stage-only) "
+                "regression confidence bounds at a given stress Z."
+            )
         valid = ("sf", "R", "ff", "F", "Hf")
         if on not in valid:
             raise ValueError("`on` must be one of {}".format(valid))
@@ -623,6 +797,24 @@ class DegradationModel:
         return ax
 
     def __repr__(self):
+        if self.is_accelerated:
+            names = self.life_model.parameter_names()
+            dist_name = self.life_model.distribution.name
+            reg_name = self.life_model.reg_model.name
+            param_string = "\n".join(
+                f"{name:>10}: {p}"
+                for name, p in zip(names, self.life_model.params)
+            )
+            return (
+                "Degradation Analysis SurPyval Model"
+                "\n==================================="
+                f"\nPath Model          : {self.path_model.name}"
+                f"\nThreshold           : {self.threshold}"
+                f"\nNumber of Units     : {len(self.units)}"
+                f"\nCensored Units      : {int((self.c == 1).sum())}"
+                f"\nLife Distribution   : {dist_name} ({reg_name} covariates)"
+                "\nParameters          :\n" + param_string
+            )
         param_string = "\n".join(
             [
                 f"{name:>10}: {p}"
@@ -691,6 +883,7 @@ class DegradationAnalysis_:
         distribution=Weibull,
         how: str = "MLE",
         population_method: str = "moments",
+        Z: npt.ArrayLike | None = None,
     ) -> DegradationModel:
         """
         Fit a degradation analysis model.
@@ -736,6 +929,20 @@ class DegradationAnalysis_:
             quadratic, logarithmic, lloyd-lipow) and requires
             measurement noise (some unit with more measurements than
             path parameters).
+        Z : array like, optional
+            Stress covariates for accelerated degradation testing (ADT).
+            When given, the life model is fitted as a *regression* on the
+            pseudo failure times -- ``log(pseudo failure time) = f(Z) +
+            noise`` -- so that life can be predicted at any stress. ``Z`` is
+            aligned to ``x``/``y``/``i`` (one row per measurement) and must be
+            constant within each unit (a unit is tested at a single stress);
+            it is reduced to one covariate row per unit. If ``distribution``
+            is already a regression fitter (e.g. ``AFT(Weibull)``,
+            ``WeibullPH``, ``CoxPH``) it is used directly; a plain
+            distribution (e.g. ``Weibull``) is wrapped in an accelerated
+            failure time model, ``AFT(distribution)``. The returned model's
+            prediction methods (``sf``, ``ff``, ``qf``, ``random`` ...) then
+            take the stress vector ``Z`` at which to evaluate life.
 
         Returns
         -------
@@ -883,7 +1090,17 @@ class DegradationAnalysis_:
         pseudo_failure_times = np.where(events, pseudo, last_time)
         c = np.where(events, 0, 1)
 
-        life_model = distribution.fit(x=pseudo_failure_times, c=c, how=how)
+        Z_units = None
+        if Z is None:
+            life_model = distribution.fit(x=pseudo_failure_times, c=c, how=how)
+        else:
+            Z_units = self._handle_Z(Z, i_arr, units)
+            reg = (
+                distribution
+                if _is_regression_fitter(distribution)
+                else AFT(distribution)
+            )
+            life_model = reg.fit(x=pseudo_failure_times, Z=Z_units, c=c)
 
         model = DegradationModel(
             x=x_arr,
@@ -902,6 +1119,7 @@ class DegradationAnalysis_:
             path_param_sample_cov=path_param_sample_cov,
             population_method=population_method,
             path_selection=path_selection,
+            Z=Z_units,
         )
         # Recorded so the bootstrap confidence bounds can rerun the pipeline
         # (with the selected path model held fixed) on resampled units.
@@ -977,6 +1195,7 @@ class DegradationAnalysis_:
         x: str = "x",
         y: str = "y",
         i: str = "i",
+        Z_cols: "str | list[str] | None" = None,
         **fit_kwargs,
     ) -> DegradationModel:
         """
@@ -993,6 +1212,10 @@ class DegradationAnalysis_:
             ``"y"``.
         i : str, optional
             Column of the unit identifiers. Defaults to ``"i"``.
+        Z_cols : str or list of str, optional
+            Column(s) of the stress covariates for accelerated degradation
+            testing. When given, the selected columns are passed as ``Z`` to
+            :meth:`fit`, fitting a covariate (ADT) life model.
         **fit_kwargs
             Remaining arguments (``threshold``, ``path``,
             ``distribution``, ``how``) passed to :meth:`fit`.
@@ -1002,9 +1225,51 @@ class DegradationAnalysis_:
         DegradationModel
             The fitted degradation model.
         """
+        if Z_cols is not None:
+            cols = [Z_cols] if isinstance(Z_cols, str) else list(Z_cols)
+            fit_kwargs["Z"] = df[cols].to_numpy()
         return self.fit(
             df[x].to_numpy(), df[y].to_numpy(), df[i].to_numpy(), **fit_kwargs
         )
+
+    @staticmethod
+    def _handle_Z(
+        Z: npt.ArrayLike, i_arr: npt.NDArray, units: npt.NDArray
+    ) -> npt.NDArray:
+        """
+        Reduce a per-measurement covariate array to one row per unit.
+
+        ``Z`` is aligned to the measurement arrays (one row per measurement,
+        like ``x``/``y``/``i``); a unit is tested at a single stress, so ``Z``
+        must be constant within each unit. Returns a ``(n_units, n_cov)`` array
+        aligned to ``units``.
+        """
+        Z_arr = np.asarray(Z, dtype=float)
+        if Z_arr.ndim == 1:
+            Z_arr = Z_arr.reshape(-1, 1)
+        if Z_arr.ndim != 2:
+            raise ValueError("Z must be one or two dimensional")
+        if len(Z_arr) != len(i_arr):
+            raise ValueError(
+                "Z must have one row per measurement (same length as x, y, "
+                "and i); got {} rows for {} measurements".format(
+                    len(Z_arr), len(i_arr)
+                )
+            )
+        if not np.isfinite(Z_arr).all():
+            raise ValueError("Z must contain only finite values")
+
+        Z_units = np.empty((len(units), Z_arr.shape[1]))
+        for idx, unit in enumerate(units):
+            rows = Z_arr[i_arr == unit]
+            if not np.allclose(rows, rows[0]):
+                raise ValueError(
+                    "Z must be constant within each unit (unit {} has "
+                    "varying covariates); a unit is tested at a single "
+                    "stress".format(unit)
+                )
+            Z_units[idx] = rows[0]
+        return Z_units
 
     @staticmethod
     def _handle_xyi(

--- a/surpyval/tests/degradation/test_degradation_analysis.py
+++ b/surpyval/tests/degradation/test_degradation_analysis.py
@@ -6,7 +6,7 @@ import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
 import pytest  # noqa: E402
 
-from surpyval import LogNormal, Weibull  # noqa: E402
+from surpyval import AFT, LogNormal, Weibull, WeibullPH  # noqa: E402
 from surpyval.degradation import (  # noqa: E402
     PATH_MODELS,
     DegradationAnalysis,
@@ -621,3 +621,157 @@ def test_predict_failure_time_validation(x_new, y_new):
 def test_input_validation(kwargs):
     with pytest.raises(ValueError):
         DegradationAnalysis.fit(**kwargs)
+
+
+# -- accelerated degradation testing (ADT) --------------------------------
+
+
+def adt_data(gamma=0.8, b0=0.5, threshold=100.0, intercept=10.0, seed=0):
+    """
+    Linear degradation whose rate accelerates with a stress covariate:
+    ``y = a + b(Z) t`` with ``b(Z) = b0 exp(gamma Z)``. Higher stress means a
+    faster rate, an earlier threshold crossing, and a shorter life -- so the
+    fitted AFT coefficient should recover ``gamma``.
+    """
+    rng = np.random.default_rng(seed)
+    times = np.arange(1, 11) * 5.0
+    xs, ys, ii, ZZ = [], [], [], []
+    uid = 0
+    for Z in [0.0, 0.5, 1.0, 1.5]:
+        for _ in range(12):
+            b = b0 * np.exp(gamma * Z) * np.exp(rng.normal(0, 0.15))
+            a = intercept + rng.normal(0, 1.0)
+            y = a + b * times + rng.normal(0, 0.5, size=times.size)
+            xs.append(times)
+            ys.append(y)
+            ii.append(np.full(times.size, uid))
+            ZZ.append(np.full(times.size, Z))
+            uid += 1
+    return (
+        np.concatenate(xs),
+        np.concatenate(ys),
+        np.concatenate(ii),
+        np.concatenate(ZZ),
+    )
+
+
+def test_adt_recovers_stress_coefficient():
+    x, y, i, Z = adt_data(gamma=0.8)
+    model = DegradationAnalysis.fit(x, y, i, threshold=100.0, Z=Z)
+    assert model.is_accelerated
+    # last fitted parameter is the AFT covariate coefficient; it should be
+    # close to the simulated stress coefficient gamma.
+    assert model.life_model.params[-1] == pytest.approx(0.8, abs=0.2)
+
+
+def test_adt_wraps_plain_distribution_in_aft():
+    x, y, i, Z = adt_data()
+    model = DegradationAnalysis.fit(
+        x, y, i, threshold=100.0, distribution=Weibull, Z=Z
+    )
+    assert model.is_accelerated
+    assert model.life_model.kind == "Accelerated Failure Time"
+
+
+def test_adt_accepts_explicit_regression_fitter():
+    x, y, i, Z = adt_data()
+    m_aft = DegradationAnalysis.fit(
+        x, y, i, threshold=100.0, distribution=AFT(LogNormal), Z=Z
+    )
+    m_ph = DegradationAnalysis.fit(
+        x, y, i, threshold=100.0, distribution=WeibullPH, Z=Z
+    )
+    assert m_aft.is_accelerated
+    assert m_ph.is_accelerated
+    # AFT and PH with a Weibull baseline are equivalent; their predicted mean
+    # life at a stress should agree closely even though the coefficients live
+    # on different scales.
+    m_wb = DegradationAnalysis.fit(x, y, i, threshold=100.0, Z=Z)
+    assert m_ph.mean(Z=[1.0]) == pytest.approx(m_wb.mean(Z=[1.0]), rel=0.05)
+
+
+def test_adt_predictions_require_and_use_Z():
+    x, y, i, Z = adt_data()
+    model = DegradationAnalysis.fit(x, y, i, threshold=100.0, Z=Z)
+    # higher stress => shorter life across every predictor
+    assert model.mean(Z=[0.0]) > model.mean(Z=[1.5])
+    assert model.sf(50.0, Z=[0.0]) > model.sf(50.0, Z=[1.5])
+    assert model.qf(0.5, Z=[0.0]) > model.qf(0.5, Z=[1.5])
+    # qf inverts sf: sf(qf(p)) == 1 - p
+    q = float(np.ravel(model.qf(0.3, Z=[0.5]))[0])
+    assert float(np.ravel(model.sf(q, Z=[0.5]))[0]) == pytest.approx(
+        0.7, abs=1e-3
+    )
+    # random draws match the analytic mean
+    draws = model.random(5000, Z=[1.0], random_state=1)
+    assert len(draws) == 5000
+    assert draws.mean() == pytest.approx(model.mean(Z=[1.0]), rel=0.1)
+
+
+def test_adt_missing_Z_raises():
+    x, y, i, Z = adt_data()
+    model = DegradationAnalysis.fit(x, y, i, threshold=100.0, Z=Z)
+    for call in (
+        lambda: model.sf(50.0),
+        lambda: model.ff(50.0),
+        lambda: model.qf(0.5),
+        lambda: model.mean(),
+        lambda: model.random(3),
+    ):
+        with pytest.raises(ValueError):
+            call()
+
+
+def test_plain_model_rejects_Z():
+    slopes = np.array([0.31, 0.28, 0.44, 0.37])
+    x, y, i = linear_data(slopes)
+    model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    assert not model.is_accelerated
+    with pytest.raises(ValueError):
+        model.sf(300.0, Z=[1.0])
+
+
+def test_adt_two_stage_bounds_not_implemented():
+    x, y, i, Z = adt_data()
+    model = DegradationAnalysis.fit(x, y, i, threshold=100.0, Z=Z)
+    with pytest.raises(NotImplementedError):
+        model.cb(50.0)
+    with pytest.raises(NotImplementedError):
+        model.life_parameter_covariance()
+    # the first-stage regression bounds are still available on the life model
+    band = model.life_model.cb(50.0, [1.0], on="sf")
+    assert band.shape[-1] == 2
+
+
+def test_adt_fit_from_df_with_Z_cols():
+    x, y, i, Z = adt_data()
+    df = pd.DataFrame({"x": x, "y": y, "i": i, "stress": Z})
+    m_df = DegradationAnalysis.fit_from_df(
+        df, threshold=100.0, Z_cols="stress"
+    )
+    m_arr = DegradationAnalysis.fit(x, y, i, threshold=100.0, Z=Z)
+    assert m_df.is_accelerated
+    assert np.allclose(m_df.life_model.params, m_arr.life_model.params)
+
+
+def test_adt_Z_must_be_constant_within_unit():
+    x, y, i, Z = adt_data()
+    Z_bad = Z.copy()
+    Z_bad[0] = 99.0  # perturb one measurement of one unit
+    with pytest.raises(ValueError):
+        DegradationAnalysis.fit(x, y, i, threshold=100.0, Z=Z_bad)
+
+
+def test_adt_Z_length_must_match():
+    x, y, i, Z = adt_data()
+    with pytest.raises(ValueError):
+        DegradationAnalysis.fit(x, y, i, threshold=100.0, Z=Z[:-1])
+
+
+def test_adt_repr():
+    x, y, i, Z = adt_data()
+    model = DegradationAnalysis.fit(x, y, i, threshold=100.0, Z=Z)
+    out = repr(model)
+    assert "Degradation Analysis SurPyval Model" in out
+    assert "covariates" in out
+    assert "beta_0" in out


### PR DESCRIPTION
## Summary

Implements **Stage-1 accelerated degradation testing (ADT) covariates** for the degradation module (DEVELOPMENT.md §7). Passing a per-unit stress covariate `Z` to `DegradationAnalysis.fit` now fits a *regression* life model on the pseudo failure times instead of a plain distribution, so degradation life can be predicted at any stress condition — life at use conditions is one call.

## What changed

- **`fit(x, y, i, threshold, Z=...)`** reduces the per-measurement `Z` (aligned to `x`/`y`/`i`) to one row per unit — validated constant within each unit and finite — then feeds `(pseudo_failure_time_i, c_i, Z_i)` to a regression fitter. A plain distribution (e.g. `Weibull`) is auto-wrapped in `AFT(distribution)`; an explicit regression fitter (`AFT(LogNormal)`, `WeibullPH`, `CoxPH`, …) is used directly (detected via its `fit` signature taking a `Z` parameter).
- **Covariate-aware predictors** — `sf`/`ff`/`df`/`hf`/`Hf`/`qf`/`mean`/`random` take a required stress vector `Z` for accelerated models and reject it for plain ones. Since the regression fitters expose no closed `qf`/`mean`/`random`, `qf` inverts the survival function by bisection, `mean` integrates it, and `random` uses inverse-transform sampling.
- **Bounds guards** — first-stage regression confidence bounds stay available via `life_model.cb(x, Z, ...)`; the two-stage `DegradationModel.cb` and `life_parameter_covariance` raise `NotImplementedError` for covariate models (the generated-regressor correction is not yet derived for the regression life fit).
- **`fit_from_df` gains `Z_cols`**; `__repr__` reports the covariate model.

## Theory / validation

For a linear degradation path with stress acting on the rate, `T = (y_t − a)/b(Z)`, so `log T = log(y_t − a) − log b(Z)` — exactly an AFT model. Tests confirm the fitted AFT coefficient recovers the simulated stress coefficient, that AFT and `WeibullPH` give matching mean-life predictions (on different coefficient scales), and that higher stress yields shorter predicted life across every predictor.

## Tests / checks

- 11 new ADT tests plus the full degradation suite (122 tests) pass.
- flake8, black, and mypy clean.
- `DEVELOPMENT.md` updated to mark Stage 1 shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_