### PR TITLE
Renewal / virtual-age diagnostics (residuals + trend test)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,25 @@
 Changelog
 =========
 
-v0.13.0 (unreleased)
+v0.14.0 (unreleased)
 --------------------
+
+Recurrent events
+~~~~~~~~~~~~~~~~
+
+- Added residual (``residuals``: ``cumulative_hazard`` / ``pit`` /
+  ``martingale``) and trend-test (``trend_test``) diagnostics to the renewal /
+  virtual-age imperfect-repair models (``GeneralizedRenewal``,
+  ``GeneralizedOneRenewal``, ``ARA``, ``ARI``), completing the diagnostic
+  coverage of the recurrent module. These processes have no marginal
+  cumulative intensity, so the time-rescaling residuals come from each one's
+  *conditional* intensity -- the cumulative hazard accumulated over each
+  interarrival given the model's virtual age (Kijima / ARA), time scaling
+  (G1R) or intensity reduction (ARI) -- and are iid Exp(1) under the fitted
+  model.
+
+v0.13.0 (18 Jul 2026)
+---------------------
 
 Distributions
 ~~~~~~~~~~~~~~

--- a/surpyval/recurrent/renewal/ara.py
+++ b/surpyval/recurrent/renewal/ara.py
@@ -120,6 +120,25 @@ class ARA(RenewalFitMixin):
         out.m = m
         return out
 
+    def _rescaled_increments(self, model, data):
+        """
+        Per-interval cumulative-hazard increments ``H(v_k + x_k) - H(v_k)``
+        (the time-rescaling residuals) for a fitted ARA model, with ``v_k`` the
+        arithmetic-reduction virtual age at the start of interval ``k``.
+        Aligned with ``data`` rows; iid Exp(1) over the observed intervals
+        under the fitted model.
+        """
+        _, idx = np.unique(data.i, return_index=True)
+        arrival_by_item = np.split(data.x, idx)[1:]
+        interarrival = data.get_interarrival_times()
+        virtual_ages = np.concatenate(
+            [ara_virtual_ages(a, model.rho, model.m) for a in arrival_by_item]
+        )
+        x_new = interarrival + virtual_ages
+        return np.asarray(
+            model.model.Hf(x_new) - model.model.Hf(virtual_ages), dtype=float
+        )
+
     def create_negll_func(self, data, dist, m):
         _, idx = np.unique(data.i, return_index=True)
         arrival_by_item = np.split(data.x, idx)[1:]

--- a/surpyval/recurrent/renewal/ari.py
+++ b/surpyval/recurrent/renewal/ari.py
@@ -120,6 +120,35 @@ class ARI(RenewalFitMixin):
         out.m = m
         return out
 
+    def _rescaled_increments(self, model, data):
+        """
+        Per-interval compensator increments (time-rescaling residuals) for a
+        fitted ARI model: the integral of the reduced intensity over each
+        interval, ``[Lambda_0(t) - Lambda_0(prev)] - R * (t - prev)``, where
+        ``R`` is the intensity reduction in force after the previous event.
+        Aligned with ``data`` rows; iid Exp(1) over the observed intervals
+        under the fitted model.
+        """
+        rho, m = model.rho, model.m
+        dist = model.model
+        _, idx = np.unique(data.i, return_index=True)
+        x_by_item = np.split(data.x, idx)[1:]
+        c_by_item = np.split(data.c, idx)[1:]
+
+        increments = []
+        for x_item, c_item in zip(x_by_item, c_by_item):
+            prev = 0.0
+            reduction = 0.0
+            history_iif = []
+            for t, censor in zip(x_item, c_item):
+                delta_cif = float(dist.cif(t) - dist.cif(prev))
+                increments.append(delta_cif - reduction * (t - prev))
+                if censor == 0:
+                    history_iif.append(float(dist.iif(t)))
+                    reduction = ari_reduction(history_iif, rho, m)
+                prev = t
+        return np.asarray(increments, dtype=float)
+
     def create_negll_func(self, data, dist, m):
         _, idx = np.unique(data.i, return_index=True)
         x_by_item = np.split(data.x, idx)[1:]

