### PR TITLE
Cramer-von Mises goodness of fit for the renewal / virtual-age models (closes #144)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,8 @@ Recurrent events
 ~~~~~~~~~~~~~~~~
 
 - Added residual (``residuals``: ``cumulative_hazard`` / ``pit`` /
-  ``martingale``) and trend-test (``trend_test``) diagnostics to the renewal /
+  ``martingale``), trend-test (``trend_test``) and Cramer-von Mises
+  goodness-of-fit (``cramer_von_mises``) diagnostics to the renewal /
   virtual-age imperfect-repair models (``GeneralizedRenewal``,
   ``GeneralizedOneRenewal``, ``ARA``, ``ARI``), completing the diagnostic
   coverage of the recurrent module. These processes have no marginal
@@ -16,7 +17,10 @@ Recurrent events
   *conditional* intensity -- the cumulative hazard accumulated over each
   interarrival given the model's virtual age (Kijima / ARA), time scaling
   (G1R) or intensity reduction (ARI) -- and are iid Exp(1) under the fitted
-  model.
+  model. The Cramer-von Mises transforms use the compensator built from those
+  increments (there being no closed-form intensity), and its p-value comes
+  from a parametric bootstrap that resimulates each item and refits the full
+  imperfect-repair model per replicate.
 
 v0.13.0 (18 Jul 2026)
 ---------------------

--- a/surpyval/recurrent/diagnostics.py
+++ b/surpyval/recurrent/diagnostics.py
@@ -260,16 +260,59 @@ def cvm_statistic(u):
     return float(1.0 / (12.0 * m) + np.sum((u - (2 * j - 1) / (2 * m)) ** 2))
 
 
-def _cvm_pvalue(data, item_cif, simulate_refit, n_boot, seed):
+def _renewal_conditional_uniforms(data, increments):
+    """
+    The conditionally-uniform transforms behind the Cramer-von Mises statistic
+    for a renewal / virtual-age process, which has no marginal cumulative
+    intensity: the compensator ``Lambda(t_k)`` is the running sum of the
+    per-interval rescaled increments (``increments`` aligned with ``data``
+    rows), and conditional on the number of events the normalised transforms
+    ``Lambda(t_k) / Lambda(close)`` are iid U(0, 1). A failure-truncated item's
+    last event is its (random) window close, so it is excluded and the rest are
+    normalised by the transform there (Crow's ``M = N - 1`` convention); a
+    right-censored item uses all its events, normalised by the compensator at
+    the censoring time.
+    """
+    increments = np.asarray(increments, dtype=float)
+    c = np.asarray(data.c)
+    u = []
+    n_systems = 0
+    for item in np.unique(data.i):
+        mask = data.i == item
+        cumulative = np.cumsum(increments[mask])
+        c_item = c[mask]
+        n_systems += 1
+        close = float(cumulative[-1])
+        if np.any(c_item == 1):
+            used = cumulative[c_item == 0]
+        else:
+            used = cumulative[:-1]
+        if used.size == 0 or close <= 0:
+            continue
+        u.append(used / close)
+    if not u:
+        raise ValueError(
+            "No usable event times for the Cramer-von Mises statistic."
+        )
+    return np.concatenate(u), n_systems
+
+
+def _cvm_pvalue(
+    data, payload, simulate_refit, n_boot, seed, uniforms=_conditional_uniforms
+):
     """
     Shared Cramer-von Mises core: the observed statistic comes from the
-    conditionally-uniform transforms of ``data`` under ``item_cif``; the
-    p-value is a parametric bootstrap driven by ``simulate_refit(rng)``,
-    which simulates one dataset from the fitted model, refits it, and returns
-    ``(sim_data, refit_item_cif)`` (or raises to signal a failed replicate).
+    conditionally-uniform transforms of ``data`` under ``payload`` (computed
+    by ``uniforms(data, payload)``); the p-value is a parametric bootstrap
+    driven by ``simulate_refit(rng)``, which simulates one dataset from the
+    fitted model, refits it, and returns ``(sim_data, refit_payload)`` (or
+    raises to signal a failed replicate). ``uniforms`` is
+    :func:`_conditional_uniforms` for the intensity models (``payload`` is a
+    per-item CIF) and :func:`_renewal_conditional_uniforms` for the renewal
+    models (``payload`` is the per-interval rescaled increments).
     """
     _validate_diagnostic_data(data, "The Cramer-von Mises test")
-    u, n_systems = _conditional_uniforms(data, item_cif)
+    u, n_systems = uniforms(data, payload)
     observed = cvm_statistic(u)
 
     rng = np.random.default_rng(seed)
