### PR TITLE
Survival tree: support the full data model (all censoring + truncation)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -91,6 +91,27 @@ Regression
 Experimental
 ~~~~~~~~~~~~
 
+- The experimental ``SurvivalTree`` (and therefore ``RandomSurvivalForest``)
+  now supports the **full SurPyval data model**: observed, left-, right- and
+  interval-censored observations with optional left and/or right truncation.
+  The risk-set log-rank split only exists for observed / right-censored
+  (optionally left-truncated) data, so the tree gains a second split
+  criterion -- the full-likelihood exponential deviance split of Davis &
+  Anderson (1989) -- in which every candidate split is scored by the joint
+  maximised exponential log-likelihood of its children, with each observation
+  type contributing its exact likelihood term (including the
+  ``S(t_l) - S(t_r)`` truncation correction). A new ``split_rule`` parameter
+  (``"auto"`` default) keeps the log-rank split for data it is defined on --
+  existing behaviour is unchanged -- and switches to the deviance split
+  otherwise; forcing ``"log-rank"`` on incompatible data raises a clear
+  error. All candidate children within a node are scored over a common
+  parameter window so the criterion is monotone (a split can never score
+  below its parent), and splits with no likelihood gain stop the branch.
+  Nonparametric leaves now use the Turnbull NPMLE when the data has left or
+  interval censoring or right truncation (Nelson-Aalen otherwise, as
+  before); parametric (Weibull) leaves already supported the full data
+  model. ``fit`` also accepts the ``xl``/``xr`` and ``tl``/``tr``
+  conveniences.
 - Fixed a crash in the experimental ``RandomSurvivalForest``: a degenerate
   bootstrap sample (e.g. heavily tied event times) could make a terminal
   node's Weibull covariance step raise, taking down the whole forest fit. A

