### PR TITLE
Document the 0.16 diagnostics & validation features

### DIFF
--- a/docs/Competing Risks SurPyval Modelling.rst
+++ b/docs/Competing Risks SurPyval Modelling.rst
@@ -62,6 +62,50 @@ Once fitted, you can query the CIF for each cause:
     plt.title('Competing Risks CIF by Cause')
 
 
+Comparing incidence across groups: Gray's test
+----------------------------------------------
+
+Having estimated a cumulative incidence function for each group, ``surpyval.
+gray_test`` tests whether the CIFs *differ* for a chosen cause. It is the
+competing-risks analogue of the log-rank test, but with an important
+distinction: where a cause-specific log-rank compares the instantaneous
+*hazards* of a cause, Gray's test compares the *incidence* — the CIFs directly.
+It does this by keeping competing-cause failures in the subdistribution risk
+set with an inverse-probability-of-censoring weight, rather than removing them.
+Reach for it when the clinical or engineering question is "how many fail of this
+cause", not "how fast".
+
+Pass the observed times ``x``, the per-observation cause label ``e``, the group
+label, and the ``cause`` of interest (use ``c`` for censored rows). Here two
+groups have genuinely different cause-1 incidence:
+
+.. jupyter-execute::
+
+    from surpyval import gray_test
+
+    rng = np.random.default_rng(7)
+
+    def simulate(n, p_cause1):
+        is1 = rng.random(n) < p_cause1
+        t = rng.exponential(6.0, n)
+        return t, np.where(is1, 1, 2)         # causes labelled 1 and 2
+
+    x_a, e_a = simulate(300, 0.35)
+    x_b, e_b = simulate(300, 0.60)            # higher cause-1 incidence
+    x = np.concatenate([x_a, x_b])
+    e = np.concatenate([e_a, e_b])
+    group = np.array([0] * 300 + [1] * 300)
+
+    result = gray_test(x, e, group, cause=1)
+    print('statistic = %.2f   df = %d   p = %.3g'
+          % (result.statistic, result.df, result.p_value))
+
+The tiny ``p``-value correctly flags the difference in cause-1 incidence. On
+data where the two groups share the same incidence the test is calibrated,
+returning ``p``-values spread over ``[0, 1]`` — including under heavy censoring,
+which is where the inverse-probability weighting earns its keep.
+
+
 Fine-Gray Sub-distribution Hazards
 ----------------------------------
 

--- a/docs/Non-Parametric SurPyval Modelling.rst
+++ b/docs/Non-Parametric SurPyval Modelling.rst
@@ -188,14 +188,37 @@ And finally, an example with completely arbitrary censoring:
 With a completely arbitrary set of data we have created a non-parametric estimate of the survival
 curve that can be used to estimate probabilities.
 
