### PR TITLE
Cut 0.12.0: version bump, changelog, and PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish to PyPI
+
+# Publishes a release to PyPI when a version tag (e.g. v0.12.0) is pushed.
+# Authentication uses PyPI Trusted Publishing (OIDC) -- no API token is stored
+# in the repository. The trusted publisher must be configured once on PyPI for
+# the ``surpyval`` project (workflow ``publish.yml``, environment ``pypi``).
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set-up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Check tag matches package version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$TAG" != "$PKG" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match pyproject version $PKG" >&2
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/surpyval
+    permissions:
+      id-token: write  # required for Trusted Publishing (OIDC)
+    steps:
+      - name: Download distribution artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,30 +1,82 @@
 Changelog
 =========
 
-v0.11.0 (planned)
------------------
+v0.12.0 (15 Jul 2026)
+---------------------
+
+A large release consolidating the regression, recurrent-event, competing-risks,
+degradation, and multivariate work accumulated since ``v0.10.1``. Requires
+Python 3.11+ and NumPy 2.
+
+Regression
+~~~~~~~~~~
+
+- Standardised every univariate regression fitter (accelerated failure time,
+  proportional hazards, proportional odds, additive hazards, accelerated life)
+  on a common instance-based ``fit()`` / ``fit_from_df()`` API with pandas and
+  `formulaic <https://matthewwardrop.github.io/formulaic/>`_ formula support.
+- ``CoxPH`` gained the Efron tie handling in addition to Breslow, and its
+  analytic (Efron) information matrix is now correct, so standard errors and
+  p-values are produced for tied data.
+- Added delta-method confidence bounds to the parametric regression models:
+  ``cb()`` on a predicted function at a covariate vector, ``param_cb()`` on a
+  single coefficient, and ``covariance()`` / ``standard_errors()`` /
+  ``parameter_names()`` on the fitted parameters.
+- Added ``BuckleyJames``, a semi-parametric accelerated-failure-time model with
+  an unspecified error distribution (the accelerated-time counterpart of Cox),
+  fitted by the Buckley-James imputation iteration with percentile-bootstrap
+  coefficient intervals.
+- Added a parametric ``AdditiveHazards`` regression fitter.
+
+Competing risks
+~~~~~~~~~~~~~~~~
+
+- Added a competing-risks regression module with a cause-specific Cox model and
+  a Fine-Gray subdistribution-hazard model (``CompetingRisksProportionalHazards``),
+  each with ``fit()`` / ``fit_from_df()`` and cumulative-incidence prediction.
+
+Recurrent events
+~~~~~~~~~~~~~~~~~
 
 - Standardised the recurrent-model API on the same instance-based fitters the
