### PR TITLE
Add serialisation to the semi-parametric regression models (Cox, Lin-Ying, Buckley-James)

### DIFF
--- a/docs/Regression Modelling with SurPyval.rst
+++ b/docs/Regression Modelling with SurPyval.rst
@@ -862,3 +862,24 @@ needs the fitted data, so re-fit if you need that. Models with a bespoke
 covariate link (an Accelerated Life parameter-substitution model, whose link is
 an arbitrary life-model) cannot be rebuilt from a name and raise
 ``NotImplementedError`` when serialised.
+
+The **semi-parametric** regression models save and load the same way, each on
+its own result class: Cox proportional hazards
+(``SemiParametricRegressionModel``), the Lin-Ying additive-hazards model
+(``AdditiveHazardsModel``), and the Buckley-James AFT (``BuckleyJamesModel``).
+Because their baseline is nonparametric, what is stored is the fitted
+coefficients plus the baseline step arrays (or, for Buckley-James, the residual
+survival), so the reloaded model predicts identically:
+
+.. jupyter-execute::
+
+    from surpyval import CoxPH
+    from surpyval.univariate.regression import SemiParametricRegressionModel
+
+    cox = CoxPH.fit(x=x, Z=Z, c=c)
+    cox_reloaded = SemiParametricRegressionModel.from_dict(cox.to_dict())
+    print("match:", np.allclose(cox.sf(t, Z_use), cox_reloaded.sf(t, Z_use)))
+
+Cox's time-varying-covariate prediction (``predict_tvc``), the additive model's
+covariance, and Buckley-James's ``bootstrap_ci`` (which keeps a copy of the fit
+data) all survive the round-trip.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,18 @@ v0.15.0 (unreleased)
 Regression
 ~~~~~~~~~~
 
+- Added serialisation to the **semi-parametric** regression models, each on its
+  own result class: Cox proportional hazards
+  (``SemiParametricRegressionModel``), the Lin-Ying additive-hazards model
+  (``AdditiveHazardsModel``), and the Buckley-James AFT (``BuckleyJamesModel``)
+  now have ``to_dict``/``from_dict`` and ``to_json``/``from_json``. Because the
+  baseline is nonparametric, the coefficients plus the fitted baseline step
+  arrays (or, for Buckley-James, the residual survival) are stored, so the
+  reloaded model predicts identically -- including Cox's ``predict_tvc`` for a
+  time-varying-covariate fit, the additive model's covariance / standard
+  errors, and Buckley-James's ``bootstrap_ci`` (its fit data is kept).
+  ``SemiParametricRegressionModel`` is now exported from
+  ``surpyval.univariate.regression``.
 - Added serialisation to the parametric regression models:
   ``ParametricRegressionModel`` now has ``to_dict``/``from_dict`` and
   ``to_json``/``from_json``, so a fitted Accelerated Failure Time,

