### PR TITLE
Add serialisation to the parametric regression models

### DIFF
--- a/docs/Regression Modelling with SurPyval.rst
+++ b/docs/Regression Modelling with SurPyval.rst
@@ -815,3 +815,50 @@ assumption is violated (e.g. survival curves cross), a lower-AIC PH model can
 still give misleading predictions. Goodness-of-fit diagnostics like
 Schoenfeld residuals (for PH) or log-log survival plots should accompany any
 model comparison.
+
+Saving and loading a fitted model
+---------------------------------
+
+A fitted parametric regression model can be serialised to a plain dictionary
+or a JSON file and rebuilt later — so you can fit once and reuse the model
+without the training data on hand. This works for the fixed-form parametric
+families: Accelerated Failure Time, Proportional Hazards, Proportional Odds
+and (parametric) Additive Hazards.
+
+.. jupyter-execute::
+
+    import tempfile, os
+    from surpyval import WeibullAFT
+    from surpyval.univariate.regression import ParametricRegressionModel
+
+    model = WeibullAFT.fit(x=x, Z=Z, c=c)
+
+    # to a dictionary (JSON-serialisable) ...
+    blob = model.to_dict()
+
+    # ... and back
+    restored = ParametricRegressionModel.from_dict(blob)
+
+    # the restored model predicts identically
+    import numpy as np
+    t = np.array([1.0, 5.0, 20.0])
+    Z_use = Z[0]
+    print("match:", np.allclose(model.sf(t, Z_use), restored.sf(t, Z_use)))
+
+Use ``to_json`` / ``from_json`` for a file directly:
+
+.. jupyter-execute::
+
+    path = os.path.join(tempfile.mkdtemp(), "aft.json")
+    model.to_json(path)
+    reloaded = ParametricRegressionModel.from_json(path)
+    print(reloaded)
+
+If the fitted model carried a computable parameter covariance, it is stored in
+the dictionary, so the reloaded model can also produce confidence bounds
+(``cb``, ``param_cb``, ``standard_errors``) without the original data. Only the
+prediction/inference state is serialised — the empirical overlay in ``plot``
+needs the fitted data, so re-fit if you need that. Models with a bespoke
+covariate link (an Accelerated Life parameter-substitution model, whose link is
+an arbitrary life-model) cannot be rebuilt from a name and raise
+``NotImplementedError`` when serialised.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,23 @@ Changelog
 v0.15.0 (unreleased)
 --------------------
 
+Regression
+~~~~~~~~~~
+
+- Added serialisation to the parametric regression models:
+  ``ParametricRegressionModel`` now has ``to_dict``/``from_dict`` and
+  ``to_json``/``from_json``, so a fitted Accelerated Failure Time,
+  Proportional Hazards, Proportional Odds or (parametric) Additive Hazards
+  model can be saved and rebuilt without the training data. The restored model
+  predicts identically (``sf``/``ff``/``df``/``hf``/``Hf``/``phi``/``random``);
+  if the fit's parameter covariance was computable it is stored too, so the
+  reloaded model also produces confidence bounds (``cb``/``param_cb``/
+  ``standard_errors``). Distribution and family are resolved by name from a
+  restricted set, so an untrusted dict cannot load arbitrary objects. Models
+  with a bespoke covariate link (an Accelerated Life parameter-substitution
+  model) are refused with a clear error. ``ParametricRegressionModel`` is now
+  exported from ``surpyval.univariate.regression``.
+
 Experimental
 ~~~~~~~~~~~~
 