-The Turnbull fitter also accepts truncation (``tl``/``tr``), and on
-well-sized samples the truncated estimate is well behaved. Be aware,
-though, that the truncated NPMLE is a delicate object: on small or
-heavily truncated samples it can be non-identifiable (classically, mass
-can escape below every observation's entry time), in which case the EM
-does not converge to a useful estimate. SurPyval warns when the EM
-stops without converging -- treat the estimate with suspicion when it
-does.
+The Turnbull fitter also accepts truncation (``tl``/``tr``). Under
+truncation the EM iterates with the Kaplan-Meier self-consistency update
+(the canonical Turnbull M-step), and the requested hazard-form estimator
+(Fleming-Harrington / Nelson-Aalen) is applied to the converged step
+function -- so on well-sized samples the truncated estimate converges and
+is well behaved.
+
+Be aware, though, that the truncated NPMLE is a delicate object: on small
+or heavily truncated samples it can be *non-identifiable* -- classically,
+probability mass escapes below every observation's entry time and the
+survival estimate collapses. SurPyval detects this degenerate fixed point,
+raises a warning, and sets a ``degenerate`` flag on the model, rather than
+silently returning an all-zero curve. It also warns if the EM stops before
+converging. Treat the estimate with suspicion whenever either flag is
+raised:
+
+.. jupyter-execute::
+
+    import warnings
+    from surpyval import Turnbull as TB
+
+    # A small, heavily truncated, mixed-censoring sample.
+    x = [1, 2, [3, 6], 7, 8, 9, [5, 9], [4, 10], [7, 10], 11, 12]
+    c = [1, 1, 2, 0, 0, 0, 2, 2, 2, -1, 0]
+    n = [1, 2, 1, 3, 2, 2, 1, 1, 2, 1, 1]
+    tl = [0, 0, 0, 0, 0, 2, 3, 3, 1, 1, 5]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        model = TB.fit(x=x, c=c, n=n, tl=tl)
+    print('degenerate:', model.degenerate)
 
 What is interesting about the Turbull estimate is that it first finds the data in the 'xrd' format.
 This is done even though we might not have a complete failure occur in an interval. This can be seen by looking at the number of deaths/failures occur at each value.
@@ -230,3 +253,100 @@ of observation, and the highest value, if right truncated also has 100% chance o
 
 The implications of this are detailed in the Parametric section, because the only way to gain an understanding of these situations is by assuming a shape of the distribution. That is, by doing parametric analysis. This is possible since if the distribution within the truncated ends has a shape that matches to a particular distribution you can then extrapolate beyond the observed values. Parametric analysis is therefore incredibly powerful for prediction / extrapolation.
 
+
+Comparing two groups: the log-rank test
+---------------------------------------
+
+Having estimated a survival curve for each of several groups, the natural next
+question is whether they *differ*. The **log-rank test** is the standard answer:
+at every event time it compares the observed number of failures in each group
+with the number expected if all groups shared one survival curve, and combines
+those differences into a chi-squared statistic with ``k - 1`` degrees of freedom
+(``k`` groups). A small ``p``-value is evidence the groups differ.
+
+.. jupyter-execute::
+
+    import numpy as np
+    import surpyval as surv
+    from surpyval import logrank
+
+    np.random.seed(1)
+    control = surv.Weibull.random(200, 10, 1.2)
+    treatment = surv.Weibull.random(200, 16, 1.2)   # longer-lived
+    x = np.concatenate([control, treatment])
+    group = np.array(['control'] * 200 + ['treatment'] * 200)
+
+    result = logrank(x, group)
+    print(result)
+
+The test accepts right-censored data through the ``c`` argument, and offers the
+Gehan, Tarone-Ware and Fleming-Harrington weightings (via ``weighting=``) when
+you want to emphasise early or late differences instead of the equal-weight
+log-rank.
+
+Stratified log-rank
+~~~~~~~~~~~~~~~~~~~~~
+
+When a *nuisance* factor influences survival — a study site, a batch — comparing
+groups while ignoring it can be badly misleading if the groups are unevenly
+distributed across its levels. The **stratified** log-rank accumulates the
+observed-minus-expected counts *within* each stratum before forming the
+statistic, so groups are only ever compared against others in the same stratum.
+Pass a ``strata`` label per observation.
+
+The example below is confounded on purpose: the baseline hazard differs sharply
+by site, and the group is unevenly allocated across sites, but there is no true
+group effect. The pooled test is fooled; the stratified test is not:
+
+.. jupyter-execute::
+
+    np.random.seed(2)
+    n = 600
+    site = np.random.randint(0, 2, n)
+    group = np.where(site == 0, np.random.random(n) < 0.8,
+                     np.random.random(n) < 0.2).astype(int)
+    baseline = np.where(site == 0, 4.0, 20.0)
+    x = np.random.exponential(baseline)              # no group effect
+
+    print('pooled     p = %.4g' % logrank(x, group).p_value)
+    print('stratified p = %.4g' % logrank(x, group, strata=site).p_value)
+
+Restricted mean survival time
+-----------------------------
+
+A hazard ratio (from Cox or the log-rank test) is only interpretable when the
+proportional-hazards assumption holds. When it does not — survival curves that
+cross, treatments that help early but not late — the **restricted mean survival
+time** (RMST) is an assumption-light alternative. It is simply the area under
+the survival curve up to a horizon :math:`\tau`, i.e. the average event-free
+time over the first :math:`\tau` units, and it is always well defined.
+
+Any fitted non-parametric model exposes ``rmst(tau)``, returning the point
+estimate with its standard error and confidence interval:
+
+.. jupyter-execute::
+
+    from surpyval import KaplanMeier
+
+    control_model = KaplanMeier.fit(control)
+    rmst = control_model.rmst(tau=20)
+    print('RMST(20) = %.2f  (95%% CI %.2f - %.2f)'
+          % (rmst['rmst'], rmst['lower'], rmst['upper']))
+
+To compare two groups, ``surpyval.rmst_diff`` gives the difference in RMST with
+a standard error, confidence interval and two-sided ``p``-value. The horizon
+defaults to the smaller of the two groups' largest observed times (their common
+support):
+
+.. jupyter-execute::
+
+    from surpyval import rmst_diff
+
+    treatment_model = KaplanMeier.fit(treatment)
+    diff = rmst_diff(treatment_model, control_model, tau=20)
+    print('RMST difference = %.2f  (p = %.4g)'
+          % (diff['difference'], diff['p_value']))
+
+The treatment group spends about four more time units event-free over the first
+twenty — a difference on the natural time scale, with no proportional-hazards
+assumption required.

