### PR TITLE
Turnbull EM correctness under truncation (#203)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -71,6 +71,28 @@ Diagnostics & validation
   constant predictor is worse); and the AUC is ~1 for a near-perfect ordering
   and ~0.5 for a random one.
 
+Correctness
+~~~~~~~~~~~
+
+- **Turnbull EM under truncation** (#203). Three statistical defects in the
+  truncated Turnbull NPMLE are fixed. (1) The EM now iterates with the
+  Kaplan-Meier self-consistency update (``p`` proportional to the expected
+  counts ``d``), the canonical M-step; the ``Fleming-Harrington`` /
+  ``Nelson-Aalen`` inner estimators set ``R = exp(-H)``, which violates that
+  fixed point and left even healthy truncated fits reporting tol-level
+  non-convergence -- they now converge, and the requested hazard-form
+  estimator is applied to the *converged* ladder. (2) The expected counts are
+  confined to the identifiable support each iteration, stopping the ghost
+  step from migrating mass below every entry window. (3) The convergence
+  check is no longer NaN-blind: a non-finite update or a total mass collapse
+  is detected as a *degenerate, non-identifiable* fixed point and reported
+  with an explicit warning and a ``degenerate`` flag on the model, instead of
+  a silent all-zero survival curve. Untruncated fits are unchanged. Validated:
+  the issue's degenerate reproduction is now flagged and warned; a
+  left-truncated sample recovers ``S(median)`` to within 0.04 with all three
+  inner estimators; and the documented untruncated example is byte-for-byte
+  identical.
+
 v0.15.2 (20 Jul 2026)
 ---------------------
 

--- a/surpyval/tests/univariate/nonparametric/test_turnbull.py
+++ b/surpyval/tests/univariate/nonparametric/test_turnbull.py
@@ -208,3 +208,90 @@ def test_turnbull_docstring_example_unchanged():
         0.09680497,
     ]
     assert np.allclose(model.R, expected, atol=1e-6)
+
+
+# -- #203: EM correctness under truncation ------------------------------------
+
+
+def _degenerate_case():
+    # The reproduction from issue #203: a small, heavily truncated, mixed-
+    # censoring sample on which the truncated EM used to migrate all mass
+    # below the observation windows and return an all-zero survival curve
+    # silently.
+    x = [1, 2, [3, 6], 7, 8, 9, [5, 9], [4, 10], [7, 10], 11, 12]
+    c = [1, 1, 2, 0, 0, 0, 2, 2, 2, -1, 0]
+    n = [1, 2, 1, 3, 2, 2, 1, 1, 2, 1, 1]
+    tl = [0, 0, 0, 0, 0, 2, 3, 3, 1, 1, 5]
+    return x, c, n, tl
+
+
+def test_turnbull_degenerate_state_is_flagged_and_warns():
+    x, c, n, tl = _degenerate_case()
+    with pytest.warns(UserWarning, match="degenerate"):
+        model = surpyval.Turnbull.fit(x=x, c=c, n=n, tl=tl)
+    # The degenerate direction is detected and surfaced, rather than a
+    # silent all-zero survival curve being returned as if converged.
+    assert model.degenerate is True
+
+
+def test_turnbull_healthy_truncated_fit_is_not_flagged():
+    # A well-sized left-truncated sample is a genuine, identifiable fit: it
+    # must not trip the degenerate detector.
+    x, tl = _left_truncated_sample(n=600, seed=7)
+    model = surpyval.Turnbull.fit(
+        x, tl=tl, turnbull_estimator="Kaplan-Meier", max_iter=5000
+    )
+    assert model.degenerate is False
+
+
+def test_turnbull_truncated_estimators_converge():
+    # With the Kaplan-Meier self-consistency M-step, the hazard-form
+    # estimators (which used to iterate on a biased update and never reach
+    # ``tol`` under truncation) now converge on a healthy truncated sample.
+    rng = np.random.default_rng(5)
+    x = rng.weibull(1.5, 250) * 10
+    tl = rng.uniform(0, 3, 250)
+    keep = x > tl
+    x, tl = x[keep], tl[keep]
+    for est in ("Kaplan-Meier", "Fleming-Harrington", "Nelson-Aalen"):
+        model = surpyval.Turnbull.fit(
+            x, tl=tl, turnbull_estimator=est, max_iter=5000
+        )
+        assert model.converged is True
+        assert model.degenerate is False
+
+
+def test_turnbull_left_truncation_recovers_survival():
+    # All three inner estimators recover S(median) of the true Weibull to
+    # well within 0.04 on a left-truncated sample.
+    rng = np.random.default_rng(11)
+    x = rng.weibull(1.5, 400) * 10
+    tl = rng.uniform(0, 3, 400)
+    keep = x > tl
+    x, tl = x[keep], tl[keep]
+    median = 10 * (np.log(2)) ** (1 / 1.5)
+    for est in ("Kaplan-Meier", "Fleming-Harrington", "Nelson-Aalen"):
+        model = surpyval.Turnbull.fit(
+            x, tl=tl, turnbull_estimator=est, max_iter=5000
+        )
+        s_med = float(np.atleast_1d(model.sf(median))[0])
+        assert abs(s_med - 0.5) < 0.04
+
+
+def test_turnbull_untruncated_default_is_unchanged():
+    # The #203 fix is scoped to truncated fits; the documented untruncated
+    # Fleming-Harrington example must be byte-for-byte unchanged.
+    x = np.array([[1, 5], [2, 3], [3, 6], [1, 8], [9, 10]])
+    model = surpyval.Turnbull.fit(x)
+    expected = [
+        1.0,
+        1.0,
+        0.63472351,
+        0.29479882,
+        0.2631432,
+        0.2631432,
+        0.2631432,
+        0.09680497,
+    ]
+    assert np.allclose(model.R, expected, atol=1e-6)
+    assert model.degenerate is False

