### PR TITLE
Add worked examples for regression and degradation features

### DIFF
--- a/docs/Competing Risks SurPyval Modelling.rst
+++ b/docs/Competing Risks SurPyval Modelling.rst
@@ -7,10 +7,8 @@ theoretical background see :doc:`Competing Risks Analysis`.
 
 .. note::
 
-    The competing risks subsystem is under active development. The
-    ``CompetingRisks`` example on this page is executed when the documentation
-    is built; the ``FineGray`` and ``CompetingRisksProportionalHazards``
-    snippets show the (working) regression API.
+    Every example on this page is executed when the documentation is built, so
+    the outputs shown are produced by the installed version of surpyval.
 
 Standard imports used throughout this page:
 
@@ -71,16 +69,56 @@ The Fine-Gray model estimates the effect of covariates directly on the
 cumulative incidence function of a chosen cause, using an
 inverse-probability-of-censoring-weighted subdistribution risk set. ``e`` is
 the per-observation cause label (``None`` for a censored row) and ``cause``
-selects the cause of interest:
+selects the cause of interest.
 
-.. code-block:: python
+Here we simulate two-cause data whose cause-1 incidence follows a Fine-Gray
+model with coefficients :math:`(0.7, -0.4)`, apply right-censoring, and recover
+the coefficients:
+
+.. jupyter-execute::
 
     from surpyval.univariate.competing_risks import FineGray
 
-    # x times, Z covariates, e cause labels, c censoring flags
-    model = FineGray.fit(x, Z, e, c=c, cause=0)
-    print(model)                 # coefficients, standard errors, p-values
-    model.cif(t, Z=[0.5, 1.2])   # cumulative incidence of cause 0
+    rng = np.random.default_rng(1)
+    N, beta, p = 800, np.array([0.7, -0.4]), 0.5
+    Z = rng.uniform(-1, 1, size=(N, 2))
+    phi = np.exp(Z @ beta)
+    p1 = 1 - (1 - p) ** phi                    # P(cause = 1 | Z)
+    is1 = rng.uniform(size=N) < p1
+
+    x = np.empty(N)
+    e = np.empty(N, dtype=object)
+    v = rng.uniform(size=N)
+    w = 1 - (1 - v * p1) ** (1 / phi)          # invert the cause-1 CIF
+    x[is1] = (-np.log(np.clip(1 - w / p, 1e-12, 1.0)))[is1]
+    e[is1] = 1
+    x[~is1] = rng.exponential(1.0, size=N)[~is1]   # cause 2 mops up the rest
+    e[~is1] = 2
+
+    cens = rng.exponential(3.0, size=N)        # independent right-censoring
+    c = (x > cens).astype(int)
+    x = np.minimum(x, cens)
+    e[c == 1] = None
+
+    model = FineGray.fit(x, Z, e, c=c, cause=1)
+    model
+
+The IPCW correction is what lets the coefficients come back near their true
+values *under* censoring — a naive unweighted subdistribution risk set would be
+biased. Because the model targets the incidence directly, ``cif`` reads off the
+cumulative incidence of the cause at any covariate value:
+
+.. jupyter-execute::
+
+    t = np.linspace(0, 3, 200)
+    for z1, label in [(-1.0, 'Z1 = -1'), (1.0, 'Z1 = +1')]:
+        plt.plot(t, model.cif(t, Z=[z1, 0.0]), label=label)
+    plt.legend()
+    plt.xlabel('Time')
+    plt.ylabel('Cumulative incidence of cause 1')
+
+A positive :math:`\beta_0` raises the cause-1 incidence, so the ``Z1 = +1``
+curve sits above ``Z1 = -1``.
 
 Cause-Specific Proportional Hazards
 -----------------------------------
@@ -88,13 +126,20 @@ Cause-Specific Proportional Hazards
 ``CompetingRisksProportionalHazards`` fits a proportional-hazards model per
 cause. With ``how="Cox"`` (the default) each cause is a Cox model with the
 other causes treated as censored; ``how="Fine-Gray"`` fits the subdistribution
-model above for every cause:
+model above for every cause. It reuses the simulated data from the previous
+section:
 
-.. code-block:: python
+.. jupyter-execute::
 
     from surpyval.univariate.competing_risks import (
         CompetingRisksProportionalHazards,
     )
 
