### PR TITLE
Add package-level from_dict/from_json readers for serialised models

### DIFF
--- a/docs/Regression Modelling with SurPyval.rst
+++ b/docs/Regression Modelling with SurPyval.rst
@@ -854,6 +854,17 @@ Use ``to_json`` / ``from_json`` for a file directly:
     reloaded = ParametricRegressionModel.from_json(path)
     print(reloaded)
 
+If you don't know (or don't want to hard-code) which class wrote a file, the
+package-level readers ``surpyval.from_json`` / ``surpyval.from_dict`` dispatch
+on the serialised content itself and work for every serialisable SurPyval
+model:
+
+.. jupyter-execute::
+
+    import surpyval
+
+    print(surpyval.from_json(path))
+
 If the fitted model carried a computable parameter covariance, it is stored in
 the dictionary, so the reloaded model can also produce confidence bounds
 (``cb``, ``param_cb``, ``standard_errors``) without the original data. Only the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,18 @@ Changelog
 v0.15.0 (unreleased)
 --------------------
 
+Serialisation
+~~~~~~~~~~~~~
+
+- Added package-level readers for serialised models:
+  ``surpyval.from_dict(model_dict)`` and ``surpyval.from_json(fp)`` restore a
+  model of the right class from any model's ``to_dict`` dictionary /
+  ``to_json`` file, so the caller no longer needs to know which class wrote
+  it. Dispatch reads the serialised dictionary itself: the ``"model"`` class
+  tag written by most models, or the ``"parameterization"`` marker
+  (``"parametric"``, ``"non-parametric"``, ``"parametric-regression"``) of the
+  core univariate families. The class-level readers are unchanged.
+
 Machine learning
 ~~~~~~~~~~~~~~~~
 

--- a/surpyval/__init__.py
+++ b/surpyval/__init__.py
@@ -86,6 +86,11 @@ from surpyval.univariate.regression import *  # isort: skip # noqa: F401,F403,E5
 from surpyval.utils.surpyval_data import SurpyvalData  # isort: skip
 from surpyval.utils.recurrent_utils import handle_xicn  # isort: skip
 
+# Package-level readers for serialised models: `surpyval.from_json` /
+# `surpyval.from_dict` restore a model of the right class from any
+# model's `to_json` file / `to_dict` dictionary.
+from surpyval.serialisation import from_dict, from_json  # isort: skip
+
 NUM = np.float64
 TINIEST = np.finfo(np.float64).tiny
 EPS = np.sqrt(np.finfo(NUM).eps)