--- a/surpyval/tests/univariate/regression/test_serialisation.py
+++ b/surpyval/tests/univariate/regression/test_serialisation.py
@@ -1,0 +1,178 @@
+"""Serialisation of the parametric regression models.
+
+The fixed-form regression families -- Accelerated Failure Time, Proportional
+Hazards, Proportional Odds and (parametric) Additive Hazards -- round-trip
+through ``to_dict``/``from_dict`` (and the JSON file variants): the restored
+model predicts identically to the original, its parameter names line up, and
+-- when a covariance was stored -- it reproduces the same confidence bounds
+without needing the original data. Models whose covariate link cannot be
+rebuilt from a name (Accelerated Life parameter-substitution) are refused, and
+an untrusted dict cannot resolve an arbitrary distribution.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from surpyval import AFT, AH, PH, PO, AcceleratedLife, Power, Weibull
+from surpyval.univariate.regression.parametric_regression_model import (
+    ParametricRegressionModel,
+)
+
+
+def _fit_data(seed=0, n=120):
+    rng = np.random.default_rng(seed)
+    Z = rng.normal(0, 1, (n, 2))
+    lin = 0.5 * Z[:, 0] - 0.3 * Z[:, 1]
+    x = np.abs(Weibull.random(n, 10.0, 2.0) * np.exp(-lin / 2.0)) + 0.1
+    c = np.zeros(n)
+    return x, Z, c
+
+
+FAMILIES = {
+    "AFT": AFT,
+    "PH": PH,
+    "PO": PO,
+    "AH": AH,
+}
+
+
+@pytest.mark.parametrize("name", list(FAMILIES))
+def test_predictions_round_trip(name):
+    x, Z, c = _fit_data()
+    model = FAMILIES[name](Weibull).fit(x, Z=Z, c=c)
+    restored = ParametricRegressionModel.from_dict(model.to_dict())
+
+    xs = np.array([2.0, 5.0, 10.0])
+    Zq = np.array([0.4, -0.2])
+    for fn in ("sf", "ff", "df", "hf", "Hf"):
+        a = np.asarray(getattr(model, fn)(xs, Zq), dtype=float)
+        b = np.asarray(getattr(restored, fn)(xs, Zq), dtype=float)
+        assert np.allclose(a, b, rtol=1e-10, atol=1e-12), fn
+    assert np.allclose(model.params, restored.params)
+    assert model.parameter_names() == restored.parameter_names()
+    assert model.kind == restored.kind
+    assert model.distribution.name == restored.distribution.name
+
+
+@pytest.mark.parametrize("name", list(FAMILIES))
+def test_confidence_bounds_round_trip(name):
+    x, Z, c = _fit_data()
+    model = FAMILIES[name](Weibull).fit(x, Z=Z, c=c)
+    d = model.to_dict()
+    # a well-behaved fit stores a finite covariance
+    assert "covariance" in d
+    restored = ParametricRegressionModel.from_dict(d)
+
+    xs = np.array([2.0, 5.0, 10.0])
+    Zq = np.array([0.4, -0.2])
+    cb1 = np.asarray(model.cb(xs, Zq, on="sf"), dtype=float)
+    cb2 = np.asarray(restored.cb(xs, Zq, on="sf"), dtype=float)
+    assert np.allclose(cb1, cb2, rtol=1e-6, atol=1e-8)
+    se1 = model.standard_errors()
+    se2 = restored.standard_errors()
+    assert np.allclose(se1, se2, rtol=1e-6, atol=1e-8, equal_nan=True)
+    pc1 = model.param_cb(model.parameter_names()[-1])
+    pc2 = restored.param_cb(restored.parameter_names()[-1])
+    assert np.allclose(pc1, pc2, rtol=1e-6, atol=1e-8)
+
+
+def test_json_file_round_trip(tmp_path):
+    x, Z, c = _fit_data()
+    model = AFT(Weibull).fit(x, Z=Z, c=c)
+    fp = tmp_path / "model.json"
+    model.to_json(fp)
+    restored = ParametricRegressionModel.from_json(fp)
+    xs = np.array([2.0, 5.0, 10.0])
+    Zq = np.array([0.4, -0.2])
+    assert np.allclose(
+        np.asarray(model.sf(xs, Zq), dtype=float),
+        np.asarray(restored.sf(xs, Zq), dtype=float),
+    )
+    # the dict is genuinely JSON-serialisable
+    with open(fp) as f:
+        assert json.load(f)["parameterization"] == "parametric-regression"
+
+
+def test_to_dict_is_json_serialisable():
+    x, Z, c = _fit_data()
+    model = PH(Weibull).fit(x, Z=Z, c=c)
+    # must not raise
+    json.dumps(model.to_dict())
+
+
+def test_phi_round_trip():
+    x, Z, c = _fit_data()
+    model = AFT(Weibull).fit(x, Z=Z, c=c)
+    restored = ParametricRegressionModel.from_dict(model.to_dict())
+    Zq = np.array([0.4, -0.2])
+    assert np.allclose(
+        np.asarray(model.phi(Zq), dtype=float),
+        np.asarray(restored.phi(Zq), dtype=float),
+    )
+
+
+def test_accelerated_life_is_refused():
+    rng = np.random.default_rng(1)
+    n = 100
+    Z = (np.abs(rng.normal(0, 1, n)) + 0.5).reshape(-1, 1)
+    x = np.abs(Weibull.random(n, 10.0, 2.0)) + 0.1
+    c = np.zeros(n)
+    model = AcceleratedLife(Weibull, Power).fit(x, Z=Z, c=c)
+    with pytest.raises(NotImplementedError, match="fixed-form"):
+        model.to_dict()
+
+
+def test_from_dict_rejects_unknown_distribution():
+    x, Z, c = _fit_data()
+    d = AFT(Weibull).fit(x, Z=Z, c=c).to_dict()
+    d["distribution"] = "os"  # a real surpyval-importable name, not a dist
+    with pytest.raises(ValueError, match="Unknown distribution"):
+        ParametricRegressionModel.from_dict(d)
+
+
+def test_from_dict_rejects_wrong_parameterization():
+    with pytest.raises(ValueError, match="parametric-regression"):
+        ParametricRegressionModel.from_dict({"parameterization": "parametric"})
+
+
+def test_restored_without_covariance_refuses_bounds():
+    x, Z, c = _fit_data()
+    d = AFT(Weibull).fit(x, Z=Z, c=c).to_dict()
+    d.pop("covariance", None)  # simulate a predictions-only dict
+    restored = ParametricRegressionModel.from_dict(d)
+    # predictions still work
+    sf = np.asarray(restored.sf(5.0, [0.1, 0.1]), dtype=float)
+    assert np.isfinite(sf).all()
+    # but bounds are unavailable without the covariance or data
+    with pytest.raises(ValueError):
+        restored.cb(5.0, [0.1, 0.1])
+
+
+def test_fixed_and_feature_names_preserved():
+    x, Z, c = _fit_data()
+    model = AFT(Weibull).fit(x, Z=Z, c=c, fixed={"alpha": 10.0})
+    restored = ParametricRegressionModel.from_dict(model.to_dict())
+    assert restored.fixed == {"alpha": 10.0}
+    # a fixed parameter is held at its value
+    assert restored.params[0] == pytest.approx(10.0)
+
+
+def test_dataframe_fit_metadata_preserved():
+    import pandas as pd
+
+    x, Z, c = _fit_data()
+    df = pd.DataFrame({"x": x, "c": c, "z0": Z[:, 0], "z1": Z[:, 1]})
+    model = AFT(Weibull).fit_from_df(
+        df, x_col="x", c_col="c", Z_cols=["z0", "z1"]
+    )
+    restored = ParametricRegressionModel.from_dict(model.to_dict())
+    assert restored.feature_names == ["z0", "z1"]
+    # array-Z prediction matches the original
+    xs = np.array([2.0, 5.0])
+    Zq = np.array([0.4, -0.2])
+    assert np.allclose(
+        np.asarray(model.sf(xs, Zq), dtype=float),
+        np.asarray(restored.sf(xs, Zq), dtype=float),
+    )

--- a/surpyval/univariate/regression/__init__.py
+++ b/surpyval/univariate/regression/__init__.py
@@ -50,6 +50,7 @@ from .proportional_hazards import (
     ProportionalHazardsFitter,
     WeibullPH,
 )
+from .parametric_regression_model import ParametricRegressionModel
 from .proportional_odds import (
     PO,
     ExponentialPO,
@@ -63,6 +64,8 @@ from .proportional_odds import (
 )
 
 __all__ = [
+    # Base result class (holds to_dict / from_dict / to_json / from_json)
+    "ParametricRegressionModel",
     # Buckley-James semi-parametric AFT
     "BuckleyJames",
     "BuckleyJamesModel",

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -1,3 +1,6 @@
+import json
+import types
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import autograd.numpy as np
@@ -21,6 +24,29 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
 
+# Regression families whose fitted model round-trips through ``to_dict`` /
+# ``from_dict``: each has a fixed-form covariate link (a log-linear multiplier
+# ``exp(beta'Z)`` or an additive ``beta'Z`` term) that is fully determined by
+# the ``kind`` plus the distribution and coefficients, so the fitter -- and
+# therefore every prediction -- can be rebuilt from the distribution's name.
+# Maps kind -> (public fitter factory name, covariate-link form).
+_SERIALISABLE_KINDS: "dict[str, tuple[str, str]]" = {
+    "Accelerated Failure Time": ("AFT", "exp"),
+    "Proportional Hazard": ("PH", "exp"),
+    "Proportional Odds": ("PO", "exp"),
+    "Additive Hazard": ("AH", "additive"),
+}
+
+# The covariate-link (``reg_model``) names those families produce. A model
+# carrying any other link is a bespoke/custom link that cannot be rebuilt from
+# a name alone, so serialisation refuses it rather than round-trip it wrongly.
+_SERIALISABLE_REG_NAMES = {
+    "Log Linear [exp(beta'Z)]",  # AFT, PO
+    "Log Linear [e^(beta'Z)]",  # PH
+    "Additive [beta'Z]",  # AH
+}
+
+
 class ParametricRegressionModel:
     """
     Result of ``.fit()`` or ``.from_params()`` method for parametric