--- a/surpyval/experimental/forest/deviance_split.py
+++ b/surpyval/experimental/forest/deviance_split.py
@@ -1,0 +1,299 @@
+r"""Full-likelihood (exponential deviance) split for survival trees.
+
+The risk-set log-rank split (see ``log_rank_split``) is defined only for
+data that can be expressed in the xrd (risk set / death count) format:
+observed and right-censored observations, optionally with delayed entry
+(left truncation). Left-censored, interval-censored and right-truncated
+observations carry their event information as *probabilities of intervals*
+rather than as points entering and leaving a risk set, so no risk-set
+statistic exists for them.
+
+The likelihood does not have that limitation. This module implements the
+classic parametric alternative -- the exponential log-likelihood
+(deviance) split of Davis & Anderson (1989), scored with SurPyval's full
+likelihood so that every observation type contributes exactly:
+
+- observed ``x``:            :math:`\log \lambda - \lambda x`
+- right censored at ``x``:   :math:`-\lambda x`
+- left censored at ``x``:    :math:`\log(1 - e^{-\lambda x})`
+- interval ``(x_l, x_r]``:   :math:`\log(e^{-\lambda x_l} - e^{-\lambda x_r})`
+- truncated to ``(t_l, t_r]``: minus
+  :math:`\log(S(t_l) - S(t_r))`
+
+A candidate split is scored by the joint maximised log-likelihood of its
+two children; since the parent's log-likelihood is constant within a node,
+maximising :math:`\ell_L^* + \ell_R^*` maximises the deviance gain
+:math:`2(\ell_L^* + \ell_R^* - \ell_{parent}^*)`. For purely observed /
+right-censored data this rule and the log-rank rule pick very similar
+splits; the deviance rule simply remains defined for everything else.
+
+References
+----------
+Davis, R.B. and Anderson, J.R., 1989. Exponential survival trees.
+*Statistics in Medicine*, 8(8), pp.947-961.
+"""
+
+from collections.abc import Iterable
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.optimize import minimize_scalar
+
+from surpyval.utils.surpyval_data import SurpyvalData
+
+# Cap on candidate split values per feature: above this, candidates are
+# thinned to quantiles so a node's split search stays O(cap * n).
+_MAX_SPLIT_CANDIDATES = 64
+
+# Value used for non-finite likelihoods so the bounded optimiser can keep
+# working (it cannot handle inf/nan).
+_HUGE = 1e300
+
+
+def needs_full_likelihood_split(data: SurpyvalData) -> bool:
+    """
+    True when ``data`` cannot be expressed in the xrd format -- i.e. it
+    contains left censoring, interval censoring, or right truncation --
+    so the risk-set log-rank split is undefined and the full-likelihood
+    (deviance) split must be used.
+    """
+    return bool(
+        np.isfinite(data.t[:, 1]).any()
+        or (data.c == 2).any()
+        or (data.c == -1).any()
+    )
+
+
+def _exp_neg_ll_parts(data: SurpyvalData):
+    """
+    Pre-extract the arrays the exponential negative log-likelihood needs,
+    so the optimiser's objective is pure vectorised arithmetic.
+    """
+    a_trunc = np.maximum(data.x_tl, 0.0)  # exponential support starts at 0
+    return (
+        data.x_o,
+        data.n_o,
+        data.x_r,
+        data.n_r,
+        data.x_l,
+        data.n_l,
+        data.x_il,
+        data.x_ir,
+        data.n_i,
+        a_trunc,
+        data.x_tr,
+        data.n_t,
+    )
+
+
+def _exp_neg_ll(theta: float, parts) -> float:
+    """
+    Negative log-likelihood of an exponential distribution with rate
+    ``lambda = exp(theta)`` under the full data model (all censoring
+    types plus truncation). Returns a large finite value where the
+    likelihood is degenerate so bounded optimisation stays stable.
+    """
+    (
+        x_o,
+        n_o,
+        x_r,
+        n_r,
+        x_l,
+        n_l,
+        x_il,
+        x_ir,
+        n_i,
+        t_a,
+        t_r,
+        n_t,
+    ) = parts
+    lam = np.exp(theta)
+    ll = 0.0
+    with np.errstate(all="ignore"):
+        if x_o.size:
+            ll += np.sum(n_o * (theta - lam * x_o))
+        if x_r.size:
+            ll += -lam * np.sum(n_r * x_r)
+        if x_l.size:
+            # F(x) = 1 - exp(-lam x)
+            ll += np.sum(n_l * np.log(-np.expm1(-lam * x_l)))
+        if x_il.size:
+            # S(xl) - S(xr) = exp(-lam xl)(1 - exp(-lam (xr - xl)))
+            ll += np.sum(
+                n_i * (-lam * x_il + np.log(-np.expm1(-lam * (x_ir - x_il))))
+            )
+        if t_a.size:
+            # subtract log(S(tl) - S(tr)) per truncated observation
+            finite_tr = np.isfinite(t_r)
+            log_denom = -lam * t_a
+            if finite_tr.any():
+                width = np.where(finite_tr, t_r - t_a, np.inf)
+                log_denom = log_denom + np.where(
+                    finite_tr, np.log(-np.expm1(-lam * width)), 0.0
+                )
+            ll -= np.sum(n_t * log_denom)
+    if not np.isfinite(ll):
+        return _HUGE
+    return -float(ll)
+
+
+def _exp_theta0(data: SurpyvalData) -> "float | None":
+    """
+    Crude ``log(lambda)`` scale for centring the search window:
+    event-weight over exposure, or ``None`` when the data carries no
+    event information.
+    """
+    exposure = 0.0
+    events = 0.0
+    if data.x_o.size:
+        exposure += float(np.sum(data.n_o * data.x_o))
+        events += float(np.sum(data.n_o))
+    if data.x_r.size:
+        exposure += float(np.sum(data.n_r * data.x_r))
+    if data.x_l.size:
+        exposure += float(np.sum(data.n_l * data.x_l)) / 2.0
+        events += float(np.sum(data.n_l))
+    if data.x_il.size:
+        exposure += float(np.sum(data.n_i * (data.x_il + data.x_ir))) / 2.0
+        events += float(np.sum(data.n_i))
+    if exposure <= 0 or events <= 0:
+        return None
+    return float(np.log(events / exposure))
+
+
+def _exp_max_ll(
+    data: SurpyvalData, bounds: "tuple[float, float] | None" = None
+) -> float:
+    """
+    Maximised exponential log-likelihood of ``data`` under the full data
+    model, via a bounded scalar search over ``log(lambda)``.
+
+    ``bounds`` fixes the search window. Within a node, every candidate
+    child must be scored over the SAME window as the parent: for
+    degenerate data directions (e.g. a likelihood whose supremum sits at
+    ``lambda -> 0``) the attained value depends on where the window
+    ends, so per-subset windows would make the child and parent scores
+    incomparable. A common window guarantees, by additivity of the
+    log-likelihood over a partition, that a split never scores below
+    its parent.
+    """
+    parts = _exp_neg_ll_parts(data)
+
+    if bounds is None:
+        theta0 = _exp_theta0(data)
+        if theta0 is None:
+            return -_HUGE
+        bounds = (theta0 - 15.0, theta0 + 15.0)
+
+    res = minimize_scalar(
+        _exp_neg_ll,
+        args=(parts,),
+        bounds=bounds,
+        method="bounded",
+        options={"xatol": 1e-6},
+    )
+    # The bounded method can converge slightly inside a boundary
+    # supremum; take the better of the optimiser's answer and the
+    # window edges.
+    best = min(
+        float(res.fun),
+        _exp_neg_ll(bounds[0], parts),
+        _exp_neg_ll(bounds[1], parts),
+    )
+    return -best
+
+
+def _candidate_values(Z_u: NDArray) -> NDArray:
+    """Unique candidate split values, quantile-thinned for large nodes."""
+    values = np.unique(Z_u)
+    if values.size > _MAX_SPLIT_CANDIDATES:
+        quantiles = np.linspace(0, 1, _MAX_SPLIT_CANDIDATES)
+        values = np.unique(np.quantile(Z_u, quantiles))
+    return values
+
+
+def deviance_split(
+    data: SurpyvalData,
+    Z: NDArray,
+    min_leaf_samples: int,
+    min_leaf_failures: int,
+    feature_indices_in: Iterable[int],
+) -> tuple[int, float]:
+    """
+    Best ``(feature index, value)`` split by the exponential deviance
+    criterion under the full likelihood.
+
+    Mirrors ``log_rank_split``'s contract: candidates leaving either
+    child with fewer than ``min_leaf_samples`` observations or fewer
+    than ``min_leaf_failures`` event-informative observations (any
+    observation that is not purely right censored, weighted by ``n``)
+    are discarded, and ``(-1, -inf)`` is returned when no candidate
+    survives.
+
+    Parameters
+    ----------
+    data : SurpyvalData
+        Survival data in the full xcnt data model: observed, left, right
+        and interval censoring, with optional left and/or right
+        truncation.
+    Z : NDArray
+        Covariate matrix, shape ``(n_samples, n_features)``.
+    min_leaf_samples : int
+        Minimum number of samples each child must keep.
+    min_leaf_failures : int
+        Minimum ``n``-weighted count of event-informative observations
+        (``c != 1``) each child must keep.
+    feature_indices_in : Iterable[int]
+        Indices of the features considered for the split.
+
+    Returns
+    -------
+    tuple[int, float]
+        The best feature index and split value, or ``(-1, -inf)`` if no
+        valid split exists.
+    """
+    best_score = -np.inf
+    best_u = -1
+    best_v = -float("inf")
+
+    event_weight = data.n * (data.c != 1)
+
+    # All candidates -- and both children of each -- are scored over the
+    # parent's search window, so their maximised log-likelihoods are
+    # directly comparable (see _exp_max_ll).
+    theta0 = _exp_theta0(data)
+    if theta0 is None:
+        return best_u, best_v
+    bounds = (theta0 - 15.0, theta0 + 15.0)
+    parent_ll = _exp_max_ll(data, bounds)
+
+    for u in feature_indices_in:
+        Z_u = Z[:, u]
+        for v in _candidate_values(Z_u):
+            mask = Z_u <= v
+            n_left = int(mask.sum())
+            if n_left < min_leaf_samples:
+                continue
+            if (mask.size - n_left) < min_leaf_samples:
+                continue
+            if event_weight[mask].sum() < min_leaf_failures:
+                continue
+            if event_weight[~mask].sum() < min_leaf_failures:
+                continue
+
+            score = _exp_max_ll(data[mask], bounds) + _exp_max_ll(
+                data[~mask], bounds
+            )
+            if score > best_score:
+                best_score = score
+                best_u = int(u)
+                best_v = float(v)
+
+    # A split that does not improve on the parent's log-likelihood by a
+    # meaningful margin carries no information (for fully degenerate
+    # data every partition scores exactly the parent value); stop
+    # rather than split arbitrarily.
+    if best_u != -1 and best_score <= parent_ll + 1e-6:
+        return -1, -float("inf")
+
+    return best_u, best_v