--- a/surpyval/tests/univariate/regression/test_semiparametric_serialisation.py
+++ b/surpyval/tests/univariate/regression/test_semiparametric_serialisation.py
@@ -1,0 +1,199 @@
+"""Serialisation of the semi-parametric regression models.
+
+The three semi-parametric regression result classes -- Cox proportional
+hazards (``SemiParametricRegressionModel``), the Lin-Ying additive-hazards
+model (``AdditiveHazardsModel``), and the Buckley-James AFT
+(``BuckleyJamesModel``) -- round-trip through ``to_dict``/``from_dict`` (and
+the JSON file variants). Each stores its coefficients plus the fitted
+nonparametric baseline (or residual survival), so the restored model predicts
+identically. Cox's ``phi`` and TVC prediction, the additive model's
+covariance, and Buckley-James's bootstrap CI all survive the round-trip.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from surpyval import AdditiveHazards, BuckleyJames
+from surpyval.datasets import load_rossi_static
+from surpyval.univariate.regression import (
+    CoxPH,
+    SemiParametricRegressionModel,
+)
+from surpyval.univariate.regression.additive_hazards.additive_hazards import (
+    AdditiveHazardsModel,
+)
+from surpyval.univariate.regression.buckley_james.buckley_james import (
+    BuckleyJamesModel,
+)
+
+
+def _semipar_data(seed=0, n=80):
+    rng = np.random.default_rng(seed)
+    Z = rng.normal(0, 1, (n, 2))
+    lin = 0.3 * Z[:, 0] - 0.2 * Z[:, 1]
+    x = np.abs(rng.weibull(1.5, n) * 20 * np.exp(-lin)) + 0.5
+    c = np.zeros(n)
+    return x, Z, c
+
+
+# -- Cox ------------------------------------------------------------------
+
+
+def test_cox_round_trip_predictions():
+    rossi = load_rossi_static()
+    Zc = ["fin", "age", "race", "wexp", "mar", "paro", "prio"]
+    model = CoxPH.fit_from_df(
+        rossi, x_col="week", c_col="arrest", Z_cols=Zc, method="efron"
+    )
+    restored = SemiParametricRegressionModel.from_dict(
+        json.loads(json.dumps(model.to_dict()))
+    )
+    Zq = np.array([1.0, 30.0, 1.0, 1.0, 0.0, 1.0, 3.0])
+    t = np.array([10.0, 30.0, 52.0])
+    for fn in ("hf", "Hf", "sf", "ff", "df"):
+        a = np.asarray(getattr(model, fn)(t, Zq), dtype=float)
+        b = np.asarray(getattr(restored, fn)(t, Zq), dtype=float)
+        assert np.allclose(a, b, rtol=1e-12, atol=1e-14), fn
+    assert np.allclose(model.beta, restored.beta)
+    assert model.tie_method == restored.tie_method
+    assert restored.feature_names == Zc
+
+
+def test_cox_json_file_round_trip(tmp_path):
+    x, Z, c = _semipar_data()
+    model = CoxPH.fit(x, Z, c=c)
+    fp = tmp_path / "cox.json"
+    model.to_json(fp)
+    restored = SemiParametricRegressionModel.from_json(fp)
+    t = np.array([5.0, 15.0])
+    Zq = np.array([0.3, -0.4])
+    assert np.allclose(
+        np.asarray(model.sf(t, Zq), dtype=float),
+        np.asarray(restored.sf(t, Zq), dtype=float),
+    )
+
+
+def test_cox_tvc_round_trip():
+    # a small start-stop (time-varying-covariate) fit: each subject has two
+    # contiguous intervals with a covariate that changes at the split.
+    rng = np.random.default_rng(3)
+    n = 40
+    ident, start, stop, event, Zrows = [], [], [], [], []
+    for s in range(n):
+        split = 3.0
+        end = split + np.abs(rng.weibull(1.4)) * 6.0 + 0.5
+        z0 = rng.normal(0, 1)
+        ident += [s, s]
+        start += [0.0, split]
+        stop += [split, end]
+        event += [0, 1]  # event on the terminal interval
+        Zrows += [[z0], [z0 + 0.2]]
+    model = CoxPH.fit_tvc(
+        np.array(ident),
+        np.array(start),
+        np.array(stop),
+        np.array(event),
+        np.array(Zrows),
+    )
+    assert model.is_tvc
+    restored = SemiParametricRegressionModel.from_dict(model.to_dict())
+    assert restored.is_tvc
+    s = np.array([0.0])
+    st = np.array([8.0])
+    Zpath = np.array([[0.5]])
+    ta, sa, Ha = model.predict_tvc(s, st, Zpath)
+    tb, sb, Hb = restored.predict_tvc(s, st, Zpath)
+    assert np.allclose(ta, tb) and np.allclose(sa, sb) and np.allclose(Ha, Hb)
+
+
+def test_cox_from_dict_rejects_wrong_model():
+    with pytest.raises(ValueError, match="SemiParametricRegressionModel"):
+        SemiParametricRegressionModel.from_dict({"model": "Other"})
+
+
+# -- Lin-Ying additive hazards --------------------------------------------
+
+
+def test_additive_hazards_round_trip():
+    x, Z, c = _semipar_data(seed=1)
+    model = AdditiveHazards.fit(x, Z, c=c)
+    restored = AdditiveHazardsModel.from_dict(
+        json.loads(json.dumps(model.to_dict()))
+    )
+    xs = np.array([5.0, 15.0, 30.0])
+    Zq = np.array([0.4, -0.2])
+    for fn in ("hf", "Hf", "sf", "ff", "df"):
+        a = np.asarray(getattr(model, fn)(xs, Zq), dtype=float)
+        b = np.asarray(getattr(restored, fn)(xs, Zq), dtype=float)
+        assert np.allclose(a, b, rtol=1e-12, atol=1e-14), fn
+    assert np.allclose(model.beta, restored.beta)
+    # covariance / standard errors survive
+    assert np.allclose(model.cov, restored.cov)
+    assert np.allclose(model.se, restored.se)
+
+
+def test_additive_hazards_json_file_round_trip(tmp_path):
+    x, Z, c = _semipar_data(seed=2)
+    model = AdditiveHazards.fit(x, Z, c=c)
+    fp = tmp_path / "ah.json"
+    model.to_json(fp)
+    restored = AdditiveHazardsModel.from_json(fp)
+    xs = np.array([5.0, 20.0])
+    Zq = np.array([0.1, 0.1])
+    assert np.allclose(
+        np.asarray(model.Hf(xs, Zq), dtype=float),
+        np.asarray(restored.Hf(xs, Zq), dtype=float),
+    )
+
+
+def test_additive_hazards_rejects_wrong_model():
+    with pytest.raises(ValueError, match="AdditiveHazardsModel"):
+        AdditiveHazardsModel.from_dict({"model": "Other"})
+
+
+# -- Buckley-James --------------------------------------------------------
+
+
+def test_buckley_james_round_trip():
+    x, Z, c = _semipar_data(seed=4)
+    model = BuckleyJames.fit(x, Z, c=c)
+    restored = BuckleyJamesModel.from_dict(
+        json.loads(json.dumps(model.to_dict()))
+    )
+    xs = np.array([5.0, 15.0, 30.0])
+    Zq = np.array([0.4, -0.2])
+    for fn in ("sf", "ff", "Hf"):
+        a = np.asarray(getattr(model, fn)(xs, Zq), dtype=float)
+        b = np.asarray(getattr(restored, fn)(xs, Zq), dtype=float)
+        assert np.allclose(a, b, rtol=1e-12, atol=1e-14), fn
+    assert np.allclose(model.beta, restored.beta)
+
+
+def test_buckley_james_bootstrap_ci_survives_round_trip():
+    x, Z, c = _semipar_data(seed=5)
+    model = BuckleyJames.fit(x, Z, c=c)
+    restored = BuckleyJamesModel.from_dict(model.to_dict())
+    ci1 = model.bootstrap_ci(n_boot=50, seed=1)
+    ci2 = restored.bootstrap_ci(n_boot=50, seed=1)
+    assert np.allclose(ci1, ci2)
+
+
+def test_buckley_james_json_file_round_trip(tmp_path):
+    x, Z, c = _semipar_data(seed=6)
+    model = BuckleyJames.fit(x, Z, c=c)
+    fp = tmp_path / "bj.json"
+    model.to_json(fp)
+    restored = BuckleyJamesModel.from_json(fp)
+    xs = np.array([5.0, 20.0])
+    Zq = np.array([0.1, 0.1])
+    assert np.allclose(
+        np.asarray(model.sf(xs, Zq), dtype=float),
+        np.asarray(restored.sf(xs, Zq), dtype=float),
+    )
+
+
+def test_buckley_james_rejects_wrong_model():
+    with pytest.raises(ValueError, match="BuckleyJamesModel"):
+        BuckleyJamesModel.from_dict({"model": "Other"})

--- a/surpyval/univariate/regression/__init__.py
+++ b/surpyval/univariate/regression/__init__.py
@@ -51,6 +51,7 @@ from .proportional_hazards import (
     WeibullPH,
 )
 from .parametric_regression_model import ParametricRegressionModel
+from .semi_parametric_regression_model import SemiParametricRegressionModel
 from .proportional_odds import (
     PO,
     ExponentialPO,
@@ -64,8 +65,9 @@ from .proportional_odds import (
 )
 
 __all__ = [
-    # Base result class (holds to_dict / from_dict / to_json / from_json)
+    # Result classes that hold to_dict / from_dict / to_json / from_json
     "ParametricRegressionModel",
+    "SemiParametricRegressionModel",
     # Buckley-James semi-parametric AFT
     "BuckleyJames",
     "BuckleyJamesModel",

--- a/surpyval/univariate/regression/additive_hazards/additive_hazards.py
+++ b/surpyval/univariate/regression/additive_hazards/additive_hazards.py
@@ -40,8 +40,10 @@ Lin, D. Y. and Ying, Z. (1994), "Semiparametric analysis of the additive
 risk model", Biometrika 81, 61-71.
 """
 
