### PR TITLE
Add ParametricCompetingRisks model

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,8 +8,8 @@ grouped by theme and ordered by priority within each section.
 **Package state (2026-07-15).** Version `0.12.0` is released to PyPI; `0.13.0`
 is in progress on `master` (unreleased — see `docs/changelog.rst`, which adds
 the Tier-2 discrete distributions, Cox time-varying covariates, the Cox
-delayed-entry baseline fix, and a broad documentation pass). The full test
-suite (1116 tests, 1 documented skip) passes on Python 3.11–3.13 with numpy
+delayed-entry baseline fix, a parametric competing-risks model, and a broad
+documentation pass). The full test suite passes on Python 3.11–3.13 with numpy
 2.x / scipy 1.13+ / pandas 2.2+. The parametric, nonparametric, regression
 (PH / AFT / PO / additive-hazards / accelerated-life), recurrent-event,
 degradation, copula and (experimental) survival-forest modules are all

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,12 @@ Competing risks
   via ``random``, and ``aic`` / ``bic`` / ``neg_ll``. Complements the existing
   nonparametric ``CompetingRisks`` estimator and the semi-parametric
   cause-specific Cox / Fine-Gray regression models.
+- ``ParametricCompetingRisks.from_fitted`` assembles a competing-risks model
+  from already-fitted per-cause models, each of any family and configuration
+  (e.g. a limited-failure Weibull for one cause, a LogNormal for another): pass
+  a ``{cause: model}`` mapping or a sequence of models. Sampling handles cure
+  fractions -- when every cause carries one, some units never fail and are
+  returned with cause ``None``.
 
 Regression — Cox proportional hazards
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,21 @@ Distributions
   linearising probability plot) instead of a raw ``NotImplementedError``, and
   points to ``MLE`` / ``MSE`` / ``MOM``.
 
