### PR TITLE
Add serialisation to the degradation models

### DIFF
--- a/docs/Degradation Analysis.rst
+++ b/docs/Degradation Analysis.rst
@@ -809,6 +809,34 @@ rather than through noisy per-unit pseudo failure times. The general-path models
 remain the better choice when each unit truly follows a smooth deterministic
 trend observed with error, or when you need a specific parametric path shape.
 
+Saving and loading a fitted model
+---------------------------------
+
+Every fitted degradation model can be serialised to a dictionary or JSON file
+and rebuilt later — the general-path ``DegradationModel``, the stochastic-
+process ``WienerProcessModel`` / ``GammaProcessModel``, and the
+``InducedFailureDistribution``:
+
+.. jupyter-execute::
+
+    from surpyval.degradation import DegradationAnalysis, DegradationModel
+
+    saveable = DegradationAnalysis.fit(
+        np.tile(np.arange(100, 1100, 100), 4),
+        10 + np.repeat([0.31, 0.28, 0.44, 0.37], 10)
+        * np.tile(np.arange(100, 1100, 100), 4),
+        np.repeat([1, 2, 3, 4], 10),
+        threshold=150,
+    )
+    reloaded = DegradationModel.from_dict(saveable.to_dict())
+    grid = np.array([300.0, 450.0, 600.0])
+    print("match:", np.allclose(saveable.sf(grid), reloaded.sf(grid)))
+
+Use ``to_json`` / ``from_json`` for a file directly. ``DegradationModel`` stores
+its raw data, so the reloaded model can also produce bootstrap confidence
+bounds; its fitted life model (plain or accelerated) round-trips through its own
+serialisation.
+
 References
 ----------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,21 @@ Changelog
 v0.15.0 (unreleased)
 --------------------
 
+Degradation
+~~~~~~~~~~~
+
+- Added serialisation to the fitted degradation models:
+  ``DegradationModel``, the stochastic-process models ``WienerProcessModel``
+  and ``GammaProcessModel``, and the Monte-Carlo ``InducedFailureDistribution``
+  now have ``to_dict``/``from_dict`` and ``to_json``/``from_json``. The process
+  models store their few parameters; the induced distribution stores its
+  samples (the ``inf`` never-fails draws are written as ``null`` so the result
+  is valid JSON); and ``DegradationModel`` stores its raw data, the path model
+  (by name) and per-unit fits, the population summaries, and the fitted life
+  model (via its own ``to_dict`` -- plain or accelerated), so the reloaded
+  model reproduces its predictions and per-unit paths and (because the data is
+  kept) its bootstrap confidence bounds too.
+
 Recurrent events
 ~~~~~~~~~~~~~~~~~
 

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -11,6 +11,7 @@ observed time.
 """
 
 import inspect
+import json
 import warnings
 from dataclasses import dataclass, field
 from numbers import Number
@@ -159,6 +160,49 @@ class InducedFailureDistribution:
         self.threshold = float(threshold)
         self.path_name = path_name
         self.prob_never_fails = float(np.mean(~np.isfinite(self.samples)))
+
+    def to_dict(self) -> dict:
+        """
+        Serialise this induced failure-time distribution to a plain dict.
+
+        Stores the Monte-Carlo samples (the ``inf`` never-fails draws are
+        written as ``null`` so the result is valid JSON), the threshold and the
+        path model's name.
+        """
+        samples = [
+            None if not np.isfinite(s) else float(s) for s in self.samples
+        ]
+        return {
+            "model": "InducedFailureDistribution",
+            "samples": samples,
+            "threshold": self.threshold,
+            "path_name": self.path_name,
+        }
+
+    def to_json(self, fp) -> None:
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "InducedFailureDistribution":
+        """Rebuild an induced failure-time distribution from a dict."""
+        if model_dict.get("model") != "InducedFailureDistribution":
+            raise ValueError(
+                "Must create an induced failure-time distribution from an "
+                "InducedFailureDistribution dict"
+            )
+        samples = np.array(
+            [np.inf if s is None else s for s in model_dict["samples"]],
+            dtype=float,
+        )
+        return cls(samples, model_dict["threshold"], model_dict["path_name"])
+
+    @classmethod
+    def from_json(cls, fp) -> "InducedFailureDistribution":
+        """Load from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     def ff(self, x: npt.ArrayLike) -> "float | npt.NDArray":
         """Failure probability ``P(T <= x)`` from the Monte-Carlo draws."""
