### PR TITLE
Modernise and fully pin the docs build toolchain

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,13 @@ Misc
 - The bundled dataset loaders use pandas' default (C) CSV engine instead of
   ``engine="python"`` (#207) -- identical parses, faster, and one less thing
   for security scanners to worry about; the loaders are now covered by tests.
+- Modernised the documentation build toolchain (``docs/requirements.txt``):
+  the 2022-era pins (``sphinx 5.3``, ``jupyter-sphinx 0.4``) left ``ipykernel``
+  unpinned, and against current ipykernel 7 the notebook execution hangs or
+  crashes -- one of the reasons hosted docs builds kept failing. The new set
+  (sphinx 8.2, sphinx-rtd-theme 3.1, jupyter-sphinx 0.5.3, ipykernel capped
+  below 7) is fully pinned and validated by a complete docs build in a clean
+  virtualenv.
 
 v0.15.1 (20 Jul 2026)
 ---------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,17 @@
+# Documentation build toolchain (used by ReadTheDocs and local builds).
+#
+# This is a coherent, fully pinned set validated by a complete docs
+# build (every jupyter-execute cell runs) in a clean virtualenv on top
+# of `pip install .`. Bump versions together and re-validate with:
+#   python -m sphinx -b html docs docs/_build/html
+#
+# ipykernel is capped below 7: jupyter-sphinx notebook execution hangs
+# or crashes (zmq "Socket operation on non-socket") against the
+# ipykernel 7 line.
 matplotlib>=3.10
-sphinx-copybutton
-sphinx==5.3.0
-sphinx_rtd_theme==1.1.1
-sphinx-notfound-page==1.0.2
-jupyter-sphinx==0.4.0
-ipykernel
+sphinx==8.2.3
+sphinx_rtd_theme==3.1.0
+sphinx-copybutton==0.5.2
+sphinx-notfound-page==1.1.0
+jupyter-sphinx==0.5.3
+ipykernel==6.31.0


### PR DESCRIPTION
Second 0.15.2 item. The 2022-era docs pins (sphinx==5.3.0, jupyter-sphinx==0.4.0) left ipykernel unpinned; against the current ipykernel 7 line, jupyter-sphinx notebook execution hangs or crashes (zmq "Socket operation on non-socket") - reproduced in a clean venv with ReadTheDocs' exact install. Combined with the (now fixed) Turnbull hang, this is why hosted docs builds kept failing.

New fully pinned set: sphinx 8.2.3, sphinx_rtd_theme 3.1.0, sphinx-copybutton 0.5.2, sphinx-notfound-page 1.1.0, jupyter-sphinx 0.5.3, ipykernel 6.31.0 (capped below 7, with a comment explaining why). Validated by a complete 73-page docs build - every jupyter-execute cell runs - in a clean virtualenv on top of pip install ., reproducing the RTD install path ("build succeeded, 15 warnings").

Docs-only change; no package code touched. Changelog updated under 0.15.2.

Generated with Claude Code
https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_