### PR TITLE
Add serialisation to the renewal / imperfect-repair models

### DIFF
--- a/docs/Recurrent Event Modelling with SurPyval.rst
+++ b/docs/Recurrent Event Modelling with SurPyval.rst
@@ -539,8 +539,9 @@ JSON file and rebuilt later. The intensity model is stateless, so only its name
 and the fitted parameters are stored (for the nonparametric MCF, the step
 arrays); the reloaded model reproduces every prediction exactly. This works for
 the parametric intensity fits (``CrowAMSAA`` / ``Duane`` / ``Cox-Lewis`` /
-``HPP``), the nonparametric MCF, the proportional-intensity regression, and the
-two cause-specific containers.
+``HPP``), the nonparametric MCF, the proportional-intensity regression, the two
+cause-specific containers, and the renewal / imperfect-repair models
+(``RenewalModel`` — generalized renewal, G1 renewal, ARA, ARI).
 
 .. jupyter-execute::
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,16 @@ Degradation
 Recurrent events
 ~~~~~~~~~~~~~~~~~
 
+- Added serialisation to the renewal / imperfect-repair models
+  (``RenewalModel``): the generalized-renewal (Kijima-I/II), G1 renewal, ARA
+  and ARI families now have ``to_dict``/``from_dict`` and
+  ``to_json``/``from_json``. These processes have no closed-form intensity
+  (their MCF comes from a sampler closure that cannot be pickled), so the dict
+  stores the family, the underlying distribution (by name) and its parameters,
+  the restoration parameter and the family option (``kijima_type`` or memory
+  ``m``); on load the family's fitter rebuilds the sampler from those, so the
+  simulated MCF reproduces exactly. This completes serialisation coverage of
+  every non-experimental fitted model in the package.
 - Added serialisation to the fitted recurrent-event models:
   ``ParametricRecurrenceModel`` (NHPP/HPP intensity fits),
   ``NonParametricCounting`` (the MCF estimate), ``ProportionalIntensityModel``

--- a/surpyval/recurrent/renewal/renewal_model.py
+++ b/surpyval/recurrent/renewal/renewal_model.py
@@ -1,3 +1,6 @@
+import json
+from typing import Any
+
 import numpy as np
 
 from surpyval.recurrent.inference import LikelihoodInferenceMixin