@@ -336,6 +380,132 @@ class DegradationModel:
         self.path_selection = path_selection
         self.Z = Z
         self._unit_index = {unit: idx for idx, unit in enumerate(units)}
+
+    # -- serialisation -----------------------------------------------------
+
+    @staticmethod
+    def _life_model_to_dict(life_model) -> dict:
+        out = life_model.to_dict()
+        out["_life_class"] = (
+            "ParametricRegressionModel"
+            if isinstance(life_model, ParametricRegressionModel)
+            else "Parametric"
+        )
+        return out
+
+    @staticmethod
+    def _life_model_from_dict(life_dict: dict):
+        life_dict = dict(life_dict)
+        life_class = life_dict.pop("_life_class")
+        if life_class == "ParametricRegressionModel":
+            return ParametricRegressionModel.from_dict(life_dict)
+        return Parametric.from_dict(life_dict)
+
+    def to_dict(self) -> dict:
+        """
+        Serialise this fitted degradation model to a plain, JSON-serialisable
+        dict.
+
+        Everything needed to rebuild the model is stored: the raw measurement
+        data, the path model (by name) and its per-unit fitted parameters, the
+        pseudo failure times and censor flags, the fitted life model (its own
+        ``to_dict``), and the population summaries. The restored model
+        reproduces the life predictions and per-unit paths, and (because the
+        raw data is kept) its bootstrap confidence bounds too.
+
+        See Also
+        --------
+        from_dict, to_json, from_json
+        """
+        return {
+            "model": "DegradationModel",
+            "x": np.asarray(self.x, dtype=float).tolist(),
+            "y": np.asarray(self.y, dtype=float).tolist(),
+            "i": np.asarray(self.i).tolist(),
+            "units": np.asarray(self.units).tolist(),
+            "threshold": float(self.threshold),
+            "path_model": self.path_model.name,
+            "path_params": np.asarray(self.path_params, dtype=float).tolist(),
+            "pseudo_failure_times": np.asarray(
+                self.pseudo_failure_times, dtype=float
+            ).tolist(),
+            "c": np.asarray(self.c).tolist(),
+            "life_model": self._life_model_to_dict(self.life_model),
+            "measurement_var": float(self.measurement_var),
+            "path_param_mean": np.asarray(
+                self.path_param_mean, dtype=float
+            ).tolist(),
+            "path_param_cov": np.asarray(
+                self.path_param_cov, dtype=float
+            ).tolist(),
+            "path_param_sample_cov": np.asarray(
+                self.path_param_sample_cov, dtype=float
+            ).tolist(),
+            "population_method": self.population_method,
+            "path_selection": self.path_selection,
+            "Z": None if self.Z is None else np.asarray(self.Z).tolist(),
+            "how": self._how,
+        }
+
+    def to_json(self, fp) -> None:
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "DegradationModel":
+        """
+        Rebuild a degradation model from a :meth:`to_dict` dictionary.
+
+        The path model is resolved by name and the life model by its own
+        ``from_dict``; both are restricted to the known types.
+
+        See Also
+        --------
+        to_dict, to_json, from_json
+        """
+        if model_dict.get("model") != "DegradationModel":
+            raise ValueError(
+                "Must create a degradation model from a DegradationModel dict"
+            )
+        Z = model_dict.get("Z")
+        out = cls(
+            x=np.array(model_dict["x"], dtype=float),
+            y=np.array(model_dict["y"], dtype=float),
+            i=np.array(model_dict["i"]),
+            units=np.array(model_dict["units"]),
+            threshold=float(model_dict["threshold"]),
+            path_model=get_path_model(model_dict["path_model"]),
+            path_params=np.array(model_dict["path_params"], dtype=float),
+            pseudo_failure_times=np.array(
+                model_dict["pseudo_failure_times"], dtype=float
+            ),
+            c=np.array(model_dict["c"]),
+            life_model=cls._life_model_from_dict(model_dict["life_model"]),
+            measurement_var=float(model_dict["measurement_var"]),
+            path_param_mean=np.array(
+                model_dict["path_param_mean"], dtype=float
+            ),
+            path_param_cov=np.array(model_dict["path_param_cov"], dtype=float),
+            path_param_sample_cov=np.array(
+                model_dict["path_param_sample_cov"], dtype=float
+            ),
+            population_method=model_dict["population_method"],
+            path_selection=model_dict.get("path_selection"),
+            Z=None if Z is None else np.array(Z, dtype=float),
+        )
+        # Recorded so bootstrap bounds can rerun the pipeline; the original
+        # distribution object is not serialised, so bounds default to the
+        # analytic method after a reload.
+        out._distribution = None
+        out._how = model_dict.get("how", "MLE")
+        return out
+
+    @classmethod
+    def from_json(cls, fp) -> "DegradationModel":
+        """Load a model from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     @property
     def is_accelerated(self) -> bool:

--- a/surpyval/degradation/process_models.py
+++ b/surpyval/degradation/process_models.py
@@ -21,6 +21,8 @@ degradation:
   distribution comes from the (regularised) incomplete gamma function.
 """
 