--- a/surpyval/experimental/forest/forest.py
+++ b/surpyval/experimental/forest/forest.py
@@ -28,6 +28,7 @@ class RandomSurvivalForest:
         n_features_split: int | float | str = "sqrt",
         bootstrap: bool = True,
         parametric: bool = True,
+        split_rule: str = "auto",
     ):
         self.data: SurpyvalData = data
         Z = np.asarray(Z)
@@ -38,6 +39,7 @@ class RandomSurvivalForest:
         self.n_trees = n_trees
         self.bootstrap = bootstrap
         self.parametric = parametric
+        self.split_rule = split_rule
 
         # Create Trees
         if self.bootstrap:
@@ -61,6 +63,7 @@ class RandomSurvivalForest:
                 min_leaf_failures=min_leaf_failures,
                 n_features_split=n_features_split,
                 parametric=parametric,
+                split_rule=split_rule,
             )
             for i in range(self.n_trees)
         )
@@ -68,11 +71,15 @@ class RandomSurvivalForest:
     @classmethod
     def fit(
         cls,
-        x: ArrayLike,
-        Z: ArrayLike | NDArray,
-        c: ArrayLike,
+        x: ArrayLike | None = None,
+        Z: ArrayLike | NDArray | None = None,
+        c: ArrayLike | None = None,
         n: ArrayLike | None = None,
         t: ArrayLike | None = None,
+        xl: ArrayLike | None = None,
+        xr: ArrayLike | None = None,
+        tl: ArrayLike | None = None,
+        tr: ArrayLike | None = None,
         n_trees: int = 100,
         max_depth: int | float = float("inf"),
         min_leaf_samples: int = 5,
@@ -80,10 +87,15 @@ class RandomSurvivalForest:
         n_features_split: int | float | str = "sqrt",
         bootstrap: bool = True,
         leaf_type: str = "parametric",
+        split_rule: str = "auto",
     ):
         parametric = parse_leaf_type(leaf_type)
 
