### PR TITLE
Reject MPP fitting for Beta with a clean error

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,41 +5,27 @@ debt, and improvement priorities. It is forward-looking only: completed work is
 not recorded here (see `docs/changelog.rst` for release history). Items are
 grouped by theme and ordered by priority within each section.
 
-**Package state (2026-07-14).** Version `0.11.1`. The full test suite (994
-tests, 1 documented skip) passes on Python 3.11–3.13 with numpy 2.x / scipy
-1.13+ / pandas 2.2+. The parametric, nonparametric, regression (PH / AFT / PO /
-additive-hazards / accelerated-life), recurrent-event, degradation, copula and
-(experimental) survival-forest modules are all implemented and tested. The
-correctness and release items in §1–§2 are the highest-value next steps.
+**Package state (2026-07-15).** Version `0.12.0` (released to PyPI). The full
+test suite (1078 tests, 1 documented skip) passes on Python 3.11–3.13 with numpy
+2.x / scipy 1.13+ / pandas 2.2+. The parametric, nonparametric, regression (PH /
+AFT / PO / additive-hazards / accelerated-life), recurrent-event, degradation,
+copula and (experimental) survival-forest modules are all implemented and
+tested. With 0.12.0 shipped, the degradation extensions (§7) and correctness
+hardening (§2, §6) are the highest-value next steps.
 
 ---
 
-## 1. Release — cut 0.12.0
+## 1. Release & docs polish
 
-Two genuine blockers, both process rather than code:
+0.12.0 is released to PyPI. The changelog (`docs/changelog.rst`) carries a real
+per-version history, and `.github/workflows/publish.yml` builds the sdist/wheel
+and uploads on a `v*` tag via PyPI Trusted Publishing (OIDC), with a guard that
+the tag matches the packaged version. Remaining polish (non-blocking):
 
-- **Rewrite the changelog.** `docs/changelog.rst` tops out at `v0.11.0
-  (planned)`, whose bullets are a TODO wishlist rather than a record; there is
-  no `0.11.1` entry and nothing for the large body of work since (parametric
-  additive hazards, recurrent parameter-uncertainty + diagnostics, discrete
-  lifetime distributions, `handle_xicn` validation, copula and degradation
-  features, the simulation/`dist='t'` cleanups, the Fine-Gray regression
-  implementation, the Efron-Hessian fix, delta-method confidence bounds
-  (`cb`/`param_cb`/`covariance`) on the parametric regression models, and the
-  cause-specific Cox competing-risks CIF fix plus `fit_from_df`, the
-  Buckley-James semi-parametric AFT model, two-stage degradation
-  confidence bounds (`DegradationModel.cb`), and Stage-1 accelerated
-  degradation testing covariates (`DegradationAnalysis.fit(..., Z=...)`)).
-  Write real per-version entries before tagging.
-- **Add a publish workflow.** `.github/workflows/actions.yml` is CI-only (lint +
-  pytest matrix + coverage, `on: [push]`). There is no tag-triggered
-  `pypa/gh-action-pypi-publish` step, so releasing to PyPI is fully manual. Add
-  a release workflow and tag `v0.12.0`.
-
-Polish (non-blocking): add a `docs` optional-dependency group (docs deps
-currently live only in `docs/requirements.txt`); add API doc pages for the
-newer surfaces (multivariate copulas, degradation RUL, the experimental
-forest).
+- Add a `docs` optional-dependency group (docs deps currently live only in
+  `docs/requirements.txt`).
+- Add API doc pages for the newer surfaces (multivariate copulas, degradation
+  RUL / ADT covariates, the experimental forest).
 
 ---
 
@@ -61,10 +47,6 @@ forest).
   Neither is a common need, so both are deferred. Also: only right-censoring
   and left-truncation (`tl`) are wired; right/interval truncation is missing
   (see §6).
-- **`Beta` MPP guard.** `Beta` does not set `supports_mpp = False`, so
-  `Beta.fit(how="MPP")` passes the support check and hits a raw
-  `NotImplementedError` (`beta.py:404`) instead of the clean `ValueError` other
-  MPP-unsupported distributions raise. One-line consistency fix.
 
 ---
 

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -367,6 +367,16 @@ def test_beta_cannot_be_offset(how):
         Beta.fit(x, offset=True, how=how)
 
 
+def test_beta_rejects_mpp():
+    # Beta has no linearising probability plot (its CDF is the incomplete
+    # beta function and it is not a location-scale family), so MPP fitting
+    # must raise the clean ValueError rather than a raw NotImplementedError.
+    assert Beta.supports_mpp is False
+    x = Beta.random(200, 2.0, 5.0)
+    with pytest.raises(ValueError, match="probability plot"):
+        Beta.fit(x, how="MPP")
+
+
 def test_beta4_recovers_parameters():
     # The four-parameter Beta estimates the support bounds (a, b) along
     # with the two shape parameters.

--- a/surpyval/univariate/parametric/distributions/beta.py
+++ b/surpyval/univariate/parametric/distributions/beta.py
@@ -18,6 +18,13 @@ class Beta_(ParametricFitter):
             param_map={"alpha": 0, "beta": 1},
             plot_x_scale="linear",
         )
+        # The Beta distribution has no linearising probability plot: its CDF
+        # is the regularised incomplete beta function (no closed-form inverse),
+        # and with two interacting shape parameters on bounded support it is
+        # not a location-scale family, so there is no parameter-free transform
+        # that turns the probability plot into a straight line. Fit by MLE, MSE
+        # or MOM instead (MOM is analytic for the Beta).
+        self.supports_mpp = False
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         if (c is not None) and (c == 0).all():

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -338,7 +338,8 @@ class ParametricFitter:
         if how == "MPP" and not self.supports_mpp:
             detail = (
                 f"{self.name} distribution does not work"
-                " with probability plot fitting"
+                " with probability plot fitting; use how='MLE', 'MSE' or"
+                " 'MOM' instead"
             )
             raise ValueError(detail)
 


### PR DESCRIPTION
## Summary

`Beta.fit(how="MPP")` hit a raw `NotImplementedError` deep in `beta.py` instead of the clean `ValueError` other MPP-unsupported distributions raise. This resolves the §2 correctness item.

**Why MPP is genuinely impossible for Beta** (not just unimplemented): MPP/probability-plotting works only when a *parameter-free* transform linearises the CDF (e.g. Weibull's `log(-log(1-F))`). Beta's `mpp_y_transform` is literally `qf(y, alpha, beta)` — it needs the parameters being estimated. Its CDF is the regularised incomplete beta function (no closed-form inverse), and with two interacting shape parameters on bounded support it isn't a location-scale family, so no linearising transform exists.

## Changes

- Set `supports_mpp = False` on `Beta` (matching `Beta4` and the discrete distributions) so the method is rejected up front with the clean `ValueError`.
- Extend the guard message in `parametric_fitter.py` to name the working alternatives — `MLE` / `MSE` / `MOM`. `MSE` fits the parametric CDF to the empirical CDF and needs no linearisation, so it's the natural probability-plot-flavoured estimator for Beta; `MOM` is analytic.
- Add a regression test (`test_beta_rejects_mpp`).
- Refresh `DEVELOPMENT.md`: the release section now reflects the shipped 0.12.0, and the resolved Beta MPP item is removed.

## Verification

Confirmed `Beta.fit` still works via `MLE` / `MSE` / `MOM`, and `how="MPP"` now raises the clean, alternative-naming `ValueError`. flake8 / black / mypy clean; the parametric-fit and discrete suites pass (206 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_