### PR TITLE
Add serialisation to the recurrent-event models

### DIFF
--- a/docs/Recurrent Event Modelling with SurPyval.rst
+++ b/docs/Recurrent Event Modelling with SurPyval.rst
@@ -531,6 +531,38 @@ Each ``model.models[cause]`` is an ordinary fitted recurrence model, so it
 carries the full ``cif`` / ``iif``, inference and diagnostic behaviour shown
 above; ``total_cif`` sums the causes for the overall event intensity.
 
+Saving and loading a fitted model
+---------------------------------
+
+Every fitted recurrence model can be serialised to a plain dictionary or a
+JSON file and rebuilt later. The intensity model is stateless, so only its name
+and the fitted parameters are stored (for the nonparametric MCF, the step
+arrays); the reloaded model reproduces every prediction exactly. This works for
+the parametric intensity fits (``CrowAMSAA`` / ``Duane`` / ``Cox-Lewis`` /
+``HPP``), the nonparametric MCF, the proportional-intensity regression, and the
+two cause-specific containers.
+
+.. jupyter-execute::
+
+    import numpy as np
+    from surpyval.recurrent import CrowAMSAA
+    from surpyval.recurrent.parametric.parametric_recurrence import (
+        ParametricRecurrenceModel,
+    )
+
+    events = np.sort(np.random.default_rng(0).uniform(0, 1000, 40))
+    fitted = CrowAMSAA.fit(events)
+
+    blob = fitted.to_dict()                                   # -> dict
+    restored = ParametricRecurrenceModel.from_dict(blob)      # <- dict
+    t = np.array([100.0, 500.0, 900.0])
+    print("match:", np.allclose(fitted.cif(t), restored.cif(t)))
+
+Use ``to_json`` / ``from_json`` for a file directly. The likelihood-inference
+state (the fitted data and the log-likelihood) is not serialised, so a reloaded
+model behaves like a ``from_params`` one for confidence bounds and diagnostics
+— re-fit if you need those.
+
 References
 ----------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,22 @@ Changelog
 v0.15.0 (unreleased)
 --------------------
 
+Recurrent events
+~~~~~~~~~~~~~~~~~
+
+- Added serialisation to the fitted recurrent-event models:
+  ``ParametricRecurrenceModel`` (NHPP/HPP intensity fits),
+  ``NonParametricCounting`` (the MCF estimate), ``ProportionalIntensityModel``
+  (proportional-intensity regression), and the competing-risks containers
+  ``CauseSpecificMCF`` and ``CauseSpecificNHPP`` now have
+  ``to_dict``/``from_dict`` and ``to_json``/``from_json``. The intensity model
+  is stateless, so each stores its name plus the fitted parameters (or, for the
+  MCF, the ``x``/``mcf_hat``/``var`` step arrays), and the reloaded model
+  reproduces ``cif``/``iif``/``mcf`` exactly. Intensity models are resolved by
+  name from a restricted set. The likelihood/data state is not stored, so a
+  reloaded model behaves like a ``from_params`` one for confidence bounds and
+  diagnostics.
+
 Regression
 ~~~~~~~~~~
 