-        data = SurpyvalData(x, c, n, t, group_and_sort=False)
+        if Z is None:
+            raise ValueError("The covariate matrix Z is required")
+        data = SurpyvalData(
+            x, c, n, t, xl=xl, xr=xr, tl=tl, tr=tr, group_and_sort=False
+        )
         return cls(
             data,
             Z,
@@ -94,6 +106,7 @@ class RandomSurvivalForest:
             n_features_split,
             bootstrap,
             parametric,
+            split_rule,
         )
 
     def sf(

--- a/surpyval/experimental/forest/node.py
+++ b/surpyval/experimental/forest/node.py
@@ -5,7 +5,11 @@ from functools import cached_property
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from surpyval import Exponential, NelsonAalen, Weibull
+from surpyval import Exponential, NelsonAalen, Turnbull, Weibull
+from surpyval.experimental.forest.deviance_split import (
+    deviance_split,
+    needs_full_likelihood_split,
+)
 from surpyval.experimental.forest.log_rank_split import log_rank_split
 from surpyval.univariate.parametric import NeverOccurs
 from surpyval.utils.surpyval_data import SurpyvalData
@@ -37,6 +41,7 @@ class IntermediateNode(Node):
         split_feature_value: float,
         feature_indices_in: NDArray,
         parametric: bool = True,
+        split_rule: str = "log_rank",
     ):
         # Set split attributes
         self.split_feature_index = split_feature_index
@@ -59,6 +64,7 @@ class IntermediateNode(Node):
             min_leaf_failures=min_leaf_failures,
             n_features_split=n_features_split,
             parametric=parametric,