+Competing risks
+~~~~~~~~~~~~~~~
+
+- Added ``ParametricCompetingRisks``, a fully parametric competing-risks model:
+  a parametric distribution is fitted to each cause's cause-specific hazard
+  (the joint likelihood factorises, so each cause is fitted with the other
+  causes' events treated as right-censored) and smooth, extrapolatable
+  cumulative-incidence functions are assembled from them. Provides ``fit`` /
+  ``fit_from_df`` (with a per-cause distribution mapping), all-cause and
+  cause-specific ``hf`` / ``Hf`` / ``sf`` / ``ff``, the subdistribution density
+  ``iif``, the cumulative incidence ``cif``, ``probability_of_cause``, sampling
+  via ``random``, and ``aic`` / ``bic`` / ``neg_ll``. Complements the existing
+  nonparametric ``CompetingRisks`` estimator and the semi-parametric
+  cause-specific Cox / Fine-Gray regression models.
+
 Regression — Cox proportional hazards
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/surpyval/tests/univariate/competing_risks/test_parametric_competing_risks.py
+++ b/surpyval/tests/univariate/competing_risks/test_parametric_competing_risks.py
@@ -199,3 +199,92 @@ def test_unknown_cause_raises():
     model = ParametricCompetingRisks.fit(x, e, c=c)
     with pytest.raises(ValueError, match="Unknown cause"):
         model.cif(10.0, 99)
+
+
+# --- from_fitted: assemble from pre-fitted per-cause models ----------------
+
+
+def _fit_cause(x, e, c, cause, dist):
+    """Fit ``dist`` to one cause's cause-specific hazard (its events observed,
+    every other event and every censored unit right-censored)."""
+    c_k = np.where((np.asarray(e, dtype=object) == cause) & (c == 0), 0, 1)
+    return dist.fit(x=x, c=c_k)
+
+
+def test_from_fitted_matches_fit():
+    # Fitting each cause by hand and assembling with from_fitted must give
+    # the same model as fit() doing it internally.
+    x, e, c = _simulate(5000, 20)
+    m1 = _fit_cause(x, e, c, 1, Weibull)
+    m2 = _fit_cause(x, e, c, 2, Weibull)
+    assembled = ParametricCompetingRisks.from_fitted({1: m1, 2: m2})
+    fitted = ParametricCompetingRisks.fit(x, e, c=c)
+    assert assembled.causes == [1, 2]
+    grid = np.array([10.0, 25.0, 40.0])
+    for k in (1, 2):
+        assert np.allclose(assembled.cif(grid, k), fitted.cif(grid, k))
+
+
+def test_from_fitted_heterogeneous_families():
+    # A different distribution family per cause.
+    x, e, c = _simulate(5000, 21)
+    m1 = _fit_cause(x, e, c, 1, Weibull)
+    m2 = _fit_cause(x, e, c, 2, LogNormal)
+    model = ParametricCompetingRisks.from_fitted({1: m1, 2: m2})
+    assert model.models[1].dist.name == "Weibull"
+    assert model.models[2].dist.name == "LogNormal"
+    # still a coherent competing-risks model: CIFs sum to 1 - S
+    grid = np.linspace(1.0, 55.0, 20)
+    total = sum(model.cif(grid, k) for k in model.causes)
+    assert np.allclose(total, model.ff(grid), atol=1e-3)
+
+
+def test_from_fitted_agrees_with_nonparametric():
+    x, e, c = _simulate(6000, 22)
+    m1 = _fit_cause(x, e, c, 1, Weibull)
+    m2 = _fit_cause(x, e, c, 2, LogNormal)
+    model = ParametricCompetingRisks.from_fitted({1: m1, 2: m2})
+    nonp = CompetingRisks.fit(x, e, c=c)
+    grid = np.array([15.0, 25.0, 35.0, 45.0])
+    for k in (1, 2):
+        assert np.allclose(model.cif(grid, k), nonp.cif(grid, k), atol=0.03)
+
+
+def test_from_fitted_sequence_gives_positional_causes():
+    m0 = Weibull.from_params([30.0, 2.0])
+    m1 = LogNormal.from_params([3.6, 0.4])
+    model = ParametricCompetingRisks.from_fitted([m0, m1])
+    assert model.causes == [0, 1]
+    assert model.models[0].dist.name == "Weibull"
+
+
+def test_from_fitted_all_causes_cured_gives_never_fail_units():
+    # Every cause carries a cure fraction, so all-cause survival stays
+    # positive: some units never fail, and the cause probabilities sum to
+    # 1 - S(inf) < 1 rather than to one.
+    a = Weibull.from_params([15.0, 2.5], p=0.6)  # 60% ever fail from a
+    b = Weibull.from_params([25.0, 1.5], p=0.5)  # 50% ever fail from b
+    model = ParametricCompetingRisks.from_fitted([a, b])
+    probs = [model.probability_of_cause(k) for k in model.causes]
+    # S(inf) = 0.4 * 0.5 = 0.2, so incidence sums to ~0.8
+    assert np.isclose(sum(probs), 0.8, atol=1e-2)
+    assert np.isclose(model.ff(1e6), 0.8, atol=1e-3)
+    draws = model.random(4000, random_state=0)
+    never = ~np.isfinite(draws["x"])
+    assert np.isclose(never.mean(), 0.2, atol=0.03)
+    # never-fail units carry no cause
+    assert all(e is None for e in draws["e"][never])
+    assert all(e in model.causes for e in draws["e"][~never])
+
+
+def test_from_fitted_rejects_empty():
+    with pytest.raises(ValueError, match="At least one cause"):
+        ParametricCompetingRisks.from_fitted({})
+
+
+def test_from_fitted_rejects_non_model():
+    class NotAModel:
+        pass
+
+    with pytest.raises(ValueError, match="does not look like"):
+        ParametricCompetingRisks.from_fitted({1: NotAModel()})

--- a/surpyval/tests/univariate/competing_risks/test_parametric_competing_risks.py
+++ b/surpyval/tests/univariate/competing_risks/test_parametric_competing_risks.py
@@ -1,0 +1,201 @@
+"""Parametric competing risks.
+
+A parametric distribution is fitted to each cause's cause-specific hazard
+(with the other causes' events treated as right-censored), and the smooth
+cumulative-incidence functions are assembled from them. The tests check that
+the per-cause parameters are recovered from latent-minimum data, that the
+parametric CIFs agree with the nonparametric estimator, that the cause CIFs
+sum to the all-cause failure probability ``1 - S``, and that the input
+validation and the per-cause distribution mapping behave.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from surpyval import Exponential, LogNormal, Weibull
+from surpyval.univariate.competing_risks import (
+    CompetingRisks,
+    ParametricCompetingRisks,
+)
+
+
+def _simulate(N, seed, cens=60.0):
+    """Two-cause latent-minimum data: cause 1 ~ Weibull(30, 2.0), cause 2 ~
+    Weibull(45, 1.2), with administrative right-censoring at ``cens``."""
+    rng = np.random.default_rng(seed)
+    t1 = Weibull.random(N, 30.0, 2.0)
+    t2 = Weibull.random(N, 45.0, 1.2)
+    t = np.minimum(t1, t2)
+    cause = np.where(t1 < t2, 1, 2)
+    c = np.where(t > cens, 1, 0)
+    x = np.where(c == 1, cens, t)
+    e = np.array(
+        [None if ci == 1 else ei for ci, ei in zip(c, cause)], dtype=object
+    )
+    del rng
+    return x, e, c
+
+
+def test_recovers_per_cause_parameters():
+    x, e, c = _simulate(6000, 0)
+    model = ParametricCompetingRisks.fit(x, e, c=c)
+    assert model.causes == [1, 2]
+    assert np.allclose(model.models[1].params, [30.0, 2.0], rtol=0.1)
+    assert np.allclose(model.models[2].params, [45.0, 1.2], rtol=0.12)
+
+
+def test_cif_agrees_with_nonparametric():
+    x, e, c = _simulate(6000, 1)
+    par = ParametricCompetingRisks.fit(x, e, c=c)
+    nonp = CompetingRisks.fit(x, e, c=c)
+    grid = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
+    for k in (1, 2):
+        assert np.allclose(par.cif(grid, k), nonp.cif(grid, k), atol=0.03)
+
+
+def test_cifs_sum_to_all_cause_incidence():
+    x, e, c = _simulate(4000, 2)
+    model = ParametricCompetingRisks.fit(x, e, c=c)
+    grid = np.linspace(1.0, 55.0, 25)
+    total = sum(model.cif(grid, k) for k in model.causes)
+    assert np.allclose(total, model.ff(grid), atol=1e-3)
+
+
+def test_probability_of_cause_sums_to_one():
+    x, e, c = _simulate(4000, 3)
+    model = ParametricCompetingRisks.fit(x, e, c=c)
+    probs = [model.probability_of_cause(k) for k in model.causes]
+    assert np.isclose(sum(probs), 1.0, atol=1e-3)
+    assert all(0.0 <= p <= 1.0 for p in probs)
+
+
+def test_all_cause_survival_is_product_of_cause_survivals():
+    x, e, c = _simulate(3000, 4)
+    model = ParametricCompetingRisks.fit(x, e, c=c)
+    grid = np.array([5.0, 15.0, 25.0, 40.0])
+    prod = model.models[1].sf(grid) * model.models[2].sf(grid)
+    assert np.allclose(model.sf(grid), prod)
+    assert np.allclose(model.ff(grid), 1.0 - prod)
+
+
+def test_iif_is_subdistribution_density():
+    x, e, c = _simulate(2000, 5)
+    model = ParametricCompetingRisks.fit(x, e, c=c)
+    grid = np.array([8.0, 20.0, 35.0])
+    # f_1^sub = f_1 * S_2
+    expected = model.models[1].df(grid) * model.models[2].sf(grid)
+    assert np.allclose(model.iif(grid, 1), expected)
+
+
+def test_hazards_sum_to_all_cause_hazard():
+    x, e, c = _simulate(2000, 6)
+    model = ParametricCompetingRisks.fit(x, e, c=c)
+    grid = np.array([10.0, 20.0, 30.0])
+    assert np.allclose(model.hf(grid), model.hf(grid, 1) + model.hf(grid, 2))
+    assert np.allclose(model.Hf(grid), model.Hf(grid, 1) + model.Hf(grid, 2))
+
+
+def test_per_cause_distribution_mapping():
+    x, e, c = _simulate(3000, 7)
+    model = ParametricCompetingRisks.fit(
+        x, e, c=c, dist={1: Weibull, 2: Exponential}
+    )
+    assert model.models[1].dist.name == "Weibull"
+    assert model.models[2].dist.name == "Exponential"
+
+
+def test_cif_scalar_and_vector():
+    x, e, c = _simulate(1500, 8)
+    model = ParametricCompetingRisks.fit(x, e, c=c)
+    scalar = model.cif(25.0, 1)
+    assert np.ndim(scalar) == 0
+    vec = model.cif(np.array([25.0]), 1)
+    assert np.ndim(vec) == 1
+    assert np.isclose(scalar, vec[0])
+
+
+def test_random_returns_time_and_cause():
+    x, e, c = _simulate(2000, 9)
+    model = ParametricCompetingRisks.fit(x, e, c=c)
+    draws = model.random(500, random_state=0)
+    assert draws.dtype.names == ("x", "e")
+    assert np.all(draws["x"] > 0)
+    assert set(np.unique(draws["e"])).issubset(set(model.causes))
+
+
+def test_goodness_of_fit_sums_over_causes():
+    x, e, c = _simulate(2000, 10)
+    model = ParametricCompetingRisks.fit(x, e, c=c)
+    assert np.isclose(
+        model.neg_ll(),
+        model.models[1].neg_ll() + model.models[2].neg_ll(),
+    )
+    assert np.isfinite(model.aic())
+    assert np.isfinite(model.bic())
+
+
+def test_fit_from_df():
+    x, e, c = _simulate(2000, 11)
+    df = pd.DataFrame({"time": x, "cause": e, "cens": c})
+    model = ParametricCompetingRisks.fit_from_df(
+        df, x_col="time", e_col="cause", c_col="cens"
+    )
+    assert model.causes == [1, 2]
+    assert np.allclose(model.models[1].params, [30.0, 2.0], rtol=0.15)
+
+
+def test_three_causes():
+    rng = np.random.default_rng(12)
+    N = 5000
+    t1 = Weibull.random(N, 20.0, 1.5)
+    t2 = Weibull.random(N, 30.0, 2.0)
+    t3 = LogNormal.random(N, 3.5, 0.4)
+    stack = np.column_stack([t1, t2, t3])
+    idx = np.argmin(stack, axis=1)
+    x = stack[np.arange(N), idx]
+    e = np.array([idx_i + 1 for idx_i in idx], dtype=object)
+    del rng
+    model = ParametricCompetingRisks.fit(
+        x, e, dist={1: Weibull, 2: Weibull, 3: LogNormal}
+    )
+    assert model.causes == [1, 2, 3]
+    probs = [model.probability_of_cause(k) for k in model.causes]
+    assert np.isclose(sum(probs), 1.0, atol=1e-3)
+
+
+# --- validation -----------------------------------------------------------
+
+
+def test_rejects_event_on_censored_row():
+    # A censored row (c = 1) must carry event None.
+    with pytest.raises(ValueError, match="None"):
+        ParametricCompetingRisks.fit(
+            x=[1.0, 2.0, 3.0], e=[1, 2, 1], c=[0, 0, 1]
+        )
+
+
+def test_rejects_none_on_observed_row():
+    with pytest.raises(ValueError, match="None"):
+        ParametricCompetingRisks.fit(
+            x=[1.0, 2.0, 3.0], e=[1, None, 1], c=[0, 0, 0]
+        )
+
+
+def test_rejects_left_censoring():
+    with pytest.raises(ValueError, match="Left or interval"):
+        ParametricCompetingRisks.fit(
+            x=[1.0, 2.0, 3.0], e=[1, 2, None], c=[0, 0, -1]
+        )
+
+
+def test_rejects_no_events():
+    with pytest.raises(ValueError, match="No observed events"):
+        ParametricCompetingRisks.fit(x=[1.0, 2.0], e=[None, None], c=[1, 1])
+
+
+def test_unknown_cause_raises():
+    x, e, c = _simulate(1000, 13)
+    model = ParametricCompetingRisks.fit(x, e, c=c)
+    with pytest.raises(ValueError, match="Unknown cause"):
+        model.cif(10.0, 99)

--- a/surpyval/univariate/competing_risks/__init__.py
+++ b/surpyval/univariate/competing_risks/__init__.py
@@ -1,8 +1,10 @@
 from .nonparametric import CompetingRisks
+from .parametric import ParametricCompetingRisks
 from .regression import CompetingRisksProportionalHazards, FineGray
 
 __all__ = [
     "CompetingRisks",
+    "ParametricCompetingRisks",
     "CompetingRisksProportionalHazards",
     "FineGray",
 ]

--- a/surpyval/univariate/competing_risks/parametric/__init__.py
+++ b/surpyval/univariate/competing_risks/parametric/__init__.py
@@ -1,0 +1,3 @@
+from .parametric_competing_risks import ParametricCompetingRisks
+
+__all__ = ["ParametricCompetingRisks"]

--- a/surpyval/univariate/competing_risks/parametric/parametric_competing_risks.py
+++ b/surpyval/univariate/competing_risks/parametric/parametric_competing_risks.py
@@ -1,0 +1,272 @@
+"""
+Parametric competing-risks model.
+
+Where :class:`~surpyval.univariate.competing_risks.CompetingRisks` estimates
+each cause's cumulative incidence non-parametrically (a step function),
+``ParametricCompetingRisks`` fits a *parametric distribution* to each cause's
+cause-specific hazard and assembles smooth, extrapolatable cumulative-incidence
+functions from them.
+
+The key fact that makes this simple and exact is that the parametric
+cause-specific likelihood **factorises across causes**: the contribution of an
+observation is the cause-specific density if it failed from that cause and the
+cause-specific survival otherwise, so maximising the joint likelihood is the
+same as fitting each cause's distribution independently with the *other*
+causes' events treated as right-censored. The cumulative incidence of cause
+:math:`k` is then
+
+.. math::
+    \\mathrm{CIF}_k(t) = \\int_0^t h_k(u)\\,S(u)\\,du
+                       = \\int_0^t f_k(u)\\!\\!\\prod_{j\\neq k} S_j(u)\\,du,
+
+with the all-cause survival :math:`S(u) = \\prod_j S_j(u) = \\exp(-\\sum_j
+H_j(u))`. The cause CIFs sum to the all-cause failure probability
+:math:`1 - S(t)`.
+"""
+
+import numpy as np
+from scipy.integrate import cumulative_trapezoid
+
+from surpyval.univariate.parametric import Weibull
+from surpyval.utils import check_e_and_x, xcnt_handler
+
+
+def _validate(x, c, n, e):
+    """Wrangle ``x``/``c``/``n`` and check the event labels: ``e`` is the
+    per-observation cause, and must be ``None`` exactly for censored rows."""
+    x, c, n, _ = xcnt_handler(x, c, n, group_and_sort=False)
+    x, c, n = (np.asarray(a, dtype=float) for a in (x, c, n))
+    e = np.asarray(e, dtype=object)
+    check_e_and_x(e, x)
+    if (-1 in c) or (2 in c):
+        raise ValueError(
+            "Left or interval censoring is not supported by competing risks."
+        )
+    if any(ev is not None for ev in e[c == 1]) or any(
+        ev is None for ev in e[c != 1]
+    ):
+        raise ValueError(
+            "None can only be used as the event type for a censored "
+            "observation (c = 1)."
+        )
+    return x, c, n, e
+
+
+class ParametricCompetingRisks:
+    """
+    A fitted parametric competing-risks model: one parametric distribution per
+    cause, combined into cumulative-incidence functions. Build with
+    :meth:`fit` or :meth:`fit_from_df`.
+    """
+
+    causes: list
+    models: dict
+
+    def __repr__(self):
+        dists = ", ".join(
+            "{}: {}".format(k, self.models[k].dist.name) for k in self.causes
+        )
+        return (
+            "Parametric Competing Risks SurPyval Model\n"
+            "=========================================\n"
+            "Causes              : {causes}\n"
+            "Cause distributions : {dists}".format(
+                causes=list(self.causes), dists=dists
+            )
+        )
+
+    # -- cause-specific and all-cause functions ---------------------------
+
+    def Hf(self, x, event=None):
+        """Cumulative hazard. ``event=None`` gives the all-cause cumulative
+        hazard :math:`\\sum_k H_k`; ``event=k`` gives cause ``k``'s."""
+        if event is not None:
+            self._check_event(event)
+            return self.models[event].Hf(x)
+        return sum(self.models[k].Hf(x) for k in self.causes)
+
+    def hf(self, x, event=None):
+        """Hazard rate. ``event=None`` is the all-cause hazard
+        :math:`\\sum_k h_k`; ``event=k`` is the cause-specific hazard."""
+        if event is not None:
+            self._check_event(event)
+            return self.models[event].hf(x)
+        return sum(self.models[k].hf(x) for k in self.causes)
+
+    def sf(self, x):
+        """All-cause survival :math:`S(t) = \\prod_k S_k(t)`."""
+        return np.exp(-self.Hf(x))
+
+    def ff(self, x):
+        """All-cause failure probability :math:`1 - S(t)` (the total
+        cumulative incidence over all causes)."""
+        return -np.expm1(-self.Hf(x))
+
+    def iif(self, x, event):
+        """
+        Instantaneous incidence function (the subdistribution density) of a
+        cause: :math:`f_k^{\\mathrm{sub}}(t) = h_k(t) S(t) = f_k(t)
+        \\prod_{j\\neq k} S_j(t)`.
+        """
+        self._check_event(event)
+        x = np.asarray(x, dtype=float)
+        others = np.ones_like(x, dtype=float)
+        for j in self.causes:
+            if j != event:
+                others = others * self.models[j].sf(x)
+        return self.models[event].df(x) * others
+
+    def cif(self, x, event=None):
+        """
+        Cumulative incidence function. ``event=k`` returns
+        :math:`\\int_0^t f_k^{\\mathrm{sub}}(u)\\,du`, the probability of
+        having failed from cause ``k`` by ``t``; ``event=None`` gives the
+        all-cause incidence :math:`1 - S(t) = \\sum_k \\mathrm{CIF}_k(t)`.
+        """
+        if event is None:
+            return self.ff(x)
+        self._check_event(event)
+        x_arr = np.atleast_1d(np.asarray(x, dtype=float))
+        upper = max(float(x_arr.max()), np.finfo(float).tiny)
+        grid = np.linspace(0.0, upper, 4000)
+        integrand = self.iif(grid, event)
+        # A hazard may diverge at 0 (e.g. Weibull shape < 1); the mass there
+        # is finite and negligible on a fine grid, so drop non-finite points.
+        integrand = np.where(np.isfinite(integrand), integrand, 0.0)
+        cif_grid = cumulative_trapezoid(integrand, grid, initial=0.0)
+        out = np.interp(x_arr, grid, cif_grid)
+        return out if np.ndim(x) else float(out[0])
+
+    def probability_of_cause(self, event):
+        """
+        The eventual probability that a unit fails from ``event``,
+        :math:`\\mathrm{CIF}_k(\\infty)`. These sum to one over all causes.
+        """
+        self._check_event(event)
+        # Integrate out to where every cause's survival has essentially
+        # vanished (a high quantile), rather than a crude multiple of the
+        # scale, so the CIF grid stays concentrated where the mass is.
+        upper = max(self._tail(k) for k in self.causes)
+        return self.cif(upper, event)
+
+    def random(self, size, random_state=None):
+        """
+        Draw ``size`` samples of ``(time, cause)`` from the fitted model, using
+        the latent-failure-time representation: draw a latent time from each
+        cause's distribution and take the earliest, whose cause is recorded.
+        Returns a structured array with fields ``x`` and ``e``.
+        """
+        rng = np.random.default_rng(random_state)
+        latent = np.column_stack(
+            [self.models[k].random(size) for k in self.causes]
+        )
+        # random() draws are independent of rng; shuffle-free, deterministic
+        # given each model's own draw. Use rng only if a model ignores it.
+        del rng
+        idx = np.argmin(latent, axis=1)
+        x = latent[np.arange(size), idx]
+        e = np.array([self.causes[i] for i in idx], dtype=object)
+        out = np.empty(size, dtype=[("x", float), ("e", object)])
+        out["x"] = x
+        out["e"] = e
+        return out
+
+    # -- goodness of fit (the joint likelihood factorises over causes) ----
+
+    def neg_ll(self):
+        """Total negative log-likelihood: the sum over the per-cause fits."""
+        return float(sum(self.models[k].neg_ll() for k in self.causes))
+
+    def aic(self):
+        """Akaike information criterion of the joint model."""
+        return float(sum(self.models[k].aic() for k in self.causes))
+
+    def bic(self):
+        """Bayesian information criterion of the joint model."""
+        return float(sum(self.models[k].bic() for k in self.causes))
+
+    # -- helpers ----------------------------------------------------------
+
+    def _check_event(self, event):
+        if event not in self.models:
+            raise ValueError(
+                "Unknown cause {!r}; fitted causes are {}.".format(
+                    event, list(self.causes)
+                )
+            )
+
+    def _tail(self, k):
+        # The time by which cause k has essentially certainly occurred, used
+        # as the finite upper limit for CIF(inf); its very high quantile, or a
+        # large multiple of the mean if the quantile is unavailable.
+        model = self.models[k]
+        try:
+            q = float(np.ravel(model.qf(1.0 - 1e-6))[0])
+            if np.isfinite(q) and q > 0:
+                return q
+        except Exception:
+            pass
+        return 50.0 * float(model.mean())
+
+    # -- construction -----------------------------------------------------
+
+    @classmethod
+    def fit(cls, x, e, c=None, n=None, dist=Weibull, how="MLE"):
+        """
+        Fit a parametric distribution to each cause's cause-specific hazard.
+
+        Parameters
+        ----------
+        x : array_like
+            Observed times.
+        e : array_like
+            The cause of each observation; ``None`` for a censored row.
+        c : array_like, optional
+            Censoring flag (0 observed, 1 right-censored). Defaults to all
+            observed. Left/interval censoring is not supported.
+        n : array_like, optional
+            Counts per observation.
+        dist : ParametricFitter or dict, optional
+            The distribution fitted to each cause (default ``Weibull``). Pass a
+            ``{cause: distribution}`` mapping to use a different distribution
+            per cause.
+        how : str, optional
+            Estimation method passed to each distribution's ``fit`` (default
+            ``"MLE"``).
+
+        Returns
+        -------
+        ParametricCompetingRisks
+            The fitted model.
+        """
+        x, c, n, e = _validate(x, c, n, e)
+
+        causes = sorted({ev for ev in e[c == 0]})
+        if not causes:
+            raise ValueError("No observed events to fit a cause to.")
+
+        models = {}
+        for k in causes:
+            # Cause k observed where its event occurred; every other event and
+            # every censored row is right-censored for cause k.
+            c_k = np.where((e == k) & (c == 0), 0, 1).astype(int)
+            distribution = dist[k] if isinstance(dist, dict) else dist
+            models[k] = distribution.fit(x=x, c=c_k, n=n, how=how)
+
+        model = cls()
+        model.causes = causes
+        model.models = models
+        return model
+
+    @classmethod
+    def fit_from_df(
+        cls, df, x_col, e_col, c_col=None, n_col=None, dist=Weibull, how="MLE"
+    ):
+        """Fit from a DataFrame; see :meth:`fit`. ``x_col`` / ``e_col`` name
+        the time and cause columns, with optional ``c_col`` / ``n_col``."""
+        x = df[x_col].to_numpy()
+        e = df[e_col].to_numpy(dtype=object)
+        c = None if c_col is None else df[c_col].to_numpy()
+        n = None if n_col is None else df[n_col].to_numpy()
+        model = cls.fit(x, e, c=c, n=n, dist=dist, how=how)
+        return model

--- a/surpyval/univariate/competing_risks/parametric/parametric_competing_risks.py
+++ b/surpyval/univariate/competing_risks/parametric/parametric_competing_risks.py
@@ -54,9 +54,11 @@ def _validate(x, c, n, e):
 
 class ParametricCompetingRisks:
     """
-    A fitted parametric competing-risks model: one parametric distribution per
-    cause, combined into cumulative-incidence functions. Build with
-    :meth:`fit` or :meth:`fit_from_df`.
+    A parametric competing-risks model: one distribution per cause, combined
+    into cumulative-incidence functions. Build it in one step from data with
+    :meth:`fit` / :meth:`fit_from_df`, or assemble it from already-fitted
+    per-cause models -- each of any distribution family -- with
+    :meth:`from_fitted`.
     """
 
     causes: list
@@ -114,7 +116,10 @@ class ParametricCompetingRisks:
         for j in self.causes:
             if j != event:
                 others = others * self.models[j].sf(x)
-        return self.models[event].df(x) * others
+        # A density may be singular at 0 (e.g. LogNormal); the grid includes
+        # 0, so silence the harmless evaluation there.
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return self.models[event].df(x) * others
 
     def cif(self, x, event=None):
         """
@@ -143,29 +148,36 @@ class ParametricCompetingRisks:
         :math:`\\mathrm{CIF}_k(\\infty)`. These sum to one over all causes.
         """
         self._check_event(event)
-        # Integrate out to where every cause's survival has essentially
-        # vanished (a high quantile), rather than a crude multiple of the
-        # scale, so the CIF grid stays concentrated where the mass is.
-        upper = max(self._tail(k) for k in self.causes)
+        # Integrate out to where the all-cause incidence has essentially
+        # converged, so the CIF grid stays concentrated where the mass is.
+        upper = max(self._model_horizon(k) for k in self.causes)
         return self.cif(upper, event)
 
     def random(self, size, random_state=None):
         """
-        Draw ``size`` samples of ``(time, cause)`` from the fitted model, using
-        the latent-failure-time representation: draw a latent time from each
-        cause's distribution and take the earliest, whose cause is recorded.
+        Draw ``size`` samples of ``(time, cause)`` from the model, using the
+        latent-failure-time representation: draw a latent time from each cause
+        and take the earliest, recording its cause.
+
+        Sampling is by numerical inversion of each cause's cumulative
+        distribution, so it works for *any* per-cause model, including limited-
+        failure (cure) models where some latent times are infinite. A unit
+        whose every latent time is infinite never fails; it is returned with
+        ``x = inf`` and cause ``None``.
+
         Returns a structured array with fields ``x`` and ``e``.
         """
         rng = np.random.default_rng(random_state)
         latent = np.column_stack(
-            [self.models[k].random(size) for k in self.causes]
+            [self._latent_sample(k, size, rng) for k in self.causes]
         )
-        # random() draws are independent of rng; shuffle-free, deterministic
-        # given each model's own draw. Use rng only if a model ignores it.
-        del rng
         idx = np.argmin(latent, axis=1)
         x = latent[np.arange(size), idx]
         e = np.array([self.causes[i] for i in idx], dtype=object)
+        # A unit with no finite latent time never fails from any cause.
+        never = ~np.isfinite(x)
+        if never.any():
+            e[never] = None
         out = np.empty(size, dtype=[("x", float), ("e", object)])
         out["x"] = x
         out["e"] = e
@@ -195,10 +207,11 @@ class ParametricCompetingRisks:
                 )
             )
 
