### PR TITLE
Add time-varying-covariate (start-stop) Cox proportional hazards

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -144,15 +144,24 @@ minimisation fallback so staggered-risk-set data converges). Right/interval
 truncation for Cox is rejected with a clear error (a 2-D `tl`), since the
 forward partial likelihood cannot express it. The outstanding work is:
 
-- **Time-varying covariates via start-stop format** `(t_start, t_stop, event,
-  Z)` — each interval is a left-truncated observation. The delayed-entry
-  machinery this needs is now verified (episode-splitting invariance holds), so
-  this is buildable; what remains is the ergonomic start-stop input handling and
-  per-interval covariates. Difficulty varies by family:
+- **Time-varying covariates for Cox — done.** `CoxPH.fit_tvc` /
+  `fit_tvc_from_df` take counting-process (start-stop) data `(ident, start,
+  stop, event, Z)`, one row per interval on which the covariates are constant.
+  `handle_tvc` validates the structure (non-overlapping intervals, at most one
+  terminal event on a subject's last interval) and maps each interval to a
+  delayed-entry observation `(x = stop, tl = start, c = 1 − event)`, which the
+  partial likelihood fits exactly. The Breslow baseline was fixed to respect
+  `tl` (and to weight by `n`), so `H0` is now correct for delayed-entry /
+  start-stop data. `SemiParametricRegressionModel.predict_tvc` gives the
+  survival of a subject along a supplied covariate path,
+  `H(t) = Σ_{u_j ≤ t} h0(u_j) exp(β'Z(u_j))`, reducing to `sf(t, Z)` for a
+  constant covariate.
+- **Time-varying covariates for the parametric families — future work.** Each
+  interval is a left-truncated observation; difficulty varies by family:
   - Additive hazards (Lin-Ying): easiest — `H(t) = H₀(t) + β'·∫Z(s)ds`
     accumulates linearly; interval contributions are just `β'·Z·Δt`.
-  - Cox PH and parametric PH: medium — cumulative hazard is additive over
-    intervals, so segments compose cleanly.
+  - Parametric PH: medium — cumulative hazard is additive over intervals, so
+    segments compose cleanly (as in the Cox case above).
   - Parametric AFT: harder — must track cumulative "accelerated age"
     `φ(Z₁)·t₁ + φ(Z₂)·(t₂−t₁) + …` across prior intervals.
   - Parametric PO: not practical — no additive structure; needs numerical

--- a/docs/Regression Modelling with SurPyval.rst
+++ b/docs/Regression Modelling with SurPyval.rst
@@ -204,6 +204,80 @@ The step-function shape is the signature of the non-parametric baseline —
 the model makes no smoothness assumptions about :math:`h_0(x)`.
 
 
+Time-Varying Covariates
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes a covariate changes *during* a subject's follow-up — a dose is
+increased, a treatment begins, a machine is moved to a harsher environment.
+Cox handles this through the **counting-process (start-stop) format**: each
+subject contributes one row per interval :math:`(\text{start}, \text{stop}]`
+on which its covariates are constant, and ``event`` is 1 only on the interval
+that ends at the subject's failure. Because each interval is exactly a
+delayed-entry (left-truncated) observation, the partial likelihood fits this
+format directly — splitting a subject into intervals with the same covariates
+leaves the fit unchanged.
+
+Use :meth:`CoxPH.fit_tvc` (arrays) or :meth:`CoxPH.fit_tvc_from_df` (a
+start-stop ``DataFrame``). In the example below a covariate ``stress`` switches
+from 0 to 1 at a random time for each unit and genuinely raises the hazard once
+it turns on; units that fail before the switch contribute a single interval,
+those that survive it contribute two:
+
+.. jupyter-execute::
+
+    import pandas as pd
+    from surpyval import CoxPH
+
+    rng = np.random.default_rng(0)
+    n, lam, beta = 2000, 0.5, 1.0
+    switch = rng.uniform(0.3, 1.5, size=n)
+    t_low = rng.exponential(1 / lam, size=n)
+    t_high = switch + rng.exponential(1 / (lam * np.exp(beta)), size=n)
+    T = np.where(t_low > switch, t_high, t_low)
+
+    rows = []
+    for i in range(n):
+        if T[i] <= switch[i]:                    # failed before the switch
+            rows.append((i, 0.0, T[i], 1, 0.0))
+        else:                                    # survived it: two intervals
+            rows.append((i, 0.0, switch[i], 0, 0.0))
+            rows.append((i, switch[i], T[i], 1, 1.0))
+    df = pd.DataFrame(rows, columns=['id', 'start', 'stop', 'event', 'stress'])
+
+    model = CoxPH.fit_tvc_from_df(
+        df, id_col='id', start_col='start', stop_col='stop',
+        event_col='event', Z_cols='stress',
+    )
+    model
+
+The fitted coefficient recovers the simulated log-hazard-ratio of the stress
+(:math:`\beta \approx 1`) — a plain Cox fit that ignored the timing of the
+switch could not.
+
+Because survival now depends on the *whole* covariate path, evaluate it with
+:meth:`~surpyval.univariate.regression.semi_parametric_regression_model.SemiParametricRegressionModel.predict_tvc`,
+passing a subject's intervals. It returns the times, survival and cumulative
+hazard along that path; with a single constant interval it reduces exactly to
+``sf``. Here a unit stressed from ``t = 1`` onward has visibly lower survival
+than one never stressed:
+
+.. jupyter-execute::
+
+    t_never, s_never, _ = model.predict_tvc(start=[0.0], stop=[3.0], Z=[[0.0]])
+    t_late, s_late, _ = model.predict_tvc(
+        start=[0.0, 1.0], stop=[1.0, 3.0], Z=[[0.0], [1.0]]
+    )
+    plt.step(t_never, s_never, where='post', label='never stressed')
+    plt.step(t_late, s_late, where='post', label='stressed after t=1')
+    plt.legend()
+    plt.xlabel('Time')
+    plt.ylabel('S(t)')
+
+Only left-truncation / delayed entry is available for Cox (supply a 1-D ``tl``
+to :meth:`CoxPH.fit`); right or interval truncation is rejected, because the
+forward partial likelihood cannot express it.
+
+
 Semi-Parametric — Additive Hazards
 ----------------------------------
 

--- a/docs/regression/cox_ph.rst
+++ b/docs/regression/cox_ph.rst
@@ -1,3 +1,20 @@
+Cox Proportional Hazards
+========================
+
+Fitter
+------
+
 .. autoclass:: surpyval.univariate.regression.proportional_hazards.cox_ph.CoxPH_
    :members:
    :inherited-members:
+
+Fitted model
+------------
+
+The object returned by :meth:`CoxPH.fit` / :meth:`CoxPH.fit_tvc`. It exposes
+the usual survival functions at a covariate vector (``sf``, ``ff``, ``df``,
+``hf``, ``Hf``) and, for models fitted from time-varying-covariate (start-stop)
+data, ``predict_tvc`` for the survival of a subject along a covariate path.
+
+.. autoclass:: surpyval.univariate.regression.semi_parametric_regression_model.SemiParametricRegressionModel
+   :members:

--- a/surpyval/tests/univariate/regression/test_tvc.py
+++ b/surpyval/tests/univariate/regression/test_tvc.py
@@ -1,0 +1,221 @@
+"""
+Tests for time-varying-covariate (start-stop) Cox proportional hazards:
+``CoxPH.fit_tvc`` / ``fit_tvc_from_df``, the ``handle_tvc`` validation, the
+delayed-entry baseline, and ``predict_tvc``.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from surpyval import CoxPH
+from surpyval.univariate.regression.proportional_hazards.tvc import handle_tvc
+
+
+@pytest.fixture(autouse=True)
+def _seed():
+    np.random.seed(0)
+
+
+def _split_dataset(seed=1, n=400):
+    """Constant-covariate data, plus a start-stop split of each subject at an
+    interior time. The split must give the identical fit."""
+    rng = np.random.default_rng(seed)
+    Z = rng.normal(size=(n, 1))
+    T = rng.exponential(1 / np.exp(Z[:, 0] * 0.7))
+    s = T * rng.uniform(0.3, 0.7, size=n)
+
+    ident = np.repeat(np.arange(n), 2)
+    start = np.empty(2 * n)
+    stop = np.empty(2 * n)
+    event = np.zeros(2 * n, dtype=int)
+    Ztvc = np.empty((2 * n, 1))
+    start[0::2], stop[0::2], event[0::2], Ztvc[0::2] = 0.0, s, 0, Z
+    start[1::2], stop[1::2], event[1::2], Ztvc[1::2] = s, T, 1, Z
+    return (ident, start, stop, event, Ztvc), (Z, T)
+
+
+def test_fit_tvc_matches_episode_split_beta_and_baseline():
+    (ident, start, stop, event, Ztvc), (Z, T) = _split_dataset()
+    tvc = CoxPH.fit_tvc(ident, start, stop, event, Ztvc)
+    c0 = np.zeros(T.size, dtype=int)
+    ref = CoxPH.fit(x=T, Z=Z, c=c0, tl=np.zeros(T.size))
+
+    assert tvc.is_tvc
+    # Splitting a subject with a constant covariate is an exact identity of
+    # both the partial likelihood and the (delayed-entry) baseline hazard.
+    assert np.isclose(tvc.beta[0], ref.beta[0], atol=1e-4)
+    tq = np.quantile(T, [0.25, 0.5, 0.75])
+    assert np.allclose(
+        np.interp(tq, tvc.x, tvc.H0),
+        np.interp(tq, ref.x, ref.H0),
+        atol=1e-3,
+    )
+
+
+def test_fit_tvc_recovers_time_varying_effect():
+    # Genuine time-varying covariate: 0 until a per-subject switch time, then
+    # 1. The event time is simulated under the corresponding time-varying
+    # hazard, and fit_tvc must recover the coefficient.
+    rng = np.random.default_rng(2)
+    n, lam, beta = 8000, 0.5, 1.2
+    tau = rng.uniform(0.3, 1.5, size=n)
+    t1 = rng.exponential(1 / lam, size=n)
+    t2 = tau + rng.exponential(1 / (lam * np.exp(beta)), size=n)
+    T = np.where(t1 > tau, t2, t1)
+
+    ids, s0, s1, ev, z = [], [], [], [], []
+    for i in range(n):
+        if T[i] <= tau[i]:
+            ids += [i]
+            s0 += [0.0]
+            s1 += [T[i]]
+            ev += [1]
+            z += [0.0]
+        else:
+            ids += [i, i]
+            s0 += [0.0, tau[i]]
+            s1 += [tau[i], T[i]]
+            ev += [0, 1]
+            z += [0.0, 1.0]
+    model = CoxPH.fit_tvc(
+        np.array(ids),
+        np.array(s0),
+        np.array(s1),
+        np.array(ev),
+        np.array(z).reshape(-1, 1),
+    )
+    assert abs(model.beta[0] - beta) < 0.15
+
+
+def test_fit_tvc_from_df_matches_arrays():
+    (ident, start, stop, event, Ztvc), _ = _split_dataset()
+    arrays = CoxPH.fit_tvc(ident, start, stop, event, Ztvc)
+    df = pd.DataFrame(
+        {
+            "id": ident,
+            "t0": start,
+            "t1": stop,
+            "ev": event,
+            "z": Ztvc[:, 0],
+        }
+    )
+    from_df = CoxPH.fit_tvc_from_df(
+        df,
+        id_col="id",
+        start_col="t0",
+        stop_col="t1",
+        event_col="ev",
+        Z_cols="z",
+    )
+    assert np.isclose(arrays.beta[0], from_df.beta[0])
+    assert from_df.feature_names == ["z"]
+
+
+def test_predict_tvc_constant_reduces_to_sf():
+    (ident, start, stop, event, Ztvc), _ = _split_dataset()
+    model = CoxPH.fit_tvc(ident, start, stop, event, Ztvc)
+    z = np.array([0.5])
+    t = np.array([0.3, 0.7, 1.2])
+    # a single constant interval spanning the times must equal sf(t, Z)
+    _, sf_tvc, Hf_tvc = model.predict_tvc([0.0], [10.0], [z], times=t)
+    assert np.allclose(sf_tvc, model.sf(t, z))
+    assert np.allclose(Hf_tvc, model.Hf(t, z))
+
+
+def test_predict_tvc_changing_covariate_is_monotone_and_responds():
+    (ident, start, stop, event, Ztvc), _ = _split_dataset()
+    model = CoxPH.fit_tvc(ident, start, stop, event, Ztvc)
+
+    times, sf, _ = model.predict_tvc(
+        start=[0.0, 0.5], stop=[0.5, 5.0], Z=[[-1.0], [1.5]]
+    )
+    # survival is a proper (non-increasing) curve
+    assert np.all(np.diff(sf) <= 1e-12)
+    assert np.all((sf >= 0) & (sf <= 1))
+    # switching to a higher-hazard covariate late must leave survival below
+    # the all-low-covariate path at the final time
+    _, sf_low, _ = model.predict_tvc(
+        start=[0.0], stop=[5.0], Z=[[-1.0]], times=times[-1:]
+    )
+    assert sf[-1] < sf_low[-1]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        # overlapping intervals
+        dict(
+            ident=[1, 1],
+            start=[0, 1],
+            stop=[3, 4],
+            event=[0, 1],
+            Z=[[0.1], [0.2]],
+        ),
+        # more than one event
+        dict(
+            ident=[1, 1],
+            start=[0, 2],
+            stop=[2, 4],
+            event=[1, 1],
+            Z=[[0.1], [0.2]],
+        ),
+        # event on a non-final interval
+        dict(
+            ident=[1, 1],
+            start=[0, 2],
+            stop=[2, 4],
+            event=[1, 0],
+            Z=[[0.1], [0.2]],
+        ),
+        # start >= stop
+        dict(
+            ident=[1, 1],
+            start=[0, 4],
+            stop=[2, 4],
+            event=[0, 1],
+            Z=[[0.1], [0.2]],
+        ),
+        # length mismatch
+        dict(
+            ident=[1, 1],
+            start=[0, 2],
+            stop=[2, 4],
+            event=[0],
+            Z=[[0.1], [0.2]],
+        ),
+        # bad event value
+        dict(
+            ident=[1],
+            start=[0],
+            stop=[2],
+            event=[2],
+            Z=[[0.1]],
+        ),
+    ],
+)
+def test_handle_tvc_validation(kwargs):
+    with pytest.raises(ValueError):
+        handle_tvc(**kwargs)
+
+
+def test_handle_tvc_maps_columns():
+    x, c, n, tl, Z, ident = handle_tvc(
+        ident=[1, 1, 2],
+        start=[0, 2, 0],
+        stop=[2, 4, 3],
+        event=[0, 1, 0],
+        Z=[[0.1], [0.2], [0.3]],
+    )
+    assert np.array_equal(x, [2.0, 4.0, 3.0])
+    assert np.array_equal(c, [1, 0, 1])  # event -> c=0, else c=1
+    assert np.array_equal(tl, [0.0, 2.0, 0.0])
+
+
+def test_predict_tvc_input_validation():
+    (ident, start, stop, event, Ztvc), _ = _split_dataset()
+    model = CoxPH.fit_tvc(ident, start, stop, event, Ztvc)
+    with pytest.raises(ValueError):
+        model.predict_tvc(start=[0.0, 1.0], stop=[1.0], Z=[[0.1], [0.2]])
+    with pytest.raises(ValueError):
+        model.predict_tvc(start=[2.0], stop=[1.0], Z=[[0.1]])

--- a/surpyval/univariate/regression/proportional_hazards/cox_ph.py
+++ b/surpyval/univariate/regression/proportional_hazards/cox_ph.py
@@ -28,6 +28,7 @@ from surpyval.univariate.nonparametric import (
 
 from surpyval.utils import validate_coxph, validate_coxph_df_inputs
 from ..semi_parametric_regression_model import SemiParametricRegressionModel
+from .tvc import handle_tvc
 
 nonparametric_dists = {
     "Nelson-Aalen": NelsonAalen,
@@ -145,23 +146,29 @@ class CoxPH_:
     # http://www-personal.umich.edu/~yili/lect4notes.pdf
 
     def baseline(
-        self, beta, x, c, n, Z
+        self, beta, x, c, n, Z, tl=None
     ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
-        # Uses the Breslow method to compute the baseline hazard.
+        # Breslow baseline hazard. The risk set at each event time ``tau_i``
+        # is every observation that has entered (``tl < tau_i``; delayed
+        # entry / start-stop) and has not yet exited (``x >= tau_i``), each
+        # weighted by its count ``n`` and hazard multiplier ``exp(Z'beta)``.
+        # Respecting ``tl`` is what makes the baseline correct for
+        # left-truncated and time-varying-covariate (start-stop) data.
 
         unique_x = np.unique(x)
+        if tl is None:
+            tl = np.full(x.shape[0], -np.inf)
 
         d = np.zeros_like(unique_x)
         r = np.zeros_like(unique_x)
+        e_beta_z = np.exp(Z @ beta)
 
         for i, tau_i in enumerate(unique_x):
             mask_d_i = (x == tau_i) & (c == 0)
             d[i] = n[mask_d_i].sum()
 
-            mask_at_risk_i = x >= tau_i
-            Z_ri = Z[mask_at_risk_i, :]
-
-            r[i] = np.exp(Z_ri @ beta).sum()
+            mask_at_risk_i = (tl < tau_i) & (x >= tau_i)
+            r[i] = (n[mask_at_risk_i] * e_beta_z[mask_at_risk_i]).sum()
 
         return unique_x, r, d
 
@@ -510,7 +517,7 @@ class CoxPH_:
         model.phi = lambda Z: np.exp(Z @ model.beta)
         model.params = res.x
 
-        x, r, d = self.baseline(model.beta, x, c, n, Z)
+        x, r, d = self.baseline(model.beta, x, c, n, Z, tl)
         model.x = x
         model.r = r
         model.d = d
@@ -567,6 +574,84 @@ class CoxPH_:
         model.feature_names = feature_names
         model._model_spec = model_spec
 
+        return model
+
+    def fit_tvc(
+        self,
+        ident: npt.ArrayLike,
+        start: npt.ArrayLike,
+        stop: npt.ArrayLike,
+        event: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        n: npt.ArrayLike | None = None,
+        method: str = "efron",
+        tol: float = 1e-10,
+    ) -> SemiParametricRegressionModel:
+        """
+        Fit a Cox model with time-varying covariates in start-stop format.
+
+        Each row is one interval ``(start, stop]`` of a subject (identified by
+        ``ident``) on which the covariate row ``Z`` is constant; ``event`` is 1
+        only on the interval that ends at the subject's event. The rows are
+        validated (see :func:`~surpyval.univariate.regression.
+        proportional_hazards.tvc.handle_tvc`) and fitted as delayed-entry
+        observations -- exact for the Cox partial likelihood.
+
+        Parameters
+        ----------
+        ident, start, stop, event, Z : array_like
+            The start-stop interval data (subject id, entry time, exit time,
+            terminal-event flag, and per-interval covariates).
+        n : array_like, optional
+            Count weight per interval row.
+        method : {'efron', 'breslow'}, optional
+            Tie-handling method. Default ``'efron'``.
+        tol : float, optional
+            Optimiser tolerance.
+
+        Returns
+        -------
+        SemiParametricRegressionModel
+            The fitted model, with ``is_tvc`` set and TVC-aware prediction
+            available through :meth:`~surpyval.univariate.regression.
+            semi_parametric_regression_model.SemiParametricRegressionModel.
+            predict_tvc`.
+        """
+        x, c, n_arr, tl, Z_arr, _ = handle_tvc(ident, start, stop, event, Z, n)
+        model = self.fit(
+            x=x, Z=Z_arr, c=c, n=n_arr, tl=tl, method=method, tol=tol
+        )
+        model.is_tvc = True
+        return model
+
+    def fit_tvc_from_df(
+        self,
+        df: "pd.DataFrame",
+        id_col: str,
+        start_col: str,
+        stop_col: str,
+        event_col: str,
+        Z_cols: str | list[str],
+        n_col: str | None = None,
+        method: str = "efron",
+    ) -> SemiParametricRegressionModel:
+        """
+        Fit a time-varying-covariate Cox model from a start-stop DataFrame.
+
+        See :meth:`fit_tvc`; ``Z_cols`` names the covariate column(s) and the
+        remaining arguments name the id / start / stop / event columns.
+        """
+        cols = [Z_cols] if isinstance(Z_cols, str) else list(Z_cols)
+        model = self.fit_tvc(
+            ident=df[id_col].to_numpy(),
+            start=df[start_col].to_numpy(),
+            stop=df[stop_col].to_numpy(),
+            event=df[event_col].to_numpy(),
+            Z=df[cols].to_numpy(),
+            n=None if n_col is None else df[n_col].to_numpy(),
+            method=method,
+        )
+        model.feature_names = cols
         return model
 
 

--- a/surpyval/univariate/regression/proportional_hazards/tvc.py
+++ b/surpyval/univariate/regression/proportional_hazards/tvc.py
@@ -1,0 +1,137 @@
+"""
+Time-varying-covariate (start-stop) data handling for Cox proportional
+hazards.
+
+Time-varying covariates are represented in the *counting-process* (start-stop)
+long format: each subject contributes one row per interval ``(start, stop]`` on
+which its covariate vector is constant, and only the interval that ends at the
+subject's event carries ``event = 1``. Because each interval is exactly a
+left-truncated (delayed-entry) observation entering at ``start`` and leaving
+at ``stop``, the Cox partial likelihood fits this format directly once it is
+mapped to ``x = stop``, ``tl = start`` and ``c = 1 - event`` -- the
+episode-splitting identity guarantees a subject split into contiguous
+intervals with the same covariates gives the same fit as the unsplit subject.
+
+``handle_tvc`` validates the start-stop structure and performs that mapping.
+"""
+
+import numpy as np
+
+
+def handle_tvc(ident, start, stop, event, Z, n=None):
+    """
+    Validate start-stop time-varying-covariate data and map it to the arrays
+    the Cox partial likelihood fits.
+
+    Parameters
+    ----------
+    ident : array_like
+        Subject identifier for each interval row. Rows sharing an identifier
+        are the successive observation intervals of one subject.
+    start, stop : array_like
+        The open-closed interval ``(start, stop]`` each row is observed over.
+        ``start`` is the delayed-entry (left-truncation) time.
+    event : array_like
+        1 if the subject's terminal event occurs at ``stop`` on this interval,
+        0 otherwise (interval end is an administrative censoring / covariate
+        change). A subject has at most one ``event = 1`` row, and it must be
+        its last interval.
+    Z : array_like
+        Covariate matrix, one row per interval, constant on that interval.
+    n : array_like, optional
+        Count weight per row. Defaults to 1.
+
+    Returns
+    -------
+    x, c, n, tl, Z, ident : ndarray
+        ``x = stop``, ``c = 1 - event`` (0 event, 1 right-censored),
+        ``tl = start``, and the (sorted-within-subject) covariate rows and
+        identifiers, ready for ``CoxPH.fit(x=x, Z=Z, c=c, n=n, tl=tl)``.
+    """
+    ident = np.asarray(ident)
+    start = np.asarray(start, dtype=float)
+    stop = np.asarray(stop, dtype=float)
+    event = np.asarray(event)
+    Z = np.asarray(Z, dtype=float)
+    if Z.ndim == 1:
+        Z = Z.reshape(-1, 1)
+    n = np.ones(ident.shape[0]) if n is None else np.asarray(n, dtype=float)
+
+    nrow = ident.shape[0]
+    for name, arr in (
+        ("start", start),
+        ("stop", stop),
+        ("event", event),
+        ("n", n),
+    ):
+        if arr.shape[0] != nrow:
+            raise ValueError(
+                "ident, start, stop, event, Z and n must have the same "
+                "length; {} has {} rows, expected {}".format(
+                    name, arr.shape[0], nrow
+                )
+            )
+    if Z.shape[0] != nrow:
+        raise ValueError(
+            "Z must have one row per interval (same length as ident); got "
+            "{} rows, expected {}".format(Z.shape[0], nrow)
+        )
+    if nrow == 0:
+        raise ValueError("no interval rows were supplied")
+    if not (np.isfinite(start).all() and np.isfinite(stop).all()):
+        raise ValueError("start and stop must be finite")
+    if np.any(start >= stop):
+        raise ValueError(
+            "every interval must have start < stop (an interval covers the "
+            "open-closed window (start, stop])"
+        )
+    if not np.isin(event, [0, 1]).all():
+        raise ValueError("event must be 0 or 1")
+    if not np.isfinite(Z).all():
+        raise ValueError("Z must contain only finite values")
+
+    # Reassemble in subject-contiguous, start-sorted order so the returned
+    # arrays are tidy and the per-subject checks are simple.
+    order = np.lexsort((start, ident))
+    ident, start, stop, event, n = (
+        ident[order],
+        start[order],
+        stop[order],
+        event[order],
+        n[order],
+    )
+    Z = Z[order]
+
+    uniq, first, counts = np.unique(
+        ident, return_index=True, return_counts=True
+    )
+    for u, f, cnt in zip(uniq, first, counts):
+        s_start = start[f : f + cnt]
+        s_stop = stop[f : f + cnt]
+        s_event = event[f : f + cnt]
+        # Non-overlapping: each interval must start at or after the previous
+        # interval's stop (touching intervals are contiguous, which is the
+        # usual case; a gap is allowed -- the subject is simply not at risk in
+        # the gap).
+        if cnt > 1 and np.any(s_start[1:] < s_stop[:-1] - 1e-12):
+            raise ValueError(
+                "subject {!r} has overlapping intervals; start-stop rows for "
+                "a subject must not overlap".format(u)
+            )
+        n_events = int((s_event == 1).sum())
+        if n_events > 1:
+            raise ValueError(
+                "subject {!r} has more than one event=1 interval; a subject "
+                "may experience at most one terminal event".format(u)
+            )
+        if n_events == 1 and s_event[-1] != 1:
+            raise ValueError(
+                "subject {!r} has event=1 on a non-final interval; the event "
+                "must terminate observation (it can only fall on the interval "
+                "with the largest stop time)".format(u)
+            )
+
+    x = stop
+    c = np.where(event == 1, 0, 1).astype(int)
+    tl = start
+    return x, c, n, tl, Z, ident

--- a/surpyval/univariate/regression/semi_parametric_regression_model.py
+++ b/surpyval/univariate/regression/semi_parametric_regression_model.py
@@ -17,6 +17,9 @@ class SemiParametricRegressionModel:
     feature_names: list[str] | None = None
     formula: str | None = None
     _model_spec: Any = None
+    #: True when fitted from time-varying-covariate (start-stop) data via
+    #: ``CoxPH.fit_tvc``; enables :meth:`predict_tvc`.
+    is_tvc: bool = False
 
     # Attributes populated by the fitter (``CoxPH.fit`` / ``fit_from_df``).
     params: npt.NDArray
@@ -90,3 +93,78 @@ class SemiParametricRegressionModel:
         self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"
     ) -> npt.NDArray:
         return self.hf(x, Z) * self.sf(x, Z)
+
+    def predict_tvc(
+        self,
+        start: npt.ArrayLike,
+        stop: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        times: "npt.ArrayLike | None" = None,
+    ) -> "tuple[npt.NDArray, npt.NDArray, npt.NDArray]":
+        r"""
+        Survival for a subject whose covariates vary over time.
+
+        With a time-varying covariate the survival function depends on the
+        whole covariate path, not a single vector:
+
+        .. math::
+            H(t \mid Z(\cdot)) = \int_0^t e^{\beta' Z(u)}\, dH_0(u)
+            = \sum_{u_j \le t} h_0(u_j)\, e^{\beta' Z(u_j)},
+
+        summing the fitted baseline-hazard jumps ``h0`` weighted by the hazard
+        multiplier of the covariate value *active* at each jump time. With a
+        single constant interval this reduces exactly to ``sf(t, Z)``.
+
+        Parameters
+        ----------
+        start, stop : array_like
+            The subject's covariate-path intervals ``(start, stop]``, one per
+            row (as given to :meth:`~...CoxPH.fit_tvc`). Usually contiguous
+            from ``0``.
+        Z : array_like
+            The covariate row active on each interval, one row per interval.
+        times : array_like, optional
+            Times at which to return survival. Defaults to the fitted baseline
+            jump times that fall within the covariate path.
+
+        Returns
+        -------
+        times, sf, Hf : ndarray
+            The evaluation times and the survival and cumulative-hazard values
+            of the subject along its covariate path. Outside the supplied path
+            the nearest interval's covariate is held constant.
+        """
+        start_a = np.atleast_1d(np.asarray(start, dtype=float))
+        stop_a = np.atleast_1d(np.asarray(stop, dtype=float))
+        Z_a = np.asarray(Z, dtype=float)
+        if Z_a.ndim == 1:
+            Z_a = Z_a.reshape(-1, 1)
+        if not (start_a.shape[0] == stop_a.shape[0] == Z_a.shape[0]):
+            raise ValueError(
+                "start, stop and Z must have the same number of rows"
+            )
+        if np.any(start_a >= stop_a):
+            raise ValueError("every interval must have start < stop")
+
+        order = np.argsort(start_a)
+        start_a, stop_a, Z_a = start_a[order], stop_a[order], Z_a[order]
+
+        # The active interval at a baseline jump time u is the last interval
+        # whose start is at or before u; times outside the path are clamped to
+        # the first/last interval (covariate held constant).
+        base_t = self.x
+        active = np.searchsorted(start_a, base_t, side="right") - 1
+        active = np.clip(active, 0, start_a.shape[0] - 1)
+        phi = np.exp(Z_a[active] @ self.beta)
+        H_cum = np.cumsum(self.h0 * phi)
+
+        if times is None:
+            within = (base_t > start_a[0]) & (base_t <= stop_a[-1])
+            query = base_t[within]
+        else:
+            query = np.atleast_1d(np.asarray(times, dtype=float))
+
+        idx = np.searchsorted(base_t, query, side="right") - 1
+        last = H_cum.shape[0] - 1
+        Hf = np.where(idx >= 0, H_cum[np.clip(idx, 0, last)], 0.0)
+        return query, np.exp(-Hf), Hf


### PR DESCRIPTION
## Summary

A full time-varying-covariate (TVC) handler for Cox PH, built on the delayed-entry machinery verified in #126. Covers the §6 "time-varying covariates via start-stop format" item for Cox.

## What's added

- **`handle_tvc`** (`proportional_hazards/tvc.py`) — validates counting-process (start-stop) data: one row per interval `(ident, start, stop, event, Z)` on which covariates are constant. Checks non-overlapping intervals and at most one terminal event on a subject's final interval, then maps each interval to a delayed-entry observation `(x=stop, tl=start, c=1−event)`. Because each interval is exactly a left-truncated observation, the partial likelihood fits it directly (the episode-splitting identity).
- **`CoxPH.fit_tvc`** and **`CoxPH.fit_tvc_from_df`** — array and DataFrame entry points; the fitted model is tagged `is_tvc`.
- **Baseline fix** — the Breslow baseline now respects `tl` (and weights by `n`): the risk set at each event time excludes not-yet-entered subjects. Previously `baseline()` ignored `tl`, so **`H0` was wrong for any left-truncated fit** even though β was correct. `H0` now satisfies the episode-splitting identity (verified in tests). This corrects a latent bug affecting all delayed-entry Cox fits, not just TVCs.
- **`predict_tvc`** on the model — survival of a subject along a supplied covariate path, `H(t) = Σ_{u_j≤t} h0(u_j)·exp(β'Z(u_j))`, reducing exactly to `sf(t, Z)` for a constant covariate.

## Tests

`test_tvc.py` (13 tests): episode-split equivalence for **both β and baseline `H0`**, recovery of a genuine time-varying effect from simulated switch-covariate data (β=1.2 recovered), the DataFrame path, `predict_tvc` (constant reduces to `sf`; changing covariate responds correctly), and the six validation guards. Full regression suite passes (120); flake8 / black / mypy clean.

## Notes

TVCs for the *parametric* families (AFT/PH/PO) remain future work (documented in §6). This PR delivers the Cox path, which is where TVCs are most used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_