-    model = CompetingRisksProportionalHazards.fit(x, Z, e, c=c, how="Cox")
-    model.cif(t, Z=[0.5, 1.2], event=0)
+    csph = CompetingRisksProportionalHazards.fit(x, Z, e, c=c, how="Cox")
+    # cumulative incidence of cause 1 at a covariate vector
+    csph.cif(np.array([0.5, 1.0, 2.0]), Z=[0.5, -0.5], event=1)
+
+The cause-specific model answers "what drives the rate of this cause among those
+still at risk", while Fine-Gray answers "what drives the eventual incidence of
+this cause"; the two coincide only when the competing causes are unaffected by
+the covariates.

--- a/docs/Degradation Analysis.rst
+++ b/docs/Degradation Analysis.rst
@@ -276,14 +276,107 @@ their parameters (linear, quadratic, logarithmic, Lloyd-Lipow) and
 requires a
 positive measurement variance.
 
-A note on uncertainty
----------------------
+Confidence bounds
+-----------------
 
-The pseudo-failure-time approach is a two-stage method: the life
-distribution is fitted to *estimated* failure times as if they had been
-observed exactly, so the reported confidence bounds on the life model do
-not include the path-fitting or extrapolation uncertainty. This is the
-standard, pragmatic form of degradation analysis; random-effects
-(Lu-Meeker, fitted by REML) and stochastic-process (Wiener, gamma
-process) degradation models, which propagate that uncertainty, are
-candidates for future work.
+The pseudo-failure-time approach is a *two-stage* estimator: the life
+distribution is fitted to *extrapolated* failure times as if they had been
+observed exactly. The plain life-model bounds therefore treat the pseudo
+failure times as certain and are too narrow. ``DegradationModel.cb`` corrects
+this, folding the first-stage (path-fit and extrapolation) uncertainty back
+into the life-model covariance with an analytic delta-method /
+generated-regressor correction:
+
+.. jupyter-execute::
+
+    import numpy as np
+    from matplotlib import pyplot as plt
+    from surpyval.degradation import DegradationAnalysis
+
+    rng = np.random.default_rng(0)
+    times = np.arange(1, 9) * 100.0
+    n_units = 60
+    x = np.tile(times, n_units)
+    unit = np.repeat(np.arange(n_units), times.size)
+    slopes = rng.normal(0.22, 0.05, size=n_units)     # between-unit spread
+    y = 10 + np.repeat(slopes, times.size) * x + rng.normal(0, 2.0, size=x.size)
+
+    model = DegradationAnalysis.fit(x, y, unit, threshold=150)
+
+    t = np.linspace(400, 800, 200)
+    band = model.cb(t, on='sf')                # (n, 2): two-stage [lower, upper]
+    plt.plot(t, model.sf(t), 'b', label='S(t)')
+    plt.fill_between(t, band[:, 0], band[:, 1], alpha=0.2,
+                     label='95% two-stage band')
+    plt.legend()
+    plt.xlabel('Time')
+    plt.ylabel('S(t)')
+
+The correction adds a positive term to the life-model information inverse, so
+the two-stage parameter covariance (``model.life_parameter_covariance()``) is
+the ordinary MLE covariance *plus* the propagated first-stage variance — the
+bounds widen to their correct coverage. A slower, assumption-light cross-check
+resamples whole units and reruns the whole pipeline:
+
+.. jupyter-execute::
+
+    model.cb(np.array([500.0, 600.0]), on='sf', method='bootstrap',
+             n_boot=100, seed=0)
+
+Random-effects (Lu-Meeker, fitted by REML) and stochastic-process (Wiener,
+gamma-process) degradation models, which propagate this uncertainty through a
+single likelihood rather than a two-stage correction, are candidates for future
+work.
+
+
+Accelerated degradation testing (covariates)
+--------------------------------------------
+
+In accelerated degradation testing (ADT) units are run at *elevated stress*
+(temperature, voltage, load) so they degrade fast enough to measure, and life
+is then extrapolated back to use conditions. Passing a per-unit stress
+covariate ``Z`` to :meth:`DegradationAnalysis.fit` fits a *regression* life
+model on the pseudo failure times instead of a plain distribution, so life can
+be predicted at any stress. A plain distribution is wrapped automatically in an
+accelerated-failure-time model; an explicit regression fitter
+(``AFT(LogNormal)``, ``WeibullPH``, …) is used as given.
+
+.. jupyter-execute::
+
+    rng = np.random.default_rng(0)
+    times = np.arange(1, 11) * 5.0
+    xs, ys, ids, Zs = [], [], [], []
+    uid = 0
+    for stress in [0.0, 0.5, 1.0, 1.5]:        # four stress levels
+        for _ in range(12):
+            rate = 0.5 * np.exp(0.8 * stress) * np.exp(rng.normal(0, 0.1))
+            path = 10 + rng.normal(0, 1) + rate * times
+            xs.append(times)
+            ys.append(path + rng.normal(0, 0.5, times.size))
+            ids.append(np.full(times.size, uid))
+            Zs.append(np.full(times.size, stress))
+            uid += 1
+    xd, yd, idd, Zd = (np.concatenate(a) for a in (xs, ys, ids, Zs))
+
+    model = DegradationAnalysis.fit(xd, yd, idd, threshold=100.0, Z=Zd)
+    model
+
+The last fitted coefficient is the stress effect (higher stress ⇒ faster
+degradation ⇒ shorter life). The prediction methods now take the stress vector
+``Z`` at which to evaluate life, so life at use conditions is one call:
+
+.. jupyter-execute::
+
+    for stress in [0.0, 0.5, 1.0]:
+        print(f'stress {stress}: mean life = {model.mean(Z=[stress]):.1f}')
+
+    t = np.linspace(0, 300, 200)
+    for stress in [0.0, 0.5, 1.0]:
+        plt.plot(t, model.sf(t, Z=[stress]), label=f'stress {stress}')
+    plt.legend()
+    plt.xlabel('Time')
+    plt.ylabel('Reliability at stress')
+
+``qf`` and ``mean`` invert / integrate the regression survival function, and
+``random`` draws from it. First-stage regression confidence bounds are available
+through ``model.life_model.cb(x, Z, ...)``.

