### PR TITLE
Document the flexibility of surpyval's data input formats

### DIFF
--- a/docs/Data Wrangler Examples.rst
+++ b/docs/Data Wrangler Examples.rst
@@ -85,3 +85,119 @@ Surpyval also offers the ability to use a pandas DataFrame as an input. All you 
 
     model = surv.Weibull.fit_from_df(df, xl='xl', xr='xr')
     print(model)
+
+
+Combining every input type in one fit
+-------------------------------------
+
+The real strength of the surpyval format is that these ingredients — exact,
+left-, right- and interval-censoring, repeat counts, and truncation — compose
+freely in a **single** ``fit`` call. Each row of ``x`` carries its own censoring
+flag ``c`` and count ``n``; a row is interval-censored simply by giving it two
+values ``[lower, upper]``:
+
+.. jupyter-execute::
+
+    x = [10, 12, [15, 20], 22, 25, 30]   # a [lo, hi] row is interval-censored
+    c = [0,  1,   2,       -1,  0,  1]    # observed, right, interval, left, ...
+    n = [5,  3,   2,        1,  4,  2]    # each row repeated n times
+    model = surv.Weibull.fit(x=x, c=c, n=n, tl=5)   # all left-truncated at 5
+    model
+
+Nothing above is special-cased: any mix of the flags is accepted, and the fitter
+condenses the data to its densest form internally.
+
+
+Same data, whichever format you have it in
+-------------------------------------------
+
+Because the formats all describe the same thing, the same dataset gives the same
+fit however you assemble it. Here failure / suspension / left / interval lists
+are converted with ``fsli_to_xcnt`` and compared to the hand-built ``xcnt``
+form — the fitted parameters agree exactly:
+
+.. jupyter-execute::
+
+    f = [12, 18, 18, 25]        # exact failures
+    s = [30, 30]                # right-censored (suspended)
+    l = [8]                     # left-censored
+    i = [[15, 20], [22, 26]]    # interval-censored
+
+    x, c, n, t = surv.fsli_to_xcnt(f, s, l, i)
+    from_lists = surv.Weibull.fit(x=x, c=c, n=n)
+
+    hand = surv.Weibull.fit(
+        x=[12, 18, 25, 30, 8, [15, 20], [22, 26]],
+        c=[0, 0, 0, 1, -1, 2, 2],
+        n=[1, 2, 1, 2, 1, 1, 1],
+    )
+    print("from lists :", from_lists.params)
+    print("hand xcnt  :", hand.params)
+
+
+Truncation, four ways
+---------------------
+
+Truncation can be a single shared bound, a per-observation array, an upper
+(right) bound, or a two-sided observation window — pass ``tl`` and/or ``tr``:
+
+.. jupyter-execute::
+
+    x = [674, 792, 1153, 1450, 1555]
+
+    print("shared tl   :", surv.Weibull.fit(x=x, tl=500).params)
+    print("per-unit tl :", surv.Weibull.fit(
+        x=x, tl=[100, 200, 300, 400, 500]).params)
+    print("right tr    :", surv.Weibull.fit(x=x, tr=2000).params)
+    print("window tl,tr:", surv.Weibull.fit(x=x, tl=100, tr=2000).params)
+
+The same columns can live in a DataFrame — ``c``, ``n``, ``tl`` and ``tr`` are
+all optional columns you point ``fit_from_df`` at:
+
+.. jupyter-execute::
+
+    df = pd.DataFrame({
+        'x':  [674, 792, 1153, 1450, 1555, 2000],
+        'c':  [0,   0,   0,    1,    0,    1],
+        'n':  [1,   2,   1,    3,    1,    2],
+        'tl': [500, 500, 500,  500,  500,  500],
+    })
+    surv.Weibull.fit_from_df(df, x='x', c='c', n='n', tl='tl')
+
+
+Format converters
+-----------------
+
+surpyval ships helpers to reshape common external layouts into the ``xcnt``
+format its fitters use, and into the "at risk / deaths" (``xrd``) format the
+non-parametric estimators think in:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 66
+
+   * - Helper
+     - Converts
+   * - ``fs_to_xcnt(f, s)``
+     - failures + suspensions (right-censored) → ``xcnt``
+   * - ``fsl_to_xcnt(f, s, l)``
+     - as above, plus left-censored
+   * - ``fsli_to_xcnt(f, s, l, i)``
+     - as above, plus interval-censored
+   * - ``xcnt_to_xrd(x, c, n, t)``
+     - ``xcnt`` → at-risk / deaths (``xrd``)
+   * - ``xrd_to_xcnt(x, r, d)``
+     - ``xrd`` → ``xcnt``
+   * - ``xcn_to_fs(x, c, n)``
+     - ``xcnt`` → failure / suspension lists
+
+For example, any ``xcnt`` data folds into the ``xrd`` form — the count at risk
+and the number of deaths at each distinct time:
+
+.. jupyter-execute::
+
+    x, c, n = [1, 2, 3, 4, 5], [0, 0, 1, 0, 1], [2, 1, 1, 3, 1]
+    times, at_risk, deaths = surv.xcnt_to_xrd(x, c, n)
+    print("times  :", times)
+    print("at risk:", at_risk)
+    print("deaths :", deaths)


### PR DESCRIPTION
## Summary

surpyval's input format is unusually flexible — exact / left / right / interval censoring, repeat counts, and left/right/interval truncation all compose in one `fit` call, and data can arrive in several equivalent formats. The docs showed these piecemeal but never together. This extends the data-wrangling guide with executed examples of the combinations:

- **Everything in one fit** — a single `Weibull.fit` mixing observed, right-, left- and interval-censored rows with per-row counts and truncation.
- **Format equivalence** — the same dataset assembled from failure/suspension/left/interval lists (`fsli_to_xcnt`) versus hand-built `xcnt` gives *identical* fitted parameters.
- **Truncation four ways** — a shared `tl`, a per-observation `tl` array, a right bound `tr`, and a two-sided window; plus the same carried as `fit_from_df` columns (`c`/`n`/`tl`).
- **Format converters** — a reference table of the `*_to_*` helpers with an `xcnt → xrd` (at-risk / deaths) example.

## Verification

Every block is `jupyter-execute` (runs at build time) and was verified to run, including an isolated docs build of the page (build succeeded, no warnings). Docs aren't part of CI (lint + pytest only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_