--- a/docs/Regression Modelling with SurPyval.rst
+++ b/docs/Regression Modelling with SurPyval.rst
@@ -278,6 +278,126 @@ to :meth:`CoxPH.fit`); right or interval truncation is rejected, because the
 forward partial likelihood cannot express it.
 
 
+Checking the proportional-hazards assumption
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A Cox fit is only trustworthy if its central assumption holds: that each
+covariate multiplies the baseline hazard by a *constant* factor over time. When
+a coefficient is really drifting with time — a treatment that helps early but
+not late, say — the single number Cox reports is a time-average that can hide
+the effect entirely.
+
+The standard check is the **Grambsch-Therneau test**, built on the scaled
+Schoenfeld residuals. A fitted model exposes it through
+:meth:`~surpyval.univariate.regression.semi_parametric_regression_model.SemiParametricRegressionModel.check_ph`.
+It returns a joint ``global`` test and a ``per_covariate`` breakdown; a *small*
+``p``-value is evidence *against* proportional hazards. We fit the tires model
+with :meth:`CoxPH.fit_from_df` so the report carries the covariate names:
+
+.. jupyter-execute::
+
+    cols = ['Wedge gauge', 'Interbelt gauge', 'Peel force',
+            'Wedge gauge×peel force']
+    model = CoxPH.fit_from_df(tires, x_col='Survival', Z_cols=cols,
+                              c_col='Censoring')
+
+    ph = model.check_ph()
+    print('global p-value:', round(ph['global']['p_value'], 3))
+    for row in ph['per_covariate']:
+        print(f"  {row['covariate']:24s} p = {row['p_value']:.3f}")
+
+Here every ``p``-value is large, so there is no evidence against proportional
+hazards — the Cox coefficients can be read as constant hazard ratios.
+
+The residuals underlying the test (and several others) are available directly
+through
+:meth:`~surpyval.univariate.regression.semi_parametric_regression_model.SemiParametricRegressionModel.compute_residuals`,
+with ``kind`` one of ``"schoenfeld"``, ``"scaled_schoenfeld"``,
+``"martingale"``, ``"deviance"``, ``"score"`` or ``"dfbeta"``. Martingale
+residuals plotted against a covariate reveal non-linear functional form;
+deviance residuals highlight poorly-predicted individuals:
+
+.. jupyter-execute::
+
+    martingale = model.compute_residuals('martingale')
+    print('martingale residuals sum to zero:',
+          np.isclose(martingale.sum(), 0.0))
+
+Schoenfeld, score and martingale residuals all sum to zero at the maximum of
+the partial likelihood — a useful sanity check that the fit has converged.
+
+
+Cluster-robust standard errors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The model-based standard errors assume every observation is independent. When
+the data are *clustered* — several failures from the same machine, repeated
+events on the same subject, items drawn in grouped batches — that assumption is
+wrong and the naive errors are too small. The **Lin-Wei sandwich** (or
+"robust") variance corrects for it, using the dfbeta residuals grouped by
+cluster.
+
+Pass a ``cluster`` label per observation to
+:meth:`~surpyval.univariate.regression.semi_parametric_regression_model.SemiParametricRegressionModel.robust_summary`;
+with no cluster argument each observation is its own cluster (the ordinary
+robust variance):
+
+.. jupyter-execute::
+
+    summary = model.robust_summary()
+    for name, se, p in zip(summary['covariate'], summary['se'],
+                           summary['p_value']):
+        print(f"  {name:24s} robust SE = {se:8.3f}   p = {p:.3f}")
+
+To see why clustering matters, imagine every tire had been measured *twice* and
+both rows entered the fit as if independent. Ignoring that would understate the
+standard errors by exactly :math:`\sqrt{2}`; passing the shared ``cluster``
+label recovers the correct value.
+
+
+Stratified Cox models
+~~~~~~~~~~~~~~~~~~~~~~~
+
+When proportional hazards fails for a *nuisance* covariate — a study site, a
+batch, a device generation you do not want to model explicitly — the standard
+remedy is **stratification**: fit a separate baseline hazard for each stratum
+while sharing the coefficients :math:`\beta`. Risk sets never cross a stratum
+boundary, so the comparison is always within-stratum.
+
+Pass ``strata`` (a label per observation) to :meth:`CoxPH.fit`, or
+``strata_col`` to :meth:`CoxPH.fit_from_df`. The example below is deliberately
+adversarial: the baseline hazard differs by an order of magnitude across three
+sites *and* the covariate is correlated with the site. An ordinary Cox fit is
+badly confounded; the stratified fit recovers the true coefficient:
+
+.. jupyter-execute::
+
+    st_rng = np.random.default_rng(0)
+    n_st = 600
+    site = st_rng.integers(0, 3, n_st)
+    Z_st = st_rng.normal(site.astype(float), 1.0).reshape(-1, 1)   # confounded
+    baseline = np.array([1.0, 6.0, 30.0])[site]
+    x_st = st_rng.exponential(baseline / np.exp(0.8 * Z_st[:, 0]))  # true 0.8
+    c_st = (st_rng.random(n_st) < 0.15).astype(int)
+
+    pooled = CoxPH.fit(x=x_st, Z=Z_st, c=c_st)
+    stratified = CoxPH.fit(x=x_st, Z=Z_st, c=c_st, strata=site)
+    print(f"true beta   = 0.80")
+    print(f"pooled      = {pooled.beta[0]:.3f}   (confounded by site)")
+    print(f"stratified  = {stratified.beta[0]:.3f}")
+
+Prediction on a stratified model needs a ``stratum`` argument to pick the right
+baseline; ``sf``, ``Hf``, ``hf``, ``ff`` and ``df`` all accept it:
+
+.. jupyter-execute::
+
+    stratified.sf(x=1.0, Z=[[0.0]], stratum=0)
+
+The residual diagnostics and robust errors above assume a single baseline, so
+they are not available on a stratified model; the coefficients and their
+model-based ``p``-values are.
+
+
 Semi-Parametric — Buckley-James (AFT)
 -------------------------------------
 
