### PR TITLE
Implement moment and entropy for limited-failure, zero-inflated and offset models

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -257,10 +257,13 @@ MLE fitting, dependence measures and conditional-inversion sampling. Outstanding
   fundamental limitation of probability-plotting the family, not a bug
   (`test_fit.py:352` skips it deliberately). Worth a clear docstring/warning
   pointing users to MLE.
-- **Niche unimplemented paths (deferred, genuine but low-value):** defective
-  (LFP) `qf`/`moment`/`entropy`; MSE estimation with truncation;
-  `ExactEventTime` for interval-censored data. Each raises an explicit
-  `NotImplementedError` today; implement only if a use case appears.
+- **Niche unimplemented paths (deferred, genuine but low-value):** MSE
+  estimation with truncation and `ExactEventTime` for interval-censored data
+  each raise an explicit `NotImplementedError` today; implement only if a use
+  case appears. (Defective/offset/zero-inflated `qf` and `moment` are now
+  implemented; `entropy` is defined where it exists — no probability atom —
+  and raises a clear error for limited-failure / zero-inflated models, whose
+  mixed discrete-continuous law has no single differential entropy.)
 
 ---
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,17 @@ Distributions
 - ``Beta.fit(how="MPP")`` now raises a clear ``ValueError`` (the Beta has no
   linearising probability plot) instead of a raw ``NotImplementedError``, and
   points to ``MLE`` / ``MSE`` / ``MOM``.