+import json
+
 import numpy as np
 from scipy.integrate import quad
 from scipy.optimize import brentq, minimize_scalar
@@ -144,6 +146,38 @@ class WienerProcessModel:
         self.threshold = float(threshold)
         self.params = np.array([self.mu, self.sigma])
         self.param_names = ["mu", "sigma"]
+
+    def to_dict(self) -> dict:
+        """Serialise this fitted Wiener-process model to a plain dict."""
+        return {
+            "model": "WienerProcessModel",
+            "mu": self.mu,
+            "sigma": self.sigma,
+            "threshold": self.threshold,
+        }
+
+    def to_json(self, fp) -> None:
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "WienerProcessModel":
+        """Rebuild a Wiener-process model from a :meth:`to_dict` dict."""
+        if model_dict.get("model") != "WienerProcessModel":
+            raise ValueError(
+                "Must create a Wiener-process model from a WienerProcessModel "
+                "dict"
+            )
+        return cls(
+            model_dict["mu"], model_dict["sigma"], model_dict["threshold"]
+        )
+
+    @classmethod
+    def from_json(cls, fp) -> "WienerProcessModel":
+        """Load a model from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     def _ig(self, distance):
         # Inverse-Gaussian (mean nu, shape lam) parameters for first passage
@@ -339,6 +373,38 @@ class GammaProcessModel:
         self.threshold = float(threshold)
         self.params = np.array([self.alpha, self.beta])
         self.param_names = ["alpha", "beta"]
+
+    def to_dict(self) -> dict:
+        """Serialise this fitted gamma-process model to a plain dict."""
+        return {
+            "model": "GammaProcessModel",
+            "alpha": self.alpha,
+            "beta": self.beta,
+            "threshold": self.threshold,
+        }
+
+    def to_json(self, fp) -> None:
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "GammaProcessModel":
+        """Rebuild a gamma-process model from a :meth:`to_dict` dict."""
+        if model_dict.get("model") != "GammaProcessModel":
+            raise ValueError(
+                "Must create a gamma-process model from a GammaProcessModel "
+                "dict"
+            )
+        return cls(
+            model_dict["alpha"], model_dict["beta"], model_dict["threshold"]
+        )
+
+    @classmethod
+    def from_json(cls, fp) -> "GammaProcessModel":
+        """Load a model from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     def _ff_distance(self, t, distance):
         # P(T <= t) = P(W(t) >= distance) with W(t) ~ Gamma(alpha t, beta).