@@ -282,8 +325,8 @@ def _cvm_pvalue(data, item_cif, simulate_refit, n_boot, seed):
             # over hundreds of refits they would swamp the console.
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", RuntimeWarning)
-                sim_data, refit_item_cif = simulate_refit(rng)
-                u_b, _ = _conditional_uniforms(sim_data, refit_item_cif)
+                sim_data, refit_payload = simulate_refit(rng)
+                u_b, _ = uniforms(sim_data, refit_payload)
         except (ValueError, RuntimeError, np.linalg.LinAlgError):
             failures += 1
             continue
@@ -442,3 +485,64 @@ def cramer_von_mises_regression(model, n_boot=200, seed=None):
         return sim_data, refit_cif
 
     return _cvm_pvalue(data, item_cif, simulate_refit, n_boot, seed)
+
+
+def cramer_von_mises_renewal(model, n_boot=200, seed=None):
+    """
+    Cramer-von Mises goodness-of-fit test of a fitted renewal / virtual-age
+    imperfect-repair model; see :meth:`RenewalModel.cramer_von_mises` for the
+    user-facing documentation.
+
+    These processes have no marginal cumulative intensity, so the transforms
+    use the compensator built from each interval's rescaled increment (the
+    conditional-intensity residual). The bootstrap simulates, for every item,
+    a fresh sequence with the item's observed number of events from the fitted
+    model, refits the full imperfect-repair model, and recomputes the
+    statistic -- so the p-value accounts for the restoration and lifetime /
+    intensity parameters having been estimated. It is therefore markedly
+    slower than the residual diagnostics (each replicate is a multi-start
+    optimisation).
+    """
+    from surpyval.utils.recurrent_utils import handle_xicn
+
+    data = model.data
+    fitter = model._fitter
+    increments = fitter._rescaled_increments(model, data)
+    # The observed per-item event counts drive the (count-terminated)
+    # bootstrap: each item is resimulated with the same number of events.
+    counts = [
+        int((data.c[data.i == item] == 0).sum()) for item in np.unique(data.i)
+    ]
+
+    def simulate_refit(rng):
+        x_b, i_b = [], []
+        new_id = 0
+        for count in counts:
+            if count < 1:
+                continue
+            new_id += 1
+            child = int(rng.integers(0, 2**31 - 1))
+            sim = model.count_terminated_simulation_data(
+                count - 1, items=1, seed=child
+            )
+            x_b.extend(np.asarray(sim.x, dtype=float).tolist())
+            i_b.extend([new_id] * sim.x.size)
+        if len(x_b) < 2:
+            raise ValueError("too few simulated events to refit")
+        sim_data = handle_xicn(
+            np.asarray(x_b, dtype=float),
+            np.asarray(i_b),
+            as_recurrent_data=True,
+        )
+        refit = fitter._refit(model, sim_data)
+        refit_increments = refit._fitter._rescaled_increments(refit, sim_data)
+        return sim_data, refit_increments
+
+    return _cvm_pvalue(
+        data,
+        increments,
+        simulate_refit,
+        n_boot,
+        seed,
+        uniforms=_renewal_conditional_uniforms,
+    )

--- a/surpyval/recurrent/renewal/ara.py
+++ b/surpyval/recurrent/renewal/ara.py
@@ -139,6 +139,13 @@ class ARA(RenewalFitMixin):
             model.model.Hf(x_new) - model.model.Hf(virtual_ages), dtype=float
         )
 
+    def _refit(self, model, data):
+        """Refit this model family on ``data`` with the same lifetime
+        distribution and memory; used by the Cramer-von Mises bootstrap."""
+        return self.fit_from_recurrent_data(
+            data, dist=model.model.dist, m=model.m
+        )
+
     def create_negll_func(self, data, dist, m):
         _, idx = np.unique(data.i, return_index=True)
         arrival_by_item = np.split(data.x, idx)[1:]

--- a/surpyval/recurrent/renewal/ari.py
+++ b/surpyval/recurrent/renewal/ari.py
@@ -149,6 +149,13 @@ class ARI(RenewalFitMixin):
                 prev = t
         return np.asarray(increments, dtype=float)
 
+    def _refit(self, model, data):
+        """Refit this model family on ``data`` with the same baseline
+        intensity and memory; used by the Cramer-von Mises bootstrap."""
+        return self.fit_from_recurrent_data(
+            data, dist=model.model.dist, m=model.m
+        )
+
     def create_negll_func(self, data, dist, m):
         _, idx = np.unique(data.i, return_index=True)
         x_by_item = np.split(data.x, idx)[1:]

