### PR TITLE
Stamp a schema version into every serialised model dictionary

### DIFF
--- a/docs/Regression Modelling with SurPyval.rst
+++ b/docs/Regression Modelling with SurPyval.rst
@@ -881,6 +881,12 @@ itself:
     doc = collection.find_one({"distribution": "Weibull"})
     model = surpyval.from_dict(doc)
 
+Every document also carries a ``"schema"`` version stamped by ``to_dict``.
+It changes only when a document's shape changes incompatibly, so models
+stored today stay recognisable to future SurPyval versions; a document
+written by a *newer* schema than the installed SurPyval understands is
+refused with a clear error rather than misread.
+
 If the fitted model carried a computable parameter covariance, it is stored in
 the dictionary, so the reloaded model can also produce confidence bounds
 (``cb``, ``param_cb``, ``standard_errors``) without the original data. Only the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,13 @@ v0.15.0 (unreleased)
 Serialisation
 ~~~~~~~~~~~~~
 
+- Every serialised model dictionary now carries a schema version
+  (``"schema": 1``), stamped by every ``to_dict``. The version is bumped only
+  when a dictionary's shape changes incompatibly, so documents stored today
+  (in files or MongoDB) stay recognisable to future SurPyval versions: the
+  package-level ``surpyval.from_dict`` refuses documents written by a *newer*
+  schema with a clear error, and treats documents with no ``"schema"`` key
+  (written before versioning) as schema 0, which remains loadable.
 - MongoDB compatibility, verified for every serialisable model: BSON is
   stricter than JSON (numpy integer scalars and arrays are rejected, and
   dictionary keys must be strings), so every model's ``to_dict`` output is now

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -37,6 +37,7 @@ from ._bounds import (
 )
 from .path_models import PATH_MODELS, PathModel, get_path_model
 from .population import reml_estimate, reml_estimate_nonlinear
+from surpyval.serialisation import stamp_schema
 
 
 def _is_regression_fitter(fitter) -> bool:
@@ -172,12 +173,14 @@ class InducedFailureDistribution:
         samples = [
             None if not np.isfinite(s) else float(s) for s in self.samples
         ]
-        return {
-            "model": "InducedFailureDistribution",
-            "samples": samples,
-            "threshold": self.threshold,
-            "path_name": self.path_name,
-        }
+        return stamp_schema(
+            {
+                "model": "InducedFailureDistribution",
+                "samples": samples,
+                "threshold": self.threshold,
+                "path_name": self.path_name,
+            }
+        )
 
     def to_json(self, fp) -> None:
         """Write :meth:`to_dict` to ``fp`` as JSON."""