--- a/surpyval/recurrent/competing_risks/nonparametric/cause_specific_mcf.py
+++ b/surpyval/recurrent/competing_risks/nonparametric/cause_specific_mcf.py
@@ -12,6 +12,8 @@ See ``surpyval.univariate.competing_risks`` for the univariate
 (time-to-first-event) competing-risks models.
 """
 
+import json
+
 from autograd import numpy as np
 from matplotlib import pyplot as plt
 
@@ -50,6 +52,58 @@ class CauseSpecificMCF:
 
     def __repr__(self):
         return "Cause-specific MCF with causes: {}".format(self.event_types)
+
+    # -- serialisation -----------------------------------------------------
+
+    def to_dict(self):
+        """
+        Serialise this fitted cause-specific MCF to a plain, JSON-serialisable
+        dict: the list of event types and each cause's per-cause MCF estimate.
+
+        See Also
+        --------
+        from_dict, to_json, from_json
+        """
+        return {
+            "model": "CauseSpecificMCF",
+            "event_types": list(self.event_types),
+            "models": [
+                self.models[cause].to_dict() for cause in self.event_types
+            ],
+        }
+
+    def to_json(self, fp):
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict):
+        """
+        Rebuild a cause-specific MCF from a :meth:`to_dict` dictionary.
+
+        See Also
+        --------
+        to_dict, to_json, from_json
+        """
+        if model_dict.get("model") != "CauseSpecificMCF":
+            raise ValueError(
+                "Must create a cause-specific MCF from a CauseSpecificMCF dict"
+            )
+        out = cls()
+        out.event_types = list(model_dict["event_types"])
+        out.models = {
+            cause: NonParametricCounting.from_dict(sub)
+            for cause, sub in zip(out.event_types, model_dict["models"])
+        }
+        return out
+
+    @classmethod
+    def from_json(cls, fp):
+        """Load a cause-specific MCF from a JSON file written by
+        :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     def mcf(self, x, cause, interp="step"):
         """Cause-specific MCF evaluated at ``x`` for the given ``cause``."""

--- a/surpyval/recurrent/competing_risks/parametric/cause_specific_nhpp.py
+++ b/surpyval/recurrent/competing_risks/parametric/cause_specific_nhpp.py
@@ -19,9 +19,15 @@ reuses the whole intensity-fitting, inference and diagnostic machinery
 unchanged.
 """
 
+import json
+
 from matplotlib import pyplot as plt
 
 from surpyval.recurrent.parametric.crow_amsaa import CrowAMSAA
+from surpyval.recurrent.parametric.parametric_recurrence import (
+    ParametricRecurrenceModel,
+)
+from surpyval.recurrent.serialisation import intensity_dist_by_name
 from surpyval.utils.recurrent_utils import handle_xicn
 
 
@@ -42,6 +48,62 @@ class CauseSpecificNHPP:
         return "Cause-specific {} with causes: {}".format(
             self.dist.name, self.event_types
         )
+
+    # -- serialisation -----------------------------------------------------
+
+    def to_dict(self):
+        """
+        Serialise this fitted cause-specific NHPP to a plain,
+        JSON-serialisable dict: the shared intensity model's name, the list of
+        event types, and each cause's fitted intensity model.
+
+        See Also
+        --------
+        from_dict, to_json, from_json
+        """
+        return {
+            "model": "CauseSpecificNHPP",
+            "dist": self.dist.name,
+            "event_types": list(self.event_types),
+            "models": [
+                self.models[cause].to_dict() for cause in self.event_types
+            ],
+        }
+
+    def to_json(self, fp):
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict):
+        """
+        Rebuild a cause-specific NHPP from a :meth:`to_dict` dictionary.
+
+        See Also
+        --------
+        to_dict, to_json, from_json
+        """
+        if model_dict.get("model") != "CauseSpecificNHPP":
+            raise ValueError(
+                "Must create a cause-specific NHPP from a CauseSpecificNHPP "
+                "dict"
+            )
+        out = cls()
+        out.dist = intensity_dist_by_name(model_dict["dist"])
+        out.event_types = list(model_dict["event_types"])
+        out.models = {
+            cause: ParametricRecurrenceModel.from_dict(sub)
+            for cause, sub in zip(out.event_types, model_dict["models"])
+        }
+        return out
+
+    @classmethod
+    def from_json(cls, fp):
+        """Load a cause-specific NHPP from a JSON file written by
+        :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     # --- per-item observation windows ------------------------------------
 

--- a/surpyval/recurrent/nonparametric/mcf.py
+++ b/surpyval/recurrent/nonparametric/mcf.py
@@ -1,3 +1,5 @@
+import json
+
 from autograd import numpy as np
 from matplotlib import pyplot as plt
 from scipy.stats import norm