@@ -38,6 +64,10 @@ class ParametricRegressionModel:
     feature_names: list[str] | None = None
     formula: str | None = None
     _model_spec: Any = None
+    #: Set only on models rebuilt by :meth:`from_dict` that carried a stored
+    #: parameter covariance; lets them produce confidence bounds without the
+    #: original data. ``None`` on freshly fitted models.
+    _restored_covariance: "npt.NDArray | None" = None
 
     # Attributes populated after construction (by ``fit`` / ``from_params``).
     # Declared here so static type checkers know their types.
@@ -64,6 +94,185 @@ class ParametricRegressionModel:
     _bic: float
     _aic: float
     _aic_c: float
+
+    # -- serialisation -----------------------------------------------------
+
+    def to_dict(self) -> dict:
+        """
+        Serialise this fitted regression model to a plain ``dict``.
+
+        The returned dictionary is JSON-serialisable and captures everything
+        needed to rebuild the model for prediction (``sf``/``ff``/``df``/
+        ``hf``/``Hf``/``phi``/``random``): the ``kind``, the distribution's
+        name, the covariate-link identity, the fitted parameters, and the
+        covariate-coefficient names. If the model was fit from data and its
+        parameter covariance can be computed, that is stored too, so the
+        restored model can also produce confidence bounds
+        (``cb``/``param_cb``/``standard_errors``).
+
+        Only the fixed-form parametric families round-trip -- Accelerated
+        Failure Time, Proportional Hazards, Proportional Odds and (parametric)
+        Additive Hazards -- whose covariate link is fully determined by the
+        ``kind`` and coefficients. A model with a bespoke covariate link (for
+        example an Accelerated Life parameter-substitution model, whose link
+        is an arbitrary life-model) cannot be rebuilt from a name and raises
+        ``NotImplementedError``.
+
+        See Also
+        --------
+        from_dict, to_json, from_json
+        """
+        if self.kind not in _SERIALISABLE_KINDS:
+            raise NotImplementedError(
+                "Serialisation is implemented for the fixed-form regression "
+                "families (Accelerated Failure Time, Proportional Hazard, "
+                "Proportional Odds, Additive Hazard); the {!r} model's "
+                "covariate link cannot be rebuilt from a name.".format(
+                    self.kind
+                )
+            )
+        reg_name = getattr(self.reg_model, "name", None)
+        if reg_name not in _SERIALISABLE_REG_NAMES:
+            raise NotImplementedError(
+                "This {} model carries a non-standard covariate link ({!r}) "
+                "that cannot be serialised; only the built-in log-linear / "
+                "additive links round-trip.".format(self.kind, reg_name)
+            )
+        phi_param_map = getattr(self.reg_model, "phi_param_map", None)
+        if not isinstance(phi_param_map, dict):
+            raise NotImplementedError(
+                "This model's covariate coefficients are not a fixed name map "
+                "and cannot be serialised."
+            )
+
+        out: dict[str, Any] = {
+            "parameterization": "parametric-regression",
+            "kind": self.kind,
+            "distribution": self.distribution.name,
+            "reg_model_name": reg_name,
+            "phi_param_map": {
+                str(k): int(v) for k, v in phi_param_map.items()
+            },
+            "params": np.asarray(self.params, dtype=float).tolist(),
+            "k": int(self.k),
+            "k_dist": int(self.k_dist),
+            "fixed": {str(k): float(v) for k, v in self.fixed.items()},
+            "gamma": float(getattr(self, "gamma", 0.0)),
+            "p": float(getattr(self, "p", 1.0)),
+            "f0": float(getattr(self, "f0", 0.0)),
+        }
+        if self.feature_names is not None:
+            out["feature_names"] = list(self.feature_names)
+        if self.formula is not None:
+            out["formula"] = self.formula
+
+        # Store the parameter covariance so the restored model can produce
+        # confidence bounds without the original data. Only for data-fit
+        # models whose covariance is finite (a boundary optimum gives nan).
+        if hasattr(self, "data") and getattr(self, "res", None) is not None:
+            try:
+                cov = self.covariance()
+            except Exception:
+                cov = None
+            if cov is not None and np.all(np.isfinite(cov)):
+                out["covariance"] = np.asarray(cov, dtype=float).tolist()
+            if hasattr(self, "_neg_ll"):
+                out["_neg_ll"] = float(self._neg_ll)
+        return out
+
+    def to_json(self, fp: "str | Path") -> None:
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "ParametricRegressionModel":
+        """
+        Rebuild a regression model from a :meth:`to_dict` dictionary.
+
+        The distribution and fitter factory are resolved from the public
+        ``surpyval`` namespace by name (restricted to the known distributions
+        and regression families, so an untrusted dict cannot resolve arbitrary
+        attributes), then the fitted parameters are restored. The result
+        predicts identically to the original model; if a covariance was stored
+        it also produces confidence bounds.
+
+        See Also
+        --------
+        to_dict, to_json, from_json
+        """
+        import surpyval
+        from surpyval.univariate.parametric.parametric_fitter import (
+            ParametricFitter,
+        )
+
+        if model_dict.get("parameterization") != "parametric-regression":
+            raise ValueError(
+                "Must create a regression model from a parametric-regression "
+                "model dict"
+            )
+        kind = model_dict["kind"]
+        if kind not in _SERIALISABLE_KINDS:
+            raise ValueError(
+                "Cannot deserialise regression kind {!r}".format(kind)
+            )
+        factory_name, phi_kind = _SERIALISABLE_KINDS[kind]
+
+        dist = getattr(surpyval, model_dict["distribution"], None)
+        if not isinstance(dist, ParametricFitter):
+            raise ValueError(
+                "Unknown distribution {!r}".format(model_dict["distribution"])
+            )
+        factory = getattr(surpyval, factory_name)
+        fitter = factory(dist)
+
+        params = np.array(model_dict["params"], dtype=float)
+        k_dist = int(model_dict["k_dist"])
+        phi_param_map = {
+            k: int(v) for k, v in model_dict["phi_param_map"].items()
+        }
+
+        reg_model = types.SimpleNamespace(
+            name=model_dict["reg_model_name"],
+            phi_param_map=phi_param_map,
+        )
+        if phi_kind == "exp":
+            # the log-linear multiplier exp(beta'Z), matching the fitters
+            reg_model.phi = lambda Z, *p: np.exp(np.dot(Z, np.array(p)))
+
+        out = cls()
+        out.model = fitter
+        out.distribution = dist
+        out.dist = dist
+        out.reg_model = reg_model
+        out.kind = kind
+        out.params = params
+        out.dist_params = params[:k_dist]
+        out.phi_params = params[k_dist:]
+        out.k = int(model_dict["k"])
+        out.k_dist = k_dist
+        out.fixed = {
+            k: float(v) for k, v in model_dict.get("fixed", {}).items()
+        }
+        out.gamma = float(model_dict.get("gamma", 0.0))
+        out.p = float(model_dict.get("p", 1.0))
+        out.f0 = float(model_dict.get("f0", 0.0))
+        out.feature_names = model_dict.get("feature_names")
+        out.formula = model_dict.get("formula")
+
+        if "covariance" in model_dict:
+            out._restored_covariance = np.array(
+                model_dict["covariance"], dtype=float
+            )
+        if "_neg_ll" in model_dict:
+            out._neg_ll = float(model_dict["_neg_ll"])
+        return out
+
+    @classmethod
+    def from_json(cls, fp: "str | Path") -> "ParametricRegressionModel":
+        """Load a model from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     def _prepare_Z(self, Z: "npt.ArrayLike | pd.DataFrame") -> npt.NDArray:
         """