+            split_rule=split_rule,
         )
         self.right_child = build_tree(
             data[right_indices],
@@ -69,6 +75,7 @@ class IntermediateNode(Node):
             min_leaf_failures=min_leaf_failures,
             n_features_split=n_features_split,
             parametric=parametric,
+            split_rule=split_rule,
         )
 
     def apply_model_function(
@@ -88,10 +95,26 @@ class TerminalNode(Node):
         self.data = deepcopy(data)
         self.paramettric = parametric
 
+    def _nonparametric_model(self):
+        # Nelson-Aalen is a risk-set estimator, so it is only defined for
+        # observed / right-censored (optionally left-truncated) data; for
+        # anything richer -- left or interval censoring, right truncation
+        # -- the Turnbull NPMLE is the nonparametric estimator that
+        # handles the full data model.
+        if needs_full_likelihood_split(self.data):
+            return Turnbull.fit(
+                self.data.x, self.data.c, self.data.n, self.data.t
+            )
+        return NelsonAalen.fit(
+            self.data.x, self.data.c, self.data.n, self.data.t
+        )
+
     @cached_property
     def model(self):
         if self.paramettric:
-            n_failures = self.data.to_xrd()[2].sum()
+            # n-weighted count of event-informative observations (any
+            # observation that is not purely right censored).
+            n_failures = self.data.n[self.data.c != 1].sum()
             if n_failures == 0:
                 return NeverOccurs
             elif n_failures <= 1:
@@ -106,13 +129,9 @@ class TerminalNode(Node):
                 try:
                     return Exponential.fit_from_surpyval_data(self.data)
                 except Exception:
-                    return NelsonAalen.fit(
-                        self.data.x, self.data.c, self.data.n, self.data.t
-                    )
+                    return self._nonparametric_model()
         else:
-            return NelsonAalen.fit(
-                self.data.x, self.data.c, self.data.n, self.data.t
-            )
+            return self._nonparametric_model()
 
     def apply_model_function(
         self,
@@ -132,10 +151,16 @@ def build_tree(
     min_leaf_failures: int,
     n_features_split: int,
     parametric: bool = True,
+    split_rule: str = "log_rank",
 ) -> Node:
     """
     Node factory. Decides to return IntermediateNode object, or its
     sibling TerminalNode.
+
+    ``split_rule`` selects the criterion: ``"log_rank"`` (the risk-set
+    log-rank statistic; observed / right-censored data, optionally left
+    truncated) or ``"deviance"`` (the full-likelihood exponential
+    deviance split, defined for every censoring type plus truncation).
     """
     # If max_depth has been reached, return a TerminalNode
     if curr_depth == max_depth:
@@ -148,11 +173,16 @@ def build_tree(
     )
 
     # Figure out best feature-value split
-    split_feature_index, split_feature_value = log_rank_split(
-        data, Z, min_leaf_samples, min_leaf_failures, feature_indices_in
-    )
+    if split_rule == "deviance":
+        split_feature_index, split_feature_value = deviance_split(
+            data, Z, min_leaf_samples, min_leaf_failures, feature_indices_in
+        )
+    else:
+        split_feature_index, split_feature_value = log_rank_split(
+            data, Z, min_leaf_samples, min_leaf_failures, feature_indices_in
+        )
 
-    # If log_rank_split() can't suggest a feature-value split, return a
+    # If the split rule can't suggest a feature-value split, return a
     # TerminalNode
     if split_feature_index == -1 and split_feature_value == float("-Inf"):
         return TerminalNode(data, parametric)
@@ -170,4 +200,5 @@ def build_tree(
         split_feature_value=split_feature_value,
         feature_indices_in=feature_indices_in,
         parametric=parametric,
+        split_rule=split_rule,
     )

--- a/surpyval/experimental/forest/tree.py
+++ b/surpyval/experimental/forest/tree.py
@@ -3,6 +3,9 @@ from math import log2, sqrt
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
+from surpyval.experimental.forest.deviance_split import (
+    needs_full_likelihood_split,
+)
 from surpyval.experimental.forest.node import build_tree
 from surpyval.utils.surpyval_data import SurpyvalData
 
@@ -11,7 +14,24 @@ class SurvivalTree:
     """
     A Survival Tree, for use in `RandomSurvivalForest`.
 
-    The Tree is built on initialisation.
+    The Tree is built on initialisation. Supports the full SurPyval data
+    model: observed, left-, right- and interval-censored observations
+    with optional left and/or right truncation.
+
+    The split criterion is controlled by ``split_rule``:
+
+    - ``"auto"`` (default): the risk-set log-rank split when the data is
+      expressible in the xrd format (observed / right-censored,
+      optionally left-truncated), and the full-likelihood exponential
+      deviance split (Davis & Anderson, 1989) otherwise -- left or
+      interval censoring and right truncation carry their event
+      information as interval probabilities, for which no risk-set
+      statistic exists.
+    - ``"log-rank"``: force the risk-set log-rank split. Raises
+      ``ValueError`` if the data contains left/interval censoring or
+      right truncation.
+    - ``"deviance"``: force the full-likelihood deviance split (valid
+      for every data type).
     """
 
     def __init__(
@@ -23,6 +43,7 @@ class SurvivalTree:
         min_leaf_failures: int = 2,
         n_features_split: int | float | str = "sqrt",
         parametric: bool | str = "non-parametric",
+        split_rule: str = "auto",
     ):
         self.data = data
         self.Z = Z
@@ -39,6 +60,8 @@ class SurvivalTree:
             else parse_leaf_type(parametric)
         )
 
+        self.split_rule = parse_split_rule(split_rule, data)
+
         self._root = build_tree(
             data=self.data,
             Z=self.Z,
@@ -48,23 +71,43 @@ class SurvivalTree:
             min_leaf_failures=min_leaf_failures,
             n_features_split=n_features,
             parametric=is_parametric,
+            split_rule=self.split_rule,
         )
 
     @classmethod
     def fit(
         cls,
-        x: ArrayLike,
-        Z: ArrayLike | NDArray,
-        c: ArrayLike,
+        x: ArrayLike | None = None,
+        Z: ArrayLike | NDArray | None = None,
+        c: ArrayLike | None = None,
         n: ArrayLike | None = None,
         t: ArrayLike | None = None,
+        xl: ArrayLike | None = None,
+        xr: ArrayLike | None = None,
+        tl: ArrayLike | None = None,
+        tr: ArrayLike | None = None,
         max_depth: int | float = float("inf"),
         min_leaf_samples: int = 5,
         min_leaf_failures: int = 2,
         n_features_split: int | float | str = "sqrt",
         leaf_type: str = "parametric",
+        split_rule: str = "auto",
     ):
-        data = SurpyvalData(x, c, n, t, group_and_sort=False)
+        """
+        Fit a survival tree from data in the full xcnt(+truncation) data
+        model.
+
+        ``x``/``c``/``n``/``t`` follow the standard SurPyval conventions
+        (``c`` in ``{-1, 0, 1, 2}``; interval-censored entries of ``x``
+        are ``[left, right]`` pairs). Interval bounds can alternatively
+        be given as ``xl``/``xr``, and truncation as ``tl``/``tr``
+        instead of the two-column ``t``.
+        """
+        if Z is None:
+            raise ValueError("The covariate matrix Z is required")
+        data = SurpyvalData(
+            x, c, n, t, xl=xl, xr=xr, tl=tl, tr=tr, group_and_sort=False
+        )
         Z = np.asarray(Z)
         if Z.ndim == 1:
             # A 1-d Z is a single feature, one value per sample
@@ -77,6 +120,7 @@ class SurvivalTree:
             min_leaf_failures,
             n_features_split,
             parse_leaf_type(leaf_type),
+            split_rule,
         )
 
     def apply_model_function(
@@ -143,3 +187,34 @@ def parse_leaf_type(leaf_type: str):
     else:
         raise ValueError(f"leaf_type={leaf_type} is invalid. Must\
             'parametric' or 'non-parametric'")
+
+
+def parse_split_rule(split_rule: str, data: SurpyvalData) -> str:
+    """
+    Resolve the requested split rule against the data.
+
+    ``"auto"`` picks the risk-set log-rank when the data can be expressed
+    in the xrd format and the full-likelihood deviance split otherwise.
+    An explicit ``"log-rank"`` is validated against the data, since the
+    risk-set statistic is undefined for left/interval censoring and
+    right truncation.
+    """
+    rule = split_rule.lower().replace("-", "_")
+    if rule == "auto":
+        if needs_full_likelihood_split(data):
+            return "deviance"
+        return "log_rank"
+    if rule in ("log_rank", "logrank"):
+        if needs_full_likelihood_split(data):
+            raise ValueError(
+                "The risk-set log-rank split is undefined for data with "
+                "left censoring, interval censoring, or right truncation; "
+                "use split_rule='deviance' (or 'auto') for this data."
+            )
+        return "log_rank"
+    if rule in ("deviance", "exponential"):
+        return "deviance"
+    raise ValueError(
+        f"split_rule={split_rule!r} is invalid. Must be 'auto', "
+        "'log-rank' or 'deviance'."
+    )

--- a/surpyval/tests/experimental/forest/test_tree_full_data_model.py
+++ b/surpyval/tests/experimental/forest/test_tree_full_data_model.py
@@ -1,0 +1,289 @@
+"""The survival tree under the full SurPyval data model.
+
+The risk-set log-rank split only exists for observed / right-censored
+(optionally left-truncated) data, so the tree adds a full-likelihood
+exponential deviance split (Davis & Anderson, 1989) and switches to it
+automatically when the data contains left censoring, interval censoring
+or right truncation. These tests pin:
+
+- the exponential MLE inside the deviance split against SurPyval's own
+  ``Exponential.fit`` on every data type (the correctness anchor);
+- that a tree builds on every data type and, given all features, splits
+  on the signal feature and predicts the right survival ordering;
+- the auto rule selection and the guard for forcing log-rank on data it
+  cannot handle;
+- Turnbull nonparametric leaves for data Nelson-Aalen cannot fit;
+- the forest passthrough.
+"""
+
+import numpy as np
+import pytest
+from scipy.optimize import minimize_scalar
+
+from surpyval import Exponential
+from surpyval.experimental.forest import RandomSurvivalForest, SurvivalTree
+from surpyval.experimental.forest.deviance_split import (
+    _exp_neg_ll,
+    _exp_neg_ll_parts,
+    needs_full_likelihood_split,
+)
+from surpyval.utils.surpyval_data import SurpyvalData
+
+
+def _signal_data(n=120, seed=2):
+    """Feature 0 is a strong binary signal (3x scale), feature 1 noise."""
+    rng = np.random.default_rng(seed)
+    Z = np.column_stack(
+        [rng.integers(0, 2, n).astype(float), rng.normal(0, 1, n)]
+    )
+    scale = np.where(Z[:, 0] > 0.5, 4.0, 12.0)
+    x = scale * rng.weibull(1.5, n)
+    c = (rng.random(n) < 0.25).astype(int)
+    return Z, x, c
+
+
+def _intervalise(x, c, every=3):
+    """Turn every ``every``-th observed value into an interval."""
+    x_out = [
+        [v * 0.75, v * 1.25] if (i % every == 0 and c[i] == 0) else v
+        for i, v in enumerate(x)
+    ]
+    c_out = np.where((np.arange(len(x)) % every == 0) & (c == 0), 2, c)
+    return x_out, c_out
+
+
+def _fit_all_features(**kwargs):
+    np.random.seed(7)
+    return SurvivalTree.fit(
+        n_features_split="all", min_leaf_samples=10, **kwargs
+    )
+
+
+def _assert_signal_recovered(tree, mid_time=5.0):
+    assert tree._root.split_feature_index == 0
+    s_fast = float(tree.sf(mid_time, np.array([1.0, 0.0]))[0])
+    s_slow = float(tree.sf(mid_time, np.array([0.0, 0.0]))[0])
+    assert s_fast < s_slow
+
+
+# -- exponential MLE anchor ------------------------------------------------
+
+
+def _deviance_mle(data):
+    parts = _exp_neg_ll_parts(data)
+    res = minimize_scalar(
+        _exp_neg_ll,
+        args=(parts,),
+        bounds=(-20, 5),
+        method="bounded",
+        options={"xatol": 1e-9},
+    )
+    return float(np.exp(res.x))
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["right", "left", "interval", "left_trunc", "right_trunc", "mixed"],
+)
+def test_deviance_mle_matches_exponential_fit(case):
+    rng = np.random.default_rng(0)
+    n = 100
+    x = rng.exponential(10, n)
+    c = (rng.random(n) < 0.3).astype(int)
+    tl = np.full(n, -np.inf)
+    tr = np.full(n, np.inf)
+    x_in: list | np.ndarray = x
+    if case == "left":
+        c = np.where(rng.random(n) < 0.2, -1, c)
+    elif case == "interval":
+        x_in, c = _intervalise(x, c)
+    elif case == "left_trunc":
+        c = np.zeros(n)
+        tl = np.minimum(x * 0.3, 2.0)
+    elif case == "right_trunc":
+        c = np.zeros(n)
+        tr = x * 1.5 + 5.0
+    elif case == "mixed":
+        x_in, c = _intervalise(x, c)
+        c = np.where((np.arange(n) % 7 == 0) & (c != 2), -1, c)
+        tl = np.minimum(x * 0.1, 0.5)
+
+    data = SurpyvalData(x_in, c, tl=tl, tr=tr, group_and_sort=False)
+    lam_surpyval = float(Exponential.fit_from_surpyval_data(data).params[0])
+    assert np.isclose(_deviance_mle(data), lam_surpyval, rtol=1e-3)
+
+
+# -- tree building on every data type --------------------------------------
+
+
+def test_tree_right_censored_uses_log_rank():
+    Z, x, c = _signal_data()
+    tree = _fit_all_features(x=x, Z=Z, c=c)
+    assert tree.split_rule == "log_rank"
+    _assert_signal_recovered(tree)
+
+
+def test_tree_interval_censored():
+    Z, x, c = _signal_data()
+    x_in, c_in = _intervalise(x, c)
+    tree = _fit_all_features(x=x_in, Z=Z, c=c_in)
+    assert tree.split_rule == "deviance"
+    _assert_signal_recovered(tree)
+
+
+def test_tree_left_censored():
+    Z, x, c = _signal_data()
+    rng = np.random.default_rng(3)
+    c_in = np.where((rng.random(len(x)) < 0.2) & (c == 0), -1, c)
+    tree = _fit_all_features(x=x, Z=Z, c=c_in)
+    assert tree.split_rule == "deviance"
+    _assert_signal_recovered(tree)
+
+
+def test_tree_left_truncated_keeps_log_rank():
+    Z, x, _ = _signal_data()
+    n = len(x)
+    tl = np.minimum(x * 0.3, 1.0)
+    tree = _fit_all_features(
+        x=x, Z=Z, c=np.zeros(n), tl=tl, tr=np.full(n, np.inf)
+    )
+    assert tree.split_rule == "log_rank"
+    _assert_signal_recovered(tree)
+
+
+def test_tree_right_truncated():
+    Z, x, _ = _signal_data()
+    n = len(x)
+    tree = _fit_all_features(
+        x=x,
+        Z=Z,
+        c=np.zeros(n),
+        tl=np.full(n, -np.inf),
+        tr=np.full(n, float(x.max()) * 1.1),
+    )
+    assert tree.split_rule == "deviance"
+    _assert_signal_recovered(tree)
+
+
+def test_tree_everything_at_once():
+    # Interval + left + right censoring with left truncation on every
+    # row and right truncation on the event rows. (A right-censored row
+    # cannot carry finite right truncation: right-truncation sampling
+    # only admits units whose event was seen before tr.)
+    Z, x, c = _signal_data()
+    n = len(x)
+    x_in, c_in = _intervalise(x, c)
+    c_in = np.where((np.arange(n) % 7 == 0) & (c_in != 2), -1, c_in)
+    tr = np.where(c_in == 1, np.inf, float(x.max()) * 1.2)
+    tree = _fit_all_features(
+        x=x_in,
+        Z=Z,
+        c=c_in,
+        tl=np.minimum(x * 0.1, 0.5),
+        tr=tr,
+    )
+    assert tree.split_rule == "deviance"
+    _assert_signal_recovered(tree)
+
+
+def test_tree_xl_xr_convenience():
+    # pure interval-censored input via xl/xr
+    rng = np.random.default_rng(4)
+    n = 80
+    Z = np.column_stack(
+        [rng.integers(0, 2, n).astype(float), rng.normal(0, 1, n)]
+    )
+    scale = np.where(Z[:, 0] > 0.5, 4.0, 12.0)
+    x = scale * rng.weibull(1.5, n)
+    tree = _fit_all_features(xl=x * 0.8, xr=x * 1.2, Z=Z)
+    assert tree.split_rule == "deviance"
+    _assert_signal_recovered(tree)
+
+
+# -- split-rule selection and guards ---------------------------------------
+
+
+def test_forced_deviance_on_classic_data():
+    Z, x, c = _signal_data()
+    tree = _fit_all_features(x=x, Z=Z, c=c, split_rule="deviance")
+    assert tree.split_rule == "deviance"
+    _assert_signal_recovered(tree)
+
+
+def test_forced_log_rank_on_interval_data_raises():
+    Z, x, c = _signal_data()
+    x_in, c_in = _intervalise(x, c)
+    with pytest.raises(ValueError, match="undefined"):
+        SurvivalTree.fit(x=x_in, Z=Z, c=c_in, split_rule="log-rank")
+
+
+def test_invalid_split_rule_raises():
+    Z, x, c = _signal_data()
+    with pytest.raises(ValueError, match="split_rule"):
+        SurvivalTree.fit(x=x, Z=Z, c=c, split_rule="bogus")
+
+
+def test_needs_full_likelihood_split_detection():
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    assert not needs_full_likelihood_split(
+        SurpyvalData(x, np.array([0, 0, 1, 0, 1]), group_and_sort=False)
+    )
+    assert needs_full_likelihood_split(
+        SurpyvalData(x, np.array([0, 0, -1, 0, 1]), group_and_sort=False)
+    )
+    assert needs_full_likelihood_split(
+        SurpyvalData(
+            x,
+            np.zeros(5),
+            tl=np.full(5, -np.inf),
+            tr=np.full(5, 10.0),
+            group_and_sort=False,
+        )
+    )
+
+
+# -- leaves ----------------------------------------------------------------
+
+
+def test_nonparametric_turnbull_leaves_on_interval_data():
+    Z, x, c = _signal_data()
+    x_in, c_in = _intervalise(x, c)
+    tree = _fit_all_features(x=x_in, Z=Z, c=c_in, leaf_type="non-parametric")
+    # predictions are finite probabilities and decreasing in time
+    s = tree.sf(np.array([2.0, 6.0, 12.0]), np.array([1.0, 0.0]))
+    s = np.asarray(s, dtype=float)
+    assert np.all((s >= 0) & (s <= 1))
+    assert np.all(np.diff(s) <= 1e-9)
+
+
+def test_parametric_leaves_on_interval_data():
+    Z, x, c = _signal_data()
+    x_in, c_in = _intervalise(x, c)
+    tree = _fit_all_features(x=x_in, Z=Z, c=c_in, leaf_type="parametric")
+    s = np.asarray(
+        tree.sf(np.array([2.0, 6.0, 12.0]), np.array([0.0, 0.0])),
+        dtype=float,
+    )
+    assert np.all((s >= 0) & (s <= 1))
+    assert np.all(np.diff(s) <= 1e-9)
+
+
+# -- forest passthrough ----------------------------------------------------
+
+
+def test_forest_on_interval_censored_data():
+    Z, x, c = _signal_data(n=90, seed=6)
+    x_in, c_in = _intervalise(x, c)
+    np.random.seed(11)
+    forest = RandomSurvivalForest.fit(
+        x=x_in,
+        Z=Z,
+        c=c_in,
+        n_trees=5,
+        min_leaf_samples=10,
+        n_features_split="all",
+    )
+    assert all(tree.split_rule == "deviance" for tree in forest.trees)
+    s_fast = float(np.atleast_1d(forest.sf(5.0, np.array([1.0, 0.0])))[0])
+    s_slow = float(np.atleast_1d(forest.sf(5.0, np.array([0.0, 0.0])))[0])
+    assert s_fast < s_slow