--- a/surpyval/tests/degradation/test_serialisation.py
+++ b/surpyval/tests/degradation/test_serialisation.py
@@ -1,0 +1,204 @@
+"""Serialisation of the fitted degradation models.
+
+The degradation result classes round-trip through ``to_dict``/``from_dict``
+(and the JSON file variants): the Wiener and gamma stochastic-process models
+(a few floats each), the Monte-Carlo ``InducedFailureDistribution`` (including
+its ``inf`` never-fails mass), and the full ``DegradationModel`` (raw data,
+per-unit paths, population summaries, and its fitted life model -- plain or
+accelerated). Each restored model reproduces its predictions exactly.
+"""
+
+import json
+import warnings
+
+import numpy as np
+import pytest
+
+from surpyval.degradation import (
+    DegradationAnalysis,
+    DegradationModel,
+    GammaProcess,
+    GammaProcessModel,
+    InducedFailureDistribution,
+    WienerProcess,
+    WienerProcessModel,
+)
+
+
+def _rt(d):
+    return json.loads(json.dumps(d))
+
+
+def _monotone_process_data(seed=1, n_units=15):
+    rng = np.random.default_rng(seed)
+    xs, ys, ii = [], [], []
+    for u in range(n_units):
+        t = np.arange(0, 20, 2.0)
+        y = np.cumsum(np.abs(rng.normal(1.0, 0.5, t.size)))
+        xs.append(t)
+        ys.append(y)
+        ii.append(np.full(t.size, u))
+    return (np.concatenate(z) for z in (xs, ys, ii))
+
+
+def _wiener_process_data(seed=2, n_units=15):
+    rng = np.random.default_rng(seed)
+    xs, ys, ii = [], [], []
+    for u in range(n_units):
+        t = np.arange(0, 20, 2.0)
+        y = np.cumsum(rng.normal(1.0, 1.0, t.size))
+        xs.append(t)
+        ys.append(y)
+        ii.append(np.full(t.size, u))
+    return (np.concatenate(z) for z in (xs, ys, ii))
+
+
+def _linear_deg_data(seed=0):
+    rng = np.random.default_rng(seed)
+    x = np.tile(np.arange(100, 1100, 100), 4).astype(float)
+    slopes = np.repeat([0.31, 0.28, 0.44, 0.37], 10)
+    i = np.repeat([1, 2, 3, 4], 10)
+    y = 10 + slopes * x + rng.normal(0, 1, x.size)
+    return x, y, i
+
+
+# -- process models -------------------------------------------------------
+
+
+def test_gamma_process_round_trip():
+    xg, yg, ig = _monotone_process_data()
+    model = GammaProcess.fit(xg, yg, ig, threshold=15.0)
+    restored = GammaProcessModel.from_dict(_rt(model.to_dict()))
+    t = np.array([5.0, 10.0, 15.0])
+    assert np.allclose(model.sf(t), restored.sf(t))
+    assert np.allclose(model.ff(t), restored.ff(t))
+    assert (model.alpha, model.beta, model.threshold) == (
+        restored.alpha,
+        restored.beta,
+        restored.threshold,
+    )
+
+
+def test_wiener_process_round_trip(tmp_path):
+    xw, yw, iw = _wiener_process_data()
+    model = WienerProcess.fit(xw, yw, iw, threshold=20.0)
+    fp = tmp_path / "wiener.json"
+    model.to_json(fp)
+    restored = WienerProcessModel.from_json(fp)
+    t = np.array([5.0, 10.0, 15.0])
+    assert np.allclose(model.sf(t), restored.sf(t))
+    assert np.isclose(model.mean(), restored.mean())
+
+
+def test_process_model_rejects_wrong_dict():
+    with pytest.raises(ValueError, match="GammaProcessModel"):
+        GammaProcessModel.from_dict({"model": "Other"})
+    with pytest.raises(ValueError, match="WienerProcessModel"):
+        WienerProcessModel.from_dict({"model": "Other"})
+
+
+# -- induced failure distribution -----------------------------------------
+
+
+def test_induced_failure_distribution_round_trip():
+    x, y, i = _linear_deg_data()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    induced = model.induced_life(n_samples=5000, random_state=3)
+    restored = InducedFailureDistribution.from_dict(_rt(induced.to_dict()))
+    t = np.array([300.0, 450.0, 600.0])
+    assert np.allclose(induced.ff(t), restored.ff(t))
+    assert np.isclose(induced.median(), restored.median())
+    assert np.isclose(induced.prob_never_fails, restored.prob_never_fails)
+
+
+def test_induced_never_fails_mass_survives_round_trip():
+    # a straddling-zero slope population leaves a genuine inf mass
+    rng = np.random.default_rng(5)
+    xs, ys, ids = [], [], []
+    for u in range(60):
+        a = rng.normal(0.0, 0.2)
+        b = rng.normal(0.2, 0.5)  # some units never reach the threshold
+        t = np.arange(0, 20, 2.0)
+        y = a + b * t + rng.normal(0, 0.4, t.size)
+        xs.append(t)
+        ys.append(y)
+        ids.append(np.full(t.size, u))
+    x, y, i = (np.concatenate(z) for z in (xs, ys, ids))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        model = DegradationAnalysis.fit(x, y, i, threshold=30.0, path="linear")
+    induced = model.induced_life(n_samples=20000, random_state=6)
+    assert induced.prob_never_fails > 0.05
+    restored = InducedFailureDistribution.from_dict(induced.to_dict())
+    assert np.isclose(induced.prob_never_fails, restored.prob_never_fails)
+    assert np.isinf(restored.mean()) == np.isinf(induced.mean())
+
+
+# -- DegradationModel -----------------------------------------------------
+
+
+def test_degradation_model_round_trip():
+    x, y, i = _linear_deg_data()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    restored = DegradationModel.from_dict(_rt(model.to_dict()))
+    t = np.array([300.0, 450.0, 600.0])
+    assert np.allclose(model.sf(t), restored.sf(t))
+    assert np.allclose(model.ff(t), restored.ff(t))
+    assert np.allclose(model.qf(0.5), restored.qf(0.5))
+    # per-unit path evaluation matches
+    assert np.allclose(
+        model.path([100, 200], model.units[0]),
+        restored.path([100, 200], restored.units[0]),
+    )
+    # bootstrap bounds still work (the raw data was kept)
+    band = restored.cb(t, method="analytic")
+    assert np.asarray(band).shape == (3, 2)
+
+
+def test_degradation_model_json_file(tmp_path):
+    x, y, i = _linear_deg_data(seed=2)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        model = DegradationAnalysis.fit(x, y, i, threshold=150)
+    fp = tmp_path / "deg.json"
+    model.to_json(fp)
+    restored = DegradationModel.from_json(fp)
+    t = np.array([300.0, 500.0])
+    assert np.allclose(model.sf(t), restored.sf(t))
+
+
+def test_degradation_model_accelerated_round_trip():
+    # the life model is a ParametricRegressionModel; it must round-trip too
+    rng = np.random.default_rng(4)
+    xs, ys, ii, ZZ = [], [], [], []
+    uid = 0
+    for stress in [0.0, 0.5, 1.0]:
+        for _ in range(12):
+            b = (1.0 + stress) * rng.normal(1.0, 0.1)
+            t = np.arange(0, 20, 2.0)
+            y = b * t + rng.normal(0, 0.4, t.size)
+            xs.append(t)
+            ys.append(y)
+            ii.append(np.full(t.size, uid))
+            ZZ.append(np.full(t.size, stress))
+            uid += 1
+    x, y, i, Z = (np.concatenate(z) for z in (xs, ys, ii, ZZ))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        model = DegradationAnalysis.fit(
+            x, y, i, threshold=30.0, path="linear", Z=Z
+        )
+    restored = DegradationModel.from_dict(_rt(model.to_dict()))
+    assert restored.is_accelerated
+    t = np.array([10.0, 20.0, 30.0])
+    for stress in ([0.0], [0.5], [1.0]):
+        assert np.allclose(model.sf(t, Z=stress), restored.sf(t, Z=stress))
+
+
+def test_degradation_model_rejects_wrong_dict():
+    with pytest.raises(ValueError, match="DegradationModel"):
+        DegradationModel.from_dict({"model": "Other"})


