### PR TITLE
Add serialisation to the competing-risks and mixture models

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,20 @@ Changelog
 v0.15.0 (unreleased)
 --------------------
 
+Competing risks & mixtures
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Added serialisation to the competing-risks and mixture models:
+  ``MixtureModel`` (EM mixture of a base family), ``FineGrayModel``
+  (subdistribution-hazard regression), ``ParametricCompetingRisks`` (one
+  distribution per cause) and the nonparametric ``CompetingRisks`` now have
+  ``to_dict``/``from_dict`` and ``to_json``/``from_json``. The mixture stores
+  its base-family name, component parameters and weights; Fine-Gray stores its
+  coefficients, covariance and subdistribution-baseline step arrays; and the
+  competing-risks models store their per-cause sub-models (via each cause's own
+  ``to_dict``) or per-event step arrays. Every reloaded model reproduces its
+  predictions exactly.
+
 Degradation
 ~~~~~~~~~~~
 

--- a/surpyval/tests/univariate/competing_risks/test_serialisation.py
+++ b/surpyval/tests/univariate/competing_risks/test_serialisation.py
@@ -42,9 +42,7 @@ def _cr_data(seed=0, n=150):
 
 
 def test_mixture_model_round_trip():
-    x = np.concatenate(
-        [Weibull.random(80, 10, 3), Weibull.random(80, 50, 4)]
-    )
+    x = np.concatenate([Weibull.random(80, 10, 3), Weibull.random(80, 50, 4)])
     model = MixtureModel(dist=Weibull, m=2)
     model.fit(x=x)
     restored = MixtureModel.from_dict(_rt(model.to_dict()))
@@ -58,9 +56,7 @@ def test_mixture_model_round_trip():
 
 
 def test_mixture_model_json_file(tmp_path):
-    x = np.concatenate(
-        [Weibull.random(60, 8, 3), Weibull.random(60, 40, 5)]
-    )
+    x = np.concatenate([Weibull.random(60, 8, 3), Weibull.random(60, 40, 5)])
     model = MixtureModel(dist=Weibull, m=2)
     model.fit(x=x)
     fp = tmp_path / "mix.json"
@@ -75,8 +71,13 @@ def test_mixture_model_guards():
         MixtureModel.from_dict({"model": "Other"})
     with pytest.raises(ValueError, match="Unknown distribution"):
         MixtureModel.from_dict(
-            {"model": "MixtureModel", "dist": "os", "m": 2,
-             "params": [[1.0, 1.0]], "w": [1.0]}
+            {
+                "model": "MixtureModel",
+                "dist": "os",
+                "m": 2,
+                "params": [[1.0, 1.0]],
+                "w": [1.0],
+            }
         )
 
 

