### PR TITLE
Extend REML population estimation to nonlinear degradation paths (#152)

### DIFF
--- a/docs/Degradation Analysis.rst
+++ b/docs/Degradation Analysis.rst
@@ -271,10 +271,25 @@ Cholesky factor, so it is positive definite by construction — no
 clipping. On balanced designs (every unit measured at the same times)
 REML coincides with the corrected moments estimate; they differ on
 unbalanced data and when the unit count is small, where REML is
-preferable. REML is available for path models that are linear in
-their parameters (linear, quadratic, logarithmic, Lloyd-Lipow) and
-requires a
-positive measurement variance.
+preferable. REML requires a positive measurement variance.
+
+For path models that are **linear in their parameters** (linear,
+quadratic, logarithmic, Lloyd-Lipow) the design matrix :math:`X_i` is
+fixed and the marginal model above is exact. For a **nonlinear** path
+(exponential, power, Gompertz, …) the mean :math:`f(x_i, \theta_i)` is
+no longer :math:`X_i \theta_i`, so REML uses the Lindstrom–Bates FOCE
+linearisation [LindstromBates1990]_: each unit's parameters are
+estimated at their conditional (penalised-least-squares) mode, the path
+is linearised about that mode to give a working linear mixed model, and
+the linear REML step is iterated to convergence. On a linear path this
+reduces to the exact fit in a single pass. Select it the same way:
+
+.. code:: python
+
+    model = DegradationAnalysis.fit(
+        x, y, i, threshold=20, path="exponential",
+        population_method="reml",
+    )
 
 Induced failure-time distribution (Lu-Meeker)
 ---------------------------------------------
@@ -790,3 +805,7 @@ References
 .. [vanNoortwijk2009] van Noortwijk, J.M., 2009. A survey of the application of
    gamma processes in maintenance. *Reliability Engineering & System Safety*,
    94(1), pp.2-21.
+
+.. [LindstromBates1990] Lindstrom, M.J. and Bates, D.M., 1990. Nonlinear
+   mixed effects models for repeated measures data. *Biometrics*, 46(3),
+   pp.673-687.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,17 @@ Experimental
 Degradation
 ~~~~~~~~~~~
 
+- Extended ``population_method="reml"`` to **nonlinear** path models
+  (exponential, power, Gompertz, ...). Previously REML population estimation
+  was restricted to paths linear in their parameters; nonlinear paths are now
+  fitted with the Lindstrom-Bates (1990) FOCE alternating algorithm -- each
+  unit's parameters are estimated at their conditional (penalised-least-
+  squares) mode, the path is linearised about that mode into a working linear
+  mixed model, and the linear REML step is iterated to convergence. This gives
+  a positive-definite ``path_param_cov`` by construction (no PSD clipping) for
+  nonlinear paths too, which is the more robust population estimate when the
+  unit count is small. On a linear-in-parameters path the routine reduces
+  exactly to the previous linear REML fit in a single pass.
 - Added the Lu-Meeker induced failure-time distribution:
   ``DegradationModel.induced_life`` derives the population failure-time
   distribution directly from the fitted path-parameter distribution -- drawing

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -30,7 +30,7 @@ from surpyval.univariate.regression.parametric_regression_model import (
 
 from ._bounds import analytic_cb, bootstrap_cb, life_parameter_covariance
 from .path_models import PATH_MODELS, PathModel, get_path_model
-from .population import reml_estimate
+from .population import reml_estimate, reml_estimate_nonlinear
 
 
 def _is_regression_fitter(fitter) -> bool:
@@ -1070,12 +1070,13 @@ class DegradationAnalysis_:
             ``measurement_var``) is estimated. ``"moments"`` (default)
             uses the two-stage noise-corrected sample moments;
             ``"reml"`` maximises the restricted marginal likelihood of