@@ -11,6 +13,59 @@ from surpyval.utils.recurrent_utils import (
 
 @singleton_fitter
 class NonParametricCounting:
+    # -- serialisation -----------------------------------------------------
+
+    def to_dict(self):
+        """
+        Serialise this fitted MCF (mean cumulative function) estimate to a
+        plain, JSON-serialisable dict.
+
+        Stores the step arrays that ``mcf``/``mcf_cb`` read: the event times
+        ``x``, the estimate ``mcf_hat`` and its Greenwood variance ``var``.
+        The raw ``data`` is not stored (it is only needed to re-fit or to plot
+        raw counts).
+
+        See Also
+        --------
+        from_dict, to_json, from_json
+        """
+        return {
+            "model": "NonParametricCounting",
+            "x": np.asarray(self.x, dtype=float).tolist(),
+            "mcf_hat": np.asarray(self.mcf_hat, dtype=float).tolist(),
+            "var": np.asarray(self.var, dtype=float).tolist(),
+        }
+
+    def to_json(self, fp):
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict):
+        """
+        Rebuild an MCF estimate from a :meth:`to_dict` dictionary.
+
+        See Also
+        --------
+        to_dict, to_json, from_json
+        """
+        if model_dict.get("model") != "NonParametricCounting":
+            raise ValueError(
+                "Must create an MCF estimate from a NonParametricCounting dict"
+            )
+        out = cls()
+        out.x = np.array(model_dict["x"], dtype=float)
+        out.mcf_hat = np.array(model_dict["mcf_hat"], dtype=float)
+        out.var = np.array(model_dict["var"], dtype=float)
+        return out
+
+    @classmethod
+    def from_json(cls, fp):
+        """Load an MCF estimate from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
+
     def mcf(self, x, interp="step"):
         x = np.atleast_1d(x)
         # Let's not assume we can predict above the highest measurement

--- a/surpyval/recurrent/parametric/parametric_recurrence.py
+++ b/surpyval/recurrent/parametric/parametric_recurrence.py
@@ -1,3 +1,5 @@
+import json
+
 import numpy as np
 from matplotlib import pyplot as plt
 
@@ -7,6 +9,7 @@ from surpyval.recurrent.inference import (
     delta_method_std_errors,
     log_transformed_cb,
 )
+from surpyval.recurrent.serialisation import intensity_dist_by_name
 from surpyval.recurrent.simulation import RecurrenceSimulationMixin
 
 
@@ -34,6 +37,61 @@ class ParametricRecurrenceModel(
     >>> x = Exponential.random(10, 1e-3).cumsum()
     >>> model = HPP.fit(x)
     """
