### PR TITLE
Expand and complete the recurrent-event documentation for 0.14

### DIFF
--- a/docs/Recurrent Event Analysis.rst
+++ b/docs/Recurrent Event Analysis.rst
@@ -9,6 +9,8 @@ subject of single-event survival analysis. In single-event (univariate) analysis
 one is interested in only the time to the first, and only, event. In recurrent
 event analysis one is interested in the time to the first, second, third, etc.
 event. We therefore need a way to describe how many events have occurred by time t.
+For a comprehensive, book-length treatment of recurrent-event analysis, see
+[Cook2007]_.
 
 Recurrent events are modelled using counting processes and point processes.
 The underlying mathematical framework — martingale theory and stochastic
@@ -234,6 +236,54 @@ The ability of the G1 Renewal Process to capture the behaviour of when the
 intervention can improve the life of the subject is the reason why it is
 a useful model to have available.
 
+Arithmetic Reduction of Age and Intensity (ARA/ARI)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Kijima virtual-age models above are the special cases of a more general
+family due to Doyen and Gaudoin [Doyen2004]_. Rather than fold every past
+repair into a single running age, these models make the *memory* of the repair
+explicit: how many previous failures does an intervention act on?
+
+The **Arithmetic Reduction of Age** (ARA) model reduces the virtual age by a
+fixed fraction :math:`\rho` of the age accumulated over the last :math:`m`
+inter-arrival times. With infinite memory (:math:`m = \infty`) and one prior
+failure this recovers Kijima-I; with :math:`m = 1` it acts only on the most
+recent interval. The repair efficiency :math:`\rho \in (0, 1)` plays the role
+of :math:`1 - q`: :math:`\rho = 1` is as-good-as-new (perfect repair) and
+:math:`\rho = 0` is as-bad-as-old (minimal repair).
+
+The **Arithmetic Reduction of Intensity** (ARI) model instead reduces the
+*intensity* directly. After each repair the failure intensity is lowered by a
+fraction :math:`\rho` of the intensity built up over the last :math:`m`
+intervals, so the process acts on the rate of events rather than on an
+effective age. ARA and ARI coincide for a constant (homogeneous) baseline but
+differ whenever the baseline intensity varies with time.
+
+Both models take an integer memory :math:`m` (with :math:`m = \infty` the
+infinite-memory limit), which lets you dial the model from "the last repair
+undid only the most recent wear" (:math:`m = 1`) up to "every repair reaches
+back over the whole history" (:math:`m = \infty`).
+
+The Geometric Process
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A closely related idea is Lam's **geometric process** [Lam1988]_. Here the
+successive inter-arrival times :math:`X_1, X_2, \ldots` are scaled so that
+:math:`a^{\,k-1} X_k` are independent and identically distributed for a single
+ratio :math:`a > 0`. When :math:`a > 1` the inter-arrivals shrink
+geometrically (a deteriorating system), when :math:`a < 1` they grow
+(reliability growth), and :math:`a = 1` is an ordinary renewal process. The
+mean inter-arrival time is then the geometric sequence
+:math:`\mathbb{E}[X_k] = \mu / a^{\,k-1}`.
+
+This is exactly the G1 Renewal Process in a different parameterisation:
+matching the G1 scaling :math:`(1 + q)^{j}` to :math:`a^{-j}` gives
+:math:`a = 1 / (1 + q)`. A deteriorating system (:math:`a > 1`) therefore
+corresponds to a negative restoration factor, and reliability growth
+(:math:`a < 1`) to a positive one. Fitting a
+:class:`~surpyval.recurrent.GeneralizedOneRenewal` gives the geometric process
+with a parametric lifetime distribution.
+
 
 Parameter Estimation
 --------------------
@@ -265,4 +315,133 @@ integral reduces to :math:`\lambda T`.
 .. note::
 
     Full derivations for each parametric model (Crow-AMSAA, Duane, Cox-Lewis)