--- a/surpyval/recurrent/renewal/generalized_one_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_one_renewal.py
@@ -107,6 +107,11 @@ class GeneralizedOneRenewal(RenewalFitMixin):
         )
         return np.asarray(model.model.Hf(scaled), dtype=float)
 
+    def _refit(self, model, data):
+        """Refit this model family on ``data`` with the same lifetime
+        distribution; used by the Cramer-von Mises bootstrap."""
+        return self.fit_from_recurrent_data(data, dist=model.model.dist)
+
     def create_negll_func(self, x, i, c, n, dist):
         def negll_func(params):
             ll = 0

--- a/surpyval/recurrent/renewal/generalized_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_renewal.py
@@ -151,6 +151,14 @@ class GeneralizedRenewal(RenewalFitMixin):
             model.model.Hf(x_new) - model.model.Hf(virtual_ages), dtype=float
         )
 
+    def _refit(self, model, data):
+        """Refit this model family on ``data`` with the same lifetime
+        distribution and Kijima type; used by the Cramer-von Mises bootstrap.
+        """
+        return self.fit_from_recurrent_data(
+            data, dist=model.model.dist, kijima=model.kijima_type
+        )
+
     def create_negll_func(self, data, dist, kijima="i"):
         _, idx = np.unique(data.i, return_index=True)
         c = data.c

--- a/surpyval/recurrent/renewal/renewal_model.py
+++ b/surpyval/recurrent/renewal/renewal_model.py
@@ -168,6 +168,45 @@ class RenewalModel(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
             self.data, test=test, alternative=alternative
         )
 