+
+    # -- serialisation -----------------------------------------------------
+
+    def to_dict(self):
+        """
+        Serialise this fitted recurrence model to a plain, JSON-serialisable
+        dict.
+
+        The intensity model is stateless, so only its name and the fitted
+        ``params`` are stored; the reloaded model reproduces ``cif``/``iif``/
+        ``mcf``/``inv_cif`` exactly. Likelihood-inference state (the data and
+        the ``neg_ll`` closure) is not stored, so a reloaded model behaves like
+        a ``from_params`` one for confidence bounds and diagnostics.
+
+        See Also
+        --------
+        from_dict, to_json, from_json
+        """
+        return {
+            "model": "ParametricRecurrenceModel",
+            "dist": self.dist.name,
+            "params": np.asarray(self.params, dtype=float).tolist(),
+            "how": getattr(self, "how", "from_params"),
+        }
+
+    def to_json(self, fp):
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict):
+        """
+        Rebuild a recurrence model from a :meth:`to_dict` dictionary.
+
+        See Also
+        --------
+        to_dict, to_json, from_json
+        """
+        if model_dict.get("model") != "ParametricRecurrenceModel":
+            raise ValueError(
+                "Must create a recurrence model from a "
+                "ParametricRecurrenceModel dict"
+            )
+        out = cls()
+        out.dist = intensity_dist_by_name(model_dict["dist"])
+        out.params = np.array(model_dict["params"], dtype=float)
+        out.how = model_dict.get("how", "from_params")
+        return out
+
+    @classmethod
+    def from_json(cls, fp):
+        """Load a model from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     def _parameter_names(self):
         return list(self.dist.param_names)

--- a/surpyval/recurrent/regression/proportional_intensity.py
+++ b/surpyval/recurrent/regression/proportional_intensity.py
@@ -1,3 +1,5 @@
+import json
+
 import numpy as np
 from matplotlib import pyplot as plt
 
@@ -7,6 +9,7 @@ from surpyval.recurrent.inference import (
     delta_method_std_errors,
     log_transformed_cb,
 )
+from surpyval.recurrent.serialisation import intensity_dist_by_name
 from surpyval.recurrent.simulation import RecurrenceSimulationMixin
 
 
@@ -60,6 +63,76 @@ class ProportionalIntensityModel(
         for i, p in enumerate(self.coeffs):
             out += "   beta_{i}  :  {p}\n".format(i=i, p=p)
         return out
+
+    # -- serialisation -----------------------------------------------------
+
+    def to_dict(self):
+        """
+        Serialise this fitted proportional-intensity model to a plain,
+        JSON-serialisable dict.
+
+        Stores the base-rate intensity model's name, the base-rate ``params``
+        and the covariate ``coeffs``; the reloaded model reproduces
+        ``cif``/``iif`` (``Lambda_0(t; params) * exp(Z . coeffs)``) exactly.
+        The likelihood-inference state (data, ``neg_ll`` closure) is not
+        stored.
+
+        See Also
+        --------
+        from_dict, to_json, from_json
+        """
+        return {
+            "model": "ProportionalIntensityModel",
+            "kind": self.kind,
+            "parameterization": self.parameterization,
+            "dist": self.dist.name,
+            "param_names": list(self.param_names),
+            "params": np.asarray(self.params, dtype=float).tolist(),
+            "coeffs": np.asarray(self.coeffs, dtype=float).tolist(),
+        }
+
+    def to_json(self, fp):
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict):
+        """
+        Rebuild a proportional-intensity model from a :meth:`to_dict`
+        dictionary.
+
+        See Also
+        --------
+        to_dict, to_json, from_json
+        """
+        if model_dict.get("model") != "ProportionalIntensityModel":
+            raise ValueError(
+                "Must create a proportional-intensity model from a "
+                "ProportionalIntensityModel dict"
+            )
+        out = cls()
+        out.kind = model_dict["kind"]
+        out.parameterization = model_dict["parameterization"]
+        if out.kind == "HPP":
+            # the constant-rate baseline is the PI-HPP fitter itself
+            import surpyval.recurrent as recurrent
+
+            out.dist = recurrent.ProportionalIntensityHPP
+            out.bounds = ((0, None),)
+            out.support = (0.0, np.inf)
+        else:
+            out.dist = intensity_dist_by_name(model_dict["dist"])
+        out.param_names = list(model_dict["param_names"])
+        out.params = np.array(model_dict["params"], dtype=float)
+        out.coeffs = np.array(model_dict["coeffs"], dtype=float)
+        return out
+
+    @classmethod
+    def from_json(cls, fp):
+        """Load a model from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     def cif(self, x, Z):
         """

--- a/surpyval/recurrent/serialisation.py
+++ b/surpyval/recurrent/serialisation.py
@@ -1,0 +1,32 @@
+"""Shared helpers for serialising fitted recurrent-event models.
+
+The recurrence intensity models (``HPP``, ``CrowAMSAA``, ``Duane``,
+``CoxLewis``) are stateless singletons whose maths is fully determined by
+their identity, so a fitted model only needs to store its intensity model's
+name alongside the fitted parameters. The display ``name`` of an intensity
+model does not match its module attribute name, so reconstruction goes through
+an explicit name map here.
+"""
+
+
+def intensity_dist_by_name(name):
+    """
+    Resolve a recurrence intensity model from its display ``name``.
+
+    Restricted to the known intensity models so an untrusted dict cannot
+    resolve an arbitrary attribute.
+    """
+    import surpyval.recurrent as recurrent
+
+    mapping = {
+        "Homogeneous Poisson Process": recurrent.HPP,
+        "Crow-AMSAA": recurrent.CrowAMSAA,
+        "Duane": recurrent.Duane,
+        "Cox-Lewis": recurrent.CoxLewis,
+    }
+    if name not in mapping:
+        raise ValueError(
+            "Unknown recurrence intensity model '{}'; expected one of "
+            "{}".format(name, sorted(mapping))
+        )
+    return mapping[name]

--- a/surpyval/tests/recurrent/test_serialisation.py
+++ b/surpyval/tests/recurrent/test_serialisation.py
@@ -1,0 +1,222 @@
+"""Serialisation of the fitted recurrent-event models.
+
+The recurrence result classes -- the parametric intensity fit
+(``ParametricRecurrenceModel``), the nonparametric MCF
+(``NonParametricCounting``), the proportional-intensity regression
+(``ProportionalIntensityModel``), and the competing-risks containers
+(``CauseSpecificMCF``, ``CauseSpecificNHPP``) -- round-trip through
+``to_dict``/``from_dict`` (and the JSON file variants). The intensity model is
+stateless, so each stores its name plus the fitted parameters (or, for the
+MCF, the step arrays), and the reloaded model reproduces every prediction
+exactly.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from surpyval.recurrent import (
+    CrowAMSAA,
+    Duane,
+    NonParametricCounting,
+    ProportionalIntensityHPP,
+    ProportionalIntensityNHPP,
+)
+from surpyval.recurrent.competing_risks import (
+    CauseSpecificMCF,
+    CauseSpecificNHPP,
+)
+from surpyval.recurrent.parametric.parametric_recurrence import (
+    ParametricRecurrenceModel,
+)
+
+
+def _rt(d):
+    """JSON round-trip a dict (proves it is JSON-serialisable)."""
+    return json.loads(json.dumps(d))
+
+
+def _pi_data(seed=0, n_items=25):
+    rng = np.random.default_rng(seed)
+    xs, ii, cc, ZZ = [], [], [], []
+    for item in range(n_items):
+        z = rng.normal(0, 1)
+        for _ in range(int(rng.integers(2, 6))):
+            xs.append(float(rng.uniform(0, 500)))
+            ii.append(item)
+            cc.append(0)
+            ZZ.append([z])
+        xs.append(500.0)
+        ii.append(item)
+        cc.append(1)
+        ZZ.append([z])
+    return np.array(xs), np.array(ii), np.array(cc), np.array(ZZ)
+
+
+# -- ParametricRecurrenceModel --------------------------------------------
+
+
+@pytest.mark.parametrize("fitter", [CrowAMSAA, Duane])
+def test_parametric_recurrence_round_trip(fitter):
+    rng = np.random.default_rng(1)
+    x = np.sort(rng.uniform(0, 1000, 40))
+    model = fitter.fit(x)
+    restored = ParametricRecurrenceModel.from_dict(_rt(model.to_dict()))
+    xt = np.array([100.0, 500.0, 900.0])
+    assert np.allclose(model.cif(xt), restored.cif(xt))
+    assert np.allclose(model.iif(xt), restored.iif(xt))
+    assert np.allclose(model.params, restored.params)
+    assert model.dist.name == restored.dist.name
+
+
+def test_parametric_recurrence_json_file(tmp_path):
+    rng = np.random.default_rng(2)
+    x = np.sort(rng.uniform(0, 1000, 30))
+    model = CrowAMSAA.fit(x)
+    fp = tmp_path / "nhpp.json"
+    model.to_json(fp)
+    restored = ParametricRecurrenceModel.from_json(fp)
+    xt = np.array([200.0, 800.0])
+    assert np.allclose(model.cif(xt), restored.cif(xt))
+
+
+def test_parametric_recurrence_rejects_wrong_model():
+    with pytest.raises(ValueError, match="ParametricRecurrenceModel"):
+        ParametricRecurrenceModel.from_dict({"model": "Other"})
+
+
+def test_parametric_recurrence_rejects_unknown_dist():
+    d = {"model": "ParametricRecurrenceModel", "dist": "Nope", "params": [1.0]}
+    with pytest.raises(ValueError, match="Unknown recurrence intensity"):
+        ParametricRecurrenceModel.from_dict(d)
+
+
+# -- NonParametricCounting (MCF) ------------------------------------------
+
+
+def test_mcf_round_trip():
+    x = np.array([5, 10, 15, 4, 9, 12, 20], dtype=float)
+    i = np.array([1, 1, 1, 2, 2, 3, 3])
+    c = np.array([0, 0, 1, 0, 1, 0, 1])
+    model = NonParametricCounting.fit(x, i, c)
+    restored = NonParametricCounting.from_dict(_rt(model.to_dict()))
+    grid = np.array([6.0, 11.0, 16.0])
+    assert np.allclose(model.mcf(grid), restored.mcf(grid), equal_nan=True)
+    assert np.allclose(model.x, restored.x)
+    assert np.allclose(model.var, restored.var)
+
+
+def test_mcf_json_file(tmp_path):
+    x = np.array([5, 10, 15, 4, 9], dtype=float)
+    i = np.array([1, 1, 1, 2, 2])
+    c = np.array([0, 0, 1, 0, 1])
+    model = NonParametricCounting.fit(x, i, c)
+    fp = tmp_path / "mcf.json"
+    model.to_json(fp)
+    restored = NonParametricCounting.from_json(fp)
+    grid = np.array([6.0, 11.0])
+    assert np.allclose(model.mcf(grid), restored.mcf(grid), equal_nan=True)
+
+
+# -- ProportionalIntensityModel -------------------------------------------
+
+
+def test_proportional_intensity_nhpp_round_trip():
+    x, i, c, Z = _pi_data(seed=3)
+    model = ProportionalIntensityNHPP.fit(x, Z, i=i, c=c, dist=Duane)
+    restored = type(model).from_dict(_rt(model.to_dict()))
+    xt = np.array([100.0, 300.0, 450.0])
+    Zq = np.array([0.5])
+    assert np.allclose(model.cif(xt, Zq), restored.cif(xt, Zq))
+    assert np.allclose(model.iif(xt, Zq), restored.iif(xt, Zq))
+    assert np.allclose(model.params, restored.params)
+    assert np.allclose(model.coeffs, restored.coeffs)
+
+
+def test_proportional_intensity_hpp_round_trip():
+    x, i, c, Z = _pi_data(seed=4)
+    model = ProportionalIntensityHPP.fit(x, Z, i=i, c=c)
+    assert model.kind == "HPP"
+    restored = type(model).from_dict(_rt(model.to_dict()))
+    xt = np.array([100.0, 300.0])
+    Zq = np.array([0.5])
+    assert np.allclose(model.cif(xt, Zq), restored.cif(xt, Zq))
+    assert np.allclose(model.iif(xt, Zq), restored.iif(xt, Zq))
+
+
+def test_proportional_intensity_rejects_wrong_model():
+    with pytest.raises(ValueError, match="ProportionalIntensityModel"):
+        from surpyval.recurrent.regression.proportional_intensity import (
+            ProportionalIntensityModel,
+        )
+
+        ProportionalIntensityModel.from_dict({"model": "Other"})
+
+
+# -- Cause-specific containers --------------------------------------------
+
+
+def test_cause_specific_mcf_round_trip():
+    x = np.array([5, 10, 15, 4, 9, 12, 20], dtype=float)
+    i = np.array([1, 1, 1, 2, 2, 3, 3])
+    c = np.array([0, 0, 1, 0, 1, 0, 1])
+    e = np.array(["A", "B", "A", "A", "B", "B", "A"])
+    model = CauseSpecificMCF.fit(x, i, c, e=e)
+    restored = CauseSpecificMCF.from_dict(_rt(model.to_dict()))
+    assert restored.event_types == model.event_types
+    grid = np.array([6.0, 11.0, 16.0])
+    for cause in model.event_types:
+        assert np.allclose(
+            model.mcf(grid, cause),
+            restored.mcf(grid, cause),
+            equal_nan=True,
+        )
+
+
+def test_cause_specific_nhpp_round_trip():
+    rng = np.random.default_rng(5)
+    xs, ii, cc, es = [], [], [], []
+    for item in range(20):
+        for _ in range(int(rng.integers(2, 5))):
+            xs.append(float(rng.uniform(0, 400)))
+            ii.append(item)
+            cc.append(0)
+            es.append(rng.choice(["A", "B"]))
+        xs.append(400.0)
+        ii.append(item)
+        cc.append(1)
+        es.append(None)
+    model = CauseSpecificNHPP.fit(
+        np.array(xs), np.array(ii), np.array(cc), e=np.array(es, dtype=object)
+    )
+    restored = CauseSpecificNHPP.from_dict(_rt(model.to_dict()))
+    assert restored.dist.name == model.dist.name
+    assert restored.event_types == model.event_types
+    xt = np.array([50.0, 200.0, 350.0])
+    for cause in model.event_types:
+        assert np.allclose(model.cif(xt, cause), restored.cif(xt, cause))
+
+
+def test_cause_specific_nhpp_json_file(tmp_path):
+    rng = np.random.default_rng(6)
+    xs, ii, cc, es = [], [], [], []
+    for item in range(15):
+        for _ in range(int(rng.integers(2, 5))):
+            xs.append(float(rng.uniform(0, 400)))
+            ii.append(item)
+            cc.append(0)
+            es.append(rng.choice(["A", "B"]))
+        xs.append(400.0)
+        ii.append(item)
+        cc.append(1)
+        es.append(None)
+    model = CauseSpecificNHPP.fit(
+        np.array(xs), np.array(ii), np.array(cc), e=np.array(es, dtype=object)
+    )
+    fp = tmp_path / "csnhpp.json"
+    model.to_json(fp)
+    restored = CauseSpecificNHPP.from_json(fp)
+    xt = np.array([100.0, 300.0])
+    for cause in model.event_types:
+        assert np.allclose(model.cif(xt, cause), restored.cif(xt, cause))