@@ -417,35 +420,39 @@ class DegradationModel:
         --------
         from_dict, to_json, from_json
         """
-        return {
-            "model": "DegradationModel",
-            "x": np.asarray(self.x, dtype=float).tolist(),
-            "y": np.asarray(self.y, dtype=float).tolist(),
-            "i": np.asarray(self.i).tolist(),
-            "units": np.asarray(self.units).tolist(),
-            "threshold": float(self.threshold),
-            "path_model": self.path_model.name,
-            "path_params": np.asarray(self.path_params, dtype=float).tolist(),
-            "pseudo_failure_times": np.asarray(
-                self.pseudo_failure_times, dtype=float
-            ).tolist(),
-            "c": np.asarray(self.c).tolist(),
-            "life_model": self._life_model_to_dict(self.life_model),
-            "measurement_var": float(self.measurement_var),
-            "path_param_mean": np.asarray(
-                self.path_param_mean, dtype=float
-            ).tolist(),
-            "path_param_cov": np.asarray(
-                self.path_param_cov, dtype=float
-            ).tolist(),
-            "path_param_sample_cov": np.asarray(
-                self.path_param_sample_cov, dtype=float
-            ).tolist(),
-            "population_method": self.population_method,
-            "path_selection": self.path_selection,
-            "Z": None if self.Z is None else np.asarray(self.Z).tolist(),
-            "how": self._how,
-        }
+        return stamp_schema(
+            {
+                "model": "DegradationModel",
+                "x": np.asarray(self.x, dtype=float).tolist(),
+                "y": np.asarray(self.y, dtype=float).tolist(),
+                "i": np.asarray(self.i).tolist(),
+                "units": np.asarray(self.units).tolist(),
+                "threshold": float(self.threshold),
+                "path_model": self.path_model.name,
+                "path_params": np.asarray(
+                    self.path_params, dtype=float
+                ).tolist(),
+                "pseudo_failure_times": np.asarray(
+                    self.pseudo_failure_times, dtype=float
+                ).tolist(),
+                "c": np.asarray(self.c).tolist(),
+                "life_model": self._life_model_to_dict(self.life_model),
+                "measurement_var": float(self.measurement_var),
+                "path_param_mean": np.asarray(
+                    self.path_param_mean, dtype=float
+                ).tolist(),
+                "path_param_cov": np.asarray(
+                    self.path_param_cov, dtype=float
+                ).tolist(),
+                "path_param_sample_cov": np.asarray(
+                    self.path_param_sample_cov, dtype=float
+                ).tolist(),
+                "population_method": self.population_method,
+                "path_selection": self.path_selection,
+                "Z": None if self.Z is None else np.asarray(self.Z).tolist(),
+                "how": self._how,
+            }
+        )
 
     def to_json(self, fp) -> None:
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/degradation/process_models.py
+++ b/surpyval/degradation/process_models.py
@@ -28,6 +28,7 @@ from scipy.integrate import quad
 from scipy.optimize import brentq, minimize_scalar
 from scipy.special import gammaincc, gammaln
 from scipy.stats import norm
+from surpyval.serialisation import stamp_schema
 
 __all__ = [
     "WienerProcess",
@@ -149,12 +150,14 @@ class WienerProcessModel:
 
     def to_dict(self) -> dict:
         """Serialise this fitted Wiener-process model to a plain dict."""
-        return {
-            "model": "WienerProcessModel",
-            "mu": self.mu,
-            "sigma": self.sigma,
-            "threshold": self.threshold,
-        }
+        return stamp_schema(
+            {
+                "model": "WienerProcessModel",
+                "mu": self.mu,
+                "sigma": self.sigma,
+                "threshold": self.threshold,
+            }
+        )
 
     def to_json(self, fp) -> None:
         """Write :meth:`to_dict` to ``fp`` as JSON."""
@@ -376,12 +379,14 @@ class GammaProcessModel:
 
     def to_dict(self) -> dict:
         """Serialise this fitted gamma-process model to a plain dict."""
-        return {
-            "model": "GammaProcessModel",
-            "alpha": self.alpha,
-            "beta": self.beta,
-            "threshold": self.threshold,
-        }
+        return stamp_schema(
+            {
+                "model": "GammaProcessModel",
+                "alpha": self.alpha,
+                "beta": self.beta,
+                "threshold": self.threshold,
+            }
+        )
 
     def to_json(self, fp) -> None:
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/recurrent/competing_risks/nonparametric/cause_specific_mcf.py
+++ b/surpyval/recurrent/competing_risks/nonparametric/cause_specific_mcf.py
@@ -22,7 +22,7 @@ from surpyval.utils.recurrent_utils import (
     handle_xicn,
     reject_unsupported_nonparametric,
 )
-from surpyval.serialisation import to_native
+from surpyval.serialisation import stamp_schema, to_native
 
 
 def _counting_model_from_xrd(x, r, d):
@@ -65,13 +65,15 @@ class CauseSpecificMCF:
         --------
         from_dict, to_json, from_json
         """