--- a/surpyval/recurrent/renewal/fit_mixin.py
+++ b/surpyval/recurrent/renewal/fit_mixin.py
@@ -86,16 +86,18 @@ class RenewalFitMixin:
             )
         return res
 
-    @staticmethod
-    def _attach_inference(model, neg_ll, mle, n_obs, res, data):
+    def _attach_inference(self, model, neg_ll, mle, n_obs, res, data):
         """
         Store the fit artefacts and the attributes
         :class:`LikelihoodInferenceMixin` needs: ``_neg_ll`` (the negative
         log-likelihood in natural parameter space), ``_mle`` (the fitted
-        parameters in that space) and ``_n_obs``.
+        parameters in that space) and ``_n_obs``. Also keeps a reference to
+        the fitter (``_fitter``) so the fitted model can reuse its
+        family-specific rescaled-increment (time-rescaling residual) logic.
         """
         model.res = res
         model.data = data
+        model._fitter = self
         model._neg_ll = neg_ll
         model._mle = np.asarray(mle, dtype=float)
         model._n_obs = int(n_obs)

--- a/surpyval/recurrent/renewal/generalized_one_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_one_renewal.py
@@ -88,6 +88,25 @@ class GeneralizedOneRenewal(RenewalFitMixin):
             restoration_bounds=(-1, None),
         )
 
+    def _rescaled_increments(self, model, data):
+        """
+        Per-interval cumulative-hazard increments (time-rescaling residuals)
+        for a fitted G1 renewal model. The ``j``-th interarrival of an item is
+        the base lifetime scaled by ``(1 + q)^j``, so on the base time axis its
+        residual is ``H(x_j / (1 + q)^j)``. Aligned with ``data`` rows; iid
+        Exp(1) over the observed intervals under the fitted model.
+        """
+        q = model.q
+        _, idx = np.unique(data.i, return_index=True)
+        interarrival_by_item = np.split(data.get_interarrival_times(), idx)[1:]
+        scaled = np.concatenate(
+            [
+                np.asarray(arr, dtype=float) / (1.0 + q) ** np.arange(len(arr))
+                for arr in interarrival_by_item
+            ]
+        )
+        return np.asarray(model.model.Hf(scaled), dtype=float)
+
     def create_negll_func(self, x, i, c, n, dist):
         def negll_func(params):
             ll = 0

--- a/surpyval/recurrent/renewal/generalized_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_renewal.py
@@ -116,6 +116,41 @@ class GeneralizedRenewal(RenewalFitMixin):
         )
         return out
 
+    def _rescaled_increments(self, model, data):
+        """
+        Per-interval cumulative-hazard increments ``H(v_k + x_k) - H(v_k)``
+        (the time-rescaling residuals) for a fitted Kijima renewal model, where
+        ``v_k`` is the virtual age at the start of interval ``k`` and ``x_k``
+        its interarrival time. Aligned with ``data`` rows. iid Exp(1) over the
+        observed intervals under the fitted model.
+        """
+        q = model.q
+        _, idx = np.unique(data.i, return_index=True)
+        interarrival = data.get_interarrival_times()
+        if model.kijima_type == "i":
+            arrival_times = np.split(data.x, idx)[1:]
+            cumulative_previous = np.concatenate(
+                [np.concatenate([[0], arr[:-1]]) for arr in arrival_times]
+            )
+            virtual_ages = q * cumulative_previous
+        else:
+            prev_x_interarrival = np.concatenate(
+                [
+                    np.concatenate([[0], np.atleast_1d(arr)])[:-1]
+                    for arr in np.split(interarrival, idx)[1:]
+                ]
+            )
+            virtual_ages = np.concatenate(
+                [
+                    kijima_ii_from_prev_interarrival(arr, q)
+                    for arr in np.split(prev_x_interarrival, idx)[1:]
+                ]
+            )
+        x_new = interarrival + virtual_ages
+        return np.asarray(
+            model.model.Hf(x_new) - model.model.Hf(virtual_ages), dtype=float
+        )
+
     def create_negll_func(self, data, dist, kijima="i"):
         _, idx = np.unique(data.i, return_index=True)
         c = data.c