--- a/surpyval/serialisation.py
+++ b/surpyval/serialisation.py
@@ -1,0 +1,177 @@
+"""Package-level readers for serialised SurPyval models.
+
+Every serialisable fitted SurPyval model writes ``to_dict`` /
+``to_json``; the matching class-level ``from_dict`` / ``from_json``
+readers require knowing up front which class wrote the file. The
+package-level readers here dispatch on the serialised dictionary
+itself, so one call restores a model of the right class no matter
+which model wrote it:
+
+.. code:: python
+
+    import surpyval
+
+    model = surpyval.from_json("model.json")  # any model's file
+    model = surpyval.from_dict(model_dict)    # any model's dict
+
+Dispatch uses the two conventions in the serialised dictionaries:
+most classes write a ``"model"`` tag equal to their class name, and
+the core univariate families are identified by their
+``"parameterization"`` (``"parametric"``, ``"non-parametric"`` or
+``"parametric-regression"``).
+"""
+
+import json
+from importlib import import_module
+from pathlib import Path
+from typing import Any
+
+# ``"model"`` tag -> defining module. The tag every class writes into
+# its dict is its own class name, so the registry only needs to find
+# the defining module, lazily (importing everything eagerly here would
+# be a heavy import and a cycle risk).
+_TAGGED_MODELS: dict[str, str] = {
+    "SemiParametricRegressionModel": (
+        "surpyval.univariate.regression.semi_parametric_regression_model"
+    ),
+    "AdditiveHazardsModel": (
+        "surpyval.univariate.regression.additive_hazards.additive_hazards"
+    ),
+    "BuckleyJamesModel": (
+        "surpyval.univariate.regression.buckley_james.buckley_james"
+    ),
+    "MixtureModel": "surpyval.univariate.parametric.mixture_model",
+    "FineGrayModel": (
+        "surpyval.univariate.competing_risks.regression.fine_gray"
+    ),
+    "ParametricCompetingRisks": (
+        "surpyval.univariate.competing_risks.parametric"
+        ".parametric_competing_risks"
+    ),
+    "CompetingRisks": (
+        "surpyval.univariate.competing_risks.nonparametric.competing_risks"
+    ),
+    "CauseSpecificMCF": (
+        "surpyval.recurrent.competing_risks.nonparametric.cause_specific_mcf"
+    ),
+    "CauseSpecificNHPP": (
+        "surpyval.recurrent.competing_risks.parametric.cause_specific_nhpp"
+    ),
+    "NonParametricCounting": "surpyval.recurrent.nonparametric.mcf",
+    "ParametricRecurrenceModel": (
+        "surpyval.recurrent.parametric.parametric_recurrence"
+    ),
+    "ProportionalIntensityModel": (
+        "surpyval.recurrent.regression.proportional_intensity"
+    ),
+    "RenewalModel": "surpyval.recurrent.renewal.renewal_model",
+    "DegradationModel": "surpyval.degradation.degradation_analysis",
+    "InducedFailureDistribution": (
+        "surpyval.degradation.degradation_analysis"
+    ),
+    "WienerProcessModel": "surpyval.degradation.process_models",
+    "GammaProcessModel": "surpyval.degradation.process_models",
+}
+
+# ``"parameterization"`` value -> (defining module, class name), for
+# the core univariate families, which carry no ``"model"`` class tag.
+# (The non-parametric dicts do have a ``"model"`` key, but it holds the
+# estimator name -- e.g. ``"Kaplan-Meier"`` -- not a class name.)
+_PARAMETERIZATIONS: dict[str, tuple[str, str]] = {
+    "parametric": (
+        "surpyval.univariate.parametric.parametric",
+        "Parametric",
+    ),
+    "non-parametric": (
+        "surpyval.univariate.nonparametric.nonparametric",
+        "NonParametric",
+    ),
+    "parametric-regression": (
+        "surpyval.univariate.regression.parametric_regression_model",
+        "ParametricRegressionModel",
+    ),
+}
+
+
+def _resolve(module_name: str, class_name: str) -> Any:
+    return getattr(import_module(module_name), class_name)
+
+
+def from_dict(model_dict: dict) -> Any:
+    """
+    Restore any serialised SurPyval model from its dictionary.
+
+    Reads the dictionary written by any fitted model's ``to_dict`` and
+    dispatches to the right class's ``from_dict``, so the caller does
+    not need to know which class wrote it.
+
+    Parameters
+    ----------
+    model_dict : dict
+        A dictionary produced by a SurPyval model's ``to_dict``.
+
+    Returns
+    -------
+    The restored model, of whichever class serialised the dictionary.
+
+    Raises
+    ------
+    ValueError
+        If the dictionary is not recognisable as a serialised SurPyval
+        model.
+
+    Examples
+    --------
+    >>> import surpyval
+    >>> from surpyval import Weibull
+    >>> model = Weibull.fit([3.0, 4.0, 5.0, 6.0, 7.0])
+    >>> restored = surpyval.from_dict(model.to_dict())
+    >>> restored.dist.name
+    'Weibull'
+    """
+    if not isinstance(model_dict, dict):
+        raise ValueError(
+            "Expected a serialised model dict, got "
+            f"{type(model_dict).__name__}"
+        )
+
+    tag = model_dict.get("model")
+    if isinstance(tag, str) and tag in _TAGGED_MODELS:
+        return _resolve(_TAGGED_MODELS[tag], tag).from_dict(model_dict)
+
+    parameterization = model_dict.get("parameterization")
+    if parameterization in _PARAMETERIZATIONS:
+        return _resolve(*_PARAMETERIZATIONS[parameterization]).from_dict(
+            model_dict
+        )
+
+    described = ", ".join(
+        f"{k}={model_dict[k]!r}"
+        for k in ("model", "parameterization")
+        if k in model_dict
+    )
+    raise ValueError(
+        "Not a recognisable serialised SurPyval model"
+        + (f" ({described})" if described else "")
+        + ": expected a 'model' class tag or a known 'parameterization'."
+    )
+
+
+def from_json(fp: str | Path) -> Any:
+    """
+    Restore any serialised SurPyval model from a JSON file.
+
+    Reads a file written by any fitted model's ``to_json`` and
+    dispatches to the right class's reader; see :func:`from_dict`.
+
+    Parameters
+    ----------
+    fp : str | Path
+        Path to a JSON file written by a SurPyval model's ``to_json``.
+
+    Returns
+    -------
+    The restored model, of whichever class serialised the file.
+    """
+    with open(fp, "r") as f:
+        return from_dict(json.load(f))