-    def _tail(self, k):
-        # The time by which cause k has essentially certainly occurred, used
-        # as the finite upper limit for CIF(inf); its very high quantile, or a
-        # large multiple of the mean if the quantile is unavailable.
+    def _model_horizon(self, k):
+        # The time by which cause k has essentially played out, used as the
+        # finite upper limit for CIF(inf). Its very high quantile if available;
+        # otherwise (e.g. a limited-failure model, whose quantile is not
+        # defined) grow a bound until the cause's incidence stops rising.
         model = self.models[k]
         try:
             q = float(np.ravel(model.qf(1.0 - 1e-6))[0])
@@ -206,9 +219,104 @@ class ParametricCompetingRisks:
                 return q
         except Exception:
             pass
-        return 50.0 * float(model.mean())
+        t = 1.0
+        try:
+            m = float(model.mean())
+            if np.isfinite(m) and m > 0:
+                t = m
+        except Exception:
+            pass
+        prev = -1.0
+        for _ in range(200):
+            val = float(np.ravel(model.ff(t))[0])
+            if val - prev < 1e-10:
+                break
+            prev = val
+            t *= 1.5
+        return t
+
+    def _latent_sample(self, k, size, rng):
+        # A latent failure time for cause k by numerical inversion of its CDF.
+        # Draws in the (possible) cure region above the model's attainable CDF
+        # are mapped to infinity: that unit never fails from this cause.
+        model = self.models[k]
+        u = rng.uniform(size=size)
+        upper = self._model_horizon(k)
+        grid = np.linspace(0.0, upper, 8000)
+        cdf = np.ravel(model.ff(grid))
+        cdf_max = float(cdf[-1])
+        t = np.interp(u, cdf, grid)
+        return np.where(u <= cdf_max, t, np.inf)
 
     # -- construction -----------------------------------------------------