### PR DESCRIPTION
Continues the "make every fitted model saveable" campaign into the **degradation** subsystem. All four degradation result classes now round-trip through `to_dict`/`from_dict` and `to_json`/`from_json`.

### Covered
- **`WienerProcessModel`** / **`GammaProcessModel`** — a few floats each (drift/diffusion or shape/rate, plus the threshold).
- **`InducedFailureDistribution`** — the Monte-Carlo samples. The `inf` never-fails draws are written as `null` so the dict stays valid JSON, and restored back to `inf`, so `prob_never_fails` / `mean` / quantiles survive exactly.
- **`DegradationModel`** — the raw measurement data, the path model (by name) and per-unit fits, the pseudo failure times / censor flags, the population summaries, and the fitted **life model** via its own `to_dict` (a plain `Parametric` or an accelerated `ParametricRegressionModel`, tagged so `from_dict` picks the right loader). The reloaded model reproduces the life predictions and per-unit paths, and — because the raw data is kept — its **bootstrap confidence bounds** too.

### Details
- Each dict carries a `"model"` tag and `from_dict` refuses a mismatched one; the path model resolves by name and the life model through its own restricted `from_dict`.
- This composes on the already-shipped `Parametric` and `ParametricRegressionModel` serialisation — an ADT degradation fit round-trips its regression life model end-to-end.

### Validation
- Predictions round-trip exactly for all four classes, including the accelerated `DegradationModel` (regression life model) across stress levels and the induced distribution's `inf` never-fails mass; JSON file variants and guard paths covered.
- New `test_serialisation.py` (9 tests). Full degradation suite green (159 passed); flake8 / black / `mypy surpyval` clean.
- Docs ("Degradation Analysis") gain a runnable save/load section; changelog updated.

Campaign status: parametric regression ✅ (#179), semi-parametric ✅ (#180), recurrent ✅ (#181), degradation ← this PR. Next: competing-risks + mixtures, then `RenewalModel` (the experimental forest/tree are being left out per the maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_