### PR TITLE
Add residual and trend-test diagnostics to proportional-intensity recurrent regression

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,12 +89,14 @@ remains:
 
 **Medium priority**
 
-- **Diagnostics for the regression and renewal families.** `residuals()`,
-  `trend_test()` and `cramer_von_mises()` exist only on
-  `ParametricRecurrenceModel`. The proportional-intensity extension is mostly
-  plumbing (scale each item's CIF by its `exp(Z'β)` factor); the
-  renewal/virtual-age models need conditional-intensity residuals instead, which
-  is a genuinely different construction.
+- **Diagnostics for the regression and renewal families.** `residuals()` and
+  `trend_test()` now also exist on the proportional-intensity regression models
+  (each item's time-rescaling residuals use its own `exp(Z'β)`-scaled CIF).
+  Still missing: `cramer_von_mises()` for the regression family (its parametric
+  bootstrap needs a covariate-aware refit — the model does not yet hold a
+  reference to its fitter), and all three diagnostics for the renewal/virtual-
+  age models, which need conditional-intensity residuals instead — a genuinely
+  different construction.
 - **Multi-window (gapped) observation per item.** `handle_xicn` supports a
   single `[tl, tr]` window per item; genuinely gapped observation is not yet
   modelled.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -66,6 +66,16 @@ Competing risks
   -- so competing-risks data can be given as ``(x, e)`` alone, and a pandas
   cause column with ``NaN`` for censored rows works directly.
 
+Recurrent events
+~~~~~~~~~~~~~~~~
+
+- Added residual (``residuals``: ``cumulative_hazard`` / ``pit`` /
+  ``martingale``) and trend-test (``trend_test``) diagnostics to the
+  proportional-intensity regression models (``ProportionalIntensityHPP`` /
+  ``ProportionalIntensityNHPP``), matching those already on the parametric
+  recurrence models. Each item's time-rescaling residuals use its own
+  covariate-scaled cumulative intensity ``Lambda_0(t) exp(Z'beta)``.
+
 Regression — Cox proportional hazards
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/surpyval/recurrent/diagnostics.py
+++ b/surpyval/recurrent/diagnostics.py
@@ -49,14 +49,14 @@ def _per_item_windows(data):
     Group the data by item and resolve each item's observation window.
 
     Returns a list with one entry per (sorted-unique) item:
-    ``(events, entry, close, explicit_close)`` where ``events`` are the
-    item's observed event times (sorted, repeated per their counts ``n``),
-    ``entry`` is its observation start (its finite left-truncation bound,
-    else 0), ``close`` is the time its window closes (its finite
-    right-truncation bound, else its right-censoring row, else its last
-    event) and ``explicit_close`` says whether that close was given by the
-    data (``tr`` or a ``c = 1`` row) or inferred from the last event
-    (failure-truncated).
+    ``(item, events, entry, close, explicit_close)`` where ``item`` is the
+    item identifier, ``events`` are the item's observed event times (sorted,
+    repeated per their counts ``n``), ``entry`` is its observation start (its
+    finite left-truncation bound, else 0), ``close`` is the time its window
+    closes (its finite right-truncation bound, else its right-censoring row,
+    else its last event) and ``explicit_close`` says whether that close was
+    given by the data (``tr`` or a ``c = 1`` row) or inferred from the last
+    event (failure-truncated).
     """
     items = []
     for item in np.unique(data.i):
@@ -75,8 +75,21 @@ def _per_item_windows(data):
             close, explicit_close = float(events[-1]), False
         else:
             continue
-        items.append((events, entry, close, explicit_close))
+        items.append((item, events, entry, close, explicit_close))
     return items
+
+
+def _as_item_cif(cif):
+    """
+    Normalise the ``cif`` argument of the diagnostics into a factory that
+    maps an item identifier to that item's CIF callable. A plain callable
+    (the unconditional model's ``cif``) is reused for every item; a mapping
+    of ``item -> callable`` (a regression model's per-item, covariate-scaled
+    CIF) is looked up per item.
+    """
+    if callable(cif):
+        return lambda item: cif
+    return lambda item: cif[item]
 
 
 def cumulative_hazard_residuals(data, cif):
@@ -85,13 +98,18 @@ def cumulative_hazard_residuals(data, cif):
     observed event (with ``t_0`` each item's entry time), pooled across
     items in sorted-item then time order. Under the fitted model these are
     iid Exp(1).
+
+    ``cif`` is either a single callable used for every item (an unconditional
+    model) or an ``item -> callable`` mapping (a regression model, whose
+    intensity is scaled per item by ``exp(Z'beta)``).
     """
     _validate_diagnostic_data(data, "Residuals")
+    item_cif = _as_item_cif(cif)
     residuals = []
-    for events, entry, _, _ in _per_item_windows(data):
+    for item, events, entry, _, _ in _per_item_windows(data):
         if events.size == 0:
             continue
-        transformed = cif(np.concatenate([[entry], events]))
+        transformed = item_cif(item)(np.concatenate([[entry], events]))
         residuals.append(np.diff(transformed))
     if not residuals:
         raise ValueError("No observed events; no residuals to compute.")
@@ -104,11 +122,16 @@ def martingale_residuals(data, cif):
     expected count ``cif(close) - cif(entry)`` over the item's observation
     window, one per sorted-unique item. Positive values mean the item had
     more events than the model expects.
+
+    ``cif`` is either a single callable or an ``item -> callable`` mapping
+    (see :func:`cumulative_hazard_residuals`).
     """
     _validate_diagnostic_data(data, "Residuals")
+    item_cif = _as_item_cif(cif)
     residuals = []
-    for events, entry, close, _ in _per_item_windows(data):
-        expected = float(cif(close) - cif(entry))
+    for item, events, entry, close, _ in _per_item_windows(data):
+        cif_i = item_cif(item)
+        expected = float(cif_i(close) - cif_i(entry))
         residuals.append(events.size - expected)
     return np.array(residuals)
 
@@ -165,23 +188,65 @@ def _conditional_uniforms(data, cif):
     a failure-truncated item the last event is the (random) window close,
     so the remaining events are normalised by the transform at that last
     event and it is itself excluded (Crow's ``M = N - 1`` convention).
+
+    ``cif`` is either a single callable or an ``item -> callable`` mapping
+    (see :func:`cumulative_hazard_residuals`).
     """
+    item_cif = _as_item_cif(cif)
     u = []
     n_systems = 0
-    for events, entry, close, explicit_close in _per_item_windows(data):
+    for item, events, entry, close, explicit_close in _per_item_windows(data):
         n_systems += 1
+        cif_i = item_cif(item)
         used = events if explicit_close else events[:-1]
         if used.size == 0:
             continue
-        span = float(cif(close) - cif(entry))
+        span = float(cif_i(close) - cif_i(entry))
         if span <= 0:
             continue
-        u.append((cif(used) - cif(entry)) / span)
+        u.append((cif_i(used) - cif_i(entry)) / span)
     if not u:
         raise ValueError(
             "No usable event times for the Cramer-von Mises statistic."
         )
     return np.concatenate(u), n_systems
+
+
+def trend_test(data, test="laplace", alternative="two-sided"):
+    """
+    Trend test for recurrent-event data: the null hypothesis is that the
+    events follow a *homogeneous* Poisson process (no trend), so it checks
+    whether the data warranted a time-varying intensity at all. The
+    statistic uses only the event times and windows, not the fitted model,
+    so it is shared by the parametric and proportional-intensity models.
+    """
+    from surpyval.recurrent.tests import laplace, mil_hdbk_189c
+
+    _validate_diagnostic_data(data, "trend_test")
+    tests = {"laplace": laplace, "mil_hdbk_189c": mil_hdbk_189c}
+    if test not in tests:
+        raise ValueError(
+            "`test` must be one of {}; got {!r}".format(sorted(tests), test)
+        )
+
+    # The trend tests assume every system is observed from time 0.
+    x, i, T = [], [], {}
+    for item_id, (_, events, entry, close, explicit_close) in enumerate(
+        _per_item_windows(data)
+    ):
+        if entry != 0.0:
+            raise ValueError(
+                "trend tests assume observation from time 0; this data "
+                "has delayed entry (left truncation)."
+            )
+        if not explicit_close:
+            # Failure-truncated: the last event is the truncation point,
+            # exactly as the standalone tests treat T=None data.
+            events = events[:-1]
+        x.extend(events)
+        i.extend([item_id] * events.size)
+        T[item_id] = close
+    return tests[test](x, i=i, T=T, alternative=alternative)
 
 
 def cvm_statistic(u):
@@ -227,7 +292,7 @@ def cramer_von_mises(model, n_boot=200, seed=None):
     failures = 0
     while len(statistics) < n_boot and failures < 2 * n_boot:
         x_b, i_b, c_b, tl_b = [], [], [], []
-        for item_id, (_, entry, close, _) in enumerate(windows):
+        for item_id, (_, _, entry, close, _) in enumerate(windows):
             span = float(model.cif(close) - model.cif(entry))
             count = rng.poisson(span) if span > 0 else 0
             times = np.sort(

--- a/surpyval/recurrent/parametric/parametric_recurrence.py
+++ b/surpyval/recurrent/parametric/parametric_recurrence.py
@@ -8,7 +8,6 @@ from surpyval.recurrent.inference import (
     log_transformed_cb,
 )
 from surpyval.recurrent.simulation import RecurrenceSimulationMixin
-from surpyval.recurrent.tests import laplace, mil_hdbk_189c
 
 
 class ParametricRecurrenceModel(
@@ -203,34 +202,9 @@ class ParametricRecurrenceModel(
             trend direction.
         """
         self._check_has_data("trend_test")
-        data = self.data
-        diagnostics._validate_diagnostic_data(data, "trend_test")
-        tests = {"laplace": laplace, "mil_hdbk_189c": mil_hdbk_189c}
-        if test not in tests:
-            raise ValueError(
-                "`test` must be one of {}; got {!r}".format(
-                    sorted(tests), test
-                )
-            )
-
-        # The trend tests assume every system is observed from time 0.
-        x, i, T = [], [], {}
-        for item_id, (events, entry, close, explicit_close) in enumerate(
-            diagnostics._per_item_windows(data)
-        ):
-            if entry != 0.0:
-                raise ValueError(
-                    "trend tests assume observation from time 0; this data "
-                    "has delayed entry (left truncation)."
-                )
-            if not explicit_close:
-                # Failure-truncated: the last event is the truncation point,
-                # exactly as the standalone tests treat T=None data.
-                events = events[:-1]
-            x.extend(events)
-            i.extend([item_id] * events.size)
-            T[item_id] = close
-        return tests[test](x, i=i, T=T, alternative=alternative)
+        return diagnostics.trend_test(
+            self.data, test=test, alternative=alternative
+        )
 
     def cramer_von_mises(self, n_boot=200, seed=None):
         """

--- a/surpyval/recurrent/regression/proportional_intensity.py
+++ b/surpyval/recurrent/regression/proportional_intensity.py
@@ -1,6 +1,7 @@
 import numpy as np
 from matplotlib import pyplot as plt
 
+from surpyval.recurrent import diagnostics
 from surpyval.recurrent.inference import (
     LikelihoodInferenceMixin,
     delta_method_std_errors,
@@ -101,6 +102,83 @@ class ProportionalIntensityModel(
             raise ValueError(
                 "Inverse cif undefined for {}".format(self.dist.name)
             )
+
+    def _item_cif_map(self):
+        # Each item's cumulative intensity is the baseline scaled by its own
+        # ``exp(Z'beta)`` factor. The covariates are per item (static), so the
+        # item's Z is taken from its first row. Returns ``{item: cif(x)}`` for
+        # the recurrence diagnostics.
+        data = self.data
+        cif_map = {}
+        for item in np.unique(data.i):
+            Z_item = np.asarray(data.Z[data.i == item][0], dtype=float)
+            cif_map[item] = lambda x, Z=Z_item: self.cif(
+                np.asarray(x, dtype=float), Z
+            )
+        return cif_map
+
+    def residuals(self, kind="cumulative_hazard"):
+        """
+        Residual diagnostics for the fitted model, from the time-rescaling
+        theorem applied per item (each item's intensity is the baseline
+        scaled by its covariate factor ``exp(Z'beta)``).
+
+        Parameters
+        ----------
+
+        kind: {'cumulative_hazard', 'pit', 'martingale'}, optional
+            ``'cumulative_hazard'`` returns the rescaled interarrival times
+            ``cif(t_k) - cif(t_{k-1})`` of every observed event (pooled across
+            items), which are iid Exp(1) under the fitted model. ``'pit'``
+            applies the probability integral transform ``1 - exp(-e)`` to
+            those residuals, giving iid U(0, 1) values. ``'martingale'``
+            returns one residual per item: its observed event count minus the
+            count the model expects over its observation window.
+
+        Returns
+        -------
+
+        numpy array
+            The residuals.
+        """
+        cif_map = self._item_cif_map()
+        if kind in ("cumulative_hazard", "pit"):
+            e = diagnostics.cumulative_hazard_residuals(self.data, cif_map)
+            if kind == "pit":
+                return 1.0 - np.exp(-e)
+            return e
+        elif kind == "martingale":
+            return diagnostics.martingale_residuals(self.data, cif_map)
+        raise ValueError(
+            "`kind` must be 'cumulative_hazard', 'pit' or 'martingale'; "
+            "got {!r}".format(kind)
+        )
+
+    def trend_test(self, test="laplace", alternative="two-sided"):
+        """
+        Run a trend test on the data this model was fitted to. The null
+        hypothesis is a *homogeneous* Poisson process (no trend); the
+        statistic uses only the event times and windows, not the covariates,
+        so it checks whether a time-varying intensity was warranted at all.
+
+        Parameters
+        ----------
+
+        test: {'laplace', 'mil_hdbk_189c'}, optional
+            The trend test to run. Default is 'laplace'.
+        alternative: {'two-sided', 'increasing', 'decreasing'}, optional
+            The alternative hypothesis. Default is 'two-sided'.
+
+        Returns
+        -------
+
+        TrendTestResult
+            The test result, carrying the statistic, p-value and suggested
+            trend direction.
+        """
+        return diagnostics.trend_test(
+            self.data, test=test, alternative=alternative
+        )
 
     def cif_cb(self, x, Z, alpha_ci=0.05, bound="two-sided"):
         """

--- a/surpyval/tests/recurrent/test_regression_diagnostics.py
+++ b/surpyval/tests/recurrent/test_regression_diagnostics.py
@@ -1,0 +1,219 @@
+"""Residual and trend-test diagnostics for the proportional-intensity
+recurrent regression models.
+
+Each item's cumulative intensity is the baseline scaled by its covariate
+factor ``exp(Z'beta)``, so the time-rescaling residuals are computed per item
+with the item's own CIF. These tests check that the per-item plumbing is
+exactly ``model.cif(., Z_item)``, that the residual shapes and identities
+hold, and that the trend test delegates to the standalone statistic.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval.recurrent import (
+    CrowAMSAA,
+    ProportionalIntensityHPP,
+    ProportionalIntensityNHPP,
+    laplace,
+)
+
+
+def _two_group_data():
+    # Three items per covariate group; item windows close explicitly (c = 1).
+    x = [
+        9,
+        14,
+        18,
+        20,
+        7,
+        12,
+        16,
+        19,
+        20,
+        5,
+        9,
+        13,
+        16,
+        18,
+        20,
+        6,
+        10,
+        13,
+        15,
+        17,
+        19,
+        20,
+    ]
+    i = [
+        1,
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+    ]
+    c = [
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+    ]
+    Z = np.array(
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    ).reshape(-1, 1)
+    return x, i, c, Z
+
+
+def _fitted():
+    x, i, c, Z = _two_group_data()
+    return ProportionalIntensityNHPP.fit(x, Z, i=i, c=c, dist=CrowAMSAA)
+
+
+def test_cumulative_hazard_residuals_are_per_item_cif_gaps():
+    # The strongest check: each item's residuals equal the differences of its
+    # own covariate-scaled CIF over [entry, *events].
+    model = _fitted()
+    x, i, c, Z = _two_group_data()
+    x, i, c = np.array(x, float), np.array(i), np.array(c)
+    Z = Z.astype(float)
+
+    expected = []
+    for item in np.unique(i):
+        mask = i == item
+        events = np.sort(x[mask][c[mask] == 0])
+        Z_item = Z[mask][0]
+        cif = model.cif(np.concatenate([[0.0], events]), Z_item)
+        expected.append(np.diff(cif))
+    expected = np.concatenate(expected)
+
+    assert np.allclose(model.residuals("cumulative_hazard"), expected)
+    # one residual per observed event
+    assert model.residuals().size == int((c == 0).sum())
+
+
+def test_pit_residuals_transform_of_cumulative_hazard():
+    model = _fitted()
+    e = model.residuals("cumulative_hazard")
+    pit = model.residuals("pit")
+    assert np.allclose(pit, 1.0 - np.exp(-e))
+    assert np.all((pit >= 0) & (pit <= 1))
+
+
+def test_martingale_residuals_are_count_minus_expected():
+    model = _fitted()
+    x, i, c, Z = _two_group_data()
+    x, i, c = np.array(x, float), np.array(i), np.array(c)
+    Z = Z.astype(float)
+
+    expected = []
+    for item in np.unique(i):
+        mask = i == item
+        events = x[mask][c[mask] == 0]
+        Z_item = Z[mask][0]
+        close = float(x[mask].max())  # explicit c = 1 close
+        exp_count = float(model.cif(close, Z_item) - model.cif(0.0, Z_item))
+        expected.append(events.size - exp_count)
+
+    assert np.allclose(model.residuals("martingale"), expected)
+    # one martingale residual per item
+    assert model.residuals("martingale").size == np.unique(i).size
+
+
+def test_covariate_scaling_enters_the_residuals():
+    # A larger covariate scales the CIF by exp(Z'beta): the martingale
+    # expected counts of the Z=1 group differ from what the baseline alone
+    # (Z=0) would predict, unless the coefficient is exactly zero.
+    model = _fitted()
+    assert not np.isclose(model.coeffs[0], 0.0)
+    # cif for the two groups differs by the exp(beta) factor
+    t = np.array([10.0, 15.0])
+    ratio = model.cif(t, np.array([1.0])) / model.cif(t, np.array([0.0]))
+    assert np.allclose(ratio, np.exp(model.coeffs[0]))
+
+
+def test_trend_test_delegates_to_standalone_statistic():
+    model = _fitted()
+    result = model.trend_test(test="laplace")
+    # Rebuild the pooled (event, item, window) inputs the delegate uses and
+    # compare against the standalone Laplace test directly.
+    x, i, c, _ = _two_group_data()
+    x, i, c = np.array(x, float), np.array(i), np.array(c)
+    xs, items, T = [], [], {}
+    for idx, item in enumerate(np.unique(i)):
+        mask = i == item
+        events = np.sort(x[mask][c[mask] == 0])
+        xs.extend(events)
+        items.extend([idx] * events.size)
+        T[idx] = float(x[mask].max())
+    direct = laplace(xs, i=items, T=T, alternative="two-sided")
+    assert np.isclose(result.statistic, direct.statistic)
+    assert np.isclose(result.p_value, direct.p_value)
+
+
+def test_residuals_reject_interval_censored_data():
+    # Interval-censored rows cannot be placed in time, so the residuals must
+    # refuse them rather than silently mislead.
+    xl = [5, 9, 13]
+    xr = [6, 10, 14]
+    x = np.array([xl, xr]).T
+    Z = np.array([0.0, 0.0, 0.0]).reshape(-1, 1)
+    model = ProportionalIntensityNHPP.fit(
+        x, Z, i=[1, 1, 1], c=[2, 2, 2], dist=CrowAMSAA
+    )
+    with pytest.raises(ValueError, match="exact event times"):
+        model.residuals()
+
+
+def test_bad_kind_raises():
+    model = _fitted()
+    with pytest.raises(ValueError, match="cumulative_hazard"):
+        model.residuals(kind="nonsense")
+
+
+def test_hpp_proportional_intensity_diagnostics():
+    # The homogeneous proportional-intensity model exposes the same
+    # diagnostics.
+    x, i, c, Z = _two_group_data()
+    model = ProportionalIntensityHPP.fit(x, Z, i=i, c=c)
+    assert model.residuals("cumulative_hazard").size == int(
+        (np.array(c) == 0).sum()
+    )
+    assert model.residuals("martingale").size == np.unique(i).size
+    assert np.all(
+        (model.residuals("pit") >= 0) & (model.residuals("pit") <= 1)
+    )


### PR DESCRIPTION
## Summary

First step on §4 of the roadmap (recurrent-module gaps). `residuals()`, `trend_test()` and `cramer_von_mises()` existed only on the parametric recurrence models (`HPP`, `CrowAMSAA`, `Duane`, `CoxLewis`). This adds **`residuals()`** and **`trend_test()`** to the proportional-intensity **regression** models (`ProportionalIntensityHPP` / `ProportionalIntensityNHPP`).

The construction is per item: each item's cumulative intensity is the baseline scaled by its covariate factor, `Λ_i(t) = Λ₀(t)·exp(Z_i'β)`, so the time-rescaling theorem applies item-by-item with the item's own CIF.

- **`residuals("cumulative_hazard")`** — rescaled interarrival times `cif_i(t_k) − cif_i(t_{k-1})`, iid Exp(1) under the fitted model.
- **`residuals("pit")`** — `1 − exp(−e)`, iid U(0,1).
- **`residuals("martingale")`** — per item, `count_i − (cif_i(close) − cif_i(entry))`.
- **`trend_test(test=…)`** — homogeneous-Poisson (no-trend) null; covariate-independent, so it delegates to the standalone Laplace / MIL-HDBK-189C statistic.

## Implementation

- Generalised the diagnostics helpers (`cumulative_hazard_residuals`, `martingale_residuals`, `_conditional_uniforms`) to accept **either** a single CIF callable (the unconditional models — unchanged) **or** an `{item → callable}` mapping (the regression models' per-item CIF), via a small `_as_item_cif` adapter.
- `_per_item_windows` now yields the item id so per-item covariates can be looked up.
- Extracted `trend_test` into `surpyval.recurrent.diagnostics` so both model families share one implementation (the parametric model now delegates to it).

## Validation

I confirmed against a well-specified two-group simulation that the per-item plumbing is **exactly** `model.cif(·, Z_item)` (checked by hand for multiple items/covariates), that martingale residuals are `count − expected`, and that the group CIFs differ by exactly `exp(β)`. The cumulative-hazard residuals show the mild sub-unity mean that is the known property of the "gaps between observed events" definition under time-terminated windows — I verified the existing base model exhibits the identical behavior, so it's the shared residual definition, not something introduced here.

## Scope / follow-ups (noted in DEVELOPMENT.md §4)

- `cramer_von_mises()` for the regression family needs a covariate-aware parametric-bootstrap refit (the model doesn't yet hold a reference to its fitter) — deferred.
- Diagnostics for the renewal / virtual-age models need conditional-intensity residuals (a genuinely different construction) — deferred.

## Tests

8 new tests in `test_regression_diagnostics.py` (per-item CIF-gap equivalence, PIT identity, martingale-by-hand, covariate scaling, trend-test delegation, interval-censoring rejection, bad-kind error, and the HPP variant). Full recurrent suite passes (220); flake8 / black / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_