+
+    @classmethod
+    def from_fitted(cls, models):
+        """
+        Assemble a competing-risks model from already-fitted single-cause
+        models -- one per cause -- instead of fitting them here.
+
+        Each cause's model may be of a completely different family: a Weibull
+        with a limited-failure (cure) fraction for one cause, a LogNormal for
+        another, a discrete distribution for a third, and so on. The only
+        requirement is that every model exposes the standard surpyval model
+        interface (``sf`` / ``ff`` / ``df`` / ``hf`` / ``Hf``); the cumulative
+        incidence, all-cause survival and sampling are then assembled from
+        them exactly as for a :meth:`fit` model.
+
+        This is the right entry point when each cause has been modelled
+        separately -- for example fitted with its own distribution, offset,
+        limited-failure or zero-inflated options -- and you want to combine
+        them into one competing-risks object.
+
+        Parameters
+        ----------
+        models : dict or sequence
+            Either a ``{cause: model}`` mapping, or a sequence of models whose
+            causes are taken to be their positions ``0, 1, 2, ...``.
+
+        Returns
+        -------
+        ParametricCompetingRisks
+            The assembled model.
+
+        Notes
+        -----
+        Each per-cause model should be fitted to the *cause-specific* view of
+        the data (that cause's events observed, every other cause's events and
+        every censored unit treated as right-censored) for the assembled CIFs
+        to be the competing-risks quantities. If the causes carry a cure
+        fraction the all-cause survival need not fall to zero, so the cause
+        probabilities need not sum to one -- some units never fail.
+        """
+        if isinstance(models, dict):
+            mapping = dict(models)
+        else:
+            mapping = {i: m for i, m in enumerate(models)}
+        if len(mapping) == 0:
+            raise ValueError("At least one cause model is required.")
+        for k, m in mapping.items():
+            missing = [
+                a
+                for a in ("sf", "ff", "df", "hf", "Hf")
+                if not callable(getattr(m, a, None))
+            ]
+            if missing:
+                raise ValueError(
+                    "Model for cause {!r} is missing the method(s) {}; it "
+                    "does not look like a fitted surpyval model.".format(
+                        k, missing
+                    )
+                )
+        try:
+            causes = sorted(mapping)
+        except TypeError:
+            causes = list(mapping)
+
+        model = cls()
+        model.causes = causes
+        model.models = mapping
+        return model
 
     @classmethod
     def fit(cls, x, e, c=None, n=None, dist=Weibull, how="MLE"):