-    are in the API docstrings. 
+    are in the API docstrings.
+
+Truncation and Delayed Entry
+----------------------------
+
+Observation of a recurrent process rarely starts at the origin. A machine may
+already have been in service before monitoring began, or a study may only
+record events after a subject enrols. This is **left truncation** (delayed
+entry): the item is only under observation from an entry time :math:`t_L`, and
+its first observed interval is integrated from :math:`t_L` rather than from
+zero. **Right truncation** closes the observation window at a time :math:`t_R`,
+extending the compensator integral out to :math:`t_R` even if no event or
+censoring row sits exactly there.
+
+The intensity (Poisson) models handle delayed entry directly, because the
+likelihood over any interval depends only on the intensity over that interval.
+The virtual-age and history-dependent models (Kijima, G1, ARA, ARI) cannot:
+the virtual age at entry depends on the unobserved failures before entry, so
+those models require the process to be observed from the start.
+
+Model Checking: Residuals, Trend Tests, and Goodness of Fit
+-----------------------------------------------------------
+
+Having a fitted model is not the same as having a *good* model, and recurrent
+processes admit the same kind of residual analysis as ordinary regression.
+
+The key tool is the **time-rescaling theorem** [Ogata1988]_ [DaleyVereJones2003]_.
+If events follow a process with cumulative intensity :math:`\Lambda`, then
+transforming each event time by its own compensator turns the observed events
+into a *unit-rate* Poisson process. Concretely, the rescaled inter-arrival
+increments
+
+.. math::
+
+    e_k = \Lambda(x_k) - \Lambda(x_{k-1})
+
+are independent Exp(1) random variables when the fitted model is correct. So a
+simple check is whether the residuals :math:`e_k` look like an i.i.d. Exp(1)
+sample (mean one); the probability-integral transform :math:`1 - e^{-e_k}`
+turns them into U(0, 1) values for a QQ-style check, and a per-item
+**martingale residual** — observed event count minus the compensator over the
+item's window — flags items the model over- or under-predicts. For the
+virtual-age and renewal models the same construction is applied to the
+*conditional* intensity (the cumulative hazard accumulated over each interval
+given the model's virtual age or intensity reduction), so residuals extend to
+those families too.
+
+A **trend test** asks a more basic question: was a time-varying intensity
+warranted at all? The null hypothesis is a homogeneous Poisson process (no
+trend). The Laplace test and the Military-Handbook (MIL-HDBK-189C) test
+[Rigdon2000]_ both use only the event times and observation windows, not the
+fitted parameters, so they are a useful sanity check before committing to a
+particular parametric form.
+
+Finally, a **Cramér–von Mises** goodness-of-fit test [DaleyVereJones2003]_
+measures how far the conditionally-uniform transforms fall from uniformity.
+Conditional on the number of events an item shows, the normalised compensators
+:math:`\Lambda(x_k) / \Lambda(\text{close})` are i.i.d. U(0, 1) under the true
+model; the statistic aggregates their departure from uniformity. Because the
+parameters were estimated from the same data, the p-value is obtained by a
+parametric bootstrap — resimulating from the fitted model, refitting, and
+recomputing the statistic — so it accounts for the estimation. For the
+power-law (Crow-AMSAA) process this is the construction behind Crow's
+classical goodness-of-fit test.
+
+Competing Risks: Marked Recurrent Events
+----------------------------------------
+
+An item can experience events of several *mutually exclusive types* — a pump
+that suffers seal failures, bearing failures and impeller failures, say. Each
+event carries a **mark** identifying its type, and we usually want a separate
+picture per type.
+
+Non-parametrically, the **cause-specific mean cumulative function** is the MCF
+restricted to one cause. The at-risk set is shared across causes (an item is at
+risk for every cause until it leaves observation); only the event counts are
+split by type. This is the recurrent-process analogue of the cause-specific
+cumulative incidence in single-event competing risks.
+
+Parametrically, a marked Poisson process has an elegant structure: the
+cause-specific processes are **independent thinned Poisson processes**. An
+event of one cause neither advances nor interrupts another cause's intensity,
+so the joint likelihood factorises over causes. Each cause's intensity is
+therefore just the ordinary NHPP fit to that cause's events over the full
+observation window of every item, treating other-cause events exactly as a
+censored (unobserved) period. The total intensity is the sum of the
+cause-specific intensities.
+
+Gapped (Multi-Window) Observation
+---------------------------------
+
+Sometimes an item is observed over several *disjoint* windows with unobserved
+gaps in between — a fleet vehicle tracked only while it is in the depot, or a
+system monitored during business hours. Events may occur during a gap but are
+never recorded, so the analysis must not assume the item was under observation
+throughout.
+
+For a Poisson (intensity) process this has a clean solution. Because event
+counts over disjoint windows are independent, a gapped item's likelihood
+factorises over its windows, and each window can be treated as its own
+observation period with its own entry and exit. The intensity likelihood and
+the non-parametric MCF at-risk set then handle the gaps with no special
+machinery: an item is simply absent from the risk set while it is unobserved.
+The virtual-age and renewal models cannot accommodate gaps, because the virtual
+age at the start of a later window depends on the unobserved failures during
+the gap.
+
+References
+----------
+
+.. [Doyen2004] Doyen, L. and Gaudoin, O., 2004. Classes of imperfect repair
+   models based on reduction of failure intensity or virtual age. *Reliability
+   Engineering & System Safety*, 84(1), pp.45-56.
+
+.. [Lam1988] Lam, Y., 1988. Geometric processes and replacement problem. *Acta
+   Mathematicae Applicatae Sinica*, 4(4), pp.366-377.
+
+.. [Ogata1988] Ogata, Y., 1988. Statistical models for earthquake occurrences
+   and residual analysis for point processes. *Journal of the American
+   Statistical Association*, 83(401), pp.9-27.
+
+.. [DaleyVereJones2003] Daley, D.J. and Vere-Jones, D., 2003. *An Introduction
+   to the Theory of Point Processes, Volume I: Elementary Theory and Methods*,
+   2nd ed. Springer.
+
+.. [Rigdon2000] Rigdon, S.E. and Basu, A.P., 2000. *Statistical Methods for the
+   Reliability of Repairable Systems*. John Wiley & Sons.
+
+.. [Cook2007] Cook, R.J. and Lawless, J.F., 2007. *The Statistical Analysis of
+   Recurrent Events*. Springer.

--- a/docs/Recurrent Event Modelling with SurPyval.rst
+++ b/docs/Recurrent Event Modelling with SurPyval.rst
@@ -101,8 +101,26 @@ Let's look at how we can use right censoring.
     model = NonParametricCounting.fit(x, i=i, c=c)
     model.plot()
 
-At present the ``NonParametricCounting`` model does not support fitting with
-truncated data.
+The ``NonParametricCounting`` model also supports **left truncation** (delayed
+entry): an item that was already in service before observation began only joins
+the at-risk set once its entry time is reached, so events before that entry are
+estimated over a smaller risk set. Pass a per-item (or scalar) entry time with
+``tl``:
+
+.. jupyter-execute::
+
+    from surpyval.recurrent import NonParametricCounting
+
+    x = [2, 3, 5, 3, 4, 6]
+    i = [1, 1, 1, 2, 2, 2]
+    c = [0, 0, 1, 0, 0, 1]
+
+    model = NonParametricCounting.fit(x, i=i, c=c, tl=1.0)
+    model.mcf(4)
+
+Right truncation (a finite ``tr``) is not yet supported by the non-parametric
+risk-set construction; for right-truncated recurrent data use a parametric
+intensity model.
 
 Let's say this data was for the time, in years,
 between repairs on home air conditioners of a specific model. We can then use

--- a/docs/Recurrent Event Modelling with SurPyval.rst
+++ b/docs/Recurrent Event Modelling with SurPyval.rst
@@ -233,6 +233,7 @@ estimated. A large p-value means the fitted intensity is consistent with the
 data:
 
 .. jupyter-execute::
+    :stderr:
 
     gof = model.cramer_von_mises(n_boot=100, seed=1)
     print("statistic", round(gof.statistic, 3), " p-value", round(gof.p_value, 3))
@@ -379,6 +380,138 @@ The image above shows that the blue line (the model from the simulation) is in
 very good agreement to the data. This is a good indication that the underlying
 distribution is Weibull and that the repair effectiveness has been correctly
 estimated.
+
+Arithmetic Reduction Models (ARA / ARI) with SurPyval
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``ARA`` (Arithmetic Reduction of Age) and ``ARI`` (Arithmetic Reduction of
+Intensity) models make the *memory* of a repair explicit through an integer
+``m``: how many prior failures an intervention acts on. ``ARA`` reduces a
+virtual age; ``ARI`` reduces the intensity directly. Both are fitted with the
+same API as the other renewal models, plus the ``m`` argument.
+
+.. jupyter-execute::
+
+    from surpyval import Weibull
+    from surpyval.recurrent import ARA
+    import numpy as np
+
+    x = np.array([1, 3, 6, 9, 10, 1.4, 3, 6.7, 8.9, 11, 1, 2.2, 5, 7.5, 9, 12])
+    i = np.array([1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3])
+
+    model = ARA.fit(x, i, dist=Weibull, m=1)
+    model
+
+The ``Repair Efficiency`` :math:`\rho` reported here plays the role of
+:math:`1 - q`: a value near 1 is close to as-good-as-new, a value near 0 is
+as-bad-as-old. ``ARI`` fits the same way but with an intensity (counting
+process) baseline such as ``CrowAMSAA``:
+
+.. jupyter-execute::
+    :stderr:
+
+    from surpyval.recurrent import ARI, CrowAMSAA
+
+    model = ARI.fit(x, i, dist=CrowAMSAA, m=1)
+    model
+
+Checking a renewal model
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The renewal and virtual-age models carry the same diagnostics as the intensity
+models. Because they have no marginal cumulative intensity, the residuals come
+from the *conditional* intensity — the cumulative hazard accumulated over each
+interval given the model's virtual age — but under a well-specified model they
+are still an i.i.d. Exp(1) sample:
+
+.. jupyter-execute::
+    :stderr:
+
+    from surpyval import Weibull
+    from surpyval.recurrent import GeneralizedRenewal
+    import numpy as np
+
+    x = np.array([1, 3, 6, 9, 10, 1.4, 3, 6.7, 8.9, 11, 1, 2.2, 5, 7.5, 9, 12])
+    i = np.array([1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3])
+
+    model = GeneralizedRenewal.fit(x, i, dist=Weibull, kijima="i")
+    print("residual mean :", round(model.residuals().mean(), 3))
+    print("trend         :", model.trend_test().trend)
+
+    gof = model.cramer_von_mises(n_boot=50, seed=1)
+    print("CvM p-value   :", round(gof.p_value, 3))
+
+The Cramér–von Mises bootstrap refits the (multi-start) imperfect-repair model
+once per replicate, so it is noticeably slower than the residual checks; keep
+``n_boot`` modest while exploring.
+
+Gapped (multi-window) observation
+---------------------------------
+
+Sometimes an item is only observed over a few disjoint windows, with gaps in
+between during which failures may occur but are not recorded — a vehicle seen
+only while it is in the depot, for instance. Passing a ``windows`` mapping to an
+intensity model tells SurPyval each item's observation windows; every event you
+pass is then an observed failure (``c=0``), and the windows supply the
+end-of-window censoring automatically.
+
+.. jupyter-execute::
+
+    from surpyval.recurrent import CrowAMSAA
+    import numpy as np
+
+    # one item, observed on [0, 12] and [20, 40] with an unobserved gap
+    x = np.array([3, 7, 10, 25, 33, 38])
+    i = np.array([1, 1, 1, 1, 1, 1])
+
+    model = CrowAMSAA.fit(x, i, windows={1: [(0, 12), (20, 40)]})
+    model.params
+
+Because Poisson event counts over disjoint windows are independent, each window
+is fitted as its own observation period; the intensity likelihood and the
+non-parametric MCF at-risk set both account for the gaps with no extra work. The
+virtual-age / renewal models reject gapped data, since the virtual age at the
+start of a later window depends on the unobserved failures during the gap.
+
+Competing risks: marked recurrent events
+-----------------------------------------
+
+When events come in several mutually exclusive types, attach a **mark** ``e`` to
+each event (use ``None`` for censoring rows). The non-parametric
+``CauseSpecificMCF`` gives one mean cumulative function per cause, sharing the
+at-risk set across causes:
+
+.. jupyter-execute::
+
+    from surpyval.recurrent import CauseSpecificMCF
+
+    x = [3, 1, 5, 2, 4, 6]
+    i = [1, 1, 1, 2, 2, 2]
+    c = [0, 0, 1, 0, 0, 1]
+    e = ["A", "B", None, "A", "A", None]   # None marks the censoring rows
+
+    model = CauseSpecificMCF.fit(x, i, c, e=e)
+    ax = model.plot()
+
+For a parametric picture, ``CauseSpecificNHPP`` fits one intensity model per
+cause (``CrowAMSAA`` by default). A marked Poisson process decomposes into
+independent thinned Poisson processes, so each cause is fitted to its own events
+over the full observation window — other-cause events are ignored, exactly like
+a censored period:
+
+.. jupyter-execute::
+    :stderr:
+
+    from surpyval.recurrent import CauseSpecificNHPP
+
+    model = CauseSpecificNHPP.fit(x, i, c, e=e)
+    print("causes         :", model.event_types)
+    print("cause A params :", model.models["A"].params.round(3))
+    print("total cif at 6 :", round(float(model.total_cif(6.0)), 3))
+
+Each ``model.models[cause]`` is an ordinary fitted recurrence model, so it
+carries the full ``cif`` / ``iif``, inference and diagnostic behaviour shown
+above; ``total_cif`` sums the causes for the overall event intensity.
 
 References
 ----------

--- a/docs/Recurrent Event Regression Analysis.rst
+++ b/docs/Recurrent Event Regression Analysis.rst
@@ -109,9 +109,60 @@ under different conditions easy and interpretable.
 These equations outline the framework for modelling the reliability growth of a
 system, incorporating the effects of covariates on the failure intensity.
 
+More generally, any of SurPyval's counting-process baselines can play the role
+of :math:`\lambda_0(t)`. The proportional-intensity model multiplies that
+baseline by the covariate factor :math:`e^{Z\beta}`:
+
+.. math::
+
+    \lambda(t \mid Z) = \lambda_0(t)\, e^{Z\beta},
+    \qquad
+    \Lambda(t \mid Z) = \Lambda_0(t)\, e^{Z\beta}.
+
+With a constant baseline this is the proportional-intensity HPP; with a
+power-law (Duane / Crow-AMSAA) or log-linear (Cox-Lewis) baseline it is the
+proportional-intensity NHPP. Because the covariate factor scales the whole
+cumulative intensity, the ratio of expected event counts between two covariate
+settings is the constant :math:`e^{(Z_2 - Z_1)\beta}` at every time — the
+recurrent-event analogue of a hazard ratio [Cook2007r]_, and the reason the
+coefficients :math:`\beta` read directly as multiplicative effects on the event
+rate.
+
+The parameters are estimated jointly by maximum likelihood [Lawless1987]_,
+maximising the NHPP log-likelihood with the covariate-scaled intensity
+substituted in. The static, per-item covariates enter through
+:math:`e^{Z\beta}`, so an item in a harsher environment simply accumulates
+events faster. This proportional-intensity framing is standard in the
+reliability-growth literature [Rigdon2000r]_.
+
+Model checking
+--------------
+
+The fitted regression model carries the same diagnostics as the unconditional
+intensity models, applied *per item* with each item's intensity scaled by its
+own covariate factor. The time-rescaling residuals pool the rescaled
+inter-arrival increments across items (i.i.d. Exp(1) under a well-specified
+model), the trend test checks whether a time-varying baseline was warranted at
+all, and the Cramér–von Mises test provides a bootstrapped goodness-of-fit
+p-value. Confidence bounds on the fitted cumulative intensity at a covariate
+setting come from the delta method via ``cif_cb``.
+
 These methods form a comprehensive toolkit for researchers and practitioners
 working with recurrent event data, enabling detailed analysis and prediction of
 event occurrences.
+
+References
+----------
+
+.. [Cook2007r] Cook, R.J. and Lawless, J.F., 2007. *The Statistical Analysis of
+   Recurrent Events*. Springer.
+
+.. [Lawless1987] Lawless, J.F., 1987. Regression methods for Poisson process
+   data. *Journal of the American Statistical Association*, 82(399),
+   pp.808-815.
+
+.. [Rigdon2000r] Rigdon, S.E. and Basu, A.P., 2000. *Statistical Methods for the
+   Reliability of Repairable Systems*. John Wiley & Sons.
 
 
 

--- a/docs/Recurrent Event Regression Modelling with SurPyval.rst
+++ b/docs/Recurrent Event Regression Modelling with SurPyval.rst
@@ -2,6 +2,109 @@ Recurrent Event Regression Modelling with SurPyval
 ===================================================
 
 Modelling recurrent events where we have covariates is simple with surpyval.
-Using the same api as regular survival regression, all we need to do is select
-a model and fit it to our data.
+Using the same API as regular survival regression, all we need to do is select
+a model and fit it to our data. The two proportional-intensity models are
+``ProportionalIntensityHPP`` (a constant baseline rate) and
+``ProportionalIntensityNHPP`` (a time-varying baseline, e.g. Duane or
+Crow-AMSAA). Both scale a baseline intensity by a covariate factor
+:math:`e^{Z\beta}`.
 
+Proportional-Intensity HPP
+--------------------------
+
+The data are the usual recurrent ``x`` / ``i`` / ``c`` arrays plus a covariate
+matrix ``Z`` with one row per observation. Here three items are each observed
+until a right-censoring row, and each carries a single covariate (say, a duty
+cycle) that is constant for the item.
+
+.. jupyter-execute::
+
+    from surpyval.recurrent import ProportionalIntensityHPP
+    import numpy as np
+
+    x = np.array([5.0, 8.0, 6.0, 10.0, 7.0, 9.0])
+    i = np.array([1, 1, 2, 2, 3, 3])
+    c = np.array([0, 1, 0, 1, 0, 1])
+    Z = np.array([[0.1], [0.1], [0.5], [0.5], [0.9], [0.9]])
+
+    model = ProportionalIntensityHPP.fit(x, Z, i=i, c=c)
+    model
+
+The fit reports the baseline rate parameter and a covariate coefficient. The
+coefficient enters multiplicatively through :math:`e^{Z\beta}`, so it reads as
+the log of the rate ratio: a one-unit increase in the covariate multiplies the
+event rate by :math:`e^{\beta}`.
+
+Predicting at a covariate setting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To predict the expected number of events for an item, pass its covariates to
+``cif``. The instantaneous rate at a covariate setting comes from ``iif``:
+
+.. jupyter-execute::
+
+    Z_item = np.array([0.5])
+    print("expected events by t=12 :", round(float(model.cif(12.0, Z_item)), 3))
+    print("event rate at t=12      :", round(float(model.iif(12.0, Z_item)), 3))
+
+Because the covariate factor multiplies the whole cumulative intensity, the
+ratio of expected counts between two covariate settings is constant in time and
+equals :math:`e^{(Z_2 - Z_1)\beta}`:
+
+.. jupyter-execute::
+
+    z1, z2 = np.array([0.2]), np.array([0.7])
+    ratio = model.cif(10.0, z2) / model.cif(10.0, z1)
+    print("count ratio  :", round(float(ratio), 3))
+    print("exp((z2-z1)b):", round(float(np.exp((z2 - z1) @ model.coeffs)), 3))
+
+Proportional-Intensity NHPP
+---------------------------
+
+When the baseline rate itself varies with time — reliability growth, wear-out —
+use ``ProportionalIntensityNHPP`` with a counting-process baseline. The default
+baseline is the Duane model; any NHPP baseline (``CrowAMSAA``, ``CoxLewis``)
+can be supplied via ``dist``.
+
+.. jupyter-execute::
+
+    from surpyval.recurrent import ProportionalIntensityNHPP, Duane
+    import numpy as np
+
+    x = np.array([2.0, 5.0, 3.0, 7.0, 1.0, 4.0, 2.0, 6.0])
+    i = np.array([1, 1, 2, 2, 3, 3, 4, 4])
+    c = np.array([0, 1, 0, 1, 0, 1, 0, 1])
+    Z = np.array([[0.2], [0.2], [0.5], [0.5], [0.8], [0.8], [0.3], [0.3]])
+
+    model = ProportionalIntensityNHPP.fit(x, Z, i=i, c=c, dist=Duane)
+    model
+
+Confidence bounds on the fitted cumulative intensity at a covariate setting are
+available from ``cif_cb`` (delta method, computed on the log scale so they stay
+positive):
+
+.. jupyter-execute::
+
+    ts = np.array([2.0, 4.0, 6.0])
+    model.cif_cb(ts, np.array([0.5]))
+
+Model checking
+--------------
+
+The regression models carry the same diagnostics as the unconditional
+intensity models, applied per item with each item's intensity scaled by its
+covariate factor:
+
+.. jupyter-execute::
+
+    print("residual mean :", round(model.residuals().mean(), 3))
+    print("trend         :", model.trend_test().trend)
+
+The residuals are the time-rescaling residuals pooled across items (i.i.d.
+Exp(1) under a well-specified model); the trend test checks whether a
+time-varying baseline was warranted at all. A Cramér–von Mises goodness-of-fit
+test is also available via ``cramer_von_mises`` (a parametric bootstrap, so
+keep ``n_boot`` modest while exploring).
+
+See :doc:`Recurrent Event Regression Analysis` for the theory and references
+behind these models.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,19 @@ Changelog
 v0.14.0 (unreleased)
 --------------------
 
+Documentation
+~~~~~~~~~~~~~
+
+- Substantially expanded the recurrent-event documentation for the release.
+  The theory pages now cover the arithmetic-reduction (ARA/ARI) models, the
+  geometric-process view of the G1 renewal process, the time-rescaling
+  residual / trend-test / Cramer-von Mises diagnostics, marked (competing-risks)
+  recurrent events, gapped multi-window observation, and truncation, each with a
+  short References section. The worked-example pages gained runnable
+  demonstrations of ARA/ARI, renewal-model checking, gapped observation, the
+  cause-specific MCF and intensity models, and a full build-out of the
+  proportional-intensity regression examples.
+
 Recurrent events
 ~~~~~~~~~~~~~~~~
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,13 @@ Documentation
   demonstrations of ARA/ARI, renewal-model checking, gapped observation, the
   cause-specific MCF and intensity models, and a full build-out of the
   proportional-intensity regression examples.
+- Fixed and completed the recurrent-event API reference. Every model's
+  autodoc page (HPP, Duane, Cox-Lewis, Crow-AMSAA, the renewal and
+  proportional-intensity models) previously rendered as an empty "alias of
+  object" because the fitters are exposed as singletons; the pages now
+  document each model's methods. Added missing API pages for ``ARA``, ``ARI``,
+  ``NonParametricCounting``, ``CauseSpecificMCF``, ``CauseSpecificNHPP`` and the
+  fitted ``RenewalModel`` object.
 
 Recurrent events
 ~~~~~~~~~~~~~~~~

--- a/docs/counting/ara.rst
+++ b/docs/counting/ara.rst
@@ -1,0 +1,14 @@
+Arithmetic Reduction of Age (ARA)
+=================================
+
+The ``ARA`` imperfect-repair model reduces a *virtual age* by a fraction
+``rho`` of the age accumulated over the last ``m`` inter-arrival times (with
+``m = numpy.inf`` the infinite-memory limit). ``rho = 1`` is as-good-as-new and
+``rho = 0`` is as-bad-as-old. It returns a
+:doc:`Renewal Model <renewal_model>`.
+
+.. class:: ARA
+
+   .. automethod:: surpyval.recurrent.renewal.ara.ARA_.fit
+   .. automethod:: surpyval.recurrent.renewal.ara.ARA_.fit_from_recurrent_data
+   .. automethod:: surpyval.recurrent.renewal.ara.ARA_.fit_from_parameters

--- a/docs/counting/ari.rst
+++ b/docs/counting/ari.rst
@@ -1,0 +1,14 @@
+Arithmetic Reduction of Intensity (ARI)
+=======================================
+
+The ``ARI`` imperfect-repair model reduces the *failure intensity* directly by
+a fraction ``rho`` of the intensity built up over the last ``m`` inter-arrival
+times (with ``m = numpy.inf`` the infinite-memory limit). It differs from
+``ARA`` whenever the baseline intensity varies with time, and returns a
+:doc:`Renewal Model <renewal_model>`.
+
+.. class:: ARI
+
+   .. automethod:: surpyval.recurrent.renewal.ari.ARI_.fit
+   .. automethod:: surpyval.recurrent.renewal.ari.ARI_.fit_from_recurrent_data
+   .. automethod:: surpyval.recurrent.renewal.ari.ARI_.fit_from_parameters

--- a/docs/counting/cause_specific_mcf.rst
+++ b/docs/counting/cause_specific_mcf.rst
@@ -1,0 +1,5 @@
+Cause-Specific MCF
+==================
+
+.. autoclass:: surpyval.recurrent.competing_risks.nonparametric.cause_specific_mcf.CauseSpecificMCF
+   :members:

--- a/docs/counting/cause_specific_nhpp.rst
+++ b/docs/counting/cause_specific_nhpp.rst
@@ -1,0 +1,5 @@
+Cause-Specific NHPP
+===================
+
+.. autoclass:: surpyval.recurrent.competing_risks.parametric.cause_specific_nhpp.CauseSpecificNHPP
+   :members:

--- a/docs/counting/cox_lewis.rst
+++ b/docs/counting/cox_lewis.rst
@@ -1,6 +1,14 @@
 Cox-Lewis
 =========
 
-.. autoclass:: surpyval.recurrent.parametric.cox_lewis.CoxLewis_
-   :members:
-   :inherited-members:
+The Cox-Lewis NHPP with a log-linear intensity ``lambda(t) = exp(alpha + beta * t)``.
+
+.. class:: CoxLewis
+
+   .. automethod:: surpyval.recurrent.parametric.cox_lewis.CoxLewis_.fit
+   .. automethod:: surpyval.recurrent.parametric.cox_lewis.CoxLewis_.fit_from_recurrent_data
+   .. automethod:: surpyval.recurrent.parametric.cox_lewis.CoxLewis_.from_params
+   .. automethod:: surpyval.recurrent.parametric.cox_lewis.CoxLewis_.cif
+   .. automethod:: surpyval.recurrent.parametric.cox_lewis.CoxLewis_.iif
+   .. automethod:: surpyval.recurrent.parametric.cox_lewis.CoxLewis_.log_iif
+   .. automethod:: surpyval.recurrent.parametric.cox_lewis.CoxLewis_.inv_cif

--- a/docs/counting/crow_amsaa.rst
+++ b/docs/counting/crow_amsaa.rst
@@ -1,6 +1,14 @@
 Crow-AMSAA
 ==========
 
-.. autoclass:: surpyval.recurrent.parametric.crow_amsaa.CrowAMSAA_
-   :members:
-   :inherited-members:
+The Crow-AMSAA (power-law) NHPP with cumulative intensity ``(t / alpha)**beta``.
+
+.. class:: CrowAMSAA
+
+   .. automethod:: surpyval.recurrent.parametric.crow_amsaa.CrowAMSAA_.fit
+   .. automethod:: surpyval.recurrent.parametric.crow_amsaa.CrowAMSAA_.fit_from_recurrent_data
+   .. automethod:: surpyval.recurrent.parametric.crow_amsaa.CrowAMSAA_.from_params
+   .. automethod:: surpyval.recurrent.parametric.crow_amsaa.CrowAMSAA_.cif
+   .. automethod:: surpyval.recurrent.parametric.crow_amsaa.CrowAMSAA_.iif
+   .. automethod:: surpyval.recurrent.parametric.crow_amsaa.CrowAMSAA_.log_iif
+   .. automethod:: surpyval.recurrent.parametric.crow_amsaa.CrowAMSAA_.inv_cif

--- a/docs/counting/duane.rst
+++ b/docs/counting/duane.rst
@@ -1,6 +1,14 @@
 Duane
 =====
 
-.. autoclass:: surpyval.recurrent.parametric.duane.Duane_
-   :members:
-   :inherited-members:
+The Duane reliability-growth NHPP with power-law cumulative intensity ``N(t) = b * t**a``.
+
+.. class:: Duane
+
+   .. automethod:: surpyval.recurrent.parametric.duane.Duane_.fit
+   .. automethod:: surpyval.recurrent.parametric.duane.Duane_.fit_from_recurrent_data
+   .. automethod:: surpyval.recurrent.parametric.duane.Duane_.from_params
+   .. automethod:: surpyval.recurrent.parametric.duane.Duane_.cif
+   .. automethod:: surpyval.recurrent.parametric.duane.Duane_.iif
+   .. automethod:: surpyval.recurrent.parametric.duane.Duane_.log_iif
+   .. automethod:: surpyval.recurrent.parametric.duane.Duane_.inv_cif

--- a/docs/counting/g1_rp.rst
+++ b/docs/counting/g1_rp.rst
@@ -1,6 +1,10 @@
 Generalized One Renewal Process
 ===============================
 
-.. autoclass:: surpyval.recurrent.renewal.generalized_one_renewal.GeneralizedOneRenewal
-   :members:
-   :inherited-members:
+The G1 renewal process (Lam's geometric process, reparameterised): the ``j``-th inter-arrival is the base lifetime scaled by ``(1 + q)**j``. Returns a :doc:`Renewal Model <renewal_model>`.
+
+.. class:: GeneralizedOneRenewal
+
+   .. automethod:: surpyval.recurrent.renewal.generalized_one_renewal.GeneralizedOneRenewal_.fit
+   .. automethod:: surpyval.recurrent.renewal.generalized_one_renewal.GeneralizedOneRenewal_.fit_from_recurrent_data
+   .. automethod:: surpyval.recurrent.renewal.generalized_one_renewal.GeneralizedOneRenewal_.fit_from_parameters

--- a/docs/counting/grp.rst
+++ b/docs/counting/grp.rst
@@ -1,6 +1,12 @@
 Generalized Renewal Process
 ===========================
 
-.. autoclass:: surpyval.recurrent.renewal.generalized_renewal.GeneralizedRenewal
-   :members:
-   :inherited-members:
+The generalized renewal (Kijima virtual-age) process; ``kijima="i"`` or ``"ii"`` selects the age update. Returns a :doc:`Renewal Model <renewal_model>`.
+
+.. class:: GeneralizedRenewal
+
+   .. automethod:: surpyval.recurrent.renewal.generalized_renewal.GeneralizedRenewal_.fit
+   .. automethod:: surpyval.recurrent.renewal.generalized_renewal.GeneralizedRenewal_.fit_from_recurrent_data
+   .. automethod:: surpyval.recurrent.renewal.generalized_renewal.GeneralizedRenewal_.fit_from_parameters
+   .. automethod:: surpyval.recurrent.renewal.generalized_renewal.GeneralizedRenewal_.kijima_i
+   .. automethod:: surpyval.recurrent.renewal.generalized_renewal.GeneralizedRenewal_.kijima_ii

--- a/docs/counting/hpp.rst
+++ b/docs/counting/hpp.rst
@@ -1,5 +1,13 @@
 HPP
 ===
 
-.. autoclass:: surpyval.recurrent.parametric.hpp.HPP
-   :members:
+The Homogeneous Poisson Process: a constant event rate. ``cif(t) = rate * t``.
+
+.. class:: HPP
+
+   .. automethod:: surpyval.recurrent.parametric.hpp.HPP_.fit
+   .. automethod:: surpyval.recurrent.parametric.hpp.HPP_.fit_from_recurrent_data
+   .. automethod:: surpyval.recurrent.parametric.hpp.HPP_.cif
+   .. automethod:: surpyval.recurrent.parametric.hpp.HPP_.iif
+   .. automethod:: surpyval.recurrent.parametric.hpp.HPP_.log_iif
+   .. automethod:: surpyval.recurrent.parametric.hpp.HPP_.inv_cif

--- a/docs/counting/hpp_pi.rst
+++ b/docs/counting/hpp_pi.rst
@@ -1,6 +1,12 @@
 HPP Regression
 ==============
 
-.. autoclass:: surpyval.recurrent.regression.hpp_proportional_intensity.ProportionalIntensityHPP
-   :members:
-   :inherited-members:
+Proportional-intensity HPP regression: a constant baseline rate scaled by the covariate factor ``exp(Z @ beta)``.
+
+.. class:: ProportionalIntensityHPP
+
+   .. automethod:: surpyval.recurrent.regression.hpp_proportional_intensity.ProportionalIntensityHPP_.fit
+   .. automethod:: surpyval.recurrent.regression.hpp_proportional_intensity.ProportionalIntensityHPP_.fit_from_recurrent_data
+   .. automethod:: surpyval.recurrent.regression.hpp_proportional_intensity.ProportionalIntensityHPP_.cif
+   .. automethod:: surpyval.recurrent.regression.hpp_proportional_intensity.ProportionalIntensityHPP_.iif
+   .. automethod:: surpyval.recurrent.regression.hpp_proportional_intensity.ProportionalIntensityHPP_.inv_cif

--- a/docs/counting/nhpp_pi.rst
+++ b/docs/counting/nhpp_pi.rst
@@ -1,7 +1,12 @@
 NHPP Regression
 ===============
 
+Proportional-intensity NHPP regression: a time-varying baseline (Duane by default) scaled by the covariate factor ``exp(Z @ beta)``.
 
-.. autoclass:: surpyval.recurrent.regression.nhpp_proportional_intensity.ProportionalIntensityNHPP
-   :members:
-   :inherited-members:
+.. class:: ProportionalIntensityNHPP
+
+   .. automethod:: surpyval.recurrent.regression.nhpp_proportional_intensity.ProportionalIntensityNHPP_.fit
+   .. automethod:: surpyval.recurrent.regression.nhpp_proportional_intensity.ProportionalIntensityNHPP_.fit_from_recurrent_data
+   .. automethod:: surpyval.recurrent.regression.nhpp_proportional_intensity.ProportionalIntensityNHPP_.cif
+   .. automethod:: surpyval.recurrent.regression.nhpp_proportional_intensity.ProportionalIntensityNHPP_.iif
+   .. automethod:: surpyval.recurrent.regression.nhpp_proportional_intensity.ProportionalIntensityNHPP_.inv_cif

--- a/docs/counting/nonparametric_mcf.rst
+++ b/docs/counting/nonparametric_mcf.rst
@@ -1,0 +1,15 @@
+Non-Parametric Counting (MCF)
+=============================
+
+The non-parametric mean cumulative function (MCF) estimator for recurrent
+events. It supports exact events, right-censored end-of-observation rows, left
+truncation (delayed entry) and gapped multi-window observation, and provides
+Greenwood confidence bounds via ``mcf_cb``.
+
+.. class:: NonParametricCounting
+
+   .. automethod:: surpyval.recurrent.nonparametric.mcf.NonParametricCounting_.fit
+   .. automethod:: surpyval.recurrent.nonparametric.mcf.NonParametricCounting_.fit_from_recurrent_data
+   .. automethod:: surpyval.recurrent.nonparametric.mcf.NonParametricCounting_.mcf
+   .. automethod:: surpyval.recurrent.nonparametric.mcf.NonParametricCounting_.mcf_cb
+   .. automethod:: surpyval.recurrent.nonparametric.mcf.NonParametricCounting_.plot

--- a/docs/counting/renewal_model.rst
+++ b/docs/counting/renewal_model.rst
@@ -1,0 +1,12 @@
+Renewal Model
+=============
+
+The fitted-model object returned by the renewal / virtual-age fitters
+(``GeneralizedRenewal``, ``GeneralizedOneRenewal``, ``ARA``, ``ARI``). It holds
+the fitted lifetime distribution and restoration parameter and provides the
+simulation, inference (``standard_errors``, ``param_cb``) and diagnostic
+(``residuals``, ``trend_test``, ``cramer_von_mises``) behaviour.
+
+.. autoclass:: surpyval.recurrent.renewal.renewal_model.RenewalModel
+   :members:
+   :inherited-members:

--- a/docs/surpyval.counting.rst
+++ b/docs/surpyval.counting.rst
@@ -13,14 +13,34 @@ Recurrent Event (Poisson Process) Models
     counting/cox_lewis
     counting/crow_amsaa
 
+Non-Parametric Models
+---------------------
+
+.. toctree::
+    :maxdepth: 1
+
+    counting/nonparametric_mcf
+
 Renewal Models
 --------------
 
 .. toctree::
     :maxdepth: 1
 
+    counting/renewal_model
     counting/grp.rst
     counting/g1_rp.rst
+    counting/ara
+    counting/ari
+
+Competing Risks (Marked) Models
+-------------------------------
+
+.. toctree::
+    :maxdepth: 1
+
+    counting/cause_specific_mcf
+    counting/cause_specific_nhpp
 
 Recurrent Event Regression Models
 ----------------------------------


### PR DESCRIPTION
Brings the recurrent-event docs up to date with the 0.14 feature set (theory + examples, with light per-page references), **and** — after a coverage audit of the recurrent package against the docs — fills and repairs the API reference. Scoped to the recurrent module for this release.

## Narrative docs (theory + examples)

Theory (`Recurrent Event Analysis`, `Recurrent Event Regression Analysis`): arithmetic-reduction (ARA/ARI) models, the geometric-process view of G1R, the time-rescaling residual / trend-test / Cramér–von Mises diagnostics, marked (competing-risks) events, gapped multi-window observation, truncation, the general proportional-intensity NHPP framing, and a short References section on each page.

Examples (`Recurrent Event Modelling`, `Recurrent Event Regression Modelling`): runnable ARA/ARI, renewal model-checking, gapped observation, and cause-specific MCF/NHPP demonstrations; a full build-out of the previously-empty proportional-intensity regression examples.

## API-reference audit (new)

A capability audit of `surpyval.recurrent` against the docs found two gaps:

- **Missing pages** — added autodoc reference pages for `ARA`, `ARI`, `NonParametricCounting`, `CauseSpecificMCF`, `CauseSpecificNHPP`, and the fitted `RenewalModel` object, wired into the API index under new **Non-Parametric** and **Competing Risks** groups.
- **Broken pages** — every singleton-fitter model page (`HPP`, `Duane`, `Cox-Lewis`, `Crow-AMSAA`, the generalized/G1 renewal processes, and both proportional-intensity regressions) rendered as an empty *"alias of object"*, because `singleton_fitter` exposes each fitter as an instance (its class lives under a `Name_` alias that Sphinx `autoclass` treats as an alias, not a class). Rewrote those pages to document each model's methods with `automethod`, so the full recurrent API now renders (16/16 pages, previously 8 empty).

Also corrected a stale claim that `NonParametricCounting` cannot fit truncated data (it supports left truncation / delayed entry) and added a short delayed-entry example.

## Verification

Every `jupyter-execute` cell runs, and the narrative pages **and** the full API reference build clean under Sphinx (all cells executed; the three benign optimizer/bootstrap-noise blocks flagged `:stderr:`; no unreferenced citations; every API page renders its methods).

Docs-only; no library code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts