### PR TITLE
Treat a missing event (None/NaN) as a censored competing-risks observation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,6 +48,12 @@ Competing risks
   a ``{cause: model}`` mapping or a sequence of models. Sampling handles cure
   fractions -- when every cause carries one, some units never fail and are
   returned with cause ``None``.
+- Every competing-risks model (parametric, nonparametric, and the Fine-Gray /
+  cause-specific Cox regression) now treats a *missing* event value (``None``,
+  ``NaN`` or pandas ``NA``) as a censored observation with no attributed cause,
+  and derives the censoring flag ``c`` from the events when it is not supplied
+  -- so competing-risks data can be given as ``(x, e)`` alone, and a pandas
+  cause column with ``NaN`` for censored rows works directly.
 
 Regression — Cox proportional hazards
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/surpyval/tests/univariate/competing_risks/test_parametric_competing_risks.py
+++ b/surpyval/tests/univariate/competing_risks/test_parametric_competing_risks.py
@@ -288,3 +288,71 @@ def test_from_fitted_rejects_non_model():
 
     with pytest.raises(ValueError, match="does not look like"):
         ParametricCompetingRisks.from_fitted({1: NotAModel()})
+
+
+# --- censoring: a missing event (None / NaN) is a censored observation -----
+
+
+def test_nan_marks_censored_like_none():
+    # NaN in the event vector is treated the same as None -- a censored
+    # observation with no attributed cause.
+    x, e, c = _simulate(4000, 30)
+    e_none = np.asarray(e, dtype=object)
+    e_nan = np.array(
+        [np.nan if ev is None else ev for ev in e_none], dtype=object
+    )
+    from_none = ParametricCompetingRisks.fit(x, e_none, c=c)
+    from_nan = ParametricCompetingRisks.fit(x, e_nan, c=c)
+    assert from_nan.causes == from_none.causes
+    for k in from_none.causes:
+        assert np.allclose(
+            from_nan.models[k].params, from_none.models[k].params
+        )
+
+
+def test_derives_censoring_from_missing_event():
+    # Omitting c derives it from e: a missing event is censored, an event
+    # present is observed. The result must match passing c explicitly.
+    x, e, c = _simulate(4000, 31)
+    derived = ParametricCompetingRisks.fit(x, e)  # no c
+    explicit = ParametricCompetingRisks.fit(x, e, c=c)
+    assert derived.causes == explicit.causes
+    for k in explicit.causes:
+        assert np.allclose(derived.models[k].params, explicit.models[k].params)
+
+
+def test_derives_censoring_from_nan_without_c():
+    x, e, c = _simulate(3000, 32)
+    e_nan = np.array([np.nan if ev is None else ev for ev in e], dtype=object)
+    model = ParametricCompetingRisks.fit(x, e_nan)  # no c, NaN censored
+    assert model.causes == [1, 2]
+    # the censored rows are still in the risk set for each cause
+    n_cens = int(np.sum(~np.isfinite(np.asarray(e_nan, dtype=float))))
+    assert n_cens > 0
+
+
+def test_fit_from_df_with_nan_causes_and_no_censoring_column():
+    # The natural pandas representation: the cause column carries NaN for
+    # censored rows and there is no separate censoring column.
+    x, e, c = _simulate(3000, 33)
+    cause_col = [np.nan if ev is None else ev for ev in e]
+    df = pd.DataFrame({"time": x, "cause": cause_col})
+    model = ParametricCompetingRisks.fit_from_df(
+        df, x_col="time", e_col="cause"
+    )
+    assert len(model.causes) == 2
+    # recovers the cause-1 Weibull truth despite censoring being implicit
+    k1 = model.causes[0]
+    assert np.allclose(model.models[k1].params, [30.0, 2.0], rtol=0.15)
+
+
+def test_nonparametric_also_derives_censoring():
+    # The same missing-event / derived-c handling applies to the
+    # nonparametric estimator (it shares the input validator).
+    x, e, c = _simulate(3000, 34)
+    e_nan = np.array([np.nan if ev is None else ev for ev in e], dtype=object)
+    derived = CompetingRisks.fit(x, e_nan)  # no c, NaN censored
+    explicit = CompetingRisks.fit(x, e, c=c)
+    grid = np.array([10.0, 20.0, 30.0, 40.0])
+    for k in (1, 2):
+        assert np.allclose(derived.cif(grid, k), explicit.cif(grid, k))

--- a/surpyval/tests/utils/test_utils.py
+++ b/surpyval/tests/utils/test_utils.py
@@ -4,11 +4,43 @@ import pytest
 from surpyval.utils import (
     fsli_handler,
     group_xcnt,
+    is_missing_event,
+    resolve_cr_censoring,
     xcn_to_fs,
     xcnt_handler,
     xcnt_sort,
     xrd_handler,
 )