--- a/surpyval/recurrent/renewal/renewal_model.py
+++ b/surpyval/recurrent/renewal/renewal_model.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from surpyval.recurrent.inference import LikelihoodInferenceMixin
 from surpyval.recurrent.simulation import RecurrenceSimulationMixin
 
@@ -76,6 +78,95 @@ class RenewalModel(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
 
     def _parameter_bounds(self):
         return [self._restoration_bounds, *self.model.dist.bounds]
+
+    def _check_has_data(self, what):
+        if not hasattr(self, "data"):
+            raise ValueError(
+                "{} requires a model fitted from data; fit_from_parameters "
+                "models carry no data.".format(what)
+            )
+
+    def residuals(self, kind="cumulative_hazard"):
+        """
+        Residual diagnostics for the fitted imperfect-repair model, from the
+        time-rescaling theorem applied to the process's *conditional*
+        intensity (each interarrival is rescaled by the cumulative hazard
+        accumulated over it given the model's virtual age / intensity
+        reduction), so they extend the counting-process residuals to the
+        renewal / virtual-age families.
+
+        Parameters
+        ----------
+
+        kind: {'cumulative_hazard', 'pit', 'martingale'}, optional
+            ``'cumulative_hazard'`` returns the rescaled interarrival
+            increments of every observed event (pooled across items), which
+            are iid Exp(1) under the fitted model. ``'pit'`` applies the
+            probability integral transform ``1 - exp(-e)`` to those residuals,
+            giving iid U(0, 1) values. ``'martingale'`` returns one residual
+            per item: its observed event count minus the compensator (the sum
+            of the rescaled increments) accumulated over its observation.
+
+        Returns
+        -------
+
+        numpy array
+            The residuals.
+        """
+        self._check_has_data("residuals")
+        from surpyval.recurrent import diagnostics
+
+        diagnostics._validate_diagnostic_data(self.data, "Residuals")
+        increments = np.asarray(
+            self._fitter._rescaled_increments(self, self.data), dtype=float
+        )
+        c = np.asarray(self.data.c)
+
+        if kind in ("cumulative_hazard", "pit"):
+            e = increments[c == 0]
+            if kind == "pit":
+                return 1.0 - np.exp(-e)
+            return e
+        elif kind == "martingale":
+            residuals = []
+            for item in np.unique(self.data.i):
+                mask = self.data.i == item
+                observed = int((c[mask] == 0).sum())
+                residuals.append(observed - float(increments[mask].sum()))
+            return np.array(residuals)
+        raise ValueError(
+            "`kind` must be 'cumulative_hazard', 'pit' or 'martingale'; "
+            "got {!r}".format(kind)
+        )
+
+    def trend_test(self, test="laplace", alternative="two-sided"):
+        """
+        Run a trend test on the data this model was fitted to. The null
+        hypothesis is a *homogeneous* Poisson process (no trend); the statistic
+        uses only the event times and windows, not the fitted model, so it
+        checks whether an imperfect-repair model was warranted at all.
+
+        Parameters
+        ----------
+
+        test: {'laplace', 'mil_hdbk_189c'}, optional
+            The trend test to run. Default is 'laplace'.
+        alternative: {'two-sided', 'increasing', 'decreasing'}, optional
+            The alternative hypothesis. Default is 'two-sided'.
+
+        Returns
+        -------
+
+        TrendTestResult
+            The test result, carrying the statistic, p-value and suggested
+            trend direction.
+        """
+        self._check_has_data("trend_test")
+        from surpyval.recurrent import diagnostics
+
+        return diagnostics.trend_test(
+            self.data, test=test, alternative=alternative
+        )
 
     def __repr__(self):
         title = f"{self.kind} SurPyval Model"

--- a/surpyval/tests/recurrent/test_renewal_diagnostics.py
+++ b/surpyval/tests/recurrent/test_renewal_diagnostics.py
@@ -1,0 +1,134 @@
+"""Residual and trend-test diagnostics for the renewal / virtual-age
+imperfect-repair models (GeneralizedRenewal, GeneralizedOneRenewal, ARA, ARI).
+
+Unlike the counting-process models, these have no marginal cumulative
+intensity; the time-rescaling residuals come from each process's *conditional*
+intensity -- the cumulative hazard accumulated over each interarrival given the
+model's virtual age (Kijima / ARA), time scaling (G1R) or intensity reduction
+(ARI). The tests check the residual shapes and identities, that the residuals
+are genuinely iid Exp(1) under a well-specified simulate-and-refit, and that
+the trend test delegates to the standalone statistic.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval import Weibull
+from surpyval.recurrent import (
+    ARA,
+    ARI,
+    CrowAMSAA,
+    GeneralizedOneRenewal,
+    GeneralizedRenewal,
+)
+
+
+def _fit_each():
+    # One fitted model per family/configuration, on shared multi-item data.
+    x = np.array([1, 3, 6, 9, 10, 1.4, 3, 6.7, 8.9, 11, 1, 2.2, 5, 7.5, 9, 12])
+    i = np.array([1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3])
+    return {
+        "GR-i": GeneralizedRenewal.fit(x, i, dist=Weibull, kijima="i"),
+        "GR-ii": GeneralizedRenewal.fit(x, i, dist=Weibull, kijima="ii"),
+        "G1R": GeneralizedOneRenewal.fit(x, i, dist=Weibull),
+        "ARA-m2": ARA.fit(x, i, dist=Weibull, m=2),
+        "ARI": ARI.fit(x, i, dist=CrowAMSAA, m=1),
+        "_x": x,
+        "_i": i,
+    }
+
+
+MODELS = _fit_each()
+MODEL_KEYS = ["GR-i", "GR-ii", "G1R", "ARA-m2", "ARI"]
+
+
+@pytest.mark.parametrize("key", MODEL_KEYS)
+def test_residual_shapes(key):
+    model = MODELS[key]
+    x, i = MODELS["_x"], MODELS["_i"]
+    # one cumulative-hazard residual per observed event (all observed here)
+    assert model.residuals("cumulative_hazard").size == x.size
+    # one martingale residual per item
+    assert model.residuals("martingale").size == np.unique(i).size
+
+
+@pytest.mark.parametrize("key", MODEL_KEYS)
+def test_pit_is_transform_of_cumulative_hazard(key):
+    model = MODELS[key]
+    e = model.residuals("cumulative_hazard")
+    pit = model.residuals("pit")
+    assert np.allclose(pit, 1.0 - np.exp(-e))
+    assert np.all((pit >= 0) & (pit <= 1))
+
+
+@pytest.mark.parametrize("key", MODEL_KEYS)
+def test_cumulative_hazard_residuals_are_non_negative(key):
+    # A cumulative-hazard increment is non-negative by construction.
+    assert np.all(MODELS[key].residuals("cumulative_hazard") >= -1e-9)
+
+
+@pytest.mark.parametrize("key", MODEL_KEYS)
+def test_martingale_residuals_near_zero_at_mle(key):
+    # observed count minus compensator, summed, is ~0 at the fitted params.
+    assert abs(MODELS[key].residuals("martingale").sum()) < 0.5
+
+
+@pytest.mark.parametrize("key", MODEL_KEYS)
+def test_trend_test_returns_result(key):
+    result = MODELS[key].trend_test(test="laplace")
+    assert hasattr(result, "statistic")
+    assert hasattr(result, "p_value")
+
+
+def test_bad_kind_raises():
+    with pytest.raises(ValueError, match="cumulative_hazard"):
+        MODELS["GR-i"].residuals(kind="nonsense")
+
+
+def test_fit_from_parameters_has_no_residuals():
+    # A model built from parameters carries no data, so residuals must refuse.
+    model = GeneralizedRenewal.fit_from_parameters(
+        [10.0, 2.0], 0.3, kijima="i", dist=Weibull
+    )
+    with pytest.raises(ValueError, match="fitted from data"):
+        model.residuals()
+    with pytest.raises(ValueError, match="fitted from data"):
+        model.trend_test()
+
+
+# --- calibration: residuals are Exp(1) under a well-specified refit ---------
+
+
+def _simulate_refit_residuals(truth, fitter, refit_kwargs, seed):
+    data = truth.count_terminated_simulation_data(8, items=250, seed=seed)
+    model = fitter.fit_from_recurrent_data(data, **refit_kwargs)
+    return model.residuals("cumulative_hazard"), model
+
+
+def test_age_reduction_residuals_are_exp1():
+    # Kijima-I (age reduction): rescaled increments H(v+x) - H(v) are Exp(1).
+    truth = GeneralizedRenewal.fit_from_parameters(
+        [30.0, 1.6], 0.4, kijima="i", dist=Weibull
+    )
+    e, model = _simulate_refit_residuals(
+        truth, GeneralizedRenewal, dict(dist=Weibull, kijima="i"), seed=0
+    )
+    assert e.size > 1500
+    assert abs(e.mean() - 1.0) < 0.06
+    assert abs(e.var() - 1.0) < 0.12
+    # parameters recover
+    assert abs(model.q - 0.4) < 0.1
+    assert np.allclose(model.model.params, [30.0, 1.6], rtol=0.1)
+
+
+def test_intensity_reduction_residuals_are_exp1():
+    # ARI (intensity reduction): the reduced-intensity integral per interval
+    # is Exp(1) under the fitted model -- a different construction entirely.
+    truth = ARI.fit_from_parameters([20.0, 1.5], 0.5, m=1, dist=CrowAMSAA)
+    e, model = _simulate_refit_residuals(
+        truth, ARI, dict(dist=CrowAMSAA, m=1), seed=5
+    )
+    assert e.size > 1500
+    assert abs(e.mean() - 1.0) < 0.06
+    assert abs(e.var() - 1.0) < 0.15
+    assert abs(model.rho - 0.5) < 0.12


### PR DESCRIPTION
## Summary

First step on the **0.14 "recurrent events, end to end"** line (#144). `residuals()` and `trend_test()` now exist on the renewal / virtual-age imperfect-repair models — `GeneralizedRenewal`, `GeneralizedOneRenewal`, `ARA`, `ARI` — matching what the counting-process and proportional-intensity regression families already have.

These processes have **no marginal cumulative intensity**, so (as the roadmap flagged) the residuals need a genuinely different, *conditional-intensity* construction. Each interarrival is rescaled by the cumulative hazard accumulated over it given the model's state:

- **Age reduction (Kijima-I/II, ARA):** `H(v_k + x_k) − H(v_k)`, with `v_k` the virtual age at the interval start.
- **Time scaling (G1R):** `H(x_j / (1+q)^j)` — the j-th interarrival on the base time axis.
- **Intensity reduction (ARI):** `[Λ₀(t) − Λ₀(prev)] − R·Δt`, the integral of the *reduced* intensity.

Under the fitted model these increments are iid Exp(1), so `residuals("cumulative_hazard")`, `residuals("pit")` (`1 − e^{−e}`), and `residuals("martingale")` (observed count − compensator) follow exactly as for the other families.

## Design

Each fitter exposes a `_rescaled_increments(model, data)` method that reuses the **exact per-interval compensator its own likelihood already computes** — so the diagnostics can't drift from the fitted model. The fitted model keeps a reference to its fitter (added in the shared `_attach_inference`), and `RenewalModel.residuals` / `trend_test` are shared across the whole family. `trend_test` delegates to the standalone Laplace / MIL-HDBK statistic (it's model-independent).

## Validation

Not just "it runs" — I confirmed the residuals are genuinely Exp(1) by simulate-and-refit on well-specified truth models, covering **both** constructions:
- **Age reduction** (Kijima-I): mean 1.000, var ≈ 1.01, KS-vs-Exp(1) p ≈ 0.9, `q` and Weibull params recovered, martingale mean 0.
- **Intensity reduction** (ARI): mean 1.000, var ≈ 1.01, `rho` recovered.

## Tests

29 new tests in `test_renewal_diagnostics.py`: shapes/identities parametrised over all five configurations (GR-i, GR-ii, G1R, ARA-m2, ARI), martingale-≈0-at-MLE, non-negativity, trend-test delegation, no-data guard, bad-kind error, and the two Exp(1) calibration tests. Full recurrent suite passes (253); flake8 / black / mypy clean.

## Scope

Deferred (follow-up, like the regression family's split): **`cramer_von_mises`** for the renewal models — its bootstrap refits the renewal fit per replicate (a slow multistart Nelder-Mead), so it's a separate PR. Noted on #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_