### PR TITLE
Support gapped (multi-window) observation for recurrent events (#145)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,19 @@ Recurrent events
   increments (there being no closed-form intensity), and its p-value comes
   from a parametric bootstrap that resimulates each item and refits the full
   imperfect-repair model per replicate.
+- Added support for gapped (multi-window) observation: an item can be observed
+  over several disjoint time windows with unobserved gaps in between (events
+  may occur during a gap but are not recorded). Pass ``windows={item:
+  [(start, end), ...]}`` to the intensity fitters (``HPP``, ``CrowAMSAA``,
+  ``Duane``, ``CoxLewis``) and the nonparametric ``NonParametricCounting`` MCF;
+  every row of ``x`` is then an observed event and the windows supply the
+  end-of-window censoring. Because event counts over disjoint windows are
+  independent for an NHPP, each window is fitted as its own observation period,
+  so the intensity likelihood and the MCF at-risk set (an item is absent from
+  the risk set during its gaps) both handle the gaps exactly. The virtual-age /
+  renewal models (``GeneralizedRenewal``, ``GeneralizedOneRenewal``, ``ARA``,
+  ``ARI``) reject gapped data, since the virtual age at the start of a later
+  window depends on the unobserved events during the gap.
 
 v0.13.0 (18 Jul 2026)
 ---------------------

--- a/surpyval/recurrent/nonparametric/mcf.py
+++ b/surpyval/recurrent/nonparametric/mcf.py
@@ -139,7 +139,7 @@ class NonParametricCounting:
 
         return out
 
-    def fit(self, x, i=None, c=None, n=None, tl=None, tr=None):
+    def fit(self, x, i=None, c=None, n=None, tl=None, tr=None, windows=None):
         """
         Fit a nonparametric (Nelson-Aalen) MCF.
 
@@ -159,10 +159,19 @@ class NonParametricCounting:
             earlier event times are estimated over a smaller risk set.
         tr : array like or scalar, optional
             Right-truncation time per item.
+        windows : dict, optional
+            Gapped (multi-window) observation: a mapping ``{item: [(start,
+            end), ...]}`` giving each item's disjoint observation windows.
+            When given, every row in ``x`` must be an observed event (``c=0``).
+            Each window becomes its own at-risk period, so an item is correctly
+            absent from the risk set during a gap. Mutually exclusive with
+            ``tl``/``tr``.
 
         Returns
         -------
         NonParametricCounting
         """
-        data = handle_xicn(x, i, c, n, tl=tl, tr=tr, as_recurrent_data=True)
+        data = handle_xicn(
+            x, i, c, n, tl=tl, tr=tr, as_recurrent_data=True, windows=windows
+        )
         return self.fit_from_recurrent_data(data)

--- a/surpyval/recurrent/parametric/hpp.py
+++ b/surpyval/recurrent/parametric/hpp.py
@@ -288,7 +288,16 @@ class HPP(CountingProcess):
         return out
 
     def fit(
-        self, x, i=None, c=None, n=None, t=None, tl=None, tr=None, init=None
+        self,
+        x,
+        i=None,
+        c=None,
+        n=None,
+        t=None,
+        tl=None,
+        tr=None,
+        init=None,
+        windows=None,
     ):
         """
         Fits the HPP model to the provided data and returns the fitted model.
@@ -311,6 +320,12 @@ class HPP(CountingProcess):
             Right truncation time per item.
         init : array_like, optional
             Initial parameter estimates for the optimization.
+        windows : dict, optional
+            Gapped (multi-window) observation: a mapping ``{item: [(start,
+            end), ...]}`` giving each item's disjoint observation windows.
+            When given, every row in ``x`` must be an observed event (``c=0``);
+            the windows supply the end-of-window censoring rows. Mutually
+            exclusive with ``t``/``tl``/``tr``.
 
         Returns
         -------
@@ -318,6 +333,14 @@ class HPP(CountingProcess):
             An object containing the fitted model and related information.
         """
         data = handle_xicn(
-            x, i, c, n, t=t, tl=tl, tr=tr, as_recurrent_data=True
+            x,
+            i,
+            c,
+            n,
+            t=t,
+            tl=tl,
+            tr=tr,
+            as_recurrent_data=True,
+            windows=windows,
         )
         return self.fit_from_recurrent_data(data, init=init)

--- a/surpyval/recurrent/parametric/nhpp_fitter.py
+++ b/surpyval/recurrent/parametric/nhpp_fitter.py
@@ -182,6 +182,7 @@ class NHPPFitter(IntensityModel):
         tr=None,
         how="MLE",
         init=None,
+        windows=None,
     ):
         """
         Fit the NHPP model from the provided data. This function prepares the
@@ -211,6 +212,15 @@ class NHPPFitter(IntensityModel):
             Default is 'MLE'.
         init: array_like, optional
             Initial parameters for optimization.
+        windows: dict, optional
+            Gapped (multi-window) observation: a mapping ``{item: [(start,
+            end), ...]}`` giving each item's disjoint observation windows,
+            with unobserved gaps between them. When given, every row in ``x``
+            must be an observed event (``c=0``); the windows supply the
+            end-of-window censoring rows. Because event counts over disjoint
+            windows are independent for an NHPP, each window is fitted as its
+            own observation period. Mutually exclusive with ``t``/``tl``/
+            ``tr``.
 
         Returns
         -------
@@ -220,7 +230,15 @@ class NHPPFitter(IntensityModel):
             method.
         """
         data = handle_xicn(
-            x, i, c, n, t=t, tl=tl, tr=tr, as_recurrent_data=True
+            x,
+            i,
+            c,
+            n,
+            t=t,
+            tl=tl,
+            tr=tr,
+            as_recurrent_data=True,
+            windows=windows,
         )
         return self.fit_from_recurrent_data(data, how, init)
 