+
+
+def test_is_missing_event():
+    assert is_missing_event(None)
+    assert is_missing_event(np.nan)
+    assert is_missing_event(float("nan"))
+    assert not is_missing_event(0)
+    assert not is_missing_event(1)
+    assert not is_missing_event(2.0)
+
+
+def test_resolve_cr_censoring_canonicalises_missing_to_none():
+    e_in = [1, 2, np.nan, 1, None]
+    e, c = resolve_cr_censoring(e_in, [0, 0, 1, 0, 1])
+    # NaN and None both become None
+    assert e[2] is None and e[4] is None
+    assert list(e[[0, 1, 3]]) == [1, 2, 1]
+
+
+def test_resolve_cr_censoring_derives_c_from_missing():
+    e_in = [1, 2, np.nan, 1, None]
+    e, c = resolve_cr_censoring(e_in, None)
+    # missing events -> censored (1), present -> observed (0)
+    assert list(c) == [0, 0, 1, 0, 1]
+
+
+def test_resolve_cr_censoring_keeps_supplied_c():
+    e_in = [1, 2, None]
+    e, c = resolve_cr_censoring(e_in, [0, 0, 1])
+    assert list(c) == [0, 0, 1]
 
 
 def test_group_xcnt():

--- a/surpyval/univariate/competing_risks/parametric/parametric_competing_risks.py
+++ b/surpyval/univariate/competing_risks/parametric/parametric_competing_risks.py
@@ -28,12 +28,19 @@ import numpy as np
 from scipy.integrate import cumulative_trapezoid
 
 from surpyval.univariate.parametric import Weibull