### PR DESCRIPTION
The experimental `SurvivalTree` previously **crashed** on left-censored, interval-censored, and right-truncated data. Its only split criterion was the risk-set log-rank statistic, which is *mathematically undefined* for those observation types — their event information is an interval probability, not a risk-set entry/exit. This PR makes the tree (and `RandomSurvivalForest`) functional for the full SurPyval data model: observed / left / right / interval censoring with optional left and/or right truncation.

### The new split criterion
A second split rule — the **full-likelihood exponential deviance split** (Davis & Anderson, 1989, *Statistics in Medicine*) — scores every candidate split by the joint maximised exponential log-likelihood of its two children, with each observation contributing its exact term:

| Observation | Likelihood term |
|---|---|
| observed `x` | `log λ − λx` |
| right censored | `−λx` |
| left censored | `log(1 − e^{−λx})` |
| interval `(xl, xr]` | `log(e^{−λxl} − e^{−λxr})` |
| truncated to `(tl, tr]` | minus `log(S(tl) − S(tr))` |

The 1-D MLE is a bounded scalar search over `log λ`, **cross-validated against `Exponential.fit` to 1e-3 on all six data configurations** (the correctness anchor in the tests).

Two design points found the hard way:
- **Common parameter window per node.** Degenerate likelihood directions (e.g. a supremum at `λ → 0` under right truncation) made per-subset search windows incomparable — a split could score *below* its parent, which is impossible for an additive likelihood. Scoring parent and all candidate children over the parent's window restores monotonicity **by construction**.
- **No-gain stopping.** A split that doesn't improve the parent's log-likelihood carries no information (for fully degenerate data every partition ties) — the branch terminates instead of splitting arbitrarily.

