### PR TITLE
Cluster-robust (sandwich) standard errors for Cox models (#215)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,13 @@ Diagnostics & validation
   RMST-difference is the assumption-light alternative to the hazard ratio when
   proportional hazards fails; the estimate matches its analytic value and the
   two-group test is calibrated under the null.
+- **Cluster-robust standard errors** (#215). ``CoxPH`` models gain
+  ``robust_covariance(cluster=...)`` and ``robust_summary(cluster=...)`` -- the
+  Lin-Wei sandwich variance for clustered / correlated data (repeated events
+  per subject, grouped sampling), built from the dfbeta residuals. On
+  independent data it agrees with the model-based errors; on exactly
+  replicated clusters it inflates by the theoretically exact
+  ``sqrt(cluster size)``.
 
 v0.15.2 (20 Jul 2026)
 ---------------------

--- a/surpyval/tests/univariate/regression/test_cox_robust_se.py
+++ b/surpyval/tests/univariate/regression/test_cox_robust_se.py
@@ -1,0 +1,87 @@
+"""Cluster-robust (sandwich) standard errors for Cox models (#215).
+
+The Lin-Wei robust variance is validated two ways: on independent data it
+agrees with the model-based standard errors, and on data with exactly
+replicated clusters it inflates by the theoretically exact factor
+``sqrt(cluster_size)`` relative to naively treating the rows as independent.
+"""
+
+import numpy as np
+import pytest
+
+import surpyval as sp
+
+
+def _cox(seed=0, n=300):
+    rng = np.random.default_rng(seed)
+    Z = rng.normal(0, 1, (n, 2))
+    lin = 0.7 * Z[:, 0] - 0.4 * Z[:, 1]
+    x = (rng.exponential(1.0, n) / np.exp(lin)) ** (1 / 1.4)
+    c = (rng.random(n) < 0.2).astype(int)
+    return sp.CoxPH.fit(x=x, Z=Z, c=c), Z, x, c
+
+
+def test_robust_se_matches_model_based_on_independent_data():
+    m, Z, x, c = _cox()
+    model_se = np.sqrt(np.diag(np.linalg.inv(m.jac(m.beta)[1])))
+    robust_se = m.robust_summary()["se"]
+    # On independent, well-specified data the two agree closely.
+    np.testing.assert_allclose(robust_se, model_se, rtol=0.25)
+
+
+def test_robust_covariance_is_symmetric_psd():
+    m, *_ = _cox(seed=1)
+    cov = m.robust_covariance()
+    np.testing.assert_allclose(cov, cov.T, atol=1e-12)
+    assert np.all(np.linalg.eigvalsh(cov) > -1e-10)
+
+
+def test_cluster_robust_inflates_by_sqrt_cluster_size():
+    # Replicate every subject `reps` times into one cluster. Ignoring the
+    # clustering underestimates the SE by exactly sqrt(reps); the
+    # cluster-robust SE recovers it.
+    m, Z, x, c = _cox(seed=2, n=200)
+    reps = 4
+    Zc = np.repeat(Z, reps, axis=0)
+    xc = np.repeat(x, reps)
+    cc = np.repeat(c, reps)
+    clid = np.repeat(np.arange(len(x)), reps)
+    mc = sp.CoxPH.fit(x=xc, Z=Zc, c=cc)
+
+    se_ignore = mc.robust_summary()["se"]
+    se_cluster = mc.robust_summary(cluster=clid)["se"]
+    np.testing.assert_allclose(
+        se_cluster / se_ignore, np.sqrt(reps), rtol=0.02
+    )
+
+
+def test_robust_summary_fields_and_pvalues():
+    m, *_ = _cox(seed=3)
+    out = m.robust_summary()
+    assert out["se"].shape == m.beta.shape
+    assert out["covariance"].shape == (m.beta.size, m.beta.size)
+    assert np.all((out["p_value"] >= 0) & (out["p_value"] <= 1))
+    # Both coefficients are strong here, so both should be significant.
+    assert np.all(out["p_value"] < 0.05)
+
+
+def test_cluster_length_mismatch_raises():
+    m, Z, x, c = _cox(seed=4)
+    with pytest.raises(ValueError, match="one label per observation"):
+        m.robust_covariance(cluster=np.arange(len(x) - 1))
+
+
+def test_robust_summary_carries_covariate_names():
+    import pandas as pd
+
+    rng = np.random.default_rng(5)
+    n = 200
+    df = pd.DataFrame(
+        {
+            "time": rng.exponential(5.0, n),
+            "temp": rng.normal(0, 1, n),
+            "volt": rng.normal(0, 1, n),
+        }
+    )
+    m = sp.CoxPH.fit_from_df(df, x_col="time", Z_cols=["temp", "volt"])
+    assert m.robust_summary()["covariate"] == ["temp", "volt"]

--- a/surpyval/univariate/regression/proportional_hazards/diagnostics.py
+++ b/surpyval/univariate/regression/proportional_hazards/diagnostics.py
@@ -215,6 +215,84 @@ def _safe_inv(m: np.ndarray) -> np.ndarray:
         return pinv(m)
 
 
+def robust_covariance(
+    model: "SemiParametricRegressionModel", cluster=None
+) -> np.ndarray:
+    """
+    Cluster-robust ("sandwich") covariance of the Cox coefficients.
+
+    The model-based covariance assumes independent observations. For
+    clustered or correlated data (repeated events per subject, grouped
+    sampling) the Lin-Wei (1989) robust variance is
+
+    .. math::
+        V_{robust} = \\sum_c D_c D_c^{\\top},
+
+    where ``D_c`` is the sum over cluster ``c`` of the per-observation dfbeta
+    residuals (score residual times the model-based covariance). With no
+    clustering each observation is its own cluster and this is the ordinary
+    robust (Lin-Wei / HC) variance.
+
+    Parameters
+    ----------
+    cluster : array_like, optional
+        A cluster label per observation (same length and order as the fitting
+        data). ``None`` treats every observation as its own cluster.
+
+    Returns
+    -------
+    numpy.ndarray
+        The ``p x p`` robust covariance matrix. Its diagonal square-roots are
+        the robust standard errors (see :meth:`robust_standard_errors`).
+    """
+    _require_cox(model)
+    dfbeta = compute_residuals(model, "dfbeta")  # (n_obs, p)
+    n_obs = dfbeta.shape[0]
+
+    if cluster is None:
+        grouped = dfbeta
+    else:
+        cluster = np.asarray(cluster)
+        if cluster.shape[0] != n_obs:
+            raise ValueError(
+                "`cluster` must have one label per observation "
+                f"({n_obs}); got {cluster.shape[0]}."
+            )
+        labels, inv_idx = np.unique(cluster, return_inverse=True)
+        grouped = np.zeros((labels.size, dfbeta.shape[1]))
+        np.add.at(grouped, inv_idx, dfbeta)
+
+    return grouped.T @ grouped
+
+
+def robust_summary(
+    model: "SemiParametricRegressionModel", cluster=None
+) -> dict:
+    """
+    Cluster-robust standard errors, z-scores and p-values for the
+    coefficients (see :func:`robust_covariance`).
+
+    Returns
+    -------
+    dict
+        ``{"covariance", "se", "z", "p_value"}`` plus ``"covariate"`` names
+        when the model was fit from a DataFrame.
+    """
+    from scipy.stats import norm
+
+    beta = np.asarray(model.beta, dtype=float)
+    cov = robust_covariance(model, cluster)
+    se = np.sqrt(np.diag(cov))
+    with np.errstate(invalid="ignore", divide="ignore"):
+        z = beta / se
+        p = 2.0 * (1.0 - norm.cdf(np.abs(z)))
+    out = {"covariance": cov, "se": se, "z": z, "p_value": p}
+    names = getattr(model, "feature_names", None)
+    if names is not None:
+        out["covariate"] = list(names)
+    return out
+
+
 def _transform_times(t: np.ndarray, transform: str) -> np.ndarray:
     if transform == "identity":
         return t.astype(float)

--- a/surpyval/univariate/regression/semi_parametric_regression_model.py
+++ b/surpyval/univariate/regression/semi_parametric_regression_model.py
@@ -225,6 +225,29 @@ class SemiParametricRegressionModel:
 
         return check_ph(self, transform)
 
+    def robust_covariance(self, cluster=None) -> npt.NDArray:
+        """
+        Cluster-robust ("sandwich") covariance of the coefficients.
+
+        Pass ``cluster`` (one label per observation) for correlated /
+        clustered data; ``None`` gives the ordinary robust variance. See
+        :func:`~surpyval.univariate.regression.proportional_hazards.
+        diagnostics.robust_covariance`.
+        """
+        from .proportional_hazards.diagnostics import robust_covariance
+
+        return robust_covariance(self, cluster)
+
+    def robust_summary(self, cluster=None) -> dict:
+        """
+        Cluster-robust standard errors, z-scores and p-values for the
+        coefficients. See :func:`~surpyval.univariate.regression.
+        proportional_hazards.diagnostics.robust_summary`.
+        """
+        from .proportional_hazards.diagnostics import robust_summary
+
+        return robust_summary(self, cluster)
+
     def predict_tvc(
         self,
         start: npt.ArrayLike,


### PR DESCRIPTION
Third feature of the 0.16 diagnostics-and-validation cluster; builds directly on the dfbeta residuals from #211.

## Summary

`CoxPH` models gain:
- **`robust_covariance(cluster=...)`** — the Lin-Wei (1989) sandwich covariance for clustered / correlated data (repeated events per subject, grouped sampling). Built from the dfbeta residuals grouped by cluster: `V_robust = Σ_c D_c D_cᵀ`. With no `cluster` argument each observation is its own cluster (ordinary robust variance).
- **`robust_summary(cluster=...)`** — robust standard errors, z-scores and p-values (with covariate names when fit from a DataFrame).

## Correctness

- On **independent** data the robust SEs agree with the model-based SEs (rtol 0.25).
- On **exactly replicated clusters** (each subject copied `reps` times), naively treating the rows as independent underestimates the SE by exactly `sqrt(reps)`; the cluster-robust SE recovers it — validated to rtol 0.02 at `reps=4` (ratio = 2.00 = √4). This is the theoretically exact inflation, so it's strong evidence the estimator is right.
- The robust covariance is symmetric and PSD.

## Tests

`test_cox_robust_se.py` (6 tests). flake8, black, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_