-        return {
-            "model": "CauseSpecificMCF",
-            "event_types": to_native(list(self.event_types)),
-            "models": [
-                self.models[cause].to_dict() for cause in self.event_types
-            ],
-        }
+        return stamp_schema(
+            {
+                "model": "CauseSpecificMCF",
+                "event_types": to_native(list(self.event_types)),
+                "models": [
+                    self.models[cause].to_dict() for cause in self.event_types
+                ],
+            }
+        )
 
     def to_json(self, fp):
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/recurrent/competing_risks/parametric/cause_specific_nhpp.py
+++ b/surpyval/recurrent/competing_risks/parametric/cause_specific_nhpp.py
@@ -29,7 +29,7 @@ from surpyval.recurrent.parametric.parametric_recurrence import (
 )
 from surpyval.recurrent.serialisation import intensity_dist_by_name
 from surpyval.utils.recurrent_utils import handle_xicn
-from surpyval.serialisation import to_native
+from surpyval.serialisation import stamp_schema, to_native
 
 
 class CauseSpecificNHPP:
@@ -62,14 +62,16 @@ class CauseSpecificNHPP:
         --------
         from_dict, to_json, from_json
         """
-        return {
-            "model": "CauseSpecificNHPP",
-            "dist": self.dist.name,
-            "event_types": to_native(list(self.event_types)),
-            "models": [
-                self.models[cause].to_dict() for cause in self.event_types
-            ],
-        }
+        return stamp_schema(
+            {
+                "model": "CauseSpecificNHPP",
+                "dist": self.dist.name,
+                "event_types": to_native(list(self.event_types)),
+                "models": [
+                    self.models[cause].to_dict() for cause in self.event_types
+                ],
+            }
+        )
 
     def to_json(self, fp):
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/recurrent/nonparametric/mcf.py
+++ b/surpyval/recurrent/nonparametric/mcf.py
@@ -9,6 +9,7 @@ from surpyval.utils.recurrent_utils import (
     handle_xicn,
     reject_unsupported_nonparametric,
 )
+from surpyval.serialisation import stamp_schema
 
 
 @singleton_fitter
@@ -29,12 +30,14 @@ class NonParametricCounting:
         --------
         from_dict, to_json, from_json
         """
-        return {
-            "model": "NonParametricCounting",
-            "x": np.asarray(self.x, dtype=float).tolist(),
-            "mcf_hat": np.asarray(self.mcf_hat, dtype=float).tolist(),
-            "var": np.asarray(self.var, dtype=float).tolist(),
-        }
+        return stamp_schema(
+            {
+                "model": "NonParametricCounting",
+                "x": np.asarray(self.x, dtype=float).tolist(),
+                "mcf_hat": np.asarray(self.mcf_hat, dtype=float).tolist(),
+                "var": np.asarray(self.var, dtype=float).tolist(),
+            }
+        )
 
     def to_json(self, fp):
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/recurrent/parametric/parametric_recurrence.py
+++ b/surpyval/recurrent/parametric/parametric_recurrence.py
@@ -11,6 +11,7 @@ from surpyval.recurrent.inference import (
 )
 from surpyval.recurrent.serialisation import intensity_dist_by_name
 from surpyval.recurrent.simulation import RecurrenceSimulationMixin
