### PR TITLE
Show flexible fit inputs across the package (copula examples + cross-link)

### DIFF
--- a/docs/Multivariate Modelling with SurPyval.rst
+++ b/docs/Multivariate Modelling with SurPyval.rst
@@ -47,22 +47,35 @@ Fitting a copula
 ----------------
 
 The copulas live in their own package (like ``surpyval.recurrent``) and are
-not imported into the top-level namespace:
+not imported into the top-level namespace. Here we simulate correlated
+lifetimes from a known Clayton copula (see the last section) and check the fit
+recovers it:
 
-.. code:: python
+.. jupyter-execute::
 
+    import warnings
+    warnings.filterwarnings("ignore")   # copula optimisers explore log(0) regions
+
+    import numpy as np
     import surpyval as surv
     from surpyval.multivariate import Clayton
 
-    # x1, x2 are correlated lifetimes; margins are SurPyval distributions
+    truth = Clayton.from_params(
+        2.0,
+        margins=[surv.Weibull.from_params([10.0, 2.0]),
+                 surv.LogNormal.from_params([2.5, 0.5])],
+    )
+    data = truth.random(3000, random_state=1)
+    x1, x2 = data[:, 0], data[:, 1]
+
+    # margins are SurPyval distributions, fitted along with the copula
     model = Clayton.fit(
         [x1, x2],
         margins=[surv.Weibull, surv.LogNormal],
         how="IFM",
     )
-
-    model.params          # fitted copula parameter (theta)
-    model.kendall_tau()   # implied Kendall's tau
+    print("theta       :", model.params)
+    print("Kendall's tau:", round(model.kendall_tau(), 3))
     model.margins         # the two fitted univariate models
 
 Two estimation strategies are available via ``how``:
@@ -81,16 +94,24 @@ likelihood supports the **full** censoring and truncation matrix, per
 dimension, using the same convention as the univariate models
 (``c`` of ``0`` observed, ``1`` right, ``-1`` left, ``2`` interval; ``t`` for
 a truncation window). Each series of a joint observation may be censored
-independently:
+independently — pass one censoring column per series. Here each series is
+right-censored at its own threshold, and the fit still recovers the copula
+parameter:
 
-.. code:: python
+.. jupyter-execute::
 
-    # dimension-wise censoring codes, one column per series
-    model = Clayton.fit(
-        [x1, x2],
-        c=[c1, c2],
+    thresholds = np.array([14.0, 16.0])
+    c = (data > thresholds).astype(int)          # per-series right-censoring
+    x_obs = np.minimum(data, thresholds)
+
+    model_c = Clayton.fit(
+        [x_obs[:, 0], x_obs[:, 1]],
+        c=[c[:, 0], c[:, 1]],                    # one column per series
         margins=[surv.Weibull, surv.Weibull],
+        how="IFM",
     )
+    print("censored fraction:", round(c.mean(), 2))
+    print("theta (censored) :", model_c.params)
 
 Internally every censoring type reduces to evaluating the copula CDF and its
 partial derivatives at the margin-transformed bounds (interval censoring, for
@@ -99,29 +120,34 @@ example, is inclusion-exclusion on the rectangle corners of ``C``).
 Working with a fitted model
 ---------------------------
 
-.. code:: python
+The fitted model exposes the joint distribution functions, the dependence
+measures, and a correlated sampler:
 
-    model.cdf([[10, 18], [5, 25]])   # joint P(X1 <= x1, X2 <= x2)
-    model.sf([[10, 18]])             # joint survival P(X1 > x1, X2 > x2)
-    model.pdf([[10, 18]])            # joint density
-    model.conditional_cdf(x, given_dim=0)   # the copula h-function
+.. jupyter-execute::
 
-    samples = model.random(1000)     # correlated (N, 2) samples
-    model.kendall_tau()
-    model.spearman_rho()
-    model.tail_dependence()          # (lambda_lower, lambda_upper)
+    print("joint cdf  :", model.cdf([[10, 18], [5, 25]]))  # P(X1<=x1, X2<=x2)
+    print("joint sf   :", model.sf([[10, 18]]))            # P(X1>x1, X2>x2)
+    print("joint pdf  :", model.pdf([[10, 18]]))
+    print("cond. cdf  :", model.conditional_cdf(np.array([[10, 18]]),
+                                                 given_dim=0))  # h-function
+    print("Kendall tau:", round(model.kendall_tau(), 3))
+    print("Spearman   :", round(model.spearman_rho(), 3))
+    print("tail dep.  :", model.tail_dependence())          # (lower, upper)
+
+    model.random(3, random_state=0)     # correlated (N, 2) samples
 
 Building a model from known parameters
 --------------------------------------
 
 As with the univariate distributions, a model can be created directly from
-parameters and pre-built margins -- useful for Monte-Carlo simulation:
+parameters and pre-built margins -- useful for Monte-Carlo simulation (this is
+exactly how the data above was generated):
 
-.. code:: python
+.. jupyter-execute::
 
-    model = Clayton.from_params(
+    sim = Clayton.from_params(
         2.0,
         margins=[surv.Weibull.from_params([10, 2]),
                  surv.LogNormal.from_params([3, 0.4])],
     )
-    correlated_draws = model.random(10_000)
+    sim.random(5, random_state=0)

--- a/docs/Parametric SurPyval Modelling.rst
+++ b/docs/Parametric SurPyval Modelling.rst
@@ -6,6 +6,12 @@ call to the ``fit()`` method. However, the parametric models have more options t
 for count of each ``x``, ``xl`` and ``xr`` for intervally censored data (can't be used with ``x``) ``t``
 for the truncation matrix, ``tl`` for the left truncation scalar or array, and ``tr`` for the right truncation scalar or array all remain.
 
+These ingredients compose freely — any mix of censoring, counts and truncation
+in a single ``fit`` call — and the same convention is used by every model in
+the package (non-parametric, regression, recurrent, competing-risks and
+copula). See :doc:`Data Wrangler Examples` for worked examples that combine
+them and convert between input formats.
+
 Complete Data
 -------------
 


### PR DESCRIPTION
## Summary

Follow-up to #129 (which showed input flexibility in the wrangling guide): make sure the *same* flexible `fit` API is demonstrated in each model family's section.

Surveying the docs, most sections already show it in executed examples — parametric (`c`/`n`/`tl`/`tr`), non-parametric (`n`, right-censoring, delayed-entry `tl`), recurrent (censoring), and competing-risks/degradation (from #128). The one real gap was the **multivariate/copula guide**, which was *entirely static code snippets* — including its headline "full censoring & truncation matrix" feature.

## Changes

- **Multivariate guide → executed.** Converted the fitting, censoring/truncation, prediction, and from-params sections to `jupyter-execute`: simulate correlated lifetimes from a known Clayton copula, recover θ with IFM (θ=2.0 → 2.02), recover it again **under per-series right censoring**, and exercise the fitted model's joint `cdf`/`sf`/`pdf`/`conditional_cdf`, `kendall_tau`/`spearman_rho`/`tail_dependence`, and correlated sampler.
- **Cross-link.** A short note in the parametric guide pointing to the combined data-input flexibility examples, stating the same censoring/counts/truncation convention applies to every model family.

## Verification

New blocks execute at build time; verified via an isolated docs build (build succeeded, no warnings — a benign autograd `log(0)` optimizer warning is suppressed in the first cell). Docs aren't part of CI (lint + pytest only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_