@@ -45,6 +48,12 @@ class RenewalModel(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
         a transform that keeps its confidence bounds inside the support.
     """
 
+    #: Set by the fitter for the generalized-renewal family (``"i"``/``"ii"``);
+    #: absent otherwise.
+    kijima_type: Any
+    #: Set by the fitter for the ARA/ARI families (memory); absent otherwise.
+    m: Any
+
     def __init__(
         self,
         model,
@@ -67,6 +76,121 @@ class RenewalModel(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
         # Expose the restoration parameter under its conventional name
         # (``q``/``rho``) so existing usage keeps working.
         setattr(self, restoration_name, restoration)
+
+    # -- serialisation -----------------------------------------------------
+
+    def _family(self) -> str:
+        """Identify the renewal family from the fitted attributes."""
+        if getattr(self, "kijima_type", None) is not None:
+            return "GeneralizedRenewal"
+        if getattr(self, "m", None) is not None:
+            if self._dist_label == "Baseline Intensity":
+                return "ARI"
+            return "ARA"
+        return "GeneralizedOneRenewal"
+
+    def to_dict(self) -> dict:
+        """
+        Serialise this fitted renewal / imperfect-repair model to a plain,
+        JSON-serialisable dict.
+
+        These processes have no closed-form intensity -- their simulation is
+        driven by a sampler closure built from the underlying distribution and
+        the restoration parameter -- so what is stored is the family, the
+        underlying distribution (by name) and its parameters, the restoration
+        parameter, and the family's discrete option (``kijima_type`` for the
+        generalized renewal, memory ``m`` for ARA/ARI). On load the family's
+        fitter rebuilds the sampler from those, so ``mcf`` and the simulation
+        methods reproduce exactly. The likelihood/data state is not stored.
+
+        See Also
+        --------
+        from_dict, to_json, from_json
+        """
+        out: dict = {
+            "model": "RenewalModel",
+            "family": self._family(),
+            "dist": self.model.dist.name,
+            "params": np.asarray(self.model.params, dtype=float).tolist(),
+            "restoration": float(self.restoration),
+        }
+        if getattr(self, "kijima_type", None) is not None:
+            out["kijima_type"] = self.kijima_type
+        if getattr(self, "m", None) is not None:
+            out["m"] = self.m
+        return out
+
+    def to_json(self, fp) -> None:
+        """Write :meth:`to_dict` to ``fp`` as JSON."""
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "RenewalModel":
+        """
+        Rebuild a renewal model from a :meth:`to_dict` dictionary.
+
+        The family's fitter is used to reconstruct the model from parameters
+        (which regenerates the simulation sampler), so the result predicts
+        identically to the original.
+
+        See Also
+        --------
+        to_dict, to_json, from_json
+        """
+        import surpyval.recurrent as recurrent
+        from surpyval.recurrent.serialisation import intensity_dist_by_name
+
+        if model_dict.get("model") != "RenewalModel":
+            raise ValueError(
+                "Must create a renewal model from a RenewalModel dict"
+            )
+        family = model_dict["family"]
+        fitters: "dict[str, Any]" = {
+            "GeneralizedRenewal": recurrent.GeneralizedRenewal,
+            "GeneralizedOneRenewal": recurrent.GeneralizedOneRenewal,
+            "ARA": recurrent.ARA,
+            "ARI": recurrent.ARI,
+        }
+        if family not in fitters:
+            raise ValueError("Unknown renewal family {!r}".format(family))
+        fitter = fitters[family]
+        params = model_dict["params"]
+        restoration = model_dict["restoration"]
+
+        if family == "ARI":
+            # the ARI baseline is a recurrence intensity model
+            dist = intensity_dist_by_name(model_dict["dist"])
+            return fitter.fit_from_parameters(
+                params, restoration, m=model_dict["m"], dist=dist
+            )
+
+        import surpyval
+
+        dist = getattr(surpyval, model_dict["dist"], None)
+        if dist is None:
+            raise ValueError(
+                "Unknown distribution {!r}".format(model_dict["dist"])
+            )
+        if family == "GeneralizedRenewal":
+            return fitter.fit_from_parameters(
+                params,
+                restoration,
+                kijima=model_dict["kijima_type"],
+                dist=dist,
+            )
+        if family == "ARA":
+            return fitter.fit_from_parameters(
+                params, restoration, m=model_dict["m"], dist=dist
+            )
+        # GeneralizedOneRenewal
+        return fitter.fit_from_parameters(params, restoration, dist=dist)
+
+    @classmethod
+    def from_json(cls, fp) -> "RenewalModel":
+        """Load a model from a JSON file written by :meth:`to_json`."""
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
     def _new_sequence_sampler(self):
         return self._sampler_factory(self)

--- a/surpyval/tests/recurrent/test_renewal_serialisation.py
+++ b/surpyval/tests/recurrent/test_renewal_serialisation.py
@@ -1,0 +1,104 @@
+"""Serialisation of the fitted renewal / imperfect-repair models.
+
+``RenewalModel`` covers the generalized-renewal (Kijima-I/II), G1 renewal, ARA
+and ARI families. These processes have no closed-form intensity -- their mean
+cumulative function comes from a sampler closure -- so serialisation stores the
+family, the underlying distribution (by name) and its parameters, the
+restoration parameter and the family option (``kijima_type`` / memory ``m``),
+and the family's fitter rebuilds the sampler on load. The reloaded model
+reproduces the (seeded) simulated MCF exactly.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from surpyval import Weibull
+from surpyval.recurrent import (
+    ARA,
+    ARI,
+    CrowAMSAA,
+    GeneralizedOneRenewal,
+    GeneralizedRenewal,
+)
+from surpyval.recurrent.renewal.renewal_model import RenewalModel
+
+
+def _rt(d):
+    return json.loads(json.dumps(d))
+
+
+def _make(name):
+    if name == "GR-i":
+        return GeneralizedRenewal.fit_from_parameters(
+            [50.0, 2.0], 0.3, kijima="i", dist=Weibull
+        )
+    if name == "GR-ii":
+        return GeneralizedRenewal.fit_from_parameters(
+            [50.0, 2.0], 0.3, kijima="ii", dist=Weibull
+        )
+    if name == "G1R":
+        return GeneralizedOneRenewal.fit_from_parameters(
+            [50.0, 2.0], 0.2, dist=Weibull
+        )
+    if name == "ARA":
+        return ARA.fit_from_parameters([50.0, 2.0], 0.4, m=2, dist=Weibull)
+    if name == "ARI":
+        return ARI.fit_from_parameters([60.0, 2.0], 0.3, m=1, dist=CrowAMSAA)
+    raise ValueError(name)
+
+
+@pytest.mark.parametrize("name", ["GR-i", "GR-ii", "G1R", "ARA", "ARI"])
+def test_renewal_round_trip(name):
+    model = _make(name)
+    restored = RenewalModel.from_dict(_rt(model.to_dict()))
+    # the restoration parameter and family option survive
+    assert np.isclose(model.restoration, restored.restoration)
+    assert np.allclose(model.model.params, restored.model.params)
+    assert model.model.dist.name == restored.model.dist.name
+    # the seeded simulated MCF reproduces exactly (the sampler was rebuilt)
+    t = np.array([10.0, 50.0, 100.0])
+    assert np.allclose(
+        model.mcf(t, items=300, seed=7),
+        restored.mcf(t, items=300, seed=7),
+    )
+
+
+def test_renewal_kijima_type_preserved():
+    for kijima in ("i", "ii"):
+        model = GeneralizedRenewal.fit_from_parameters(
+            [50.0, 2.0], 0.3, kijima=kijima, dist=Weibull
+        )
+        restored = RenewalModel.from_dict(model.to_dict())
+        assert restored.kijima_type == kijima
+
+
+def test_renewal_memory_preserved():
+    model = ARA.fit_from_parameters([50.0, 2.0], 0.4, m=3, dist=Weibull)
+    restored = RenewalModel.from_dict(model.to_dict())
+    assert restored.m == 3
+
+
+def test_renewal_json_file(tmp_path):
+    model = _make("ARA")
+    fp = tmp_path / "renewal.json"
+    model.to_json(fp)
+    restored = RenewalModel.from_json(fp)
+    t = np.array([20.0, 80.0])
+    assert np.allclose(
+        model.mcf(t, items=200, seed=3),
+        restored.mcf(t, items=200, seed=3),
+    )
+
+
+def test_renewal_rejects_wrong_dict():
+    with pytest.raises(ValueError, match="RenewalModel"):
+        RenewalModel.from_dict({"model": "Other"})
+
+
+def test_renewal_rejects_unknown_family():
+    d = _make("ARA").to_dict()
+    d["family"] = "Nope"
+    with pytest.raises(ValueError, match="Unknown renewal family"):
+        RenewalModel.from_dict(d)


