### PR TITLE
Fix RandomSurvivalForest crash on degenerate samples; skip experimental in CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -52,8 +52,10 @@ jobs:
           pip install -r requirements_dev.txt
 
       - name: pytest
+        # The experimental modules (e.g. the survival forest) are not part of
+        # the release contract and are excluded from the deployment test run.
         run:
-          coverage run -m pytest
+          coverage run -m pytest --ignore=surpyval/tests/experimental
 
       - name: coverage
         run: |

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,16 @@ Changelog
 v0.15.0 (unreleased)
 --------------------
 
+Experimental
+~~~~~~~~~~~~
+
+- Fixed a crash in the experimental ``RandomSurvivalForest``: a degenerate
+  bootstrap sample (e.g. heavily tied event times) could make a terminal
+  node's Weibull covariance step raise, taking down the whole forest fit. A
+  terminal node now falls back to progressively simpler, more robust fits
+  (Exponential, then Nelson-Aalen). The experimental modules are also excluded
+  from the CI test run, since they are not part of the release contract.
+
 Degradation
 ~~~~~~~~~~~
 

--- a/surpyval/experimental/forest/node.py
+++ b/surpyval/experimental/forest/node.py
@@ -91,12 +91,24 @@ class TerminalNode(Node):
     @cached_property
     def model(self):
         if self.paramettric:
-            if self.data.to_xrd()[2].sum() == 0:
+            n_failures = self.data.to_xrd()[2].sum()
+            if n_failures == 0:
                 return NeverOccurs
-            elif self.data.to_xrd()[2].sum() <= 1:
+            elif n_failures <= 1:
                 return Exponential.fit_from_surpyval_data(self.data)
-            else:
+            # A degenerate bootstrap sample (e.g. heavily tied event times)
+            # can make the Weibull covariance/Hessian step fail. A single
+            # terminal node must not crash the whole forest, so fall back to
+            # progressively simpler fits that are more numerically robust.
+            try:
                 return Weibull.fit_from_surpyval_data(self.data)
+            except Exception:
+                try:
+                    return Exponential.fit_from_surpyval_data(self.data)
+                except Exception:
+                    return NelsonAalen.fit(
+                        self.data.x, self.data.c, self.data.n, self.data.t
+                    )
         else:
             return NelsonAalen.fit(
                 self.data.x, self.data.c, self.data.n, self.data.t


### PR DESCRIPTION
Two fixes for the intermittent CI failure in the experimental survival forest.

## The bug

`test_forest_all_functions` failed intermittently with `IndexError: list index out of range`. Root cause: a bootstrap sample with heavily tied event times makes a **terminal node's Weibull covariance/Hessian step** raise (numdifftools `_vstack` on an empty finite-difference sequence), and that exception propagates out and kills the whole `RandomSurvivalForest.fit`. It's random because the bootstrap draw is unseeded, so it only surfaces on unlucky samples — which is exactly what happened on #173's run.

A single terminal node getting an unlucky sample must not crash the entire forest. The fix makes `TerminalNode.model` fall back to **progressively simpler, more numerically robust fits** — Weibull → Exponential → Nelson-Aalen — when the Weibull fit raises. Verified against the previously-failing seeds: 0 crashes across 60 seeds (was failing at seed 3), and the specific failing case now returns a valid survival function.

## Skip experimental in deployments

Per your request, the CI/deployment pytest run now excludes the experimental suite (`--ignore=surpyval/tests/experimental`), since the experimental modules aren't part of the release contract. Lint/mypy still cover the whole package; only the experimental *tests* are skipped in CI. (Local `pytest` still runs everything.)

## Verification

Forest tests still pass locally (14); `--ignore` collects 0 experimental tests; node.py is flake8/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_