+import json
 from copy import copy
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -123,6 +125,83 @@ class AdditiveHazardsModel:
         for i, p in enumerate(self.beta):
             out += "   beta_{i}  :  {p}\n".format(i=i, p=p)
         return out
+
+    # -- serialisation -----------------------------------------------------
+
+    def to_dict(self) -> dict:
+        """
+        Serialise this fitted Lin-Ying additive-hazards model to a plain,
+        JSON-serialisable dict.
+
+        The baseline is nonparametric, so what is stored is the coefficients
+        ``beta`` and the fitted baseline step arrays (event times ``x`` and the
+        baseline hazard ``h0`` / cumulative hazard ``H0``), along with the
+        parameter covariance so the restored model can still report standard
+        errors. Everything needed for ``hf``/``Hf``/``sf``/``ff``/``df`` (and
+        ``se``/``cov``) round-trips exactly. The internal estimating-equation
+        matrices (``_A``, ``_b``) are not stored.
+
+        See Also
+        --------
+        from_dict, to_json, from_json
+        """
+        out: dict[str, Any] = {
+            "model": "AdditiveHazardsModel",
+            "beta": np.asarray(self.beta, dtype=float).tolist(),
+            "params": np.asarray(self.params, dtype=float).tolist(),
+            "x": np.asarray(self.x, dtype=float).tolist(),
+            "h0": np.asarray(self.h0, dtype=float).tolist(),
+            "H0": np.asarray(self.H0, dtype=float).tolist(),
+            "cov": np.asarray(self.cov, dtype=float).tolist(),
+            "se": np.asarray(self.se, dtype=float).tolist(),
+        }
+        if getattr(self, "p_values", None) is not None:
+            out["p_values"] = np.asarray(self.p_values, dtype=float).tolist()
+        if self.feature_names is not None:
+            out["feature_names"] = list(self.feature_names)
+        if self.formula is not None:
+            out["formula"] = self.formula
+        return out
+
+    def to_json(self, fp: "str | Path") -> None:
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "AdditiveHazardsModel":
+        """
+        Rebuild a Lin-Ying additive-hazards model from a :meth:`to_dict`
+        dictionary.
+
+        See Also
+        --------
+        to_dict, to_json, from_json
+        """
+        if model_dict.get("model") != "AdditiveHazardsModel":
+            raise ValueError(
+                "Must create an additive-hazards model from an "
+                "AdditiveHazardsModel dict"
+            )
+        out = cls()
+        out.beta = np.array(model_dict["beta"], dtype=float)
+        out.params = np.array(model_dict["params"], dtype=float)
+        out.x = np.array(model_dict["x"], dtype=float)
+        out.h0 = np.array(model_dict["h0"], dtype=float)
+        out.H0 = np.array(model_dict["H0"], dtype=float)
+        out.cov = np.array(model_dict["cov"], dtype=float)
+        out.se = np.array(model_dict["se"], dtype=float)
+        if "p_values" in model_dict:
+            out.p_values = np.array(model_dict["p_values"], dtype=float)
+        out.feature_names = model_dict.get("feature_names")
+        out.formula = model_dict.get("formula")
+        return out
+
+    @classmethod
+    def from_json(cls, fp: "str | Path") -> "AdditiveHazardsModel":
+        """Load a model from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     def _h0_at(self, x: npt.NDArray) -> npt.NDArray:
         # Right-continuous step lookup of the baseline (cumulative) hazard at

--- a/surpyval/univariate/regression/buckley_james/buckley_james.py
+++ b/surpyval/univariate/regression/buckley_james/buckley_james.py
@@ -33,6 +33,7 @@ two-point cycle rather than a fixed point -- a known feature of the estimator
 -- which is detected and resolved by averaging the cycle.
 """
 