@@ -815,6 +935,72 @@ assumption is violated (e.g. survival curves cross), a lower-AIC PH model can
 still give misleading predictions. Goodness-of-fit diagnostics like
 Schoenfeld residuals (for PH) or log-log survival plots should accompany any
 model comparison.
+
+Validating a survival predictor
+-------------------------------
+
+Information criteria compare models on the data they were fit to. To judge how
+well a model *predicts*, score it on held-out data. Two right-censored-standard
+metrics live in :mod:`surpyval.metrics`, and both work for **any** model that
+exposes ``sf(x, Z)`` — the parametric families, ``CoxPH``, and the
+:mod:`surpyval.beta.ml` forest.
+
+Both handle censoring by inverse-probability-of-censoring weighting (IPCW), so
+a subject censored before the horizon does not silently bias the score.
+
+- The **Brier score** ``BS(t)`` is the weighted mean squared error between the
+  predicted survival ``S(t | Z)`` and the survival indicator; the **integrated
+  Brier score** (IBS) averages it over a time grid. Lower is better; a useful
+  model scores below the marginal Kaplan-Meier reference.
+- The **time-dependent AUC** (Uno's cumulative/dynamic estimator) measures
+  discrimination as a function of the horizon — the probability that a subject
+  who has failed by ``t`` was assigned a higher risk than one still event-free.
+  0.5 is chance, 1.0 is perfect.
+
+The helper :func:`~surpyval.metrics.survival_probability` builds the predicted
+survival matrix ``S(times | Z_i)`` from a fitted model. We fit a Cox model on a
+training set and score it on an independent test set:
+
+.. jupyter-execute::
+
+    from surpyval import CoxPH, KaplanMeier
+    from surpyval.metrics import (
+        survival_probability, brier_score, integrated_brier_score, auc_td,
+    )
+
+    def make(seed, n=600):
+        r = np.random.default_rng(seed)
+        Z = r.normal(0, 1, (n, 2))
+        t = r.exponential(1.0 / np.exp(1.2 * Z[:, 0] - 0.8 * Z[:, 1]))
+        cens = r.exponential(np.median(t) * 3)
+        return np.minimum(t, cens), (cens < t).astype(int), Z
+
+    x_tr, c_tr, Z_tr = make(1)
+    x_te, c_te, Z_te = make(2)
+    cox = CoxPH.fit(x=x_tr, Z=Z_tr, c=c_tr)
+
+    times = np.quantile(x_te[c_te == 0], [0.25, 0.5, 0.75])
+    S = survival_probability(cox, Z_te, times)
+
+    _, bs = brier_score(x_te, c_te, S, times, x_train=x_tr, c_train=c_tr)
+    ibs = integrated_brier_score(x_te, c_te, S, times, x_train=x_tr, c_train=c_tr)
+    _, auc = auc_td(x_te, c_te, 1 - S, times)
+    print('Brier score :', np.round(bs, 3))
+    print('IBS         :', round(ibs, 3))
+    print('AUC         :', np.round(auc, 3))
+
+The AUC around 0.8 shows the two covariates discriminate well. To see that the
+IBS is meaningful, compare it against the marginal Kaplan-Meier — a model that
+ignores the covariates entirely. The Cox model should score lower:
+
+.. jupyter-execute::
+
+    km = KaplanMeier.fit(x_tr, c_tr)
+    S_km = np.tile([km.sf([t])[0] for t in times], (len(x_te), 1))
+    ibs_km = integrated_brier_score(
+        x_te, c_te, S_km, times, x_train=x_tr, c_train=c_tr
+    )
+    print(f'IBS  Cox = {ibs:.3f}   marginal KM = {ibs_km:.3f}')
 
 Saving and loading a fitted model
 ---------------------------------

--- a/docs/comparison_and_validation.rst
+++ b/docs/comparison_and_validation.rst
@@ -1,0 +1,34 @@
+Comparison Tests and Validation Metrics
+=======================================
+
+Group-comparison tests
+-----------------------
+
+The (weighted, optionally stratified) log-rank test for comparing survival
+distributions across groups:
+
+.. autofunction:: surpyval.univariate.nonparametric.logrank.logrank
+
+Gray's test for comparing cumulative incidence functions across groups under
+competing risks:
+
+.. autofunction:: surpyval.univariate.competing_risks.nonparametric.gray_test.gray_test
+
+Restricted mean survival time
+-----------------------------
+
+The two-group restricted-mean-survival-time difference (the per-model
+``rmst`` method lives on the non-parametric model class):
+
+.. autofunction:: surpyval.univariate.nonparametric.nonparametric.rmst_diff
+
+Prediction-validation metrics
+-----------------------------
+
+Right-censored-standard metrics for scoring a predicted survival function
+(Brier / integrated Brier score and Uno's time-dependent AUC), plus the helper
+that builds a predicted-survival matrix from any fitted model exposing
+``sf(x, Z)``.
+
+.. automodule:: surpyval.metrics.validation
+   :members:

--- a/docs/surpyval.rst
+++ b/docs/surpyval.rst
@@ -9,5 +9,6 @@ API
    surpyval.regression
    surpyval.counting
    surpyval.degradation
+   comparison_and_validation
    surpyval.utilities
    surpyval.datasets


### PR DESCRIPTION
Adds user documentation for all seven 0.16 "diagnostics, validation & correctness" features, which until now only appeared in the changelog and API docstrings.

## What's added

**Regression Modelling with SurPyval** — four new subsections under the Cox model:
- *Checking the proportional-hazards assumption* — `check_ph()` (Grambsch-Therneau) and the residual suite via `compute_residuals()` (#211)
- *Cluster-robust standard errors* — `robust_summary()` (#215)
- *Stratified Cox models* — `strata` / `strata_col` with a confounding demo and stratum-aware prediction (#214)
- *Validating a survival predictor* — Brier / integrated Brier score and time-dependent AUC, with a Brier-skill comparison against the marginal KM (#212)

**Non-Parametric SurPyval Modelling**:
- *Comparing two groups: the log-rank test* — plus the *stratified log-rank* with a confounding demo (#214)
- *Restricted mean survival time* — `rmst()` and `rmst_diff()` as the assumption-light alternative to a hazard ratio (#213)
- Updated the Turnbull truncation note for the corrected EM — KM self-consistency update, degenerate-state detection and the `degenerate` flag (#203)

**Competing Risks SurPyval Modelling**:
- *Comparing incidence across groups: Gray's test* (#216)

**API reference**: a new `comparison_and_validation` page wires `logrank`, `gray_test`, `rmst_diff` and the `surpyval.metrics` module into the API toctree. The `CoxPH` / `SemiParametricRegressionModel` autoclasses already pick up the new diagnostics methods.

## Verification

- Every new `jupyter-execute` cell was run end-to-end in a shared namespace (as the build does), including a check that the stratified-Cox example's renamed variables don't clobber later cells.
- The **full `sphinx-build` succeeds** with no new warnings attributable to these changes (the 14 warnings are pre-existing: changelog duplicate labels, kernel TCP notices, expected cell stderr).

Docs-only change — no library code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_