### PR TITLE
0.15.2 hardening: xcnt truncation warning, renewal guard, CSV engine

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,33 @@
 Changelog
 =========
 
+v0.15.2 (unreleased)
+--------------------
+
+Data handling
+~~~~~~~~~~~~~
+
+- ``xcnt_handler`` now warns when right-censored observations carry a finite
+  right-truncation time (#195). The combination is contradictory -- right
+  truncation means the unit was only observable because its event occurred
+  before ``tr``, while right censoring says the event is after the censoring
+  time -- and such rows can make truncation-adjusted likelihoods unbounded.
+
+Serialisation
+~~~~~~~~~~~~~
+
+- ``RenewalModel.from_dict`` now validates that the stored distribution name
+  resolves to a genuine distribution fitter (#206), matching the guard used
+  by every other reader, so an untrusted document cannot resolve arbitrary
+  package attributes.
+
+Misc
+~~~~
+
+- The bundled dataset loaders use pandas' default (C) CSV engine instead of
+  ``engine="python"`` (#207) -- identical parses, faster, and one less thing
+  for security scanners to worry about; the loaders are now covered by tests.
+
 v0.15.1 (20 Jul 2026)
 ---------------------
 

--- a/surpyval/datasets/__init__.py
+++ b/surpyval/datasets/__init__.py
@@ -87,7 +87,7 @@ def load_bofors_steel():
     """
 
     data_path = importlib.resources.files(data_module) / "bofors_steel.csv"
-    return pd.read_csv(data_path, engine="python")
+    return pd.read_csv(data_path)
 
 
 def load_boston_housing():
@@ -107,7 +107,7 @@ def load_boston_housing():
 
     """
     data_path = importlib.resources.files(data_module) / "boston.csv"
-    return pd.read_csv(data_path, engine="python")
+    return pd.read_csv(data_path)
 
 
 def load_g1_kaminskiy_krivtsov():
@@ -139,7 +139,7 @@ def load_heart_transplants():
     """
 
     data_path = importlib.resources.files(data_module) / "heart.csv"
-    return pd.read_csv(data_path, engine="python")
+    return pd.read_csv(data_path)
 
 
 def load_lung():
@@ -158,7 +158,7 @@ def load_lung():
     """
 
     data_path = importlib.resources.files(data_module) / "lung.csv"
-    return pd.read_csv(data_path, engine="python")
+    return pd.read_csv(data_path)
 
 
 def load_mettas_and_zhao():
@@ -244,7 +244,7 @@ def load_rossi_static():
     """
 
     data_path = importlib.resources.files(data_module) / "rossi.csv"
-    return pd.read_csv(data_path, engine="python")
+    return pd.read_csv(data_path)
 
 
 def load_rossi_time_varying():
@@ -264,7 +264,7 @@ def load_rossi_time_varying():
     """
 
     data_path = importlib.resources.files(data_module) / "rossi_tv.csv"
-    return pd.read_csv(data_path, engine="python")
+    return pd.read_csv(data_path)
 
 
 def load_tires_data():
@@ -280,7 +280,7 @@ def load_tires_data():
     """
 
     data_path = importlib.resources.files(data_module) / "tires.csv"
-    return pd.read_csv(data_path, engine="python")
+    return pd.read_csv(data_path)
 
 
 def load_sae():

--- a/surpyval/recurrent/renewal/renewal_model.py
+++ b/surpyval/recurrent/renewal/renewal_model.py
@@ -167,9 +167,15 @@ class RenewalModel(RecurrenceSimulationMixin, LikelihoodInferenceMixin):
             )
 
         import surpyval
+        from surpyval.univariate.parametric.parametric_fitter import (
+            ParametricFitter,
+        )
 
+        # Restrict the lookup to known distribution fitters so an
+        # untrusted model dict cannot resolve arbitrary surpyval
+        # attributes (matches the guard in Parametric.from_dict).
         dist = getattr(surpyval, model_dict["dist"], None)
-        if dist is None:
+        if not isinstance(dist, ParametricFitter):
             raise ValueError(
                 "Unknown distribution {!r}".format(model_dict["dist"])
             )

--- a/surpyval/tests/recurrent/test_renewal_serialisation.py
+++ b/surpyval/tests/recurrent/test_renewal_serialisation.py
@@ -102,3 +102,16 @@ def test_renewal_rejects_unknown_family():
     d["family"] = "Nope"
     with pytest.raises(ValueError, match="Unknown renewal family"):
         RenewalModel.from_dict(d)
+
+
+def test_renewal_rejects_non_distribution_attribute():
+    # The stored distribution name must resolve to a genuine
+    # distribution fitter: an untrusted dict must not be able to pull
+    # arbitrary surpyval attributes through the lookup -- issue #206.
+    model = GeneralizedRenewal.fit_from_parameters(
+        [50.0, 2.0], 0.3, kijima="i", dist=Weibull
+    )
+    d = model.to_dict()
+    d["dist"] = "CoxPH"  # real surpyval attribute, not a ParametricFitter
+    with pytest.raises(ValueError, match="Unknown distribution"):
+        RenewalModel.from_dict(d)

--- a/surpyval/tests/test_datasets.py
+++ b/surpyval/tests/test_datasets.py
@@ -1,0 +1,24 @@
+"""The bundled dataset loaders.
+
+The loaders read package-shipped CSVs with pandas' default (C) engine
+(issue #207 dropped the redundant ``engine="python"``); every loader
+must return a non-empty DataFrame.
+"""
+
+import pandas as pd
+import pytest
+
+import surpyval.datasets as datasets
+
+LOADERS = [
+    name
+    for name, obj in vars(datasets).items()
+    if callable(obj) and name.startswith("load_")
+]
+
+
+@pytest.mark.parametrize("name", LOADERS)
+def test_loader_returns_nonempty_dataframe(name):
+    df = getattr(datasets, name)()
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) > 0 and len(df.columns) > 0

--- a/surpyval/tests/utils/test_utils.py
+++ b/surpyval/tests/utils/test_utils.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest
 
@@ -330,3 +332,23 @@ def test_xcnt_handler():
     # Test with t, tl and tr
     with pytest.raises(ValueError, match="Cannot use 't' with 'tl' or 'tr'"):
         xcnt_handler(x=[1, 2], t=[[0, 3], [1, 4]], tl=[0, 1])
+
+
+def test_xcnt_handler_warns_on_right_censored_with_finite_tr():
+    # A right-censored observation with a finite right-truncation time
+    # is contradictory (the event is after the censoring time, yet
+    # truncation says it was seen before tr) and can make
+    # truncation-adjusted likelihoods unbounded -- issue #195.
+    x = [1.0, 2.0, 3.0]
+    c = [0, 1, 0]
+    with pytest.warns(UserWarning, match="right-censored"):
+        xcnt_handler(x=x, c=c, tr=[10.0, 10.0, 10.0])
+
+    # No warning when the right-censored row's truncation is infinite
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        xcnt_handler(x=x, c=c, tr=[10.0, np.inf, 10.0])
+    # ... or when there is no right censoring at all
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        xcnt_handler(x=x, c=[0, 0, 0], tr=[10.0, 10.0, 10.0])

--- a/surpyval/utils/__init__.py
+++ b/surpyval/utils/__init__.py
@@ -659,6 +659,23 @@ def xcnt_handler(
     n = n.astype(int)
     t = t.astype(float)
 
+    # A right-censored observation cannot carry finite right truncation:
+    # right-truncation sampling only admits units whose event occurred
+    # before ``tr``, while right censoring says the event is after the
+    # censoring time -- possibly beyond ``tr``. Such rows can make
+    # truncation-adjusted likelihoods unbounded (the fitted rate is
+    # driven towards zero), so flag them loudly.
+    if ((c == 1) & np.isfinite(t[:, 1])).any():
+        warnings.warn(
+            "Some right-censored observations have a finite right "
+            "truncation time. This is contradictory: right truncation "
+            "means the unit was only observable because its event "
+            "occurred before `tr`, while right censoring says the event "
+            "is after the censoring time. Such rows can make "
+            "truncation-adjusted likelihoods unbounded; check the data.",
+            stacklevel=2,
+        )
+
     if group_and_sort:
         x, c, n, t = group_xcnt(x, c, n, t)
         x, c, n, t = xcnt_sort(x, c, n, t)


### PR DESCRIPTION
Three small fixes for the 0.15.2 patch, closing #195, #206 and #207:

- xcnt_handler warns when right-censored observations carry a finite right-truncation time (#195): the combination is contradictory (right truncation means the event was seen before tr; right censoring says it is after the censoring time) and can make truncation-adjusted likelihoods unbounded.
- RenewalModel.from_dict validates that the stored distribution name resolves to a genuine ParametricFitter (#206), matching the guard in every other serialisation reader; the ARI branch already resolved through the restricted intensity map.
- The bundled dataset loaders drop engine="python" (#207): all 12 loaders parse identically with pandas' default C engine, now locked in by a loader test sweep.

Tests: warning fires exactly when it should (and not for inf-tr or uncensored rows), renewal reader rejects a real-but-wrong attribute name, all 12 loaders return non-empty frames. flake8/black/mypy clean.

Generated with Claude Code
https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_