+import json
 import warnings
 
 import numpy as np
@@ -181,6 +182,91 @@ class BuckleyJamesModel:
             self._resid_surv[np.clip(idx, 0, len(self._resid_surv) - 1)],
         )
         return out
+
+    # -- serialisation -----------------------------------------------------
+
+    def to_dict(self):
+        """
+        Serialise this fitted Buckley-James model to a plain, JSON-serialisable
+        dict.
+
+        Predictions use the residual Kaplan-Meier ``sf(t | Z) =
+        S_eps(log t + beta'Z)``, so what is stored is the coefficients ``beta``
+        and the residual survival step arrays (``_resid`` and ``_resid_surv``).
+        The fit data ``(Y, delta, Z, w)`` is stored too, so the restored model
+        can still run :meth:`bootstrap_ci`.
+
+        See Also
+        --------
+        from_dict, to_json, from_json
+        """
+        out = {
+            "model": "BuckleyJamesModel",
+            "beta": np.asarray(self.beta, dtype=float).tolist(),
+            "resid": np.asarray(self._resid, dtype=float).tolist(),
+            "resid_surv": np.asarray(self._resid_surv, dtype=float).tolist(),
+            "n_iter": int(self.n_iter),
+            "converged": bool(self.converged),
+        }
+        if self._data is not None:
+            Y, delta, Z, w = self._data
+            out["data"] = {
+                "Y": np.asarray(Y, dtype=float).tolist(),
+                "delta": np.asarray(delta, dtype=float).tolist(),
+                "Z": np.asarray(Z, dtype=float).tolist(),
+                "w": np.asarray(w, dtype=float).tolist(),
+            }
+        if self.feature_names is not None:
+            out["feature_names"] = list(self.feature_names)
+        if self.formula is not None:
+            out["formula"] = self.formula
+        return out
+
+    def to_json(self, fp):
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict):
+        """
+        Rebuild a Buckley-James model from a :meth:`to_dict` dictionary.
+
+        See Also
+        --------
+        to_dict, to_json, from_json
+        """
+        if model_dict.get("model") != "BuckleyJamesModel":
+            raise ValueError(
+                "Must create a Buckley-James model from a "
+                "BuckleyJamesModel dict"
+            )
+        data = None
+        if "data" in model_dict:
+            d = model_dict["data"]
+            data = (
+                np.array(d["Y"], dtype=float),
+                np.array(d["delta"], dtype=float),
+                np.array(d["Z"], dtype=float),
+                np.array(d["w"], dtype=float),
+            )
+        out = cls(
+            np.array(model_dict["beta"], dtype=float),
+            np.array(model_dict["resid"], dtype=float),
+            np.array(model_dict["resid_surv"], dtype=float),
+            int(model_dict["n_iter"]),
+            bool(model_dict["converged"]),
+            data,
+        )
+        out.feature_names = model_dict.get("feature_names")
+        out.formula = model_dict.get("formula")
+        return out
+
+    @classmethod
+    def from_json(cls, fp):
+        """Load a model from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     def sf(self, x, Z):
         """Survival ``P(T > x | Z) = S_eps(log x - beta'Z)`` for a single

--- a/surpyval/univariate/regression/semi_parametric_regression_model.py
+++ b/surpyval/univariate/regression/semi_parametric_regression_model.py
@@ -1,3 +1,5 @@
+import json
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 import autograd.numpy as np
@@ -64,6 +66,105 @@ class SemiParametricRegressionModel:
         for i, p in enumerate(self.params):
             out += "   beta_{i}  :  {p}\n".format(i=i, p=p)
         return out
+
+    # -- serialisation -----------------------------------------------------
+
+    def to_dict(self) -> dict:
+        """
+        Serialise this fitted Cox model to a plain, JSON-serialisable dict.
+
+        The Cox model is a proportional-hazards fit with a *nonparametric*
+        baseline, so what is stored is the covariate coefficients ``beta`` and
+        the fitted baseline step arrays (event times ``x`` and the baseline
+        hazard ``h0`` / cumulative hazard ``H0``); the hazard multiplier
+        ``phi(Z) = exp(beta'Z)`` is rebuilt from ``beta`` on load. Everything
+        needed for ``hf``/``Hf``/``sf``/``ff``/``df`` (and, for a
+        time-varying-covariate fit, ``predict_tvc``) round-trips exactly. The
+        optimiser objects (the ``neg_ll`` closure, ``jac``, ``hess``, ``res``)
+        are not stored.
+
+        See Also
+        --------
+        from_dict, to_json, from_json
+        """
+        out: dict[str, Any] = {
+            "model": "SemiParametricRegressionModel",
+            "kind": self.kind,
+            "parameterization": self.parameterization,
+            "beta": np.asarray(self.beta, dtype=float).tolist(),
+            "params": np.asarray(self.params, dtype=float).tolist(),
+            "x": np.asarray(self.x, dtype=float).tolist(),
+            "r": np.asarray(self.r, dtype=float).tolist(),
+            "d": np.asarray(self.d, dtype=float).tolist(),
+            "h0": np.asarray(self.h0, dtype=float).tolist(),
+            "H0": np.asarray(self.H0, dtype=float).tolist(),
+            "tie_method": self.tie_method,
+            "baseline_method": self.baseline_method,
+            "is_tvc": bool(self.is_tvc),
+        }
+        if getattr(self, "tl", None) is not None:
+            out["tl"] = np.asarray(self.tl, dtype=float).tolist()
+        if getattr(self, "p_values", None) is not None:
+            out["p_values"] = np.asarray(self.p_values, dtype=float).tolist()
+        if getattr(self, "_neg_log_like", None) is not None:
+            out["_neg_log_like"] = float(self._neg_log_like)
+        if self.feature_names is not None:
+            out["feature_names"] = list(self.feature_names)
+        if self.formula is not None:
+            out["formula"] = self.formula
+        return out
+
+    def to_json(self, fp: "str | Path") -> None:
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "SemiParametricRegressionModel":
+        """
+        Rebuild a Cox model from a :meth:`to_dict` dictionary.
+
+        See Also
+        --------
+        to_dict, to_json, from_json
+        """
+        if model_dict.get("model") != "SemiParametricRegressionModel":
+            raise ValueError(
+                "Must create a Cox model from a "
+                "SemiParametricRegressionModel dict"
+            )
+        out = cls(model_dict["kind"], model_dict["parameterization"])
+        beta = np.array(model_dict["beta"], dtype=float)
+        out.beta = beta
+        out.params = np.array(model_dict["params"], dtype=float)
+        out.x = np.array(model_dict["x"], dtype=float)
+        out.r = np.array(model_dict["r"], dtype=float)
+        out.d = np.array(model_dict["d"], dtype=float)
+        out.h0 = np.array(model_dict["h0"], dtype=float)
+        out.H0 = np.array(model_dict["H0"], dtype=float)
+        # phi is fully determined by beta
+        out.phi = lambda Z: np.exp(np.asarray(Z, dtype=float) @ out.beta)
+        out.tie_method = model_dict["tie_method"]
+        out.baseline_method = model_dict["baseline_method"]
+        out.is_tvc = bool(model_dict.get("is_tvc", False))
+        out.tl = (
+            np.array(model_dict["tl"], dtype=float)
+            if "tl" in model_dict
+            else None
+        )
+        if "p_values" in model_dict:
+            out.p_values = np.array(model_dict["p_values"], dtype=float)
+        if "_neg_log_like" in model_dict:
+            out._neg_log_like = float(model_dict["_neg_log_like"])
+        out.feature_names = model_dict.get("feature_names")
+        out.formula = model_dict.get("formula")
+        return out
+
+    @classmethod
+    def from_json(cls, fp: "str | Path") -> "SemiParametricRegressionModel":
+        """Load a model from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     def hf(
         self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"


### PR DESCRIPTION
Follows the parametric-regression serialisation (#179) by giving the three **semi-parametric** regression result classes the same `to_dict`/`from_dict`/`to_json`/`from_json` API. Their baseline is nonparametric, so each stores its coefficients plus the fitted baseline (or residual survival) and rebuilds the rest on load.

### What's covered
- **Cox PH** (`SemiParametricRegressionModel`) — stores `beta` + the baseline step arrays (`x`, `h0`, `H0`) and rebuilds `phi(Z) = exp(βʹZ)` from `beta`. `hf`/`Hf`/`sf`/`ff`/`df` **and** the time-varying-covariate `predict_tvc` round-trip exactly.
- **Lin-Ying additive hazards** (`AdditiveHazardsModel`) — stores `beta` + baseline (`x`, `h0`, `H0`) + the parameter covariance, so `se()`/`cov()` also survive.
- **Buckley-James AFT** (`BuckleyJamesModel`) — stores `beta` + the residual-KM arrays, plus the fit data so `bootstrap_ci` still works after a reload.

### Details
- Each dict carries a `"model"` tag and `from_dict` refuses a mismatched one.
- Optimiser closures (`neg_ll`/`jac`/`hess`/`res`) and internal estimating-equation matrices (`_A`, `_b`) are dropped — not needed for prediction or the retained inference.
- `SemiParametricRegressionModel` is now exported from `surpyval.univariate.regression` (the other two already were).

### Validation
- Predictions round-trip to `1e-12` for all three families; Cox `predict_tvc`, the additive `cov`/`se`, and Buckley-James `bootstrap_ci` (seeded) reproduce exactly after a reload; JSON file variants verified.
- New `test_semiparametric_serialisation.py` (11 tests). Full regression suite green (148 passed); flake8 / black / `mypy surpyval` clean.
- Docs ("Regression Modelling") and changelog updated.

Part of the broader effort to make every fitted model saveable. Next up in the campaign: the recurrent-event models, then degradation, then competing-risks + mixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_