--- a/surpyval/tests/test_package_serialisation.py
+++ b/surpyval/tests/test_package_serialisation.py
@@ -1,0 +1,232 @@
+"""The package-level readers ``surpyval.from_dict`` / ``surpyval.from_json``.
+
+Every serialisable model writes either a ``"model"`` class tag or a
+``"parameterization"`` marker into its ``to_dict``; the package-level
+readers dispatch on those, so a caller can restore any model without
+knowing which class wrote it. These tests pin:
+
+- registry integrity: every registered tag resolves to a class of that
+  name with a ``from_dict``;
+- dispatch: a round-trip through ``surpyval.from_dict`` restores the
+  right class and reproduces predictions, for a representative model
+  of every dictionary shape (parametric, non-parametric,
+  parametric-regression, and the tagged families);
+- the file reader ``surpyval.from_json``;
+- clear errors for unrecognisable input.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+import surpyval
+from surpyval import CoxPH, KaplanMeier, MixtureModel, Weibull, WeibullPH
+from surpyval.serialisation import (
+    _PARAMETERIZATIONS,
+    _TAGGED_MODELS,
+    _resolve,
+)
+
+
+def _rt(d):
+    """JSON round-trip a dict (proves it is JSON-serialisable)."""
+    return json.loads(json.dumps(d))
+
+
+def _regression_data(seed=0, n=60):
+    rng = np.random.default_rng(seed)
+    Z = np.column_stack(
+        [rng.integers(0, 2, n).astype(float), rng.normal(0, 1, n)]
+    )
+    x = 10 * np.exp(-0.5 * Z[:, 0]) * rng.weibull(2.0, n)
+    c = (rng.random(n) < 0.2).astype(int)
+    return x, Z, c
+
+
+# -- registry integrity ------------------------------------------------------
+
+
+def test_every_tag_resolves_to_its_class():
+    for tag, module in _TAGGED_MODELS.items():
+        resolved = _resolve(module, tag)
+        # Some fitters follow surpyval's singleton pattern, binding the
+        # module-level name to an instance of the class; from_dict is a
+        # classmethod so both dispatch identically.
+        name = getattr(resolved, "__name__", type(resolved).__name__)
+        assert name == tag
+        assert callable(resolved.from_dict)
+
+
+def test_every_parameterization_resolves():
+    for module, name in _PARAMETERIZATIONS.values():
+        cls = _resolve(module, name)
+        assert cls.__name__ == name
+        assert callable(cls.from_dict)
+
+
+# -- the three untagged core shapes ------------------------------------------
+
+
+def test_parametric_dispatch():
+    model = Weibull.fit([3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+    restored = surpyval.from_dict(_rt(model.to_dict()))
+    assert type(restored).__name__ == "Parametric"
+    assert restored.dist.name == "Weibull"
+    t = np.array([2.0, 5.0, 9.0])
+    assert np.allclose(model.sf(t), restored.sf(t))
+
+
+def test_non_parametric_dispatch():
+    model = KaplanMeier.fit([3.0, 4.0, 5.0, 6.0, 7.0], [0, 1, 0, 0, 1])
+    restored = surpyval.from_dict(_rt(model.to_dict()))
+    assert type(restored).__name__ == "NonParametric"
+    assert restored.model == "Kaplan-Meier"
+    assert np.allclose(model.R, restored.R)
+
+
+def test_parametric_regression_dispatch():
+    x, Z, c = _regression_data()
+    model = WeibullPH.fit(x=x, Z=Z, c=c)
+    restored = surpyval.from_dict(_rt(model.to_dict()))
+    assert type(restored).__name__ == "ParametricRegressionModel"
+    t = np.array([2.0, 6.0])
+    z = np.array([1.0, 0.5])
+    assert np.allclose(model.sf(t, Z=z), restored.sf(t, Z=z))
+
+
+# -- tagged families (one representative per family) --------------------------
+
+
+def test_semi_parametric_dispatch():
+    x, Z, c = _regression_data(seed=1)
+    model = CoxPH.fit(x=x, Z=Z, c=c)
+    restored = surpyval.from_dict(_rt(model.to_dict()))
+    assert type(restored).__name__ == "SemiParametricRegressionModel"
+    t = np.array([2.0, 6.0])
+    z = np.array([1.0, 0.5])
+    assert np.allclose(model.sf(t, Z=z), restored.sf(t, Z=z))
+
+
+def test_mixture_model_dispatch():
+    x = np.concatenate([Weibull.random(50, 8, 3), Weibull.random(50, 40, 4)])
+    model = MixtureModel(dist=Weibull, m=2)
+    model.fit(x=x)
+    restored = surpyval.from_dict(_rt(model.to_dict()))
+    assert type(restored).__name__ == "MixtureModel"
+    t = np.array([5.0, 20.0])
+    assert np.allclose(model.sf(t), restored.sf(t))
+
+
+def test_parametric_recurrence_dispatch():
+    from surpyval.recurrent import CrowAMSAA
+
+    x = np.array([10.0, 25.0, 45.0, 70.0, 100.0, 135.0, 175.0])
+    model = CrowAMSAA.fit(x)
+    restored = surpyval.from_dict(_rt(model.to_dict()))
+    assert type(restored).__name__ == "ParametricRecurrenceModel"
+    t = np.array([50.0, 150.0])
+    assert np.allclose(model.cif(t), restored.cif(t))
+
+
+def test_mcf_dispatch():
+    from surpyval.recurrent import NonParametricCounting
+
+    x = np.array([5.0, 12.0, 20.0, 8.0, 15.0, 25.0])
+    i = np.array([1, 1, 1, 2, 2, 2])
+    c = np.array([0, 0, 1, 0, 0, 1])
+    model = NonParametricCounting.fit(x, i, c)
+    restored = surpyval.from_dict(_rt(model.to_dict()))
+    assert type(restored).__name__ == "NonParametricCounting"
+    assert np.allclose(model.mcf_hat, restored.mcf_hat)
+
+
+def test_renewal_dispatch():
+    from surpyval.recurrent import GeneralizedRenewal
+
+    model = GeneralizedRenewal.fit_from_parameters(
+        [50.0, 2.0], 0.3, kijima="i", dist=Weibull
+    )
+    restored = surpyval.from_dict(_rt(model.to_dict()))
+    assert type(restored).__name__ == "RenewalModel"
+    assert np.isclose(model.restoration, restored.restoration)
+    assert np.allclose(model.model.params, restored.model.params)
+
+
+def test_competing_risks_dispatch():
+    from surpyval.univariate.competing_risks import CompetingRisks
+
+    rng = np.random.default_rng(3)
+    n = 60
+    x = np.abs(rng.weibull(1.3, n) * 15) + 0.2
+    e = rng.choice([1, 2], n)
+    model = CompetingRisks.fit(x, e)
+    restored = surpyval.from_dict(_rt(model.to_dict()))
+    assert type(restored).__name__ == "CompetingRisks"
+
+
+def test_process_model_dispatch():
+    from surpyval.degradation import WienerProcess
+
+    rng = np.random.default_rng(2)
+    xs, ys, ii = [], [], []
+    for u in range(10):
+        t = np.arange(0, 20, 2.0)
+        xs.append(t)
+        ys.append(np.cumsum(rng.normal(1.0, 1.0, t.size)))
+        ii.append(np.full(t.size, u))
+    model = WienerProcess.fit(
+        np.concatenate(xs),
+        np.concatenate(ys),
+        np.concatenate(ii),
+        threshold=20.0,
+    )
+    restored = surpyval.from_dict(_rt(model.to_dict()))
+    assert type(restored).__name__ == "WienerProcessModel"
+    t = np.array([5.0, 15.0])
+    assert np.allclose(model.sf(t), restored.sf(t))
+
+
+# -- the file reader ----------------------------------------------------------
+
+
+def test_from_json_file(tmp_path):
+    model = Weibull.fit([3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+    fp = tmp_path / "weibull.json"
+    model.to_json(fp)
+    restored = surpyval.from_json(fp)
+    assert restored.dist.name == "Weibull"
+    t = np.array([2.0, 5.0, 9.0])
+    assert np.allclose(model.sf(t), restored.sf(t))
+
+
+def test_from_json_file_tagged(tmp_path):
+    x, Z, c = _regression_data(seed=4)
+    model = CoxPH.fit(x=x, Z=Z, c=c)
+    fp = tmp_path / "cox.json"
+    model.to_json(fp)
+    restored = surpyval.from_json(fp)
+    assert type(restored).__name__ == "SemiParametricRegressionModel"
+
+
+# -- errors -------------------------------------------------------------------
+
+
+def test_from_dict_rejects_non_dict():
+    with pytest.raises(ValueError, match="dict"):
+        surpyval.from_dict("not a dict")
+
+
+def test_from_dict_rejects_empty_dict():
+    with pytest.raises(ValueError, match="recognisable"):
+        surpyval.from_dict({})
+
+
+def test_from_dict_rejects_unknown_tag():
+    with pytest.raises(ValueError, match="NotAModel"):
+        surpyval.from_dict({"model": "NotAModel"})
+
+
+def test_from_dict_rejects_unknown_parameterization():
+    with pytest.raises(ValueError, match="bayesian"):
+        surpyval.from_dict({"parameterization": "bayesian"})


### PR DESCRIPTION
## Summary

- **`surpyval.from_dict(model_dict)` / `surpyval.from_json(fp)`**: package-level readers that restore a model of the right class from *any* model's `to_dict` dictionary / `to_json` file — the caller no longer needs to know which class wrote it:

  ```python
  import surpyval
  model = surpyval.from_json("model.json")   # whatever wrote it
  ```

- Dispatch reads the serialised dictionary itself, using the two existing conventions:
  - the `"model"` class tag written by the seventeen tagged classes (Cox/`SemiParametricRegressionModel`, `AdditiveHazardsModel`, `BuckleyJamesModel`, `MixtureModel`, `FineGrayModel`, `ParametricCompetingRisks`, `CompetingRisks`, `CauseSpecificMCF`, `CauseSpecificNHPP`, `NonParametricCounting`, `ParametricRecurrenceModel`, `ProportionalIntensityModel`, `RenewalModel`, `DegradationModel`, `InducedFailureDistribution`, `WienerProcessModel`, `GammaProcessModel`);
  - the `"parameterization"` marker of the core univariate families (`"parametric"` → `Parametric`, `"non-parametric"` → `NonParametric`, `"parametric-regression"` → `ParametricRegressionModel`).
- Classes resolve lazily from a registry of defining modules (`surpyval/serialisation.py`), so importing `surpyval` stays light and cycle-free. The class-level readers are unchanged. Unrecognisable input raises a `ValueError` naming what was found.
- Docs: the regression serialisation example now shows the package-level reader; changelog entry added.

## Test plan

- New `surpyval/tests/test_package_serialisation.py` (18 tests): registry integrity (every tag resolves to its class — including the singleton-fitter pattern — with a callable `from_dict`), round-trip dispatch for a representative model of every dictionary shape (Weibull, Kaplan-Meier, WeibullPH, CoxPH, mixture, Crow-AMSAA, MCF, generalized renewal, competing risks, Wiener process), the `from_json` file reader, and error cases.
- All 89 serialisation-related tests pass; flake8, black, mypy clean on the whole package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_