### Behaviour preservation
`split_rule="auto"` (default) keeps the **risk-set log-rank** for observed/right-censored (optionally left-truncated) data — existing behaviour and all 14 pre-existing experimental tests unchanged — and switches to the deviance split only when the data demands it. Forcing `"log-rank"` on incompatible data raises a clear `ValueError`.

### Leaves
- Parametric (Weibull) leaves already supported the full model via SurPyval's MLE.
- Nonparametric leaves now use the **Turnbull NPMLE** when the data has left/interval censoring or right truncation (Nelson-Aalen is a risk-set estimator and cannot fit those); Nelson-Aalen otherwise, as before. The Weibull fallback chain's last resort is likewise Turnbull-aware.

### Plumbing
- `fit()` on both classes accepts `xl`/`xr` and `tl`/`tr` conveniences.
- `split_rule` passes through the forest; candidate values quantile-thinned (64) for large nodes.
- Full-depth tree on n=200 interval-censored rows builds in ~0.5 s; a 10-tree depth-3 forest in ~1.7 s.

### Validation
- New `test_tree_full_data_model.py` (20 tests): MLE anchor ×6, per-type tree building with signal-feature recovery and survival-ordering checks (interval, left-censored, left-/right-truncated, everything-at-once, `xl`/`xr`), rule selection + guards, Turnbull/parametric leaves, forest passthrough. Experimental suite: 34 passed.
- flake8 / black / `mypy surpyval` clean. (Experimental tests remain excluded from CI by design; run locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_