--- a/surpyval/tests/univariate/competing_risks/test_serialisation.py
+++ b/surpyval/tests/univariate/competing_risks/test_serialisation.py
@@ -1,0 +1,164 @@
+"""Serialisation of the competing-risks and mixture models.
+
+``MixtureModel`` (an EM mixture of a base family), ``FineGrayModel`` (the
+subdistribution-hazard regression), ``ParametricCompetingRisks`` (one
+distribution per cause) and the nonparametric ``CompetingRisks`` all round-trip
+through ``to_dict``/``from_dict`` (and the JSON file variants): each stores its
+fitted parameters (or step arrays / per-cause sub-models) and the reloaded
+model reproduces its predictions exactly.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from surpyval import MixtureModel, Weibull
+from surpyval.univariate.competing_risks import (
+    CompetingRisks,
+    FineGray,
+    ParametricCompetingRisks,
+)
+from surpyval.univariate.competing_risks.regression.fine_gray import (
+    FineGrayModel,
+)
+
+
+def _rt(d):
+    return json.loads(json.dumps(d))
+
+
+def _cr_data(seed=0, n=150):
+    rng = np.random.default_rng(seed)
+    Z = rng.normal(0, 1, (n, 2))
+    x = np.abs(rng.weibull(1.3, n) * 15) + 0.2
+    e = rng.choice([1, 2], n)
+    c = (rng.random(n) < 0.2).astype(int)
+    e = np.where(c == 1, None, e)
+    return x, Z, e, c
+
+
+# -- MixtureModel ---------------------------------------------------------
+
+
+def test_mixture_model_round_trip():
+    x = np.concatenate(
+        [Weibull.random(80, 10, 3), Weibull.random(80, 50, 4)]
+    )
+    model = MixtureModel(dist=Weibull, m=2)
+    model.fit(x=x)
+    restored = MixtureModel.from_dict(_rt(model.to_dict()))
+    t = np.array([5.0, 20.0, 50.0])
+    assert np.allclose(model.sf(t), restored.sf(t))
+    assert np.allclose(model.ff(t), restored.ff(t))
+    assert np.allclose(model.df(t), restored.df(t))
+    assert np.isclose(model.mean(), restored.mean())
+    assert np.allclose(model.params, restored.params)
+    assert np.allclose(model.w, restored.w)
+
+
+def test_mixture_model_json_file(tmp_path):
+    x = np.concatenate(
+        [Weibull.random(60, 8, 3), Weibull.random(60, 40, 5)]
+    )
+    model = MixtureModel(dist=Weibull, m=2)
+    model.fit(x=x)
+    fp = tmp_path / "mix.json"
+    model.to_json(fp)
+    restored = MixtureModel.from_json(fp)
+    t = np.array([5.0, 20.0])
+    assert np.allclose(model.sf(t), restored.sf(t))
+
+
+def test_mixture_model_guards():
+    with pytest.raises(ValueError, match="MixtureModel"):
+        MixtureModel.from_dict({"model": "Other"})
+    with pytest.raises(ValueError, match="Unknown distribution"):
+        MixtureModel.from_dict(
+            {"model": "MixtureModel", "dist": "os", "m": 2,
+             "params": [[1.0, 1.0]], "w": [1.0]}
+        )
+
+
+# -- FineGrayModel --------------------------------------------------------
+
+
+def test_fine_gray_round_trip():
+    x, Z, e, c = _cr_data()
+    model = FineGray.fit(x, Z, e, c=c, cause=1)
+    restored = FineGrayModel.from_dict(_rt(model.to_dict()))
+    t = np.array([2.0, 5.0, 10.0])
+    Zq = np.array([0.3, -0.2])
+    assert np.allclose(model.cif(t, Zq), restored.cif(t, Zq))
+    assert np.allclose(model.sf(t, Zq), restored.sf(t, Zq))
+    assert np.allclose(model.beta, restored.beta)
+    assert restored.cause == model.cause
+
+
+def test_fine_gray_json_file(tmp_path):
+    x, Z, e, c = _cr_data(seed=2)
+    model = FineGray.fit(x, Z, e, c=c, cause=1)
+    fp = tmp_path / "fg.json"
+    model.to_json(fp)
+    restored = FineGrayModel.from_json(fp)
+    t = np.array([3.0, 7.0])
+    Zq = np.array([0.1, 0.1])
+    assert np.allclose(model.cif(t, Zq), restored.cif(t, Zq))
+
+
+def test_fine_gray_guard():
+    with pytest.raises(ValueError, match="FineGrayModel"):
+        FineGrayModel.from_dict({"model": "Other"})
+
+
+# -- ParametricCompetingRisks ---------------------------------------------
+
+
+def test_parametric_competing_risks_round_trip():
+    x, _, e, c = _cr_data(seed=3)
+    model = ParametricCompetingRisks.fit(x, e, c=c)
+    restored = ParametricCompetingRisks.from_dict(_rt(model.to_dict()))
+    assert restored.causes == model.causes
+    t = np.array([2.0, 5.0, 10.0])
+    for cause in model.causes:
+        assert np.allclose(
+            model.Hf(t, event=cause), restored.Hf(t, event=cause)
+        )
+        assert np.allclose(
+            model.hf(t, event=cause), restored.hf(t, event=cause)
+        )
+
+
+def test_parametric_competing_risks_guard():
+    with pytest.raises(ValueError, match="ParametricCompetingRisks"):
+        ParametricCompetingRisks.from_dict({"model": "Other"})
+
+
+# -- nonparametric CompetingRisks -----------------------------------------
+
+
+def test_competing_risks_round_trip():
+    x, _, e, c = _cr_data(seed=4)
+    model = CompetingRisks.fit(x, e, c=c)
+    restored = CompetingRisks.from_dict(_rt(model.to_dict()))
+    assert list(restored.event_idx_map) == list(model.event_idx_map)
+    t = np.array([2.0, 5.0, 10.0])
+    for event in model.event_idx_map:
+        assert np.allclose(model.cif(t, event), restored.cif(t, event))
+        assert np.allclose(model.sf(t, event), restored.sf(t, event))
+
+
+def test_competing_risks_json_file(tmp_path):
+    x, _, e, c = _cr_data(seed=5)
+    model = CompetingRisks.fit(x, e, c=c)
+    fp = tmp_path / "cr.json"
+    model.to_json(fp)
+    restored = CompetingRisks.from_json(fp)
+    t = np.array([3.0, 8.0])
+    event = list(model.event_idx_map)[0]
+    assert np.allclose(model.cif(t, event), restored.cif(t, event))
+
+
+def test_competing_risks_guard():
+    with pytest.raises(ValueError, match="CompetingRisks"):
+        CompetingRisks.from_dict({"model": "Other"})

--- a/surpyval/univariate/competing_risks/nonparametric/competing_risks.py
+++ b/surpyval/univariate/competing_risks/nonparametric/competing_risks.py
@@ -7,6 +7,7 @@ code constitutes acceptance of these terms.
 Copyright 2022 Cartiga LLC
 """
 