+- ``Parametric.moment`` now works for limited-failure, zero-inflated and
+  offset models (it previously raised ``NotImplementedError`` under a cure
+  fraction, and silently dropped the offset). It returns the defective moment
+  of the failure-time density, consistent with ``mean`` (``moment(1) ==
+  mean()``): the offset shifts the failure times and the cured fraction
+  contributes nothing. ``Parametric.entropy`` likewise handles the offset
+  (differential entropy is translation-invariant) and now raises a clear
+  ``ValueError`` for models with a probability atom (a limited-failure mass at
+  infinity or a zero-inflation mass at the offset), where a single differential
+  entropy does not exist -- it previously returned a wrong value for
+  zero-inflated models.
 - ``Parametric.qf`` now works for limited-failure, zero-inflated and offset
   models (it previously raised ``NotImplementedError`` whenever a cure fraction
   was present). It inverts the full mixture ``F(x) = f0 + (p - f0) F0(x -

--- a/surpyval/tests/univariate/parametric/test_lfp_zi.py
+++ b/surpyval/tests/univariate/parametric/test_lfp_zi.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from surpyval import (
     Beta,
@@ -165,3 +166,75 @@ def test_qf_matches_plain_distribution_without_mixture():
     # distribution's, so ordinary models are unchanged.
     model = Weibull.from_params([10.0, 3.0])
     assert np.isclose(model.qf(0.2), Weibull.qf(0.2, 10.0, 3.0))
+
+
+# --- moment for the mixture (LFP / zero-inflation / offset) ----------------
+
+
+def test_moment_matches_plain_distribution_without_mixture():
+    model = Weibull.from_params([10.0, 3.0])
+    assert np.isclose(model.moment(2), Weibull.moment(2, 10.0, 3.0))
+    assert np.isclose(model.moment(3), Weibull.moment(3, 10.0, 3.0))
+
+
+def test_moment_one_equals_mean_across_mixtures():
+    # moment(1) must be consistent with mean() for every configuration.
+    for model in (
+        Weibull.from_params([10.0, 2.0]),
+        Weibull.from_params([10.0, 2.0], gamma=5.0),
+        Weibull.from_params([10.0, 2.0], p=0.6),
+        Weibull.from_params([10.0, 2.0], gamma=5.0, p=0.7),
+    ):
+        assert np.isclose(model.moment(1), model.mean())
+
+
+def test_offset_moment_includes_offset():
+    # Regression: the offset previously dropped out of moment. E[(gamma+X)^2]
+    # is strictly greater than E[X^2].
+    base = Weibull.from_params([10.0, 2.0])
+    offset = Weibull.from_params([10.0, 2.0], gamma=5.0)
+    assert offset.moment(2) > base.moment(2)
+    # exact binomial value: E[(g+X)^2] = g^2 + 2 g E[X] + E[X^2]
+    g = 5.0
+    expected = g**2 + 2 * g * base.moment(1) + base.moment(2)
+    assert np.isclose(offset.moment(2), expected)
+
+
+def test_lfp_moment_is_finite_and_defective():
+    # With a cure fraction the defective moment is finite and equals the base
+    # moment scaled by the failing proportion p (no offset).
+    p = 0.6
+    model = Weibull.from_params([10.0, 2.0], p=p)
+    assert np.isclose(model.moment(2), p * Weibull.moment(2, 10.0, 2.0))
+
+
+def test_defective_moment_matches_monte_carlo():
+    # cured units contribute nothing; offset shifts the failures.
+    g, p, params = 6.0, 0.7, (10.0, 2.0)
+    model = Weibull.from_params(list(params), gamma=g, p=p)
+    rng = np.random.default_rng(0)
+    n = 2_000_000
+    fail = rng.uniform(size=n) < p
+    t = np.where(fail, g + Weibull.random(n, *params), 0.0)
+    assert np.isclose(model.moment(1), t.mean(), rtol=0.02)
+    assert np.isclose(model.moment(2), (t**2).mean(), rtol=0.02)
+
+
+# --- entropy for the mixture ----------------------------------------------
+
+
+def test_entropy_is_offset_invariant():
+    # Differential entropy is translation-invariant, so an offset model has
+    # the same entropy as the un-offset one.
+    base = Weibull.from_params([10.0, 2.0])
+    offset = Weibull.from_params([10.0, 2.0], gamma=5.0)
+    assert np.isclose(offset.entropy(), base.entropy())
+
+
+def test_entropy_raises_with_a_probability_atom():
+    # A cure fraction (mass at infinity) or zero-inflation (mass at the
+    # offset) leaves no single differential entropy.
+    with pytest.raises(ValueError, match="probability atom"):
+        Weibull.from_params([10.0, 2.0], p=0.6).entropy()
+    with pytest.raises(ValueError, match="probability atom"):
+        LogNormal.from_params([2.0, 0.4], f0=0.2).entropy()

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -1,6 +1,7 @@
 import json
 from collections import namedtuple
 from copy import copy, deepcopy
+from math import comb
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -793,12 +794,29 @@ class Parametric(ParametricDistribution):
         10.0
         >>> model.moment(5)
         202150.0
+
+        Notes
+        -----
+        For an offset, limited-failure or zero-inflated model this is the
+        *defective* moment of the failure-time density, consistent with
+        :meth:`mean` (``moment(1) == mean()``): the offset shifts the failure
+        times and the cured fraction ``1 - p`` contributes nothing (rather than
+        the raw moment, which diverges when a cured fraction is present because
+        those units never fail). It is
+        :math:`p\\,\\mathbb{E}\\!\\left[(\\gamma + X)^n\\right]` for :math:`X`
+        the base distribution.
         """
-        if self.p == 1:
-            return self.dist.moment(n, *self.params)
-        else:
-            msg = "LFP distributions cannot yet have their moment calculated"
-            raise NotImplementedError(msg)
+        # Defective n-th moment E[(gamma + X)^n] weighted by the failing
+        # proportion p; the binomial expansion recombines the base raw
+        # moments. Reduces to the base moment for a plain model (gamma = 0,
+        # p = 1) and to mean() for n = 1.
+        base = [1.0] + [
+            float(self.dist.moment(k, *self.params)) for k in range(1, n + 1)
+        ]
+        shifted = sum(
+            comb(n, k) * self.gamma ** (n - k) * base[k] for k in range(n + 1)
+        )
+        return float(self.p * shifted)
 
     def entropy(self) -> float:
         r"""
@@ -817,12 +835,28 @@ class Parametric(ParametricDistribution):
         >>> model = Normal.from_params([10, 3])
         >>> model.entropy()
         2.5175508218727822
+
+        Notes
+        -----
+        The (differential) entropy is translation-invariant, so an offset does
+        not change it. It is only defined when the distribution has no
+        probability atom; a limited-failure model places mass ``1 - p`` at
+        infinity (the cured fraction) and a zero-inflated model places mass
+        ``f0`` at the offset, so a single differential entropy does not exist
+        for those and a ``ValueError`` is raised. The entropy *conditional on
+        failure* of a limited-failure model equals the entropy of the same
+        model fitted without ``lfp``.
         """
-        if self.p == 1:
+        if self.p == 1 and self.f0 == 0:
             return self.dist.entropy(*self.params)
-        else:
-            msg = "Entropy not available for LFP distribution"
-            raise NotImplementedError(msg)
+        raise ValueError(
+            "Differential entropy is undefined for a distribution with a "
+            "probability atom: a limited-failure model places mass 1 - p at "
+            "infinity (the cured fraction never fails) and a zero-inflated "
+            "model places mass f0 at the offset. Fit without lfp / zi to take "
+            "the entropy (which, for lfp, is the entropy conditional on "
+            "failure)."
+        )
 
     def cb(
         self,


### PR DESCRIPTION
## Summary

Closes the companion gap to the LFP quantile (#135): `Parametric.moment` and `Parametric.entropy` raised `NotImplementedError` whenever a cure fraction was present, and the `p == 1` branch of each silently dropped the offset (`gamma`) and, for `entropy`, the zero-inflation mass (`f0`).

### `moment`

Now returns the **defective moment** of the failure-time density, consistent with `mean()` — i.e. `moment(1) == mean()` for every configuration:

```
moment(n) = p · E[(gamma + X)^n]      (X ~ base distribution)
```

The offset shifts the failure times and the cured fraction `1 - p` contributes nothing (matching the existing `mean() = p·(base_mean + gamma)` convention — the raw moment would diverge under a cure fraction, since those units never fail). It reduces **exactly** to the base moment for a plain model, and I checked it against a 2M-draw Monte-Carlo of the defective distribution (`moment(1)` and `moment(2)` within tolerance).

### `entropy`

Differential entropy is translation-invariant, so an offset model keeps the base entropy (this was already the behaviour and is preserved). For a model with a **probability atom** — a limited-failure mass `1 - p` at infinity, or a zero-inflation mass `f0` at the offset — a single differential entropy does not exist, so it now raises a clear `ValueError` explaining why (and noting that the entropy *conditional on failure* of an LFP model is just the un-`lfp` model's entropy). This also **fixes a wrong return** for zero-inflated models: the old `p == 1` branch returned the base entropy while ignoring the `f0` atom.

## Tests

Added to `test_lfp_zi.py`: `moment` matches the plain distribution without a mixture, `moment(1) == mean()` across offset / LFP / combined configurations, the offset is included (with the exact binomial value), the LFP moment is finite and defective, a Monte-Carlo cross-check, entropy is offset-invariant, and entropy raises with a probability atom (LFP and ZI). Full parametric suite passes (472 passed, 1 skipped); flake8 / black / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_