+    def cramer_von_mises(self, n_boot=200, seed=None):
+        """
+        Cramer-von Mises goodness-of-fit test of the fitted imperfect-repair
+        model.
+
+        These processes have no marginal cumulative intensity, so the
+        conditionally-uniform transforms use the compensator built from each
+        interval's rescaled increment (the conditional-intensity residual):
+        conditional on an item's number of events, ``Lambda(t_k) /
+        Lambda(close)`` are iid U(0, 1) when the fitted model is the true one,
+        and the statistic measures their departure from uniformity. Because the
+        restoration and lifetime / intensity parameters were estimated from the
+        same data, the p-value is a parametric bootstrap: each item is
+        resimulated from the fitted model with its observed number of events,
+        the full model is refitted, and the statistic recomputed. Each
+        replicate is a multi-start optimisation, so this is much slower than
+        the residual diagnostics.
+
+        Parameters
+        ----------
+
+        n_boot: int, optional
+            Number of bootstrap replicates for the p-value. Default is 200.
+        seed: int or numpy.random.Generator, optional
+            Seed for a reproducible p-value.
+
+        Returns
+        -------
+
+        GoodnessOfFitResult
+            The observed statistic and its bootstrap p-value.
+        """
+        self._check_has_data("cramer_von_mises")
+        from surpyval.recurrent import diagnostics
+
+        return diagnostics.cramer_von_mises_renewal(
+            self, n_boot=n_boot, seed=seed
+        )
+
     def __repr__(self):
         title = f"{self.kind} SurPyval Model"
         lines = [

--- a/surpyval/tests/recurrent/test_renewal_diagnostics.py
+++ b/surpyval/tests/recurrent/test_renewal_diagnostics.py
@@ -21,6 +21,11 @@ from surpyval.recurrent import (
     GeneralizedOneRenewal,
     GeneralizedRenewal,
 )
+from surpyval.recurrent.diagnostics import (
+    GoodnessOfFitResult,
+    _renewal_conditional_uniforms,
+    cvm_statistic,
+)
 
 
 def _fit_each():
@@ -132,3 +137,64 @@ def test_intensity_reduction_residuals_are_exp1():
     assert abs(e.mean() - 1.0) < 0.06
     assert abs(e.var() - 1.0) < 0.15
     assert abs(model.rho - 0.5) < 0.12
+
+
+# --- Cramer-von Mises goodness of fit ---------------------------------------
+#
+# The bootstrap refits the (multi-start) imperfect-repair fit per replicate, so
+# these use small data and few replicates. Correctness of the underlying
+# transform is covered by the Exp(1) residual calibration above (a unit-Poisson
+# compensator is exactly what makes the conditional transforms uniform); one
+# model per construction (age reduction, intensity reduction) exercises the
+# renewal CvM plumbing.
+
+
+def _small_fit(truth, fitter, refit_kwargs, seed):
+    data = truth.count_terminated_simulation_data(6, items=35, seed=seed)
+    return fitter.fit_from_recurrent_data(data, **refit_kwargs)
+
+
+def test_cvm_age_reduction_runs_and_matches_statistic():
+    truth = GeneralizedRenewal.fit_from_parameters(
+        [30.0, 1.6], 0.4, kijima="i", dist=Weibull
+    )
+    model = _small_fit(
+        truth, GeneralizedRenewal, dict(dist=Weibull, kijima="i"), seed=0
+    )
+    result = model.cramer_von_mises(n_boot=10, seed=1)
+    assert isinstance(result, GoodnessOfFitResult)
+    assert 0.0 < result.p_value <= 1.0
+    assert result.n_systems == np.unique(model.data.i).size
+    # the observed statistic is the CvM statistic of the compensator transforms
+    inc = model._fitter._rescaled_increments(model, model.data)
+    u, _ = _renewal_conditional_uniforms(model.data, inc)
+    assert np.isclose(result.statistic, cvm_statistic(u))
+
+
+def test_cvm_intensity_reduction_runs():
+    truth = ARI.fit_from_parameters([20.0, 1.5], 0.5, m=1, dist=CrowAMSAA)
+    model = _small_fit(truth, ARI, dict(dist=CrowAMSAA, m=1), seed=4)
+    result = model.cramer_von_mises(n_boot=10, seed=2)
+    assert isinstance(result, GoodnessOfFitResult)
+    assert 0.0 < result.p_value <= 1.0
+
+
+def test_cvm_is_reproducible_with_seed():
+    truth = GeneralizedRenewal.fit_from_parameters(
+        [30.0, 1.6], 0.4, kijima="i", dist=Weibull
+    )
+    model = _small_fit(
+        truth, GeneralizedRenewal, dict(dist=Weibull, kijima="i"), seed=3
+    )
+    a = model.cramer_von_mises(n_boot=8, seed=99)
+    b = model.cramer_von_mises(n_boot=8, seed=99)
+    assert a.statistic == b.statistic
+    assert a.p_value == b.p_value
+
+
+def test_cvm_no_data_guard():
+    model = GeneralizedRenewal.fit_from_parameters(
+        [10.0, 2.0], 0.3, kijima="i", dist=Weibull
+    )
+    with pytest.raises(ValueError, match="fitted from data"):
+        model.cramer_von_mises()


### PR DESCRIPTION
## Summary

Finishes #144. `cramer_von_mises()` now exists on the renewal / virtual-age imperfect-repair models — `GeneralizedRenewal`, `GeneralizedOneRenewal`, `ARA`, `ARI` — completing the recurrent module's diagnostic coverage (residuals + trend test landed in #162).

The wrinkle: these processes have **no marginal cumulative intensity**, so the conditionally-uniform transforms can't use a `cif(t)` like the intensity/regression CvM. Instead they use the **compensator built from each interval's rescaled increment** (the conditional-intensity residual): per item, `Λ(t_k)/Λ(close)` are iid U(0,1) under the fitted model, and the CvM statistic measures their departure from uniformity.

The p-value is a parametric bootstrap that resimulates each item with its observed number of events and **refits the full imperfect-repair model per replicate**, so it accounts for the restoration and lifetime/intensity parameters being estimated. Each replicate is a multi-start optimisation, so this is markedly slower than the residual diagnostics (documented on the method).

## Design

- The shared CvM core `_cvm_pvalue` is generalised to take the conditional-uniforms function, so the intensity path (CIF-based `_conditional_uniforms`) and the renewal path (compensator-based `_renewal_conditional_uniforms`) reuse one bootstrap driver. The base and regression CvM are unchanged in behaviour.
- Each renewal fitter gains a small `_refit(model, data)` that rebuilds its own family (same lifetime/intensity distribution, Kijima type / memory) for the bootstrap.

## Correctness

The CvM's validity *is* the Exp(1) property of the rescaled increments — a unit-Poisson compensator is exactly what makes the conditional transforms uniform — and that's validated for all four families in #162's calibration tests (mean 1.000, var ≈ 1.0, KS p high). Here I confirmed the well-specified p-values are sensible across families (e.g. GR-i 0.65, ARI 0.54, G1R 0.69) and that the observed statistic equals `cvm_statistic` of the compensator transforms.

## Tests

4 new tests (kept lean because the bootstrap refits are slow): CvM runs and returns a valid `GoodnessOfFitResult` for both an age-reduction (GR-i) and an intensity-reduction (ARI) model, the observed statistic matches the transform-based computation, seed reproducibility, and the no-data guard. Full recurrent suite passes (257); flake8 / black / mypy clean.

Closes #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_