+from surpyval.serialisation import stamp_schema
 
 
 class ParametricRecurrenceModel(
@@ -55,12 +56,14 @@ class ParametricRecurrenceModel(
         --------
         from_dict, to_json, from_json
         """
-        return {
-            "model": "ParametricRecurrenceModel",
-            "dist": self.dist.name,
-            "params": np.asarray(self.params, dtype=float).tolist(),
-            "how": getattr(self, "how", "from_params"),
-        }
+        return stamp_schema(
+            {
+                "model": "ParametricRecurrenceModel",
+                "dist": self.dist.name,
+                "params": np.asarray(self.params, dtype=float).tolist(),
+                "how": getattr(self, "how", "from_params"),
+            }
+        )
 
     def to_json(self, fp):
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/recurrent/regression/proportional_intensity.py
+++ b/surpyval/recurrent/regression/proportional_intensity.py
@@ -11,6 +11,7 @@ from surpyval.recurrent.inference import (
 )
 from surpyval.recurrent.serialisation import intensity_dist_by_name
 from surpyval.recurrent.simulation import RecurrenceSimulationMixin
+from surpyval.serialisation import stamp_schema
 
 
 class ProportionalIntensityModel(
@@ -81,15 +82,17 @@ class ProportionalIntensityModel(
         --------
         from_dict, to_json, from_json
         """
-        return {
-            "model": "ProportionalIntensityModel",
-            "kind": self.kind,
-            "parameterization": self.parameterization,
-            "dist": self.dist.name,
-            "param_names": list(self.param_names),
-            "params": np.asarray(self.params, dtype=float).tolist(),
-            "coeffs": np.asarray(self.coeffs, dtype=float).tolist(),
-        }
+        return stamp_schema(
+            {
+                "model": "ProportionalIntensityModel",
+                "kind": self.kind,
+                "parameterization": self.parameterization,
+                "dist": self.dist.name,
+                "param_names": list(self.param_names),
+                "params": np.asarray(self.params, dtype=float).tolist(),
+                "coeffs": np.asarray(self.coeffs, dtype=float).tolist(),
+            }
+        )
 
     def to_json(self, fp):
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/recurrent/renewal/renewal_model.py
+++ b/surpyval/recurrent/renewal/renewal_model.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from surpyval.recurrent.inference import LikelihoodInferenceMixin
 from surpyval.recurrent.simulation import RecurrenceSimulationMixin
+from surpyval.serialisation import stamp_schema
 
 
 class RenewalModel(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
@@ -118,7 +119,7 @@ class RenewalModel(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
             out["kijima_type"] = self.kijima_type
         if getattr(self, "m", None) is not None:
             out["m"] = self.m
-        return out
+        return stamp_schema(out)
 
     def to_json(self, fp) -> None:
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/serialisation.py
+++ b/surpyval/serialisation.py
@@ -95,6 +95,21 @@ _PARAMETERIZATIONS: dict[str, tuple[str, str]] = {
 }
 
 
+# The version of the serialised-dictionary layout, stamped into every
+# ``to_dict`` output as ``"schema"``. Bump it only when a dictionary's
+# shape changes incompatibly; the readers use it to recognise (and
+# refuse, with a clear error) documents written by a newer SurPyval,
+# and to migrate older layouts where needed. Documents with no
+# ``"schema"`` key predate versioning and read as schema 0.
+SCHEMA_VERSION = 1
+
+
+def stamp_schema(model_dict: dict) -> dict:
+    """Stamp the serialisation schema version into a ``to_dict`` output."""
+    model_dict["schema"] = SCHEMA_VERSION
+    return model_dict
+
+
 def _resolve(module_name: str, class_name: str) -> Any:
     return getattr(import_module(module_name), class_name)
 
@@ -153,6 +168,14 @@ def from_dict(model_dict: dict) -> Any:
         raise ValueError(
             "Expected a serialised model dict, got "
             f"{type(model_dict).__name__}"
+        )
+
+    schema = model_dict.get("schema", 0)
+    if isinstance(schema, int) and schema > SCHEMA_VERSION:
+        raise ValueError(
+            f"This serialised model uses schema version {schema}, but "
+            f"this version of SurPyval reads schema versions up to "
+            f"{SCHEMA_VERSION}. Upgrade surpyval to load it."
         )
 
     tag = model_dict.get("model")

--- a/surpyval/tests/test_mongodb_serialisation.py
+++ b/surpyval/tests/test_mongodb_serialisation.py
@@ -52,6 +52,7 @@ from surpyval.recurrent.competing_risks import (
     CauseSpecificMCF,
     CauseSpecificNHPP,
 )
+from surpyval.serialisation import SCHEMA_VERSION
 from surpyval.univariate.competing_risks import (
     CompetingRisks,
     FineGray,
@@ -399,6 +400,7 @@ def test_mongo_round_trip(name):
         model_dict = model.to_dict()
 
     _assert_bson_native(model_dict)
+    assert model_dict["schema"] == SCHEMA_VERSION
     restored = surpyval.from_dict(_mongo_round_trip(model_dict))
     assert type(restored).__name__ == type(model).__name__
     check(model, restored)

--- a/surpyval/tests/test_package_serialisation.py
+++ b/surpyval/tests/test_package_serialisation.py
@@ -212,6 +212,29 @@ def test_from_json_file_tagged(tmp_path):
 # -- errors -------------------------------------------------------------------
 
 
+def test_schema_version_is_stamped():
+    from surpyval.serialisation import SCHEMA_VERSION
+
+    d = Weibull.fit([3.0, 4.0, 5.0, 6.0, 7.0]).to_dict()
+    assert d["schema"] == SCHEMA_VERSION
+
+
+def test_unversioned_documents_still_load():
+    # documents written before schema versioning have no "schema" key
+    model = Weibull.fit([3.0, 4.0, 5.0, 6.0, 7.0])
+    d = {k: v for k, v in model.to_dict().items() if k != "schema"}
+    restored = surpyval.from_dict(d)
+    t = np.array([2.0, 5.0])
+    assert np.allclose(model.sf(t), restored.sf(t))
+
+
+def test_newer_schema_is_refused():
+    d = Weibull.fit([3.0, 4.0, 5.0, 6.0, 7.0]).to_dict()
+    d["schema"] = 99
+    with pytest.raises(ValueError, match="schema version 99"):
+        surpyval.from_dict(d)
+
+
 def test_from_dict_rejects_non_dict():
     with pytest.raises(ValueError, match="dict"):
         surpyval.from_dict("not a dict")

--- a/surpyval/univariate/competing_risks/nonparametric/competing_risks.py
+++ b/surpyval/univariate/competing_risks/nonparametric/competing_risks.py
@@ -22,7 +22,7 @@ from surpyval.utils import (
     validate_cr_inputs,
     validate_event,
 )
-from surpyval.serialisation import to_native
+from surpyval.serialisation import stamp_schema, to_native
 
 
 class CompetingRisks:
@@ -76,7 +76,7 @@ class CompetingRisks:
         }
         for name in self._SERIALISED_ARRAYS:
             out[name] = np.asarray(getattr(self, name), dtype=float).tolist()
-        return out
+        return stamp_schema(out)
 
     def to_json(self, fp) -> None:
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/univariate/competing_risks/parametric/parametric_competing_risks.py
+++ b/surpyval/univariate/competing_risks/parametric/parametric_competing_risks.py
@@ -36,7 +36,7 @@ from surpyval.utils import (
     resolve_cr_censoring,
     xcnt_handler,
 )
-from surpyval.serialisation import to_native
+from surpyval.serialisation import stamp_schema, to_native
 
 
 def _validate(x, c, n, e):
@@ -85,11 +85,15 @@ class ParametricCompetingRisks:
         distribution (via its own ``to_dict``). The reloaded model reproduces
         every cumulative-incidence / hazard function exactly.
         """
-        return {
-            "model": "ParametricCompetingRisks",
-            "causes": to_native(list(self.causes)),
-            "models": [self.models[cause].to_dict() for cause in self.causes],
-        }
+        return stamp_schema(
+            {
+                "model": "ParametricCompetingRisks",
+                "causes": to_native(list(self.causes)),
+                "models": [
+                    self.models[cause].to_dict() for cause in self.causes
+                ],
+            }
+        )
 
     def to_json(self, fp) -> None:
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/univariate/competing_risks/regression/fine_gray.py
+++ b/surpyval/univariate/competing_risks/regression/fine_gray.py
@@ -39,6 +39,7 @@ from scipy.optimize import minimize
 from scipy.stats import norm
 
 from surpyval.utils import validate_fine_gray_inputs
+from surpyval.serialisation import stamp_schema
 
 
 def _censoring_survival(x, c, n):
@@ -192,17 +193,23 @@ class FineGrayModel:
         model reproduces ``cif``/``sf`` exactly and can still report the
         coefficient summary. The optimiser objects are not stored.
         """
-        return {
-            "model": "FineGrayModel",
-            "cause": self.cause,
-            "beta": np.asarray(self.beta, dtype=float).tolist(),
-            "se": np.asarray(self.se, dtype=float).tolist(),
-            "p_values": np.asarray(self.p_values, dtype=float).tolist(),
-            "cov": np.asarray(self.cov, dtype=float).tolist(),
-            "baseline_times": np.asarray(self._times, dtype=float).tolist(),
-            "baseline_cumhaz": np.asarray(self._cumhaz, dtype=float).tolist(),
-            "neg_ll": float(self._neg_ll),
-        }
+        return stamp_schema(
+            {
+                "model": "FineGrayModel",
+                "cause": self.cause,
+                "beta": np.asarray(self.beta, dtype=float).tolist(),
+                "se": np.asarray(self.se, dtype=float).tolist(),
+                "p_values": np.asarray(self.p_values, dtype=float).tolist(),
+                "cov": np.asarray(self.cov, dtype=float).tolist(),
+                "baseline_times": np.asarray(
+                    self._times, dtype=float
+                ).tolist(),
+                "baseline_cumhaz": np.asarray(
+                    self._cumhaz, dtype=float
+                ).tolist(),
+                "neg_ll": float(self._neg_ll),
+            }
+        )
 
     def to_json(self, fp):
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/univariate/nonparametric/nonparametric.py
+++ b/surpyval/univariate/nonparametric/nonparametric.py
@@ -10,6 +10,7 @@ from scipy.interpolate import PchipInterpolator, interp1d
 from scipy.stats import norm
 
 from surpyval.distribution import NonParametricDistribution
+from surpyval.serialisation import stamp_schema
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -1306,7 +1307,7 @@ class NonParametric(NonParametricDistribution):
                 )
             out["data"] = data_dict
 
-        return out
+        return stamp_schema(out)
 
     def to_json(self, fp: str | Path) -> None:
         with open(fp, "w+") as f:

--- a/surpyval/univariate/parametric/mixture_model.py
+++ b/surpyval/univariate/parametric/mixture_model.py
@@ -12,6 +12,7 @@ from .probability_plotting import (
     draw_probability_plot,
     probability_plot_data,
 )
+from surpyval.serialisation import stamp_schema
 
 
 class MixtureModel(Distribution):
@@ -57,13 +58,15 @@ class MixtureModel(Distribution):
         model reproduces ``sf``/``ff``/``df``/``mean``/``random`` exactly. The
         fitted data and EM responsibilities are not stored.
         """
-        return {
-            "model": "MixtureModel",
-            "dist": self.dist.name,
-            "m": int(self.m),
-            "params": np.asarray(self.params, dtype=float).tolist(),
-            "w": np.asarray(self.w, dtype=float).tolist(),
-        }
+        return stamp_schema(
+            {
+                "model": "MixtureModel",
+                "dist": self.dist.name,
+                "m": int(self.m),
+                "params": np.asarray(self.params, dtype=float).tolist(),
+                "w": np.asarray(self.w, dtype=float).tolist(),
+            }
+        )
 
     def to_json(self, fp) -> None:
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -25,6 +25,7 @@ from .probability_plotting import (
     draw_probability_plot,
     probability_plot_data,
 )
+from surpyval.serialisation import stamp_schema
 
 # Shared inputs for the confidence-bound computations: the fitted parameter
 # vector ``phi_hat`` (core params plus any LFP/ZI parameters), its covariance
@@ -222,7 +223,7 @@ class Parametric(ParametricDistribution):
         if hasattr(self, "_neg_ll"):
             out["_neg_ll"] = self._neg_ll
 
-        return out
+        return stamp_schema(out)
 
     def to_json(self, fp: str | Path) -> None:
         with open(fp, "w+") as f:

--- a/surpyval/univariate/regression/additive_hazards/additive_hazards.py
+++ b/surpyval/univariate/regression/additive_hazards/additive_hazards.py
@@ -53,6 +53,7 @@ from scipy.stats import norm
 from surpyval.utils import check_Z_and_x, wrangle_Z, xcnt_handler
 
 from ..regression_data import design_matrix_from_df, prepare_Z
+from surpyval.serialisation import stamp_schema
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -161,7 +162,7 @@ class AdditiveHazardsModel:
             out["feature_names"] = list(self.feature_names)
         if self.formula is not None:
             out["formula"] = self.formula
-        return out
+        return stamp_schema(out)
 
     def to_json(self, fp: "str | Path") -> None:
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/univariate/regression/buckley_james/buckley_james.py
+++ b/surpyval/univariate/regression/buckley_james/buckley_james.py
@@ -43,6 +43,7 @@ from surpyval.utils import (
     wrangle_Z,
     xcnt_handler,
 )
+from surpyval.serialisation import stamp_schema
 
 
 def _residual_km(e, delta, w):
@@ -220,7 +221,7 @@ class BuckleyJamesModel:
             out["feature_names"] = list(self.feature_names)
         if self.formula is not None:
             out["formula"] = self.formula
-        return out
+        return stamp_schema(out)
 
     def to_json(self, fp):
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -18,6 +18,7 @@ from ._bounds import (
     numerical_hessian,
 )
 from .regression_data import prepare_Z
+from surpyval.serialisation import stamp_schema
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -178,7 +179,7 @@ class ParametricRegressionModel:
                 out["covariance"] = np.asarray(cov, dtype=float).tolist()
             if hasattr(self, "_neg_ll"):
                 out["_neg_ll"] = float(self._neg_ll)
-        return out
+        return stamp_schema(out)
 
     def to_json(self, fp: "str | Path") -> None:
         """Write :meth:`to_dict` to ``fp`` as JSON."""

--- a/surpyval/univariate/regression/semi_parametric_regression_model.py
+++ b/surpyval/univariate/regression/semi_parametric_regression_model.py
@@ -8,6 +8,7 @@ import numpy.typing as npt
 from surpyval.utils import _get_idx
 
 from .regression_data import prepare_Z
+from surpyval.serialisation import stamp_schema
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -112,7 +113,7 @@ class SemiParametricRegressionModel:
             out["feature_names"] = list(self.feature_names)
         if self.formula is not None:
             out["formula"] = self.formula
-        return out
+        return stamp_schema(out)
 
     def to_json(self, fp: "str | Path") -> None:
         """Write :meth:`to_dict` to ``fp`` as JSON."""


### PR DESCRIPTION
## Summary

Documents you store today (in files or MongoDB) stay recognisable to future SurPyval versions:

- Every `to_dict` output now carries **`"schema": 1`**, stamped by a shared `surpyval.serialisation.stamp_schema` helper. `SCHEMA_VERSION` is bumped only when a dictionary's shape changes incompatibly — it is the hook future releases use to migrate old layouts on read.
- The package-level reader enforces it: `surpyval.from_dict` **refuses documents written by a newer schema** with a clear error ("upgrade surpyval to load it") instead of silently misreading them, and treats documents with **no `"schema"` key** (written before versioning) as schema 0, which loads as before.
- All 20 `to_dict` implementations are stamped (returns wrapped via an AST-guided rewrite, so the change is uniform); nested sub-model dictionaries — competing-risks causes, degradation life models — carry their own stamp through their own `to_dict`.

## Test plan

- The all-models MongoDB round-trip suite now asserts the stamp on every one of the 22 dictionary shapes (and re-proves each class-level `from_dict` tolerates the new key).
- New reader tests: stamp present, unversioned document still loads, newer-schema document refused.
- 45 serialisation tests pass; flake8, black, mypy clean; full CI-equivalent suite running as a cross-check locally and gated in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_