@@ -560,6 +769,10 @@ class ParametricRegressionModel:
     # -- confidence bounds -------------------------------------------------
 
     def _check_inference(self) -> None:
+        # A model deserialised with a stored covariance can produce bounds
+        # without the original data.
+        if getattr(self, "_restored_covariance", None) is not None:
+            return
         if not hasattr(self, "data") or getattr(self, "res", None) is None:
             raise ValueError(
                 "Confidence bounds are only available for models fit from "
@@ -588,6 +801,9 @@ class ParametricRegressionModel:
         A parameter driven to a boundary breaks the Wald approximation; the
         covariance is then returned filled with ``nan`` (with a warning).
         """
+        restored = getattr(self, "_restored_covariance", None)
+        if restored is not None:
+            return restored
         self._check_inference()
         names = self.parameter_names()
         p_hat = np.asarray(self.params, dtype=float)


### PR DESCRIPTION
Fitted parametric regression models could not be saved and reloaded — unlike the univariate `Parametric`/`NonParametric` models, which already have `to_dict`/`from_dict`/`to_json`/`from_json`. This adds the same serialisation to `ParametricRegressionModel`.

### What's covered
The four **fixed-form** parametric regression families, whose covariate link is fully determined by the `kind` + distribution + coefficients:
- **Accelerated Failure Time** (`AFT`)
- **Proportional Hazards** (`PH`)
- **Proportional Odds** (`PO`)
- **(parametric) Additive Hazards** (`AH`)

### How it works
- **`to_dict` / `to_json`** capture `kind`, the distribution's name, the covariate-link identity, the fitted `params`, coefficient names, and `fixed`. If the model was fit from data and its parameter covariance is finite, that's stored too.
- **`from_dict` / `from_json`** resolve the distribution and fitter factory **by name from a restricted set** (mirroring the univariate `from_dict` security pattern, so an untrusted dict can't resolve arbitrary attributes), then restore the parameters. The rebuilt fitter and its log-linear/additive link reproduce every prediction exactly.
- A restored model with a stored covariance returns it from `covariance()`, so `cb` / `param_cb` / `standard_errors` work **without the original data** (`_check_inference` and `covariance()` now honour a restored covariance).
- **Refusals**: a bespoke covariate link — an Accelerated Life parameter-substitution model, whose link is an arbitrary life-model — raises a clear `NotImplementedError`, as does any non-standard link.
- `ParametricRegressionModel` is now exported from `surpyval.univariate.regression`.

### Validation
- Predictions (`sf`/`ff`/`df`/`hf`/`Hf`/`phi`) round-trip to `1e-10` across all four families; `cb`, `standard_errors`, and `param_cb` match to `1e-6` via the stored covariance; JSON file round-trip and DataFrame-fit metadata verified.
- New `test_serialisation.py` (17 tests) covers all of the above plus the refusals and the predictions-only-dict-refuses-bounds case. Full regression suite green (158 passed); flake8 / black / `mypy surpyval` clean.
- Docs: "Regression Modelling with SurPyval" gains a runnable **"Saving and loading a fitted model"** section; changelog updated.

### Not in scope
Cox (`SemiParametricRegressionModel`), Lin-Ying additive hazards, and Buckley-James are **separate result classes** with nonparametric baselines; each needs its own serialisation and is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_