--- a/docs/Regression Modelling with SurPyval.rst
+++ b/docs/Regression Modelling with SurPyval.rst
@@ -278,6 +278,61 @@ to :meth:`CoxPH.fit`); right or interval truncation is rejected, because the
 forward partial likelihood cannot express it.
 
 
+Semi-Parametric — Buckley-James (AFT)
+-------------------------------------
+
+Cox leaves the baseline *hazard* unspecified; Buckley-James is its
+accelerated-time counterpart, leaving the error *distribution* unspecified:
+
+.. math::
+
+    \log T = \beta' Z + \varepsilon,
+
+with :math:`\varepsilon` drawn from an arbitrary distribution estimated from the
+data. It is fitted by the Buckley-James iteration — repeatedly imputing each
+censored log-time by its conditional expectation under the Kaplan-Meier of the
+current residuals, then re-fitting by least squares, until the coefficients stop
+moving. As with Cox, coefficients are in surpyval's accelerated-failure sign: a
+*positive* coefficient shortens life.
+
+.. jupyter-execute::
+
+    from surpyval import BuckleyJames
+
+    # log T = 3 - 0.8 Z + noise, right-censored: higher Z shortens life, so
+    # the accelerated-failure coefficient is +0.8.
+    rng = np.random.default_rng(0)
+    Z_bj = rng.normal(size=(400, 1))
+    T_bj = np.exp(3.0 - 0.8 * Z_bj[:, 0] + rng.normal(0, 0.5, size=400))
+    cens = np.exp(3.6)
+    c_bj = (T_bj > cens).astype(int)
+    x_bj = np.minimum(T_bj, cens)
+
+    model = BuckleyJames.fit(x=x_bj, Z=Z_bj, c=c_bj)
+    model
+
+Buckley-James has no simple closed-form standard error, so uncertainty comes
+from a percentile bootstrap — resampling, refitting, and taking coefficient
+percentiles:
+
+.. jupyter-execute::
+
+    model.bootstrap_ci(n_boot=200, seed=1)
+
+Predictions use the fitted residual distribution directly,
+:math:`S(t \mid Z) = S_\varepsilon(\log t + \beta' Z)`, so the survival curves
+shift with the covariate:
+
+.. jupyter-execute::
+
+    t = np.linspace(1, 60, 200)
+    for z in [-1.0, 0.0, 1.0]:
+        plt.step(t, model.sf(t, Z=[z]), where='post', label=f'Z = {z:g}')
+    plt.legend()
+    plt.xlabel('Time')
+    plt.ylabel('S(t)')
+
+
 Semi-Parametric — Additive Hazards
 ----------------------------------
 