### PR DESCRIPTION
The final class in the "make every fitted model saveable" campaign. `RenewalModel` — covering the **generalized-renewal (Kijima-I/II)**, **G1 renewal**, **ARA**, and **ARI** families — now round-trips through `to_dict`/`from_dict` and `to_json`/`from_json`.

### The challenge
These processes have **no closed-form intensity** — their mean cumulative function comes from a per-sequence **sampler closure** (`_sampler_factory`), which can't be JSON-serialised. So instead of pickling the closure, the dict stores what defines it:
- the **family**,
- the underlying distribution (by name) and its parameters,
- the **restoration** parameter (`q`/`rho`),
- the family's discrete option (`kijima_type` for generalized renewal, memory `m` for ARA/ARI).

`from_dict` dispatches to the family's `fit_from_parameters`, which **rebuilds the sampler** from those values — so the reloaded model's (seeded) simulated MCF reproduces exactly. The ARI baseline is itself a recurrence intensity model, resolved via the recurrent name map added in #181.

### Validation
- The **seeded simulated MCF** matches exactly after a round-trip for all five families (GR Kijima-I, GR Kijima-II, G1R, ARA, ARI-with-CrowAMSAA-baseline) — the strongest possible check that the sampler closure was faithfully regenerated. `kijima_type` / `m` / restoration preserved; JSON file variant and guard paths covered.
- New `test_renewal_serialisation.py` (10 tests). Full recurrent suite green (340 passed); flake8 / black / `mypy surpyval` clean.
- Docs and changelog updated.

### Campaign complete
Every **non-experimental** fitted model in the package is now saveable:

| Subsystem | PR |
|---|---|
| Parametric regression (AFT/PH/PO/AH) | #179 |
| Semi-parametric regression (Cox, Lin-Ying, Buckley-James) | #180 |
| Recurrent-event (NHPP/HPP, MCF, PI, cause-specific) | #181 |
| Degradation (general-path, Wiener/Gamma, induced) | #182 |
| Competing-risks + mixtures | #183 |
| Renewal / imperfect-repair | **this PR** |

The experimental `RandomSurvivalForest` / `SurvivalTree` are intentionally excluded per the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_