-            the linear mixed model, which cannot go rank-deficient and
-            is preferable with few units. REML is available for path
-            models that are linear in their parameters (linear,
-            quadratic, logarithmic, lloyd-lipow) and requires
-            measurement noise (some unit with more measurements than
-            path parameters).
+            the mixed model, which cannot go rank-deficient and is
+            preferable with few units. Linear-in-parameter paths (linear,
+            quadratic, logarithmic, lloyd-lipow) are fitted as an exact
+            linear mixed model; nonlinear paths (exponential, power,
+            gompertz, ...) are fitted by the Lindstrom-Bates FOCE
+            linearisation. Either way REML requires measurement noise
+            (some unit with more measurements than path parameters).
         Z : array like, optional
             Stress covariates for accelerated degradation testing (ADT).
             When given, the life model is fitted as a *regression* on the
@@ -1124,14 +1125,6 @@ class DegradationAnalysis_:
         else:
             path_model = get_path_model(path)
 
-        if population_method == "reml" and not path_model.linear_in_parameters:
-            raise ValueError(
-                "population_method='reml' requires a path model that is "
-                "linear in its parameters (linear, quadratic, logarithmic, "
-                "lloyd-lipow); the {} path model is not. Use "
-                "population_method='moments'".format(path_model.name)
-            )
-
         n_params = len(path_model.param_names)
         path_params = np.empty((len(units), n_params))
         pseudo = np.empty(len(units))
@@ -1140,6 +1133,7 @@ class DegradationAnalysis_:
         dof_total = 0
         estimation_cov_sum = np.zeros((n_params, n_params))
         y_by_unit = []
+        x_by_unit = []
         design_by_unit = []
 
         for idx, unit in enumerate(units):
@@ -1167,6 +1161,7 @@ class DegradationAnalysis_:
             except np.linalg.LinAlgError:
                 estimation_cov_sum += np.linalg.pinv(jtj)
             y_by_unit.append(y_unit)
+            x_by_unit.append(x_unit)
             design_by_unit.append(jacobian)
 
         # Two-stage (Lu-Meeker) noise correction: the scatter of the
@@ -1201,13 +1196,28 @@ class DegradationAnalysis_:
                     "path fitted its measurements exactly, or no unit has "
                     "more measurements than path parameters)"
                 )