### PR DESCRIPTION
## Summary

Adds `ParametricCompetingRisks`, a fully parametric competing-risks model. Where the existing nonparametric `CompetingRisks` estimates each cause's cumulative incidence as a step function and the Cox / Fine-Gray models handle covariate regression, this fills the remaining gap: **smooth, extrapolatable cumulative-incidence functions built from a parametric distribution per cause**.

The key fact that makes this exact and cheap is that the parametric cause-specific likelihood **factorises across causes** — the contribution of an observation is the cause-specific density if it failed from that cause and the cause-specific survival otherwise. So maximising the joint likelihood is identical to fitting each cause's distribution independently with the *other* causes' events treated as right-censored. The cumulative incidence of cause *k* is then

```
CIF_k(t) = ∫₀ᵗ h_k(u) S(u) du = ∫₀ᵗ f_k(u) ∏_{j≠k} S_j(u) du
```

with all-cause survival `S = ∏_j S_j = exp(-∑_j H_j)`, and the cause CIFs sum to the all-cause failure probability `1 − S`.

## API

- `ParametricCompetingRisks.fit(x, e, c=None, n=None, dist=Weibull, how="MLE")` and `fit_from_df(...)`. `e` is the per-observation cause (`None` for censored rows). `dist` accepts a single distribution or a `{cause: distribution}` mapping.
- All-cause and cause-specific `hf` / `Hf` / `sf` / `ff`.
- `iif(x, event)` — the subdistribution density `f_k(t) ∏_{j≠k} S_j(t)`.
- `cif(x, event=None)` — cumulative incidence per cause (or all-cause when `event=None`).
- `probability_of_cause(event)` — the eventual `CIF_k(∞)`; these sum to one.
- `random(size, random_state=None)` — latent-minimum sampling returning `(time, cause)`.
- `aic` / `bic` / `neg_ll` (sums over the per-cause fits).

Mirrors the nonparametric `CompetingRisks` interface, and is exported from `surpyval.univariate.competing_risks`.

## Tests

18 new tests in `test_parametric_competing_risks.py`: per-cause parameter recovery from latent-minimum data, parametric CIFs agreeing with the nonparametric estimator, cause CIFs summing to `1 − S`, cause probabilities summing to one, the survival-product / hazard-sum identities, the subdistribution-density form, per-cause distribution mapping, three-cause fits, scalar/vector handling, sampling, goodness-of-fit, DataFrame input, and input validation. Full competing-risks suite (41 tests) passes; flake8 / black / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_