+import json
 import textwrap
 
 import numpy as np
@@ -24,6 +25,84 @@ from surpyval.utils import (
 
 
 class CompetingRisks:
+    # Attributes populated by ``fit`` / ``from_dict``; declared for the type
+    # checker.
+    event_idx_map: dict
+    n_event_types: int
+    x: np.ndarray
+    d: np.ndarray
+    r: np.ndarray
+    h0: np.ndarray
+    H0: np.ndarray
+    S: np.ndarray
+    d_e: np.ndarray
+    h0_e: np.ndarray
+    H0_e: np.ndarray
+    IIF: np.ndarray
+    CIF: np.ndarray
+
+    # -- serialisation -----------------------------------------------------
+
+    _SERIALISED_ARRAYS = (
+        "x",
+        "d",
+        "r",
+        "h0",
+        "H0",
+        "S",
+        "d_e",
+        "h0_e",
+        "H0_e",
+        "IIF",
+        "CIF",
+    )
+
+    def to_dict(self) -> dict:
+        """
+        Serialise this fitted nonparametric competing-risks model to a plain,
+        JSON-serialisable dict: the event index map and the fitted step arrays
+        (the shared baseline plus the per-event incidence and cumulative-
+        incidence functions). The reloaded model reproduces every prediction
+        exactly.
+        """
+        out: dict = {
+            "model": "CompetingRisks",
+            # list of [event, index] pairs to preserve the event key types
+            "event_idx_map": [
+                [k, int(v)] for k, v in self.event_idx_map.items()
+            ],
+            "n_event_types": int(self.n_event_types),
+        }
+        for name in self._SERIALISED_ARRAYS:
+            out[name] = np.asarray(getattr(self, name), dtype=float).tolist()
+        return out
+
+    def to_json(self, fp) -> None:
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "CompetingRisks":
+        """Rebuild a nonparametric competing-risks model from a dict."""
+        if model_dict.get("model") != "CompetingRisks":
+            raise ValueError(
+                "Must create a competing-risks model from a CompetingRisks "
+                "dict"
+            )
+        out = cls()
+        out.event_idx_map = {k: int(v) for k, v in model_dict["event_idx_map"]}
+        out.n_event_types = int(model_dict["n_event_types"])
+        for name in cls._SERIALISED_ARRAYS:
+            setattr(out, name, np.array(model_dict[name], dtype=float))
+        return out
+
+    @classmethod
+    def from_json(cls, fp) -> "CompetingRisks":
+        """Load a model from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
+
     def __repr__(self):
         out = """\
         Competing Risk model with events:

--- a/surpyval/univariate/competing_risks/parametric/parametric_competing_risks.py
+++ b/surpyval/univariate/competing_risks/parametric/parametric_competing_risks.py
@@ -24,10 +24,13 @@ H_j(u))`. The cause CIFs sum to the all-cause failure probability
 :math:`1 - S(t)`.
 """
 
+import json
+
 import numpy as np
 from scipy.integrate import cumulative_trapezoid
 
 from surpyval.univariate.parametric import Weibull
+from surpyval.univariate.parametric.parametric import Parametric
 from surpyval.utils import (
     check_e_and_x,
     resolve_cr_censoring,
@@ -71,6 +74,48 @@ class ParametricCompetingRisks:
 
     causes: list
     models: dict
+
+    # -- serialisation -----------------------------------------------------
+
+    def to_dict(self) -> dict:
+        """
+        Serialise this fitted parametric competing-risks model to a plain,
+        JSON-serialisable dict: the list of causes and each cause's fitted
+        distribution (via its own ``to_dict``). The reloaded model reproduces
+        every cumulative-incidence / hazard function exactly.
+        """
+        return {
+            "model": "ParametricCompetingRisks",
+            "causes": list(self.causes),
+            "models": [self.models[cause].to_dict() for cause in self.causes],
+        }
+
+    def to_json(self, fp) -> None:
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "ParametricCompetingRisks":
+        """Rebuild a parametric competing-risks model from a dict."""
+        if model_dict.get("model") != "ParametricCompetingRisks":
+            raise ValueError(
+                "Must create a parametric competing-risks model from a "
+                "ParametricCompetingRisks dict"
+            )
+        out = cls()
+        out.causes = list(model_dict["causes"])
+        out.models = {
+            cause: Parametric.from_dict(sub)
+            for cause, sub in zip(out.causes, model_dict["models"])
+        }
+        return out
+
+    @classmethod
+    def from_json(cls, fp) -> "ParametricCompetingRisks":
+        """Load a model from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     def __repr__(self):
         dists = ", ".join(

--- a/surpyval/univariate/competing_risks/regression/fine_gray.py
+++ b/surpyval/univariate/competing_risks/regression/fine_gray.py
@@ -30,6 +30,8 @@ already had the event of interest, leave the risk set. The partial likelihood
 is the Breslow form of this weighted risk set.
 """
 
+import json
+
 import numpy as np
 from autograd import grad, hessian
 from autograd import numpy as anp
@@ -177,6 +179,66 @@ class FineGrayModel:
         self._cumhaz = fit["baseline_cumhaz"]
         self._neg_ll = fit["neg_ll"]
         self.res = fit["res"]
+
+    # -- serialisation -----------------------------------------------------
+
+    def to_dict(self):
+        """
+        Serialise this fitted Fine-Gray model to a plain, JSON-serialisable
+        dict.
+
+        Stores the coefficients and their covariance, plus the fitted
+        subdistribution baseline cumulative-hazard step arrays, so the reloaded
+        model reproduces ``cif``/``sf`` exactly and can still report the
+        coefficient summary. The optimiser objects are not stored.
+        """
+        return {
+            "model": "FineGrayModel",
+            "cause": self.cause,
+            "beta": np.asarray(self.beta, dtype=float).tolist(),
+            "se": np.asarray(self.se, dtype=float).tolist(),
+            "p_values": np.asarray(self.p_values, dtype=float).tolist(),
+            "cov": np.asarray(self.cov, dtype=float).tolist(),
+            "baseline_times": np.asarray(self._times, dtype=float).tolist(),
+            "baseline_cumhaz": np.asarray(self._cumhaz, dtype=float).tolist(),
+            "neg_ll": float(self._neg_ll),
+        }
+
+    def to_json(self, fp):
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict):
+        """Rebuild a Fine-Gray model from a :meth:`to_dict` dictionary."""
+        if model_dict.get("model") != "FineGrayModel":
+            raise ValueError(
+                "Must create a Fine-Gray model from a FineGrayModel dict"
+            )
+        return cls(
+            {
+                "cause": model_dict["cause"],
+                "beta": np.array(model_dict["beta"], dtype=float),
+                "se": np.array(model_dict["se"], dtype=float),
+                "p_values": np.array(model_dict["p_values"], dtype=float),
+                "cov": np.array(model_dict["cov"], dtype=float),
+                "baseline_times": np.array(
+                    model_dict["baseline_times"], dtype=float
+                ),
+                "baseline_cumhaz": np.array(
+                    model_dict["baseline_cumhaz"], dtype=float
+                ),
+                "neg_ll": model_dict["neg_ll"],
+                "res": None,
+            }
+        )
+
+    @classmethod
+    def from_json(cls, fp):
+        """Load a model from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     def phi(self, Z):
         return np.exp(np.asarray(Z, dtype=float) @ self.beta)

--- a/surpyval/univariate/parametric/mixture_model.py
+++ b/surpyval/univariate/parametric/mixture_model.py
@@ -1,3 +1,4 @@
+import json
 import warnings
 
 from matplotlib import pyplot as plt
@@ -44,6 +45,58 @@ class MixtureModel(Distribution):
         self.w = None
         self.p = None
         self.loglike = None
+
+    # -- serialisation -----------------------------------------------------
+
+    def to_dict(self) -> dict:
+        """
+        Serialise this fitted mixture model to a plain, JSON-serialisable dict.
+
+        Stores the base distribution's name, the number of components ``m``,
+        the per-component parameters and the mixing weights, so the reloaded
+        model reproduces ``sf``/``ff``/``df``/``mean``/``random`` exactly. The
+        fitted data and EM responsibilities are not stored.
+        """
+        return {
+            "model": "MixtureModel",
+            "dist": self.dist.name,
+            "m": int(self.m),
+            "params": np.asarray(self.params, dtype=float).tolist(),
+            "w": np.asarray(self.w, dtype=float).tolist(),
+        }
+
+    def to_json(self, fp) -> None:
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "MixtureModel":
+        """Rebuild a mixture model from a :meth:`to_dict` dictionary."""
+        import surpyval
+        from surpyval.univariate.parametric.parametric_fitter import (
+            ParametricFitter,
+        )
+
+        if model_dict.get("model") != "MixtureModel":
+            raise ValueError(
+                "Must create a mixture model from a MixtureModel dict"
+            )
+        dist = getattr(surpyval, model_dict["dist"], None)
+        if not isinstance(dist, ParametricFitter):
+            raise ValueError(
+                "Unknown distribution {!r}".format(model_dict["dist"])
+            )
+        out = cls(dist=dist, m=int(model_dict["m"]))
+        out.params = np.array(model_dict["params"], dtype=float)
+        out.w = np.array(model_dict["w"], dtype=float)
+        return out
+
+    @classmethod
+    def from_json(cls, fp) -> "MixtureModel":
+        """Load a model from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     def __repr__(self):
         if self.params is not None:


### PR DESCRIPTION
Continues the "make every fitted model saveable" campaign into the **competing-risks** and **mixture** models. All four round-trip through `to_dict`/`from_dict` and `to_json`/`from_json`.

### Covered
- **`MixtureModel`** — base-family name + number of components `m` + per-component parameters + mixing weights. `sf`/`ff`/`df`/`mean`/`random` round-trip exactly; the base distribution resolves by name from a restricted set.
- **`FineGrayModel`** — the coefficients, their covariance, and the fitted **subdistribution-baseline** cumulative-hazard step arrays (plus the `cause`); `cif`/`sf` round-trip.
- **`ParametricCompetingRisks`** — the list of causes and each cause's fitted `Parametric` (via its own `to_dict`, so mixed distribution families are fine).
- **`CompetingRisks`** (nonparametric) — the event index map and the fitted step arrays (shared baseline + per-event incidence / cumulative-incidence functions).

### Details
- Each dict carries a `"model"` tag and `from_dict` refuses a mismatched one; the mixture rejects an unknown distribution name.
- Added class-level attribute declarations to `CompetingRisks` for the type checker (its attributes were only ever set dynamically in `fit`).
- Composes on the already-shipped `Parametric` serialisation for the per-cause sub-models.

### Validation
- Predictions round-trip exactly for all four classes (verified via the real `to_dict`/`from_dict` methods), plus JSON file variants and guard paths.
- New `test_serialisation.py` (11 tests). Competing-risks + mixture suites pass (70 on a clean run).
- flake8 / black / `mypy surpyval` clean.

Note: one pre-existing test, `test_from_fitted_agrees_with_nonparametric`, does not seed the global RNG and is occasionally order-flaky (it passed 2/2 on re-run here and is unrelated to these changes) — if CI trips on it, a re-run clears it.

Campaign status: parametric regression ✅ (#179), semi-parametric ✅ (#180), recurrent ✅ (#181), degradation ✅ (#182), competing-risks + mixtures ← this PR. Last one: `RenewalModel` (experimental forest/tree excluded per the maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_