--- a/surpyval/univariate/nonparametric/turnbull.py
+++ b/surpyval/univariate/nonparametric/turnbull.py
@@ -99,8 +99,23 @@ def turnbull(
         w_lo, w_hi = w_lo[truncated], w_hi[truncated]
         n_truncated = n[truncated]
 
+    # The identifiable support: a bound may carry probability mass only if it
+    # lies inside at least one observation's support ``[lo, hi]``. Mass placed
+    # elsewhere is non-identifiable, and under truncation the ghost step
+    # otherwise migrates it below every entry window into a degenerate,
+    # all-zero-survival fixed point (issue #203). Restricting the expected
+    # counts to this region each iteration keeps the EM in the identifiable
+    # part of the parameter space.
+    cover = np.zeros(M + 1)
+    np.add.at(cover, lo, 1.0)
+    np.add.at(cover, np.minimum(hi + 1, M), -1.0)
+    identifiable = np.cumsum(cover[:M]) > 0
+
     d = np.zeros(M)
-    p = np.ones(M) / M
+    if any_truncated and identifiable.any():
+        p = identifiable / identifiable.sum()
+    else:
+        p = np.ones(M) / M
 
     if estimator == "Kaplan-Meier":
         func = km
@@ -112,6 +127,9 @@ def turnbull(
     old_err_state = np.seterr(all="ignore")
 
     converged = False
+    degenerate = False
+    r = np.zeros(M)
+    R = np.ones(M)
     for iters in range(1, max_iter + 1):
         # Prefix sums of p turn every range sum into two lookups.
         cumulative = np.concatenate([[0.0], np.cumsum(p)])
@@ -147,23 +165,63 @@ def turnbull(
 
         # Deaths/Failures/Events
         d = d_ghosts + d_observed
+        if any_truncated:
+            # Confine the expected counts to the identifiable region.
+            d = np.where(identifiable, d, 0.0)
         # total observed and unobserved failures.
         total_events = d.sum()
         # Risk set, i.e the number of items at risk at immediately before x
         r = total_events - d.cumsum() + d
-        # Find the survival function values (R) using the deaths and risk set
-        # The 'official' way to do it, which is equivalent to using KM,
-        # is to do p = (nu + mu).sum(axis=0)/(nu + mu).sum()
-        R = func(r, d)
+        # Iterate with the Kaplan-Meier self-consistency update (``p`` ∝
+        # ``d``), the canonical Turnbull M-step. The requested hazard-form
+        # estimator (Fleming-Harrington / Nelson-Aalen) sets ``R = exp(-H)``,
+        # which does *not* satisfy ``p`` ∝ ``d`` -- iterating with it biases
+        # every step and leaves truncated fits reporting tol-level
+        # non-convergence (issue #203). It is applied only to the converged
+        # ladder below. Untruncated fits keep their historical behaviour.
+        update = km if any_truncated else func
+        R = update(r, d)
         # Calculate the probability mass in each interval
         p_new = np.abs(np.diff(np.hstack([[1], R])))
-        if np.nanmax(np.abs(p_new - p)) < tol:
+        # A non-finite update, or (under truncation) a total collapse of mass,
+        # is a degenerate fixed point -- not convergence. The old ``nanmax``
+        # check silently accepted these.
+        if not np.all(np.isfinite(p_new)) or (
+            any_truncated and p_new.sum() <= 0
+        ):
+            degenerate = True
+            break
+        if any_truncated:
+            p_new = p_new / p_new.sum()
+        if np.max(np.abs(p_new - p)) < tol:
             p = p_new
             converged = True
             break
         p = p_new
 
-    if not converged:
+    # Report the requested hazard-form estimator on the converged ladder.
+    R = func(r, d)
+
+    # A converged fit whose survival has entirely collapsed (all mass forced
+    # to the boundary, so S(x) ~ 0 across the whole observed range) is the
+    # non-identifiable degenerate state, not a real estimate.
+    if not degenerate and R.size > 2:
+        reported = R[:-2]
+        if not np.all(np.isfinite(reported)) or (
+            any_truncated and np.nanmax(reported) < 1e-8
+        ):
+            degenerate = True
+
+    if degenerate:
+        warnings.warn(
+            "The Turnbull EM reached a degenerate, non-identifiable fixed "
+            "point: all probability mass migrated outside the observable "
+            "region (typically below the earliest entry time under heavy "
+            "left truncation), so the survival estimate has collapsed. The "
+            "result is unreliable -- more data or a narrower truncation range "
+            "is needed."
+        )
+    elif not converged:
         warnings.warn(
             "The Turnbull EM did not converge to within `tol` ({}) in "
             "`max_iter` ({}) iterations; the estimate may be "
@@ -246,6 +304,7 @@ def turnbull(
     out["turnbull_estimator"] = estimator
     out["iters"] = iters
     out["converged"] = converged
+    out["degenerate"] = degenerate
 
     np.seterr(**old_err_state)
 


### PR DESCRIPTION
The final feature of the 0.16 diagnostics-and-validation cluster, and the one flagged "do carefully" — it backs the survival tree and competing-risks estimators. Follow-up to the 0.15.1 hang fix: now that truncated Turnbull fits *terminate*, three real statistical defects in the EM are visible and fixed.

## The three defects

**1. Inner-estimator bias in the M-step.** The canonical Turnbull M-step is `p ∝ d` (expected counts), which the Kaplan-Meier inner estimator reproduces exactly. The default `Fleming-Harrington` (and `Nelson-Aalen`) estimators set `R = exp(-H)`, which does **not** satisfy `p ∝ d` — so every iteration was a biased update, and even healthy truncated fits reported tol-level non-convergence. **Fix:** iterate with the KM self-consistency update and apply the requested hazard-form estimator only to the *converged* `(r, d)` ladder. Confirmed: KM iteration converges (~186 iters); the FH iteration was stuck at a `3e-6` change and never reached `1e-10`.

**2. Degenerate absorbing state under truncation.** On small/heavily-truncated samples the ghost step migrates all mass below every entry window (non-identifiable region), reaching an `R = 0` everywhere fixed point. **Fix:** confine the expected counts to the identifiable support each iteration.

**3. NaN-blind convergence.** `np.nanmax(|p_new − p|) < tol` treated a NaN or collapsed update as *converged*. **Fix:** a non-finite update or a total mass collapse is now detected as a **degenerate, non-identifiable** fixed point — reported with an explicit warning and a `model.degenerate` flag — instead of a silent all-zero survival curve.

The fix is **scoped to truncated fits**; untruncated behaviour is unchanged.

## Correctness

- **The issue's degenerate reproduction** now raises a clear warning and sets `model.degenerate = True` (previously: all-zero `R`, no warning).
- **A left-truncated sample recovers `S(median)`** of the true Weibull to within **0.04** with all three inner estimators — which now **converge** (previously FH/NA did not).
- **The documented untruncated Fleming-Harrington example is byte-for-byte identical** (regression guard).

## Tests

5 new tests in `test_turnbull.py`; the full nonparametric + serialisation suites (151 tests) pass. flake8, black, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_