-            # the moment estimates are the starting values
-            reml_mean, reml_cov, reml_var, converged = reml_estimate(
-                y_by_unit,
-                design_by_unit,
-                path_param_cov,
-                measurement_var,
-            )
+            # the moment estimates are the starting values; a
+            # linear-in-parameters path is an exact linear mixed model,
+            # a nonlinear one is fitted by FOCE linearisation
+            if path_model.linear_in_parameters:
+                reml_mean, reml_cov, reml_var, converged = reml_estimate(
+                    y_by_unit,
+                    design_by_unit,
+                    path_param_cov,
+                    measurement_var,
+                )
+            else:
+                reml_mean, reml_cov, reml_var, converged = (
+                    reml_estimate_nonlinear(
+                        y_by_unit,
+                        x_by_unit,
+                        path_model,
+                        path_param_mean,
+                        path_param_cov,
+                        measurement_var,
+                        path_params,
+                    )
+                )
             if not converged:
                 warnings.warn(
                     "The REML optimisation did not report convergence; the "

--- a/surpyval/degradation/population.py
+++ b/surpyval/degradation/population.py
@@ -19,6 +19,27 @@ factor (log-diagonal) so it stays positive definite by construction.
 
 The two-stage moments estimate (computed in
 ``DegradationAnalysis.fit``) is used as the starting point.
+
+Nonlinear path models
+---------------------
+For a path model that is *nonlinear* in its parameters -- exponential,
+power, Gompertz, ... -- the measurement mean ``f(x_i, theta_i)`` is no
+longer ``X_i theta_i`` and the marginal likelihood is intractable.
+``reml_estimate_nonlinear`` handles this with the Lindstrom-Bates (1990)
+alternating algorithm (the FOCE linearisation used by ``nlme``):
+
+1. hold ``(mu, Sigma, sigma^2)`` fixed and find each unit's conditional
+   mode ``theta_hat_i`` (its penalised-least-squares / MAP estimate);
+2. linearise the path about that mode,
+   ``f(x_i, theta) ~ f(x_i, theta_hat_i) + J_i (theta - theta_hat_i)``
+   with ``J_i`` the path Jacobian at ``theta_hat_i``, forming the
+   pseudo-response ``w_i = y_i - f(x_i, theta_hat_i) + J_i theta_hat_i``;
+3. run the *linear* REML step above on ``(w_i, J_i)`` to update
+   ``(mu, Sigma, sigma^2)``,
+
+iterating 1-3 to convergence. For a linear-in-parameters path this
+reduces exactly to the linear REML in one pass (``w_i = y_i`` and the
+modes drop out), so the two routines agree.
 """
 
 import numpy as np
@@ -144,3 +165,157 @@ def reml_estimate(
     )
     _, mu, covariance, sigma2 = _reml_pieces(result.x, y_list, x_mat_list, p)
     return mu, covariance, sigma2, bool(result.success)
+
+
+def _prior_precision(cov: npt.NDArray, sigma2: float) -> npt.NDArray:
+    """Inverse of ``Sigma`` with its eigenvalues floored positive.
+
+    A rank-deficient or tiny ``Sigma`` gives a very tight (but proper)
+    prior in the deficient directions rather than a singular precision.
+    """
+    cov = (cov + cov.T) / 2.0
+    eigvals, eigvecs = np.linalg.eigh(cov)
+    floor = max(eigvals.max() * 1e-8, sigma2 * 1e-12, np.finfo(float).tiny)
+    inv_eigvals = 1.0 / np.clip(eigvals, floor, None)
+    return eigvecs @ np.diag(inv_eigvals) @ eigvecs.T
+
+
+def _conditional_mode(
+    path_model,
+    x: npt.NDArray,
+    y: npt.NDArray,
+    mu: npt.NDArray,
+    prior_precision: npt.NDArray,
+    sigma2: float,
+    theta0: npt.NDArray,
+    max_iter: int = 50,
+) -> npt.NDArray:
+    """
+    Penalised-least-squares (MAP) mode of one unit's path parameters.
+
+    Minimises ``||y - f(x, theta)||^2 / sigma^2 +
+    (theta - mu)' Sigma^-1 (theta - mu)`` by damped Gauss-Newton with a
+    backtracking line search, started from the unit's unpenalised
+    least-squares fit ``theta0``.
+    """
+    theta = np.array(theta0, dtype=float)
+
+    def penalised(t):
+        resid = y - path_model.path(x, *t)
+        delta = t - mu
+        return (resid @ resid) / sigma2 + delta @ prior_precision @ delta
+
+    obj = penalised(theta)
+    if not np.isfinite(obj):
+        return theta
+    for _ in range(max_iter):
+        jac = np.asarray(path_model.jacobian(x, *theta), dtype=float)
+        resid = y - path_model.path(x, *theta)
+        # gradient and Gauss-Newton Hessian of the penalised objective
+        # (the common factor of 2 cancels in the Newton step)
+        grad = -(jac.T @ resid) / sigma2 + prior_precision @ (theta - mu)
+        hess = (jac.T @ jac) / sigma2 + prior_precision
+        try:
+            step = np.linalg.solve(hess, grad)
+        except np.linalg.LinAlgError:
+            break
+        alpha, improved = 1.0, False
+        for _ in range(40):
+            candidate = theta - alpha * step
+            if np.isfinite(candidate).all():
+                new_obj = penalised(candidate)
+                if np.isfinite(new_obj) and new_obj < obj - 1e-14 * abs(obj):
+                    theta, obj, improved = candidate, new_obj, True
+                    break
+            alpha *= 0.5
+        if not improved:
+            break
+        scale = 1.0 + np.max(np.abs(theta))
+        if np.max(np.abs(alpha * step)) <= 1e-10 * scale:
+            break
+    return theta
+
+
+def reml_estimate_nonlinear(
+    y_list: "list[npt.NDArray]",
+    x_list: "list[npt.NDArray]",
+    path_model,
+    mean_init: npt.NDArray,
+    cov_init: npt.NDArray,
+    sigma2_init: float,
+    theta_init: npt.NDArray,
+    max_outer: int = 50,
+    tol: float = 1e-5,
+) -> tuple[npt.NDArray, npt.NDArray, float, bool]:
+    """
+    REML fit of a nonlinear random-effects degradation path by the
+    Lindstrom-Bates (1990) FOCE linearisation.
+
+    Parameters
+    ----------
+    y_list : list of ndarray
+        Each unit's measurement vector.
+    x_list : list of ndarray
+        Each unit's measurement times (used to re-evaluate the path and
+        its Jacobian at the conditional modes).
+    path_model : PathModel
+        The (nonlinear) degradation path model.
+    mean_init, cov_init, sigma2_init : ndarray, ndarray, float
+        Starting values for ``mu``, ``Sigma`` and ``sigma^2`` (typically
+        the two-stage moment estimates).
+    theta_init : ndarray
+        Per-unit unpenalised least-squares path fits, one row per unit;
+        the starting points for the conditional-mode search.
+    max_outer : int, optional
+        Maximum outer (linearise / LME) iterations. Default 50.
+    tol : float, optional
+        Relative convergence tolerance on ``(mu, Sigma, sigma^2)``.
+
+    Returns
+    -------
+    (mu, Sigma, sigma2, converged)
+    """
+    mu = np.array(mean_init, dtype=float)
+    covariance = np.array(cov_init, dtype=float)
+    sigma2 = float(sigma2_init)
+    theta_hat = np.array(theta_init, dtype=float)
+
+    converged = False
+    for _ in range(max_outer):
+        prior_precision = _prior_precision(covariance, sigma2)
+        # Step 1: conditional modes given the current population.
+        w_list, jac_list = [], []
+        for k, (y_i, x_i) in enumerate(zip(y_list, x_list)):
+            theta_i = _conditional_mode(
+                path_model,
+                x_i,
+                y_i,
+                mu,
+                prior_precision,
+                sigma2,
+                theta_hat[k],
+            )
+            theta_hat[k] = theta_i
+            # Step 2: linearise the path about the mode.
+            jac = np.asarray(path_model.jacobian(x_i, *theta_i), dtype=float)
+            fitted = np.asarray(path_model.path(x_i, *theta_i), dtype=float)
+            w_list.append(y_i - fitted + jac @ theta_i)
+            jac_list.append(jac)
+
+        # Step 3: linear REML step on the pseudo-data, warm-started from
+        # the current variance components.
+        mu_new, cov_new, sigma2_new, inner_ok = reml_estimate(
+            w_list, jac_list, covariance, sigma2
+        )
+
+        prev = np.concatenate([mu, covariance.ravel(), [sigma2]])
+        curr = np.concatenate([mu_new, cov_new.ravel(), [sigma2_new]])
+        scale = np.maximum(np.abs(prev), np.abs(curr)) + 1e-12
+        rel_change = float(np.max(np.abs(curr - prev) / scale))
+
+        mu, covariance, sigma2 = mu_new, cov_new, sigma2_new
+        if rel_change < tol:
+            converged = bool(inner_ok)
+            break
+
+    return mu, covariance, sigma2, converged

--- a/surpyval/tests/degradation/test_degradation_analysis.py
+++ b/surpyval/tests/degradation/test_degradation_analysis.py
@@ -416,18 +416,104 @@ def test_reml_on_unbalanced_data():
     assert np.isfinite(pred.failure_time)
 
 
-def test_reml_rejects_nonlinear_path():
-    x, y, i = _noisy_population_data()
-    # rejected before any per-unit fitting happens
-    with pytest.raises(ValueError, match="linear in its parameters"):
-        DegradationAnalysis.fit(
-            x,
-            y,
-            i,
-            threshold=100,
-            path="exponential",
-            population_method="reml",
-        )
+def _exponential_population_data(n_units=80, seed=0):
+    """Balanced noisy exponential degradation data: y = a exp(b t),
+    a ~ N(2, 0.15^2), b ~ N(0.05, 0.006^2), measurement noise sd 0.05."""
+    rng = np.random.default_rng(seed)
+    x_times = np.arange(1.0, 13.0, 1.0)
+    a = rng.normal(2.0, 0.15, n_units)
+    b = rng.normal(0.05, 0.006, n_units)
+    x = np.tile(x_times, n_units)
+    i = np.repeat(np.arange(n_units), len(x_times))
+    y = np.repeat(a, len(x_times)) * np.exp(
+        np.repeat(b, len(x_times)) * x
+    ) + rng.normal(0, 0.05, len(x))
+    return x, y, i
+
+
+def test_reml_nonlinear_exponential_recovers_population():
+    # REML on a nonlinear path (FOCE linearisation) recovers the
+    # generating exponential population and stays positive definite.
+    x, y, i = _exponential_population_data()
+    reml = DegradationAnalysis.fit(
+        x, y, i, threshold=6.0, path="exponential", population_method="reml"
+    )
+    assert reml.population_method == "reml"
+    assert np.allclose(reml.path_param_mean, [2.0, 0.05], atol=[0.1, 0.005])
+    assert np.isclose(reml.measurement_var, 0.0025, rtol=0.4)
+    # between-unit variances near the truth (var a = 0.0225, var b ~ 3.6e-5)
+    assert np.isclose(reml.path_param_cov[0, 0], 0.0225, rtol=0.6)
+    assert np.isclose(reml.path_param_cov[1, 1], 3.6e-5, rtol=0.6)
+    assert (np.linalg.eigvalsh(reml.path_param_cov) > 0).all()
+    # the fitted model supports Bayesian prediction
+    pred = reml.predict_rul([2.0, 4.0], [2.1, 2.4], random_state=1)
+    assert np.isfinite(pred.failure_time)
+
+
+def test_reml_nonlinear_matches_moments_on_clean_data():
+    # with plenty of units and little noise both routes should agree
+    # closely on the population mean
+    x, y, i = _exponential_population_data(n_units=120, seed=2)
+    reml = DegradationAnalysis.fit(
+        x, y, i, threshold=6.0, path="exponential", population_method="reml"
+    )
+    moments = DegradationAnalysis.fit(
+        x, y, i, threshold=6.0, path="exponential"
+    )
+    assert np.allclose(
+        reml.path_param_mean, moments.path_param_mean, rtol=0.05
+    )
+
+
+def test_reml_nonlinear_reduces_to_linear_reml():
+    # the FOCE routine applied to a linear-in-parameters path must
+    # reproduce the exact linear-mixed-model REML fit
+    from surpyval.degradation.path_models import LinearPath
+    from surpyval.degradation.population import (
+        reml_estimate,
+        reml_estimate_nonlinear,
+    )
+
+    rng = np.random.default_rng(3)
+    x_list, y_list, design_list, theta_list = [], [], [], []
+    for _ in range(40):
+        n_k = int(rng.integers(3, 9))
+        x_k = np.sort(rng.uniform(5, 60, n_k))
+        a_k, b_k = rng.normal(10.0, 1.0), rng.normal(0.4, 0.05)
+        y_k = a_k + b_k * x_k + rng.normal(0, 1.0, n_k)
+        design = np.column_stack([np.ones_like(x_k), x_k])
+        x_list.append(x_k)
+        y_list.append(y_k)
+        design_list.append(design)
+        theta_list.append(np.linalg.lstsq(design, y_k, rcond=None)[0])
+    theta_arr = np.array(theta_list)
+    cov0 = np.cov(theta_arr, rowvar=False)
+
+    lin = reml_estimate(y_list, design_list, cov0, 1.0)
+    nonlin = reml_estimate_nonlinear(
+        y_list, x_list, LinearPath, theta_arr.mean(0), cov0, 1.0, theta_arr
+    )
+    assert np.allclose(lin[0], nonlin[0], atol=1e-4)
+    assert np.allclose(lin[1], nonlin[1], rtol=1e-2, atol=1e-4)
+    assert np.isclose(lin[2], nonlin[2], rtol=1e-2)
+
+
+def test_reml_nonlinear_power_path_positive_definite():
+    # a second nonlinear family (power) also fits and stays PD
+    rng = np.random.default_rng(4)
+    n_units, x_times = 60, np.arange(1.0, 13.0, 1.0)
+    a = rng.normal(1.5, 0.1, n_units)
+    b = rng.normal(0.7, 0.05, n_units)
+    x = np.tile(x_times, n_units)
+    i = np.repeat(np.arange(n_units), len(x_times))
+    y = np.repeat(a, len(x_times)) * np.power(
+        x, np.repeat(b, len(x_times))
+    ) + rng.normal(0, 0.05, len(x))
+    reml = DegradationAnalysis.fit(
+        x, y, i, threshold=8.0, path="power", population_method="reml"
+    )
+    assert np.allclose(reml.path_param_mean, [1.5, 0.7], atol=[0.15, 0.05])
+    assert (np.linalg.eigvalsh(reml.path_param_cov) > 0).all()
 
 
 def test_reml_requires_noise():


### PR DESCRIPTION
Closes #152.

`population_method="reml"` for degradation analysis was restricted to path models **linear in their parameters** (linear, quadratic, logarithmic, Lloyd–Lipow). Nonlinear paths — exponential, power, Gompertz, … — now fit via REML too, using the **Lindstrom–Bates (1990) FOCE** alternating algorithm (the linearisation `nlme` uses):

1. hold `(μ, Σ, σ²)` fixed and estimate each unit's **conditional mode** `θ̂ᵢ` (its penalised-least-squares / MAP fit) by damped Gauss–Newton with a backtracking line search;
2. **linearise** the path about that mode, `f(xᵢ, θ) ≈ f(xᵢ, θ̂ᵢ) + Jᵢ(θ − θ̂ᵢ)`, forming the working linear mixed model with pseudo-response `wᵢ = yᵢ − f(xᵢ, θ̂ᵢ) + Jᵢ θ̂ᵢ`;
3. run the **existing linear REML step** on `(wᵢ, Jᵢ)` to update `(μ, Σ, σ²)`,

iterating to convergence. On a linear-in-parameters path this reduces **exactly** to the previous linear REML fit in a single pass (`wᵢ = yᵢ`, the modes drop out), so the two routines agree — verified by a test. As with the linear case, `Σ` is parameterised by its Cholesky factor, so `path_param_cov` is **positive definite by construction** (no PSD clipping) for nonlinear paths too — the more robust population estimate when the unit count is small, which is exactly the gap #152 flagged.

### Changes
- **`population.py`**: `reml_estimate_nonlinear` (the FOCE outer loop), `_conditional_mode` (penalised Gauss–Newton MAP), `_prior_precision` (eigenvalue-floored `Σ⁻¹`); module docstring documents the extension.
- **`degradation_analysis.py`**: removed the "REML requires a linear path" rejection; the REML branch now routes linear paths through the exact linear step and nonlinear paths through the FOCE routine; collects per-unit measurement times; `fit` docstring updated.
- **Tests**: exponential and power parameter-recovery, moments-agreement on clean data, and the exact linear-reduction consistency check; replaces the old `test_reml_rejects_nonlinear_path`.
- **Docs + changelog**: the REML section describes the FOCE linearisation for nonlinear paths, with a Lindstrom–Bates reference.

### Validation
- Exponential population (`a~N(2,0.15²)`, `b~N(0.05,0.006²)`): REML recovers mean `[2.01, 0.0496]`, variances/noise near truth, `Σ` PD.
- Power population: mean `[1.49, 0.70]` recovered, `Σ` PD.
- FOCE on a linear path reproduces the linear REML fit to `1e-4`.
- Full degradation suite green (146 passed); flake8 / black / `mypy surpyval` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_