--- a/surpyval/recurrent/renewal/ara.py
+++ b/surpyval/recurrent/renewal/ara.py
@@ -7,6 +7,7 @@ from surpyval.recurrent.renewal.renewal_model import RenewalModel
 from surpyval.utils.fitter import singleton_fitter
 from surpyval.utils.recurrent_utils import (
     handle_xicn,
+    reject_gapped_observation,
     reject_left_truncation,
     validate_memory,
     validate_renewal_censoring,
@@ -201,6 +202,7 @@ class ARA(RenewalFitMixin):
         validate_memory(m)
         validate_renewal_censoring(data.c, type(self).__name__)
         reject_left_truncation(data, type(self).__name__)
+        reject_gapped_observation(data, type(self).__name__)
 
         neg_ll = self.create_negll_func(data, dist, m)
         transform, inv_trans = self._bounds_transform(

--- a/surpyval/recurrent/renewal/ari.py
+++ b/surpyval/recurrent/renewal/ari.py
@@ -6,6 +6,7 @@ from surpyval.recurrent.renewal.fit_mixin import RenewalFitMixin
 from surpyval.utils.fitter import singleton_fitter
 from surpyval.utils.recurrent_utils import (
     handle_xicn,
+    reject_gapped_observation,
     reject_left_truncation,
     validate_memory,
     validate_renewal_censoring,
@@ -217,6 +218,7 @@ class ARI(RenewalFitMixin):
         validate_memory(m)
         validate_renewal_censoring(data.c, type(self).__name__)
         reject_left_truncation(data, type(self).__name__)
+        reject_gapped_observation(data, type(self).__name__)
 
         neg_ll = self.create_negll_func(data, dist, m)
         transform, inv_trans = self._bounds_transform(

--- a/surpyval/recurrent/renewal/generalized_one_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_one_renewal.py
@@ -7,6 +7,7 @@ from surpyval.recurrent.renewal.renewal_model import RenewalModel
 from surpyval.utils.fitter import singleton_fitter
 from surpyval.utils.recurrent_utils import (
     handle_xicn,
+    reject_gapped_observation,
     reject_left_truncation,
     validate_renewal_censoring,
 )
@@ -204,6 +205,7 @@ class GeneralizedOneRenewal(RenewalFitMixin):
         self._check_dist_eligible(dist)
         validate_renewal_censoring(data.c, type(self).__name__)
         reject_left_truncation(data, type(self).__name__)
+        reject_gapped_observation(data, type(self).__name__)
 
         neg_ll = self.create_negll_func(
             data.interarrival_times, data.i, data.c, data.n, dist

--- a/surpyval/recurrent/renewal/generalized_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_renewal.py
@@ -7,6 +7,7 @@ from surpyval.recurrent.renewal.renewal_model import RenewalModel
 from surpyval.utils.fitter import singleton_fitter
 from surpyval.utils.recurrent_utils import (
     handle_xicn,
+    reject_gapped_observation,
     reject_left_truncation,
     validate_renewal_censoring,
 )
@@ -265,6 +266,7 @@ class GeneralizedRenewal(RenewalFitMixin):
         """
         validate_renewal_censoring(data.c, type(self).__name__)
         reject_left_truncation(data, type(self).__name__)
+        reject_gapped_observation(data, type(self).__name__)
 
         neg_ll = self.create_negll_func(data, dist, kijima=kijima)
         transform, inv_trans = self._bounds_transform(

--- a/surpyval/tests/recurrent/test_gapped_observation.py
+++ b/surpyval/tests/recurrent/test_gapped_observation.py
@@ -1,0 +1,251 @@
+"""Gapped (multi-window) observation for recurrent events.
+
+An item may be observed only over several disjoint time windows, with
+unobserved gaps in between (events may occur during a gap but are never
+recorded). For an NHPP the event counts over disjoint windows are independent,
+so a gapped item's likelihood factorises over its windows; ``handle_xicn``
+expands each window into a synthetic single-window sub-item (its events plus a
+right-censored close at the window end, entering at the window start). These
+tests check that expansion, that it reproduces the exact gapped likelihood and
+recovers parameters, that the nonparametric MCF at-risk set respects the gaps,
+that the virtual-age / renewal models reject gapped data, and that malformed
+window specifications are rejected.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval import Weibull, handle_xicn
+from surpyval.recurrent import (
+    ARA,
+    ARI,
+    CrowAMSAA,
+    GeneralizedOneRenewal,
+    GeneralizedRenewal,
+    NonParametricCounting,
+)
+
+# --- expansion into synthetic single-window sub-items -----------------------
+
+
+def test_windows_expand_to_synthetic_items_with_closes():
+    x = np.array([3, 7, 10, 25, 33, 38])
+    i = np.array([1, 1, 1, 1, 1, 1])
+    data = handle_xicn(x, i, windows={1: [(0, 10), (20, 40)]})
+
+    # two windows -> two synthetic items, each ending in a c=1 close row
+    assert set(np.unique(data.i)) == {1, 2}
+    assert data.window_map == {1: (1, (0.0, 10.0)), 2: (1, (20.0, 40.0))}
+    # window 1: events 3, 7, 10 then a close at 10; entry (tl) 0
+    w1 = data.i == 1
+    assert list(data.x[w1]) == [3.0, 7.0, 10.0, 10.0]
+    assert list(data.c[w1]) == [0.0, 0.0, 0.0, 1.0]
+    assert np.all(data.tl[w1] == 0.0)
+    # window 2: events 25, 33, 38 then a close at 40; entry (tl) 20
+    w2 = data.i == 2
+    assert list(data.x[w2]) == [25.0, 33.0, 38.0, 40.0]
+    assert list(data.c[w2]) == [0.0, 0.0, 0.0, 1.0]
+    assert np.all(data.tl[w2] == 20.0)
+
+
+def test_empty_window_still_contributes_a_close():
+    # A window with no events is still an observation period: it becomes a
+    # lone right-censored close row spanning the window.
+    data = handle_xicn(
+        np.array([3.0, 7.0]),
+        np.array([1, 1]),
+        windows={1: [(0, 10), (20, 40)]},
+    )
+    w2 = data.i == 2
+    assert list(data.x[w2]) == [40.0]
+    assert list(data.c[w2]) == [1.0]
+    assert np.all(data.tl[w2] == 20.0)
+
+
+def test_window_map_defaults_to_none_for_ordinary_data():
+    data = handle_xicn(np.array([1.0, 2.0, 3.0]), np.array([1, 1, 1]))
+    assert data.window_map is None
+    assert data.observation_windows is None
+
+
+# --- the gapped likelihood matches the hand-built synthetic representation --
+
+
+def test_gapped_likelihood_matches_manual_window_items():
+    x = np.array([3, 7, 10, 25, 33, 38])
+    i = np.array([1, 1, 1, 1, 1, 1])
+    gapped = handle_xicn(x, i, windows={1: [(0, 10), (20, 40)]})
+
+    # The same thing spelled out by hand as two left-truncated single-window
+    # items, each closed by an explicit right-censoring row.
+    manual = handle_xicn(
+        np.array([3, 7, 10, 25, 33, 38, 40]),
+        np.array([1, 1, 1, 2, 2, 2, 2]),
+        c=np.array([0, 0, 0, 0, 0, 0, 1]),
+        tl=np.array([0, 0, 0, 20, 20, 20, 20]),
+    )
+    f_gapped = CrowAMSAA.create_negll_func(gapped)
+    f_manual = CrowAMSAA.create_negll_func(manual)
+    for p in ([1.4, 0.9], [4.0, 1.2], [2.0, 1.0]):
+        assert np.isclose(f_gapped(np.array(p)), f_manual(np.array(p)))
+
+
+# --- parameter recovery from a gapped NHPP simulation -----------------------
+
+
+def test_nhpp_recovers_parameters_from_gapped_data():
+    truth = CrowAMSAA.from_params([5.0, 1.4])
+    full = truth.time_terminated_simulation_data(30.0, items=400, seed=7)
+
+    # Impose a common unobserved gap (12, 20): each item is observed on
+    # [0, 12] and [20, 30], and events inside the gap are dropped.
+    gap, T = (12.0, 20.0), 30.0
+    xs, ii, windows = [], [], {}
+    for item in np.unique(full.i):
+        m = (full.i == item) & (full.c == 0)
+        ev = full.x[m]
+        ev = ev[(ev <= gap[0]) | (ev >= gap[1])]
+        xs.append(ev)
+        ii.append(np.full(ev.size, item))
+        windows[item] = [(0.0, gap[0]), (gap[1], T)]
+    x = np.concatenate(xs)
+    i = np.concatenate(ii)
+
+    model = CrowAMSAA.fit(x, i, windows=windows)
+    assert np.allclose(model.params, [5.0, 1.4], rtol=0.15)
+
+
+# --- nonparametric MCF at-risk set respects the gaps ------------------------
+
+
+def test_mcf_at_risk_set_excludes_item_during_its_gap():
+    # Item A observed continuously on [0, 50]; item B observed on [0, 10] and
+    # [30, 50] with a gap. At a time inside B's gap only A is at risk.
+    x = np.array([5.0, 20.0, 40.0, 5.0, 35.0])
+    i = np.array(["A", "A", "A", "B", "B"])
+    windows = {"A": [(0.0, 50.0)], "B": [(0.0, 10.0), (30.0, 50.0)]}
+    mcf = NonParametricCounting.fit(x, i, windows=windows)
+
+    r_at = dict(zip(mcf.x, mcf.r))
+    # x = 5 is in a window of both A and B -> risk set 2
+    assert r_at[5.0] == 2
+    # x = 20 falls in B's gap -> only A at risk
+    assert r_at[20.0] == 1
+    # x = 35 is back in B's second window and still in A's window -> 2
+    assert r_at[35.0] == 2
+
+
+# --- the virtual-age / renewal models reject gapped observation -------------
+
+
+@pytest.mark.parametrize(
+    "fit_call",
+    [
+        lambda d: GeneralizedRenewal.fit_from_recurrent_data(
+            d, dist=Weibull, kijima="i"
+        ),
+        lambda d: GeneralizedOneRenewal.fit_from_recurrent_data(
+            d, dist=Weibull
+        ),
+        lambda d: ARA.fit_from_recurrent_data(d, dist=Weibull, m=1),
+        lambda d: ARI.fit_from_recurrent_data(d, dist=CrowAMSAA, m=1),
+    ],
+)
+def test_renewal_models_reject_gapped_data(fit_call):
+    # A single window starting at 0 still carries a window_map, so the guard
+    # fires regardless of the left-truncation check.
+    data = handle_xicn(
+        np.array([3.0, 7.0, 10.0]), np.array([1, 1, 1]), windows={1: [(0, 15)]}
+    )
+    with pytest.raises(ValueError, match="gapped"):
+        fit_call(data)
+
+
+# --- malformed window specifications are rejected ---------------------------
+
+
+def test_windows_require_all_rows_observed():
+    with pytest.raises(ValueError, match="observed event"):
+        handle_xicn(
+            np.array([3.0, 7.0]),
+            np.array([1, 1]),
+            c=np.array([0, 1]),
+            windows={1: [(0, 10)]},
+        )
+
+
+def test_windows_must_cover_every_item():
+    with pytest.raises(ValueError, match="every item"):
+        handle_xicn(
+            np.array([3.0, 7.0]),
+            np.array([1, 2]),
+            windows={1: [(0, 10)]},
+        )
+
+
+def test_windows_reject_overlap():
+    with pytest.raises(ValueError, match="overlapping"):
+        handle_xicn(
+            np.array([3.0]), np.array([1]), windows={1: [(0, 10), (5, 20)]}
+        )
+
+
+def test_windows_reject_reversed_or_empty():
+    with pytest.raises(ValueError, match="reversed"):
+        handle_xicn(np.array([3.0]), np.array([1]), windows={1: [(10, 5)]})
+    with pytest.raises(ValueError, match="reversed"):
+        handle_xicn(np.array([3.0]), np.array([1]), windows={1: [(5, 5)]})
+
+
+def test_windows_reject_non_finite():
+    with pytest.raises(ValueError, match="non-finite"):
+        handle_xicn(np.array([3.0]), np.array([1]), windows={1: [(0, np.inf)]})
+
+
+def test_events_outside_all_windows_rejected():
+    with pytest.raises(ValueError, match="outside all"):
+        handle_xicn(
+            np.array([3.0, 15.0]),
+            np.array([1, 1]),
+            windows={1: [(0, 10), (20, 30)]},
+        )
+
+
+def test_windows_mutually_exclusive_with_truncation():
+    with pytest.raises(ValueError, match="must not also"):
+        handle_xicn(
+            np.array([3.0]), np.array([1]), tl=0.0, windows={1: [(0, 10)]}
+        )
+
+
+def test_windows_reject_covariates():
+    with pytest.raises(ValueError, match="does not support covariates"):
+        handle_xicn(
+            np.array([3.0]),
+            np.array([1]),
+            Z=np.array([[1.0]]),
+            windows={1: [(0, 10)]},
+        )
+
+
+# --- HPP also accepts gapped observation ------------------------------------
+
+
+def test_hpp_accepts_windows():
+    from surpyval.recurrent import HPP
+
+    # Homogeneous Poisson process of rate 2 observed on [0, 4] and [6, 10]
+    # (an unobserved gap on (4, 6)). Simulate events directly in each window.
+    rate = 2.0
+    wins = [(0.0, 4.0), (6.0, 10.0)]
+    rng = np.random.default_rng(3)
+    xs, ii, windows = [], [], {}
+    for item in range(300):
+        for a, b in wins:
+            k = rng.poisson(rate * (b - a))
+            ev = np.sort(rng.uniform(a, b, size=k))
+            xs.append(ev)
+            ii.append(np.full(ev.size, item))
+        windows[item] = wins
+    model = HPP.fit(np.concatenate(xs), np.concatenate(ii), windows=windows)
+    assert np.isclose(model.params[0], rate, rtol=0.1)

--- a/surpyval/tests/recurrent/test_gapped_observation.py
+++ b/surpyval/tests/recurrent/test_gapped_observation.py
@@ -139,26 +139,22 @@ def test_mcf_at_risk_set_excludes_item_during_its_gap():
 
 
 @pytest.mark.parametrize(
-    "fit_call",
+    "fitter, kwargs",
     [
-        lambda d: GeneralizedRenewal.fit_from_recurrent_data(
-            d, dist=Weibull, kijima="i"
-        ),
-        lambda d: GeneralizedOneRenewal.fit_from_recurrent_data(
-            d, dist=Weibull
-        ),
-        lambda d: ARA.fit_from_recurrent_data(d, dist=Weibull, m=1),
-        lambda d: ARI.fit_from_recurrent_data(d, dist=CrowAMSAA, m=1),
+        (GeneralizedRenewal, dict(dist=Weibull, kijima="i")),
+        (GeneralizedOneRenewal, dict(dist=Weibull)),
+        (ARA, dict(dist=Weibull, m=1)),
+        (ARI, dict(dist=CrowAMSAA, m=1)),
     ],
 )
-def test_renewal_models_reject_gapped_data(fit_call):
+def test_renewal_models_reject_gapped_data(fitter, kwargs):
     # A single window starting at 0 still carries a window_map, so the guard
     # fires regardless of the left-truncation check.
     data = handle_xicn(
         np.array([3.0, 7.0, 10.0]), np.array([1, 1, 1]), windows={1: [(0, 15)]}
     )
     with pytest.raises(ValueError, match="gapped"):
-        fit_call(data)
+        fitter.fit_from_recurrent_data(data, **kwargs)
 
 
 # --- malformed window specifications are rejected ---------------------------

--- a/surpyval/utils/recurrent_event_data.py
+++ b/surpyval/utils/recurrent_event_data.py
@@ -7,6 +7,13 @@ from surpyval.utils.surpyval_data import SurpyvalData
 class RecurrentEventData:
     # Optional covariate matrix, attached by ``handle_xicn`` for regression.
     Z: npt.NDArray | None = None
+    # Gapped (multi-window) observation metadata, attached by ``handle_xicn``
+    # when ``windows`` is supplied: ``window_map`` maps each synthetic
+    # single-window sub-item id to its ``(real_item, (start, end))`` and
+    # ``observation_windows`` keeps the user's original per-item windows. Both
+    # stay ``None`` for ordinary single-window data.
+    window_map: dict | None = None
+    observation_windows: dict | None = None
 
     """
     A class to handle and manipulate recurrent event data. Recurrent events are

--- a/surpyval/utils/recurrent_utils.py
+++ b/surpyval/utils/recurrent_utils.py
@@ -86,6 +86,168 @@ def validate_renewal_censoring(c: npt.ArrayLike, model_name: str) -> None:
         )
 
 
+def reject_gapped_observation(
+    data: RecurrentEventData, model_name: str
+) -> None:
+    """
+    The virtual-age / imperfect-repair models (Kijima/G1/ARA/ARI) cannot be
+    fitted to gapped (multi-window) observation. Their likelihood is built from
+    the virtual age carried across the *entire* history, so a gap in which the
+    item was unobserved -- events may have occurred but were not recorded --
+    breaks the age bookkeeping: the state at the start of a later window is
+    unknown. The intensity (NHPP) models factorise over disjoint windows and so
+    do support gaps.
+    """
+    if getattr(data, "window_map", None) is not None:
+        raise ValueError(
+            "{} does not support gapped (multi-window) observation: the "
+            "virtual age at the start of a later window depends on the "
+            "unobserved events during the gap. Use an NHPP intensity model "
+            "(HPP, CrowAMSAA, Duane, CoxLewis) for gapped data.".format(
+                model_name
+            )
+        )
+
+
+def _expand_windows(
+    x: npt.NDArray,
+    i: npt.NDArray,
+    c: npt.NDArray,
+    n: npt.NDArray,
+    windows: dict,
+) -> tuple[
+    npt.NDArray,
+    npt.NDArray,
+    npt.NDArray,
+    npt.NDArray,
+    npt.NDArray,
+    npt.NDArray,
+    dict,
+]:
+    """
+    Expand multi-window (gapped) observation into synthetic single-window
+    sub-items.
+
+    Poisson event counts over disjoint windows are independent, so a gapped
+    item's NHPP likelihood factorises over its windows. Representing each
+    window as its own single-window item -- its events (``c=0``) plus a
+    right-censored close (``c=1``) at the window end, entering (``tl``) at the
+    window start -- reproduces exactly that factorised likelihood, and makes
+    the existing NHPP likelihood *and* the nonparametric MCF at-risk set
+    handle gaps unchanged: an item is simply absent from the risk set during
+    a gap.
+
+    ``windows`` is a mapping ``{item: [(start, end), ...]}`` giving each item's
+    disjoint observation windows. Every provided row must be an observed event
+    (``c=0``); the windows supply the censoring / close rows. Returns the
+    expanded ``(x, i, c, n, tl, tr)`` arrays and a ``window_map`` from each
+    synthetic item id to its ``(real_item, (start, end))``.
+    """
+    if x.ndim != 1:
+        raise ValueError(
+            "windows (gapped observation) is not supported for "
+            "interval-valued (2D) event times"
+        )
+    if not isinstance(windows, dict):
+        raise ValueError(
+            "windows must be a dict mapping each item to a list of "
+            "(start, end) observation windows"
+        )
+    if np.any(np.asarray(c) != 0):
+        raise ValueError(
+            "with windows, every provided row must be an observed event "
+            "(c=0); the observation windows supply the censoring / close rows"
+        )
+
+    unique_i = np.unique(i)
+    missing = [ii for ii in unique_i.tolist() if ii not in windows]
+    if missing:
+        raise ValueError(
+            "windows must be given for every item; missing "
+            "{}".format(missing)
+        )
+
+    new_x: list = []
+    new_i: list = []
+    new_c: list = []
+    new_n: list = []
+    new_tl: list = []
+    new_tr: list = []
+    window_map: dict = {}
+    synth = 0
+    for ii in unique_i:
+        wins = [tuple(w) for w in windows[ii]]
+        if len(wins) == 0:
+            raise ValueError("item {} has no observation windows".format(ii))
+        for w in wins:
+            if len(w) != 2:
+                raise ValueError(
+                    "item {} has a malformed window {!r}; each window must be "
+                    "a (start, end) pair".format(ii, w)
+                )
+            a, b = float(w[0]), float(w[1])
+            if not (np.isfinite(a) and np.isfinite(b)):
+                raise ValueError(
+                    "item {} has a non-finite observation window "
+                    "({}, {})".format(ii, w[0], w[1])
+                )
+            if not (a < b):
+                raise ValueError(
+                    "item {} has an empty or reversed observation window "
+                    "({}, {}); require start < end".format(ii, w[0], w[1])
+                )
+        # sort windows by start and require they are disjoint (touching, i.e.
+        # end == next start, is allowed)
+        wins = sorted(wins, key=lambda w: float(w[0]))
+        for (a1, b1), (a2, b2) in zip(wins, wins[1:]):
+            if float(a2) < float(b1):
+                raise ValueError(
+                    "item {} has overlapping observation windows "
+                    "{} and {}".format(ii, (a1, b1), (a2, b2))
+                )
+
+        mask = np.asarray(i) == ii
+        item_x = np.asarray(x)[mask]
+        item_n = np.asarray(n)[mask]
+        assigned = np.zeros(item_x.shape[0], dtype=bool)
+        for w in wins:
+            a, b = float(w[0]), float(w[1])
+            synth += 1
+            in_win = (item_x >= a) & (item_x <= b) & (~assigned)
+            assigned |= in_win
+            for xv, nv in zip(item_x[in_win], item_n[in_win]):
+                new_x.append(float(xv))
+                new_i.append(synth)
+                new_c.append(0)
+                new_n.append(nv)
+                new_tl.append(a)
+                new_tr.append(np.inf)
+            # window close: right-censored end-of-window row at b
+            new_x.append(b)
+            new_i.append(synth)
+            new_c.append(1)
+            new_n.append(1)
+            new_tl.append(a)
+            new_tr.append(np.inf)
+            window_map[synth] = (ii, (a, b))
+        if not assigned.all():
+            outside = item_x[~assigned].tolist()
+            raise ValueError(
+                "item {} has events outside all its observation windows: "
+                "{}".format(ii, outside)
+            )
+
+    return (
+        np.array(new_x, dtype=float),
+        np.array(new_i),
+        np.array(new_c, dtype=float),
+        np.array(new_n),
+        np.array(new_tl, dtype=float),
+        np.array(new_tr, dtype=float),
+        window_map,
+    )
+
+
 def handle_xicn(
     x: npt.ArrayLike,
     i: npt.ArrayLike | None = None,
@@ -96,6 +258,7 @@ def handle_xicn(
     tr: npt.ArrayLike | None = None,
     Z: npt.ArrayLike | dict | None = None,
     as_recurrent_data: bool = True,
+    windows: dict | None = None,
 ) -> (
     RecurrentEventData
     | tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]
@@ -120,6 +283,28 @@ def handle_xicn(
     else:
         c = np.array(c)
 
+    # Gapped (multi-window) observation: each item is observed over several
+    # disjoint windows with unobserved gaps between them. Expand each window
+    # into a synthetic single-window sub-item so the rest of the handler --
+    # and the NHPP likelihood and MCF at-risk set downstream -- treat the gaps
+    # correctly without any special-casing (see ``_expand_windows``).
+    window_map: dict | None = None
+    tl_gap: npt.NDArray | None = None
+    tr_gap: npt.NDArray | None = None
+    if windows is not None:
+        if t is not None or tl is not None or tr is not None:
+            raise ValueError(
+                "windows defines each item's observation windows, so t, tl "
+                "and tr must not also be supplied"
+            )
+        if Z is not None:
+            raise ValueError(
+                "windows (gapped observation) does not support covariates Z"
+            )
+        x, i, c, n, tl_gap, tr_gap, window_map = _expand_windows(
+            x, i, c, n, windows
+        )
+
     # Truncation follows surpyval's xcnt convention (shared with the univariate
     # handler): the default window is the whole real line. No global sign
     # assumption is made about ``x`` here -- each item is instead validated
@@ -127,9 +312,13 @@ def handle_xicn(
     # (possibly negative) left-truncation bound legitimately admits negative
     # event times; an untruncated item is integrated from the fallback origin
     # 0 (see ``get_previous_x``) and so must have non-negative event times.
-    truncation = format_truncation(t, tl, tr, x.shape[0])
-    tl_arr = truncation[:, 0]
-    tr_arr = truncation[:, 1]
+    if tl_gap is not None and tr_gap is not None:
+        tl_arr = tl_gap
+        tr_arr = tr_gap
+    else:
+        truncation = format_truncation(t, tl, tr, x.shape[0])
+        tl_arr = truncation[:, 0]
+        tr_arr = truncation[:, 1]
 
     Z_arr: npt.NDArray | None = None
     if Z is not None:
@@ -273,6 +462,12 @@ def handle_xicn(
     if as_recurrent_data:
         data = RecurrentEventData(x, i, c, n, tl=tl_arr, tr=tr_arr)
         data.Z = Z_arr
+        # ``window_map`` (synthetic-item id -> (real item, (start, end))) is
+        # set only for gapped observation; it stays ``None`` otherwise and is
+        # what ``reject_gapped_observation`` keys off. ``observation_windows``
+        # keeps the user's original per-item windows for reference.
+        data.window_map = window_map
+        data.observation_windows = windows if window_map is not None else None
         return data
     else:
         return x, i, c, n


### PR DESCRIPTION
Closes #145.

## What

Adds support for **gapped (multi-window) observation** of recurrent events: an item can be observed over several disjoint time windows with unobserved gaps in between. Events may occur during a gap but are never recorded, and the fit must not assume the item was under observation during the gaps.

## Why it works

For an NHPP the event counts over disjoint windows are **independent**, so a gapped item's likelihood factorises over its windows. This PR represents each observation window as a synthetic single-window sub-item — its events (`c=0`) plus a right-censored close (`c=1`) at the window end, entering (`tl`) at the window start. That representation:

- reproduces **exactly** the factorised NHPP likelihood (verified against a hand-built two-item dataset for several parameter values), and
- makes the nonparametric MCF at-risk set correct with no special-casing — an item is simply absent from the risk set during its gaps (`to_xrd` already keys the risk set off each item's entry `tl` and last time).

## API

```python
# each item observed on [0, 12] and [20, 30] with an unobserved gap between
CrowAMSAA.fit(x, i, windows={item: [(0, 12), (20, 30)], ...})
NonParametricCounting.fit(x, i, windows={...})
```

When `windows` is given, every row of `x` must be an observed event (`c=0`); the windows supply the end-of-window censoring rows. Mutually exclusive with `t`/`tl`/`tr`, and does not support covariates `Z`.

## Changes

- **`handle_xicn`**: new `windows=` argument and `_expand_windows` helper; attaches `window_map` (synthetic-item id → `(real item, (start, end))`) and `observation_windows` to the data. Validates windows are finite, ordered, disjoint, contain all events, and cover every item.
- **Intensity fitters**: `windows=` threaded into `NHPPFitter.fit` (so `CrowAMSAA`, `Duane`, `CoxLewis`), `HPP.fit`, and `NonParametricCounting.fit`.
- **Renewal models**: new `reject_gapped_observation` guard rejects gapped data in `GeneralizedRenewal`, `GeneralizedOneRenewal`, `ARA`, `ARI` — the virtual age at the start of a later window depends on the unobserved events during the gap.

## Tests

New `test_gapped_observation.py` (19 tests): window expansion structure, empty-window closes, likelihood equals the hand-built representation, **NHPP/HPP parameter recovery from a gapped simulation** (drops events in a common gap and recovers the truth within tolerance), MCF at-risk set excludes an item during its gap, renewal models reject gaps, and the full set of malformed-window validation errors.

Full recurrent suite (276 tests) + utils/xicn validation pass; flake8, mypy, black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_