@@ -503,6 +558,58 @@ The ``PO`` factory accepts any distribution:
 A practical rule of thumb: if the Kaplan-Meier curves for different covariate
 groups converge at long times (rather than remaining parallel on the log-hazard
 scale), PO is likely a better fit than PH.
+
+
+Confidence Bounds
+-----------------
+
+A point estimate is only half the story. The parametric regression models (PH,
+AFT, PO, AL) carry the full parameter covariance, so every coefficient and every
+predicted curve comes with an interval. After a fit, the parameter covariance
+and standard errors are available directly:
+
+.. jupyter-execute::
+
+    from surpyval import WeibullPH
+
+    rng = np.random.default_rng(0)
+    Z_cb = rng.normal(size=(300, 1))
+    x_cb = 10.0 * (
+        -np.log(rng.uniform(size=300)) / np.exp(Z_cb[:, 0] * 0.8)
+    ) ** (1 / 2.0)
+    m_cb = WeibullPH.fit(x=x_cb, Z=Z_cb, c=np.zeros(300, dtype=int))
+
+    print(m_cb.parameter_names())
+    print(m_cb.standard_errors())
+
+``param_cb`` gives a Wald confidence bound on a single parameter, computed on a
+scale chosen from the parameter's support (log for a positive scale, natural for
+an unbounded coefficient) so the interval always stays valid:
+
+.. jupyter-execute::
+
+    m_cb.param_cb('beta_0')      # 95% CI for the covariate coefficient
+
+``cb`` propagates the parameter covariance through a predicted function by the
+delta method, returning a confidence *band*. Here is the survival at a covariate
+value with its 95% band:
+
+.. jupyter-execute::
+
+    x_grid = np.linspace(1, 40, 200)
+    band = m_cb.cb(x_grid, Z=[0.5], on='sf')      # (n, 2): [lower, upper]
+    sf = m_cb.sf(x_grid, Z=[0.5])
+    plt.plot(x_grid, sf, 'b', label='S(x | Z=0.5)')
+    plt.fill_between(x_grid, band[:, 0], band[:, 1], alpha=0.2,
+                     label='95% confidence band')
+    plt.legend()
+    plt.xlabel('Time')
+    plt.ylabel('S(x)')
+
+``cb`` accepts ``on='ff'``, ``'Hf'``, ``'hf'`` or ``'df'``, one- or two-sided
+bounds via ``bound=``, and any ``alpha_ci``. The convenience method
+``model.plot()`` draws the fitted survival at the mean covariate against the
+Kaplan-Meier with this band already applied.
 
 
 .. _accelerated-life:


### PR DESCRIPTION
## Summary

Several recently-shipped features had no worked examples in the docs. This adds executed, verified examples for them.

**Regression guide** (`Regression Modelling with SurPyval.rst`)
- **Buckley-James (AFT)** — a semi-parametric AFT example: fit, `bootstrap_ci`, and covariate-shifted survival curves; recovers the simulated accelerated-failure coefficient.
- **Confidence Bounds** — `covariance`/`standard_errors`, `param_cb` on a coefficient, and the delta-method `cb` band on the parametric regression models (with a plotted band).

**Competing risks guide** (`Competing Risks SurPyval Modelling.rst`)
- The Fine-Gray and cause-specific proportional-hazards snippets were static `code-block`s; they're now **executed** examples that simulate two-cause data, recover the coefficients *under censoring* (Fine-Gray via IPCW), and plot the cumulative incidence. The "under active development" note is updated.

**Degradation guide** (`Degradation Analysis.rst`)
- Replaced the now-outdated "no uncertainty propagation" note with a **Confidence bounds** section demonstrating the two-stage `DegradationModel.cb` (analytic + bootstrap) — the note wrongly said this was future work.
- Added an **Accelerated Degradation Testing (ADT)** section for covariate life fits via `DegradationAnalysis.fit(..., Z=...)`, predicting life at stress.

## Verification

Every new example block is `jupyter-execute` (runs at build time) and was verified to run standalone: Fine-Gray recovers `(0.77, -0.42)` vs true `(0.7, -0.4)`; ADT recovers the stress coefficient; the two-stage covariance was confirmed to exceed the plain MLE covariance. A full docs build is running to confirm no reference/execution warnings before merge.

Note: docs are not part of CI (lint + pytest only), so these changes don't affect the CI jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_