-from surpyval.utils import check_e_and_x, xcnt_handler
+from surpyval.utils import (
+    check_e_and_x,
+    resolve_cr_censoring,
+    xcnt_handler,
+)
 
 
 def _validate(x, c, n, e):
     """Wrangle ``x``/``c``/``n`` and check the event labels: ``e`` is the
-    per-observation cause, and must be ``None`` exactly for censored rows."""
+    per-observation cause. A missing event (``None`` / ``NaN``) marks a
+    censored observation; if ``c`` is not given it is derived from the events.
+    """
+    e, c = resolve_cr_censoring(e, c)
     x, c, n, _ = xcnt_handler(x, c, n, group_and_sort=False)
     x, c, n = (np.asarray(a, dtype=float) for a in (x, c, n))
     e = np.asarray(e, dtype=object)
@@ -46,8 +53,9 @@ def _validate(x, c, n, e):
         ev is None for ev in e[c != 1]
     ):
         raise ValueError(
-            "None can only be used as the event type for a censored "
-            "observation (c = 1)."
+            "A missing event type (None / NaN) is allowed only for a "
+            "censored observation (c = 1), and every censored observation "
+            "must have one."
         )
     return x, c, n, e
 
@@ -320,10 +328,13 @@ class ParametricCompetingRisks:
         x : array_like
             Observed times.
         e : array_like
-            The cause of each observation; ``None`` for a censored row.
+            The cause of each observation. A missing value (``None`` / ``NaN``)
+            marks a censored observation with no attributed cause.
         c : array_like, optional
-            Censoring flag (0 observed, 1 right-censored). Defaults to all
-            observed. Left/interval censoring is not supported.
+            Censoring flag (0 observed, 1 right-censored). If omitted it is
+            derived from ``e`` -- a missing event is censored, an event present
+            is observed -- so data can be passed as ``(x, e)`` alone.
+            Left/interval censoring is not supported.
         n : array_like, optional
             Counts per observation.
         dist : ParametricFitter or dict, optional

--- a/surpyval/utils/__init__.py
+++ b/surpyval/utils/__init__.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 import numpy as np
 import numpy.typing as npt
 from formulaic import Formula
-from pandas import Series
+from pandas import Series, isna
 
 COX_PH_METHODS = ["breslow", "efron"]
 FG_BASELINE_OPTIONS = ["Nelson-Aalen", "Kaplan-Meier"]
@@ -1038,8 +1038,43 @@ def check_c_and_e(c, e):
         e_i is None for e_i in e[c != 1]
     ):
         raise ValueError(
-            "None can only be used as event type for censored observation"
+            "A missing event type (None / NaN) is allowed only for a "
+            "censored observation (c = 1), and every censored observation "
+            "must have one."
         )
+
+
+def is_missing_event(value):
+    """Whether a competing-risks event value marks *no* attributed cause -- a
+    censored observation. That is Python ``None`` or any missing value
+    (``NaN``, pandas ``NA``)."""
+    if value is None:
+        return True
+    try:
+        return bool(isna(value))
+    except (TypeError, ValueError):
+        return False
+
+
+def resolve_cr_censoring(e, c):
+    """Canonicalise a competing-risks event vector and its censoring flag.
+
+    A *missing* event value (``None``, ``NaN`` or pandas ``NA``) marks a
+    right-censored observation with no attributed cause; such values are
+    canonicalised to ``None``. When ``c`` is not supplied it is derived from
+    the events -- a missing event is censored (``c = 1``), an event present is
+    observed (``c = 0``) -- so competing-risks data may be given as ``(x, e)``
+    alone, without a separate censoring array.
+
+    Returns the canonicalised event array (object dtype, ``None`` for censored)
+    and the censoring flag (unchanged if supplied, otherwise derived).
+    """
+    e = np.asarray(e, dtype=object)
+    missing = np.array([is_missing_event(v) for v in e], dtype=bool)
+    e = np.array([None if m else v for v, m in zip(e, missing)], dtype=object)
+    if c is None:
+        c = np.where(missing, 1, 0)
+    return e, c
 
 
 def wrangle_and_check_form_and_Z_cols(Z_cols, formula, df):
@@ -1109,6 +1144,9 @@ def validate_cr_inputs(x, c, n, e, method):
     # Validates the inputs prior to be used by the CoxPH model.
     # Use existing surpyval validator. But don't group and sort
     # so as to put it out of order of the event array, e.
+    # A missing event (None / NaN) marks a censored observation; if c is not
+    # given it is derived from the events.
+    e, c = resolve_cr_censoring(e, c)
     x, c, n, _ = xcnt_handler(x, c, n, group_and_sort=False)
 
     e = np.array(e)
@@ -1125,12 +1163,7 @@ def validate_cr_inputs(x, c, n, e, method):
 
     # Ensure all cases where c is 0, e is not None and
     # where c is 1 e is None
-    if any(e_i is not None for e_i in e[c == 1]) or any(
-        e_i is None for e_i in e[c != 1]
-    ):
-        raise ValueError(
-            "None can only be used as event type for censored observation"
-        )
+    check_c_and_e(c, e)
 
     # Two baselines
     # TODO: Add fleming-harrington
@@ -1325,6 +1358,9 @@ def validate_coxph(
 
 
 def validate_fine_gray_inputs(x, Z, e, c, n):
+    # A missing event (None / NaN) marks a censored observation; if c is not
+    # given it is derived from the events.
+    e, c = resolve_cr_censoring(e, c)
     x, c, n, _ = xcnt_handler(x, c, n, group_and_sort=False)
 
     e = np.array(e)


### PR DESCRIPTION
## Summary

A competing-risks observation with `c = 1` (censored) has no attributed cause. Today only Python `None` expresses that, and a separate censoring array `c` is required. Two things fall out of that which shouldn't:

1. A pandas cause column naturally uses `NaN` for censored rows, and `NaN` was **rejected** (`"None can only be used..."`).
2. You couldn't pass competing-risks data as just `(x, e)` — the canonical `(time, cause)` format — because censoring had to be given separately.

This makes **every** competing-risks model — parametric (`ParametricCompetingRisks`), nonparametric (`CompetingRisks`), and the Fine-Gray / cause-specific Cox regression — handle both:

- A **missing event** (`None`, `NaN`, or pandas `NA`) marks a censored observation with no attributed cause.
- When `c` is **omitted**, it is derived from the events: missing → censored (`c = 1`), present → observed (`c = 0`).

```python
# a pandas cause column with NaN for censored rows, no censoring column
df = pd.DataFrame({"time": t, "cause": [1, 2, np.nan, 1, np.nan]})
ParametricCompetingRisks.fit_from_df(df, x_col="time", e_col="cause")

# or just (x, e), censoring inferred from the missing events
ParametricCompetingRisks.fit(t, e=[1, 2, None, 1, None])
```

Supplying `c` explicitly still works and is validated exactly as before (`c == 1` iff the event is missing).

## Implementation

Adds two shared helpers in `surpyval.utils` — `is_missing_event` and `resolve_cr_censoring` (canonicalises missing values to `None`, derives `c` when absent) — and routes the three competing-risks validators (`validate_cr_inputs`, `validate_fine_gray_inputs`, and the parametric `_validate`) through them, so the behaviour is identical everywhere. No change to the fitted quantities — this is purely input handling.

## Tests

Unit tests for `is_missing_event` / `resolve_cr_censoring` (canonicalisation, derivation, supplied-`c` passthrough) in `test_utils.py`; parametric tests that `NaN` behaves like `None`, that omitting `c` matches passing it explicitly, that `NaN` without `c` works, and that `fit_from_df` handles a `NaN` cause column with no censoring column; plus a nonparametric integration test confirming the shared validator (derived `c` from `NaN` reproduces the explicit-`c` CIFs). Full competing-risks, utils and LFP/zi suites pass; flake8 / black / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_