### PR DESCRIPTION
Continues the "make every fitted model saveable" campaign into the **recurrent-event** subsystem. All five recurrence result classes now round-trip through `to_dict`/`from_dict` and `to_json`/`from_json`.

### Covered
- **`ParametricRecurrenceModel`** (NHPP/HPP intensity fits) — the intensity model is stateless, so it stores the model's name + fitted `params` and rebuilds the `dist` from a restricted name map; `cif`/`iif`/`mcf`/`inv_cif` round-trip exactly.
- **`NonParametricCounting`** (the MCF estimate) — stores the `x`/`mcf_hat`/`var` step arrays that `mcf`/`mcf_cb` read.
- **`ProportionalIntensityModel`** — stores the base-rate model name + `params` + covariate `coeffs`; disambiguates the PI-HPP vs PI-NHPP baseline by `kind`.
- **`CauseSpecificMCF`** / **`CauseSpecificNHPP`** — competing-risks containers that serialise `event_types` plus each per-cause sub-model, reusing the two classes above.

### Details
- New `surpyval/recurrent/serialisation.py` holds the `name → intensity-model` map (their display names — e.g. `"Crow-AMSAA"` — don't match their attribute names, so name resolution goes through an explicit, restricted map).
- Each dict carries a `"model"` tag and `from_dict` refuses a mismatched one; unknown intensity names are rejected.
- The likelihood/data state (`neg_ll` closure, fitted `data`) is not stored, so a reloaded model behaves like a `from_params` one for confidence bounds and diagnostics — consistent with the library's existing `from_params` behaviour.

### Validation
- Predictions round-trip exactly for all five classes; verified across `CrowAMSAA`/`Duane`, both `ProportionalIntensity` variants, and both cause-specific containers, plus the JSON file variants and the guard paths.
- New `test_serialisation.py` (13 tests). Full recurrent suite green (330 passed); flake8 / black / `mypy surpyval` clean.
- Docs ("Recurrent Event Modelling") gain a runnable save/load section; changelog updated.

Campaign status: parametric regression ✅ (#179), semi-parametric regression ✅ (#180), recurrent ← this PR. Next: degradation models, then competing-risks + mixtures, then the hard ones (renewal, forest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_