-  univariate distributions use. Every recurrent fitter (``HPP``, ``CrowAMSAA``,
-  ``Duane``, ``CoxLewis``, ``NonParametricCounting``, the renewal fitters
-  ``GeneralizedRenewal``/``GeneralizedOneRenewal``/``ARA``/``ARI`` and the
-  proportional-intensity fitters) is now a configured singleton instance with
-  an instance-method ``fit()`` rather than a class with a ``@classmethod fit``.
-  Public ``Model.fit(...)`` calls are unchanged. Internally this is provided by
-  the new ``surpyval.utils.fitter.singleton_fitter`` decorator. Also removed the
-  unused ``ParametricRecurrenceRegressionModel`` stub.
-- General ALT fitter full release
-- General PH fitter full release
-- Formulas
-- Add more than `Breslow <http://www-personal.umich.edu/~yili/lect4notes.pdf>`_ to the CoxPH methods.
-- Parameter confidence bound
-- Document the rationale behind using Fleming-Harrington as the default.
-- Docs on how to integrate with Pandas
-- Docs for CoxPH
-- Docs for Accelerated Life fitters
-- Create a ``RegressionFitter`` class. I keep copying code across the three fitters.
-- Allow truncation with zi and lfp models.
-- Allow truncation with regression
+  univariate distributions use: ``HPP``, ``CrowAMSAA``, ``Duane``,
+  ``CoxLewis``, ``NonParametricCounting``, the renewal fitters
+  (``GeneralizedRenewal``/``GeneralizedOneRenewal``/``ARA``/``ARI``) and the
+  proportional-intensity fitters are now configured singleton instances with an
+  instance-method ``fit()``. Public ``Model.fit(...)`` calls are unchanged;
+  internally provided by the ``surpyval.utils.fitter.singleton_fitter``
+  decorator. Removed the unused ``ParametricRecurrenceRegressionModel`` stub.
+- Added parameter-uncertainty and diagnostic support to the recurrent models,
+  and removed the ``dist='t'`` heuristic from the recurrent ``mcf_cb``.
+
+Degradation
+~~~~~~~~~~~
+
+- Added the ``surpyval.degradation`` pseudo-failure-time analysis module:
+  per-unit path fits over a library of path models, extrapolation to a failure
+  threshold, and a fitted life distribution, with population path-parameter
+  estimation (Lu-Meeker two-stage and REML) and Bayesian remaining-useful-life
+  prediction (``predict_rul``).
+- Added two-stage (delta-method and bootstrap) confidence bounds on the fitted
+  life model that fold in the first-stage path/extrapolation uncertainty
+  (``DegradationModel.cb`` / ``life_parameter_covariance``).
+- Added Stage-1 accelerated degradation testing (ADT) covariates: passing
+  ``Z`` to ``DegradationAnalysis.fit`` fits a regression life model on the
+  pseudo failure times so life can be predicted at any stress condition.
+
+Multivariate
+~~~~~~~~~~~~~
+
+- Added a ``surpyval.multivariate`` module with copula models over the
+  univariate distributions.
+
+Distributions and core
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Added discrete lifetime distributions.
+- Hardened input validation in the ``handle_xicn`` / ``xcnt_handler`` data
+  handlers, and fixed a reserved-attribute clash.
+- Simulation and ``dist='t'`` cleanups.
 
 v0.10.1.0 (25 Mar 2022)
 -----------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "surpyval"
-version = "0.11.1"
+version = "0.12.0"
 description = "A python package for survival analysis"
 readme = "README.md"
 license = {text = "MIT"}

--- a/surpyval/__init__.py
+++ b/surpyval/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.11.1"
+__version__ = "0.12.0"
 
 from autograd import numpy as np
 


### PR DESCRIPTION
## Summary

Prepares the **0.12.0** release — the release-tooling blockers from DEVELOPMENT.md §1.

- **Version bump** `0.11.1 → 0.12.0` in `pyproject.toml` and `surpyval/__init__.py`.
- **Changelog rewrite** (`docs/changelog.rst`): drops the stale `v0.11.0 (planned)` TODO wishlist and adds a real `v0.12.0` entry covering the work accumulated since `v0.10.1` — the standardized regression fitters + confidence bounds, Efron fix, Buckley-James AFT, additive hazards, the competing-risks regression module (cause-specific Cox + Fine-Gray), the instance-based recurrent API, the degradation module (pseudo-failure-time analysis, two-stage bounds, ADT covariates), copulas, discrete distributions, and `handle_xicn` validation.
- **Publish workflow** (`.github/workflows/publish.yml`): tag-triggered (`v*`) build of sdist+wheel, uploaded to PyPI via **Trusted Publishing (OIDC)** — no API token stored in the repo. Includes a guard that the pushed tag matches the packaged version.

## Verification

- `python -m build` succeeds; `twine check` **passes** both artifacts under current `packaging` (the local Debian-pinned `packaging==24.0` gives a false `license-file` error — confirmed clean in a fresh venv with `packaging 26.2`).
- Version consistent across `pyproject.toml`, `__init__.py`, and the built metadata (Metadata 2.4, `License: MIT`).
- flake8 (CI effective config) / black clean.

## Release prerequisite (manual, one-time)

Trusted Publishing needs a **trusted publisher** configured once on PyPI for the `surpyval` project before the upload step can succeed:

- **Owner:** `derrynknife`
- **Repository:** `surpyval`
- **Workflow filename:** `publish.yml`
- **Environment:** `pypi`

Once that's set, pushing the `v0.12.0` tag triggers the upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_