### PR TITLE
Harmonise theory and how-to docs across the whole package

### DIFF
--- a/docs/Competing Risks Analysis.rst
+++ b/docs/Competing Risks Analysis.rst
@@ -16,9 +16,15 @@ Classic examples:
 - A customer may churn, upgrade, or downgrade; the event that happens first
   changes the analysis for the remaining outcomes.
 
-Competing risks require special treatment because the causes are not
-independent; accounting for the wrong event type leads to biased estimates.
-This is sometimes called the "identifiability problem" in competing risks.
+Competing risks require special treatment because treating the competing
+events as ordinary independent censoring gives a quantity that cannot be
+interpreted as a real-world probability. A deeper subtlety is the
+**identifiability problem**: from competing-risks data alone the *marginal*
+(net, latent) distribution of each cause — the distribution that would be seen
+if the other causes were removed — cannot be identified without an untestable
+assumption about the dependence between causes. This is why the observable,
+well-defined target is the cumulative incidence function rather than a marginal
+cause-specific survival.
 
 Relationship to Univariate Analysis
 -------------------------------------
@@ -85,8 +91,10 @@ The overall density is:
 
     f(t) = \sum_{k=1}^{K} f_k(t) \prod_{j \neq k} S_j(t)
 
-SurPyval provides the ``CompetingRisks`` class for this model. Parameters for
-each cause distribution are estimated jointly by MLE.
+SurPyval provides the ``ParametricCompetingRisks`` class for this model. Under
+the independent-latent-times assumption the joint likelihood separates, so each
+cause's distribution is fitted independently by MLE with the *other* causes'
+events treated as right-censored.
 
 
 Regression: Fine-Gray and Cause-Specific PH
@@ -148,9 +156,9 @@ statistic is :math:`\chi^2` distributed with :math:`k - 1` degrees of freedom
 for :math:`k` groups. Reach for it when the question is "how many fail of this
 cause", and for the cause-specific log-rank when the question is "how fast".
 
-For examples of estimating cumulative incidence functions and comparing them
-with Gray's test, see the Competing Risks entry in the SurPyval Modelling
-section of the docs.
+For worked examples of estimating cumulative incidence functions, fitting the
+Fine-Gray and cause-specific proportional hazards models, and comparing groups
+with Gray's test, see the :doc:`Competing Risks SurPyval Modelling` page.
 
 
 Further Reading

--- a/docs/Competing Risks SurPyval Modelling.rst
+++ b/docs/Competing Risks SurPyval Modelling.rst
@@ -65,8 +65,9 @@ Once fitted, you can query the CIF for each cause:
 Comparing incidence across groups: Gray's test
 ----------------------------------------------
 
-Having estimated a cumulative incidence function for each group, ``surpyval.
-gray_test`` tests whether the CIFs *differ* for a chosen cause. It is the
+Having estimated a cumulative incidence function for each group,
+``surpyval.gray_test`` tests whether the CIFs *differ* for a chosen cause. It is
+the
 competing-risks analogue of the log-rank test, but with an important
 distinction: where a cause-specific log-rank compares the instantaneous
 *hazards* of a cause, Gray's test compares the *incidence* — the CIFs directly.

--- a/docs/Degradation Analysis.rst
+++ b/docs/Degradation Analysis.rst
@@ -187,8 +187,8 @@ standard tool in maintenance modelling; see [vanNoortwijk2009]_ for a survey.
 
 For worked examples of all of the above — fitting general-path and
 stochastic-process models, predicting remaining useful life, the Lu-Meeker
-diagnostic, and serialising a fitted model — see the Degradation entry in the
-SurPyval Modelling section of the docs.
+diagnostic, and serialising a fitted model — see the
+:doc:`Degradation Modelling with SurPyval` page.
 
 References
 ----------

--- a/docs/Degradation Modelling with SurPyval.rst
+++ b/docs/Degradation Modelling with SurPyval.rst
@@ -11,6 +11,11 @@ on each unit, define failure as the measurement crossing a *threshold*,
 and extrapolate each unit's degradation trend to that threshold to obtain
 a failure time — even for units that never actually failed on test.
 
+For the concepts and the underlying theory — the general-path model, the
+Lu-Meeker two-stage correction, the induced failure-time distribution, and the
+stochastic-process (Wiener/Gamma) first-passage models — see the
+:doc:`Degradation Analysis` page.
+
 SurPyval implements the classic *pseudo-failure-time* approach:
 
 1. A degradation *path model* (e.g. linear) is fitted, by least squares,
@@ -500,7 +505,7 @@ uncertainty — remain available directly through ``model.life_model.cb(x, Z,
 ...)``.
 
 Stochastic-process degradation models
-=====================================
+-------------------------------------
 
 Everything above is the **general-path** approach: fit a deterministic curve to
 each unit, extrapolate it to the threshold to get a *pseudo failure time*, then

--- a/docs/Multivariate Analysis.rst
+++ b/docs/Multivariate Analysis.rst
@@ -1,0 +1,96 @@
+Multivariate Analysis
+=====================
+
+Every distribution and model covered so far is *univariate*: each unit has a
+single event time, and units are treated as independent replicates.
+Multivariate survival analysis relaxes the independence: it models several
+*correlated* event-time series jointly. A pair of failure times on the two
+bearings of one shaft, the times to two related complications in one patient,
+or the lifetimes of two components sharing an environment are all naturally
+dependent, and pretending otherwise understates the joint risk.
+
+The difficulty is that a joint distribution mixes two very different things:
+what each series looks like *on its own*, and how the series *move together*.
+The **copula** is the device that separates them.
+
+Copulas and Sklar's theorem
+---------------------------
+
+A copula :math:`C(u_1, u_2)` is simply a joint distribution function whose
+margins are uniform on :math:`[0, 1]`. Its whole job is to encode dependence,
+stripped of any marginal shape. Sklar's theorem says that *any* joint
+distribution can be written this way: given marginal CDFs :math:`F_1, F_2`, the
+joint CDF is
+
+.. math::
+
+   H(x_1, x_2) = C\big(F_1(x_1),\, F_2(x_2)\big).
+
+Because :math:`F_1` and :math:`F_2` map each series onto uniform margins, the
+copula :math:`C` carries *only* the dependence structure. This is the key
+modelling freedom: the margins can be any survival distribution — a Weibull for
+one series, a LogNormal for the other — while the copula, chosen separately,
+governs how they are coupled. The marginal question ("how long does this
+component last?") and the dependence question ("do the two fail together?") are
+answered by different parts of the model.
+
+Families of dependence
+----------------------
+
+Different copula families describe qualitatively different dependence,
+especially in the *tails* — whether two series tend to fail together at short
+lives (lower-tail dependence) or survive together to long lives (upper-tail
+dependence):
+
+.. list-table::
+   :header-rows: 1
+
+   * - Copula
+     - Parameter
+     - Dependence
+   * - Independence
+     - none
+     - none (:math:`\tau = 0`)
+   * - Clayton
+     - :math:`\theta > 0`
+     - lower-tail (joint early failure)
+   * - Gumbel
+     - :math:`\theta \geq 1`
+     - upper-tail (joint long survival)
+   * - Frank
+     - :math:`\theta \neq 0`
+     - symmetric, no tail
+   * - Gaussian
+     - :math:`\rho \in (-1, 1)`
+     - symmetric, no tail
+
+The strength of dependence is summarised by rank measures that do not depend on
+the margins — **Kendall's** :math:`\tau` and **Spearman's** :math:`\rho` — and
+the tendency to fail (or survive) together in the extremes by the **tail
+dependence** coefficients. Choosing a family is largely a question of which
+tail behaviour matches the physics or the clinical reality.
+
+Estimation
+----------
+
+Fitting a copula model means estimating both the marginal parameters and the
+copula parameter. Two strategies trade off robustness against efficiency:
+
+- **IFM** (*Inference Functions for Margins*) fits each margin independently and
+  then estimates the copula parameter with the margins held fixed. It is fast
+  and robust, and is the usual default.
+- **MLE** optimises the copula parameter jointly with all marginal parameters.
+  It is more efficient when the model is well specified, at a higher
+  computational cost.
+
+Because the margins are ordinary survival distributions, the joint likelihood
+inherits survival analysis's treatment of incomplete data: each series of a
+joint observation can be independently right, left or interval censored, or
+truncated, using the same conventions as the univariate models. Every censoring
+type reduces to evaluating the copula CDF and its partial derivatives at the
+margin-transformed bounds — interval censoring, for instance, is
+inclusion-exclusion on the rectangle corners of :math:`C`.
+
+For worked examples — fitting a copula, handling per-series censoring, querying
+the joint distribution and dependence measures, and simulating correlated
+lifetimes — see the :doc:`Multivariate Modelling with SurPyval` page.

--- a/docs/Multivariate Modelling with SurPyval.rst
+++ b/docs/Multivariate Modelling with SurPyval.rst
@@ -1,47 +1,16 @@
 Multivariate Modelling with SurPyval
 ====================================
 
-Every distribution covered so far is *univariate*: each unit has a single
-event time and units are treated as independent replicates. The
-``surpyval.multivariate`` module opens the **multivariate** axis of the model
-atlas -- several *correlated* event-time series modelled jointly. The
-dependence between the series is specified with a **copula**, while the
-marginal behaviour of each series is any existing SurPyval distribution.
+The ``surpyval.multivariate`` module models several *correlated* event-time
+series jointly. The dependence between the series is specified with a
+**copula** while the marginal behaviour of each series is any existing SurPyval
+distribution — so the margins and the dependence are chosen independently. For
+the concepts (Sklar's theorem, the copula families and their tail behaviour,
+and the estimation strategies) see the :doc:`Multivariate Analysis` page; this
+page is the how-to.
 
-A copula ``C(u_1, u_2)`` is a joint distribution on uniform margins. Coupling
-it with real margins :math:`F_1, F_2` gives the joint CDF
-
-.. math::
-
-   H(x_1, x_2) = C\big(F_1(x_1), F_2(x_2)\big).
-
-This cleanly separates *what each series looks like on its own* (the margins)
-from *how the series move together* (the copula).
-
-Available copulas
------------------
-
-.. list-table::
-   :header-rows: 1
-
-   * - Copula
-     - Parameter
-     - Dependence
-   * - ``Independence``
-     - none
-     - none (:math:`\tau = 0`)
-   * - ``Clayton``
-     - :math:`\theta > 0`
-     - lower-tail
-   * - ``Gumbel``
-     - :math:`\theta \geq 1`
-     - upper-tail
-   * - ``Frank``
-     - :math:`\theta \neq 0`
-     - symmetric, no tail
-   * - ``Gaussian``
-     - :math:`\rho \in (-1, 1)`
-     - symmetric, no tail
+SurPyval provides the ``Independence``, ``Clayton``, ``Gumbel``, ``Frank`` and
+``Gaussian`` copulas.
 
 Fitting a copula
 ----------------

--- a/docs/Non-Parametric Estimation.rst
+++ b/docs/Non-Parametric Estimation.rst
@@ -125,12 +125,19 @@ where
 
 Using this estimate of the survival function, it can be input to the start of this procedure and it done again. This can then be repeated over and over until the values do not change. At this point we have reached the NPMLE estimate of the survival function!
 
-The Turnbull estimation is the only non-parametric method that can be used with truncated and left censored data. Therefore it must be used when using the plotting methods in the parametric package when you have truncated or left censored data.
+The Turnbull estimator is the only non-parametric method that can handle left censoring, interval censoring, and right truncation (and arbitrary combinations of censoring and truncation). Left truncation / delayed entry on its own is handled by the Kaplan-Meier, Nelson-Aalen and Fleming-Harrington estimators too, via the ``tl`` keyword; it is only the left/interval censoring and right truncation that require Turnbull. Turnbull must therefore be used to supply the plotting positions in the parametric package whenever such data is present.
 
-On Surpyval's Default
----------------------
+On Surpyval's recommended estimator
+-----------------------------------
 
-Surpyval uses the Fleming-Harrington estimator as the default. The rationale for this is because it has optimal behaviour. That is, it performs well where the Kaplan-Meier and the Nelson-Aalen behave poorly.
+Two distinct "defaults" are worth separating. When a non-parametric estimate is
+used *internally* as the plotting position for a parametric probability plot,
+surpyval uses the Nelson-Aalen estimator (as noted above), because for a
+completely observed data set it never assigns probability 1 to the largest
+value and so plots cleanly on a transformed axis. When you want a *standalone*
+non-parametric survival estimate, however, the Fleming-Harrington estimator is
+the recommended choice. The rationale is that it has near-optimal behaviour: it
+performs well where the Kaplan-Meier and the Nelson-Aalen behave poorly.
 
 The Kaplan-Meier, since it tends to 1, results in cases where it overstates the probability of failure. It is because of this that the Kaplan-Meier should not be used in circumstances of competing risks. As an example, a comparison between a Nelson-Aalen and Kaplan-Meier estimate over time (I have plotted the Fleming-Harrington estimate for later discussion):
 
@@ -142,7 +149,7 @@ On the contrary, the Nelson-Aalen estimate performs poorly with lots of ties. Th
 .. image:: images/km_na_low_comparison.png
     :align: center
 
-The Fleming-Harrington, plotted in red in the above two charts, optimises between these two estimators. The Fleming-Harrington estimate approaches the Nelson-Aalen under the conditions of where the Nelson-Aalen estimate performs well and the Kaplan-Meier does poorly. Fleming-Harrington also does well where the Nelson-Aalen estimate does poorly but the Kaplan-Meier does well. Although the two examples provided are in the extreme, it is worth using the Fleming-Harrington by default since it is more flexible; it is therefore, for this reason, that surpyval does exactly that. This is not to say not to use KM or NA, but only when you are sure you are making the correct assumptions about what you are doing!
+The Fleming-Harrington, plotted in red in the above two charts, optimises between these two estimators. The Fleming-Harrington estimate approaches the Nelson-Aalen under the conditions of where the Nelson-Aalen estimate performs well and the Kaplan-Meier does poorly. Fleming-Harrington also does well where the Nelson-Aalen estimate does poorly but the Kaplan-Meier does well. Although the two examples provided are in the extreme, it is worth reaching for the Fleming-Harrington as a general-purpose non-parametric estimator since it is more flexible; it is for this reason that surpyval recommends it. This is not to say not to use KM or NA, but only when you are sure you are making the correct assumptions about what you are doing!
 
 Comparing two groups: the log-rank test
 ---------------------------------------
@@ -163,6 +170,8 @@ A hazard ratio (from a log-rank test or a Cox model) only has a clean interpreta
     \text{RMST}(\tau) = \int_0^{\tau} S(t)\, dt,
 
 which is exactly the average event-free time over the first :math:`\tau` units and is always well defined. Comparing two groups by the **difference** in their RMST gives an effect measured in the natural units of time, with a variance obtained from Greenwood's formula, and needs no assumption about the shape of, or relationship between, the two hazards.
+
+For worked examples — fitting the Kaplan-Meier, Nelson-Aalen, Fleming-Harrington and Turnbull estimators, and comparing groups with the log-rank test and RMST difference — see the :doc:`Non-Parametric SurPyval Modelling` page.
 
 References
 ----------

--- a/docs/Non-Parametric SurPyval Modelling.rst
+++ b/docs/Non-Parametric SurPyval Modelling.rst
@@ -2,6 +2,10 @@
 Non-Parametric SurPyval Modelling
 =================================
 
+This page is the how-to companion to the :doc:`Non-Parametric Estimation` page,
+which covers the concepts and mathematics behind the Kaplan-Meier,
+Nelson-Aalen, Fleming-Harrington and Turnbull estimators.
+
 To get started, let's import some useful packages, as such, for the rest of this page we will assume the following imports have occurred:
 
 .. jupyter-execute::

--- a/docs/Parametric Estimation.rst
+++ b/docs/Parametric Estimation.rst
@@ -105,18 +105,15 @@ By using this simple change, the highest value will not be 1, and will therefore
 
 Where k is the rank of an observation k is in (1, 2, 3, 4.... n) for n observations. Using these methods we can therefore plot the linearised version above.
 
-Combining this all together is simple witht surpyval.
-
-.. code::
-
-	x = [1, 4, 5, 7, 8, 9, 12, 14]
-	model = surv.Weibull.fit(x, how='MPP', heuristic='Blom')
-	model.plot()
+Fitting a distribution this way — the probability-plotting method with a chosen
+heuristic — produces a linearised plot whose slope and intercept give the
+parameters:
 
 .. image:: images/mpp-1.png
 	:align: center
 
-In this example we have used the probability plotting method with the Blom heuristic to estimate the parameters of the distribution. SurPyval has the option to use many different plotting methods, including the regular KM, NA, and FH non-parametric estimates. All you need to do is change the 'heuristic' parameter; SurPyval includes:
+The plot above uses the Blom heuristic to estimate the parameters of the
+distribution (see the SurPyval Modelling section for the code). SurPyval has the option to use many different plotting methods, including the regular KM, NA, and FH non-parametric estimates. All you need to do is change the 'heuristic' parameter; SurPyval includes:
 
 .. list-table:: SurPyval Modelling Methods
    :header-rows: 1
@@ -167,7 +164,7 @@ In this example we have used the probability plotting method with the Blom heuri
    * - Larsen
      - 0.567
      - -0.134
-   * - Larsen
+   * - Tukey
      - 1/3
      - 1/3
    * - None
@@ -243,9 +240,18 @@ An easy and intuitive way to understand this is to compare these two possibiliti
 
 In this example, again, we need to consider whether the red or black distribution is a more likely description of the observations, including some censored ones. Althought the right censored point for the black distribuiton is very likely, this does not mean it is a good fit because the 'average' across all observations is poor. Therefore, it should be obvious that the red distribution is the better fit.
 
-But what about truncated data
+Truncated data is handled with the same logic, but on the *conditional*
+likelihood. A truncated observation was only observable because it fell inside
+its truncation window :math:`(t_{l}, t_{r}]`, so each contribution is
+renormalised by the probability of landing in that window:
 
+.. math::
 
+    l = \frac{1}{n} \sum_{i=1}^{n} \ln \frac{f(x_{i} \mid \theta)}{F(t_{r_{i}} \mid \theta) - F(t_{l_{i}} \mid \theta)}.
+
+This inflates the contribution of observations from a narrow window, correcting
+for the units that could never have been seen — exactly the delayed-entry
+(left-truncation) and right-truncation adjustments.
 
 Maximum Product of Spacings (MPS)
 ---------------------------------
@@ -275,14 +281,8 @@ or, taking logs and negating for the optimiser exactly as we did for MLE,
 
 Because a geometric mean is largest when its terms are equal, this is maximised when the spacings are as uniform as possible — precisely the "evenly spread" condition above.
 
-Why bother, when MLE already works so well? The answer is those two *end* spacings, :math:`D_{1} = F(x_{(1)}) - 0` and :math:`D_{n+1} = 1 - F(x_{(n)})`. They let MPS "see" the room beyond the smallest and largest observations — information MLE simply throws away. This matters most when a parameter controls where the distribution's support *starts or ends*: an offset (three-parameter) distribution, or a finitely bounded one such as the Uniform, Generalised Beta or Triangular. There the likelihood is badly behaved, because MLE can drive the density to infinity by sliding the support boundary right up against the most extreme data point — a degenerate, unbounded likelihood. MPS cannot be fooled this way: pushing the boundary onto :math:`x_{(1)}` forces the first spacing :math:`D_{1}` to zero, and :math:`\ln 0 = -\infty` is the *worst* possible score, so the estimator is pulled back to a sensible interior solution. This is exactly why, in the :doc:`Parametric SurPyval Modelling` notes, the Uniform and the offset Log-Logistic are recovered far better with ``how='MPS'`` than with MLE.
+Why bother, when MLE already works so well? The answer is those two *end* spacings, :math:`D_{1} = F(x_{(1)}) - 0` and :math:`D_{n+1} = 1 - F(x_{(n)})`. They let MPS "see" the room beyond the smallest and largest observations — information MLE simply throws away. This matters most when a parameter controls where the distribution's support *starts or ends*: an offset (three-parameter) distribution, or a finitely bounded one such as the Uniform. There the likelihood is badly behaved, because MLE can drive the density to infinity by sliding the support boundary right up against the most extreme data point — a degenerate, unbounded likelihood. MPS cannot be fooled this way: pushing the boundary onto :math:`x_{(1)}` forces the first spacing :math:`D_{1}` to zero, and :math:`\ln 0 = -\infty` is the *worst* possible score, so the estimator is pulled back to a sensible interior solution. This is exactly why, in the :doc:`Parametric SurPyval Modelling` notes, the Uniform and the offset Log-Logistic are recovered far better with ``how='MPS'`` than with MLE.
 
 Censoring, ties and truncation are folded in with the same reasoning used for the likelihood. A right- or left-censored point contributes its survival :math:`R(x \mid \theta)` or CDF :math:`F(x \mid \theta)` — all we know is that the true value lies beyond the one we saw — and repeated (tied) observations contribute density terms, so exact ties do not collapse a spacing to zero. Left and right truncation are handled by renormalising the spacings over the observation window: every CDF value is rescaled as :math:`\left(F(x) - F(t_{l})\right) / \left(F(t_{r}) - F(t_{l})\right)` before the gaps are taken, so the spacings again run over a unit interval, now *conditional* on the observation having fallen inside the window. This renormalisation is what lets surpyval fit right-truncated data with MPS, which is otherwise awkward for the other estimators.
 
-Trading the density for spacings costs nothing asymptotically: under the usual regularity conditions MPS is consistent and asymptotically as efficient as MLE, attaining the same asymptotic variance. Its advantage is that it *stays* consistent in the awkward cases — J- or U-shaped densities, and distributions with unknown support — where the maximum likelihood estimate is inconsistent or fails to exist at all. In surpyval it is requested with ``how='MPS'`` and, like every other estimator, returns a fully-featured model:
-
-.. code:: python
-
-    model = surv.Weibull.fit(x, how='MPS')
-
-which makes it a robust fall-back whenever an MLE fit struggles with an offset or a bounded support.
+Trading the density for spacings costs nothing asymptotically: under the usual regularity conditions MPS is consistent and asymptotically as efficient as MLE, attaining the same asymptotic variance. Its advantage is that it *stays* consistent in the awkward cases — J- or U-shaped densities, and distributions with unknown support — where the maximum likelihood estimate is inconsistent or fails to exist at all. In surpyval it is requested with ``how='MPS'`` and, like every other estimator, returns a fully-featured model (see the :doc:`Parametric SurPyval Modelling` notes for the code). This makes it a robust fall-back whenever an MLE fit struggles with an offset or a bounded support.

--- a/docs/Parametric SurPyval Modelling.rst
+++ b/docs/Parametric SurPyval Modelling.rst
@@ -333,7 +333,7 @@ The above plot does not look to be a good fit. However, if we use an offset we c
 
     model.plot()
 
-This is evidently a much better fit! The offset value for an offset distribution is saved as :code:`gamma` in the model object. Offsets can be used for any distribution supported on the half real line. Currently, this is the Weibull, Gamma, LogNormal, LogLogistic, and Exponential. For example:
+This is evidently a much better fit! The offset value for an offset distribution is saved as :code:`gamma` in the model object. Offsets can be used for any distribution whose support is the half real line :math:`(0, \infty)` — such as the Weibull, Gamma, LogNormal, LogLogistic and Exponential. For example:
 
 .. jupyter-execute::
 
@@ -382,7 +382,7 @@ A caution: offset parameters can be unidentifiable
 
 The offset ``gamma`` is a *threshold* parameter, and threshold parameters are statistically awkward. ``gamma`` trades off against the shape and scale parameters, so two very different parameter tuples can describe almost the same distribution. This means a fit can report parameters that are badly wrong while the distribution it implies is still an excellent fit to your data. It is important to understand this so you are not alarmed by - or misled by - the printed parameters.
 
-The clearest way to see this is to fit the same offset data with different estimation methods. Below we generate Gamma data shifted by ``gamma = 10`` and fit it both with maximum product of spacings (``MPP``) and maximum likelihood (``MLE``):
+The clearest way to see this is to fit the same offset data with different estimation methods. Below we generate Gamma data shifted by ``gamma = 10`` and fit it both with the probability-plotting method (``MPP``) and maximum likelihood (``MLE``):
 
 .. jupyter-execute::
 
@@ -493,7 +493,7 @@ You can see that the results are the same. This is because the maximum likelihoo
     mps_model = surv.Uniform.fit(x, how='MPS')
     print(*mps_model.params)
 
-You can see that using the MPS method we have parameters that are closer to the real values. This is because the MPS method can 'look outside' the existing values to estimate where the real value lies. See the details of this method in the 'Parametric Estimation' section. But the MPS method is useful when you need to estimate the point at which a distribution's support starts or for any disttribution that has unknown support. Concretely, this includes any offset distribution or a distribution with a finite upper and lower support (Uniform, Generalised Beta, Triangle)
+You can see that using the MPS method we have parameters that are closer to the real values. This is because the MPS method can 'look outside' the existing values to estimate where the real value lies. See the details of this method in the :doc:`Parametric Estimation` section. But the MPS method is useful when you need to estimate the point at which a distribution's support starts or for any distribution that has unknown support. Concretely, this includes any offset distribution or a distribution with a finite upper and lower support (such as the Uniform).
 
 The other important use case is when, for some reason, an alternate estimation method just does not work. For example:
 

--- a/docs/Recurrent Event Analysis.rst
+++ b/docs/Recurrent Event Analysis.rst
@@ -18,12 +18,12 @@ integrals — is known as the counting-process formulation, but that is an
 implementation detail. Users navigate by their data type: "do my subjects
 experience repeated events?" If yes, this section applies.
 
-This section is split into two subsections:
+The two broad families of recurrent-event model, which differ in their methods,
+are:
 
-    1. Recurrent Event Modelling
+    1. Recurrent Event (counting-process) Modelling
     2. Renewal Modelling
 
-These are both types of recurrent event models but they differ in their methods.
 In a recurrent event model the inter-arrival time is based on some underlying
 hazard rate, whereas in a renewal model there is an underlying distribution where,
 after each event, the apparent age of the subject is changed.
@@ -82,7 +82,6 @@ for use. These are:
 
     - Duane
     - Cox-Lewis
-    - AMSAA
     - Crow-AMSAA
 
 See the API documentation to see the details of each of these models. The key
@@ -217,9 +216,10 @@ Where :math:`\alpha` is the life parameter of a location-scale distribution and
 :math:`q` is the effectiveness of the intervention. Unlike what is possible 
 with the G-Renewal process, if q is greater than zero the model captures the
 behaviour of when the intervention can improves the life of the subject. If 
-:math:`q = 0` then the repair is as-good-as-new. If :math:`q < 0` then the
-intervention is restoring some life but not to make it as good as new. Note
-that :math:`q` cannot be less than -1.
+:math:`q = 0` then the repair is as-good-as-new. If :math:`q < 0` then each
+repair leaves the item *worse* than before — a partial or harmful repair that
+shortens the subsequent life (a deteriorating system). Note that :math:`q`
+cannot be less than -1.
 
 As an example, if the life parameter of an items was 100 hours and the repair
 effectiveness was -0.2, then after the first repair the next time to an event
@@ -421,6 +421,12 @@ machinery: an item is simply absent from the risk set while it is unobserved.
 The virtual-age and renewal models cannot accommodate gaps, because the virtual
 age at the start of a later window depends on the unobserved failures during
 the gap.
+
+For worked examples — fitting the NHPP, HPP and renewal models, estimating and
+plotting the mean cumulative function, and handling gapped observation — see the
+:doc:`Recurrent Event Modelling with SurPyval` page. For covariate models see
+the :doc:`Recurrent Event Regression Analysis` and
+:doc:`Recurrent Event Regression Modelling with SurPyval` pages.
 
 References
 ----------

--- a/docs/Recurrent Event Modelling with SurPyval.rst
+++ b/docs/Recurrent Event Modelling with SurPyval.rst
@@ -2,7 +2,10 @@ Recurrent Event Modelling with SurPyval
 =======================================
 
 This section is aims to show how you can use SurPyval to model counting
-processes.
+processes. For the concepts and mathematics behind these models — the HPP,
+the NHPP (Duane, Cox-Lewis, Crow-AMSAA), the renewal and virtual-age models,
+and the mean cumulative function — see the :doc:`Recurrent Event Analysis`
+page.
 
 Recurrent Event SurPyval Modelling
 ----------------------------------
@@ -27,7 +30,7 @@ pass it to the ``fit`` call of the ``NonParametricCounting`` class.
     model.plot()
 
 This shows the expected number of events at any time. The model is a step
-function since it is parametric and we have made no assumptions about the
+function since it is non-parametric and we have made no assumptions about the
 count between observed events.
 
 The result of this is a Non-Parametric Counting model that can be used just like
@@ -141,7 +144,7 @@ parametric models to model the number of events at any time. This is done by
 assuming a hazard rate for the inter-arrival times. This also has the same
 limitations as per single event survival analysis. That is, given we use a
 parametric representation of the hazard rate we are making assumptions about the
-shape of the cumulative incidence function. This allows us to extrapolate
+shape of the cumulative intensity function. This allows us to extrapolate
 above the highest observed values but may not be a good fit to the data.
 
 Let's fit a parametric model.
@@ -283,8 +286,8 @@ Generalized Renewal Process modelling is simple with SurPyval:
     model = GeneralizedRenewal.fit(x, dist=Weibull)
     model
 
-We cannot plot the cumulative incidence function of the model since it does
-not have a closed form solution. We can however plot the cumulative incidence
+We cannot plot the cumulative intensity function of the model since it does
+not have a closed form solution. We can however plot the cumulative intensity
 function of a monte carlo simulation of the model. Let's do that and compare
 it to a non-parametric description of the MCF:
 
@@ -301,7 +304,7 @@ second is the number of simulations to run. The more simulations you run the
 more accurate the model will be. The method returns a ``NonParametricCounting``
 model that can be used to plot the results.
 
-You can see that the cumulative incidence function of the model is a very good
+You can see that the cumulative intensity function of the model is a very good
 fit to the data. You can also see that it is "wavy." This is because the
 underlying distribution is Weibull with a reasonably high shape parameter. This
 means that the first inter-arrival time is going to be within a relatively

--- a/docs/Recurrent Event Regression Analysis.rst
+++ b/docs/Recurrent Event Regression Analysis.rst
@@ -28,7 +28,7 @@ cumulative count. So the model becomes:
 
 .. math::
 
-    N(t) = \phi\left( X \right) \lambda t
+    N(t) = \phi\left( Z \right) \lambda t
 
 In this case, just as was the case with single event proportional hazard
 models, there is a factor that relates the covariates to the counting function.
@@ -41,11 +41,11 @@ rate even during optimisation. That is, our model will be:
 
 .. math::
 
-    N(t) = e^{X \beta} \lambda t
+    N(t) = e^{Z \beta} \lambda t
 
 
 This is the proportional intensity HPP model. The log-linear (exponential)
-link function :math:`e^{X\beta}` is the standard choice because it guarantees
+link function :math:`e^{Z\beta}` is the standard choice because it guarantees
 a positive rate regardless of the sign of :math:`\beta`, mirrors the Cox model
 for single events, and gives regression coefficients a direct multiplicative
 interpretation on the rate.
@@ -59,7 +59,7 @@ of a system decreases as a function of cumulative operating time, reflecting
 the notion that systems become more reliable through usage and corrective 
 actions. In the Duane process, the cumulative number of failures is modeled as 
 a function of time, providing a way to quantify reliability growth and 
-forecast future performance. The convetntional parameterisation for the Duane
+forecast future performance. The conventional parameterisation for the Duane
 is:
 
 .. math::
@@ -94,17 +94,17 @@ under different conditions easy and interpretable.
 
     \lambda(t) = \frac{dN(t)}{dt} = \alpha \beta t^{\beta - 1}
 
-3. The Proportional Intensity model incorporating a covariate :math:`x`:
+3. The Proportional Intensity model incorporating a covariate :math:`Z`:
 
 .. math::
 
-    \lambda(t \mid x) = \lambda_0(t) \exp(\gamma x)
+    \lambda(t \mid Z) = \lambda_0(t) \exp(Z \beta)
 
 4. The adjusted failure intensity function with the covariate effect in the context of the Duane model:
 
 .. math::
 
-    \lambda(t \mid x) = \alpha \beta t^{\beta - 1} \exp(\gamma x)
+    \lambda(t \mid Z) = \alpha \beta t^{\beta - 1} \exp(Z \beta)
 
 These equations outline the framework for modelling the reliability growth of a
 system, incorporating the effects of covariates on the failure intensity.
@@ -150,6 +150,11 @@ setting come from the delta method via ``cif_cb``.
 These methods form a comprehensive toolkit for researchers and practitioners
 working with recurrent event data, enabling detailed analysis and prediction of
 event occurrences.
+
+For worked examples — fitting the proportional-intensity HPP and NHPP models,
+reading off the event-count ratio between covariate settings, and plotting the
+covariate-conditional cumulative intensity with confidence bounds — see the
+:doc:`Recurrent Event Regression Modelling with SurPyval` page.
 
 References
 ----------

--- a/docs/Regression Modelling with SurPyval.rst
+++ b/docs/Regression Modelling with SurPyval.rst
@@ -8,6 +8,11 @@ in a hot, dirty one. A patient's survival may depend on age, dosage, and
 comorbidities. The question regression modelling answers is: *how much* do these
 factors matter, and in what direction?
 
+For the concepts and mathematics behind the regression families used here — the
+proportional-hazards, accelerated-failure-time, accelerated-life, proportional-odds
+and additive-hazards models, plus the Cox diagnostics, robust and stratified fits,
+and prediction-validation metrics — see the :doc:`regression analysis` page.
+
 Regression survival modelling is fundamentally about capturing the relationship
 between covariates :math:`Z` and the survival distribution. Unlike ordinary
 regression, we must handle censored observations — items that had not yet failed

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,6 +99,7 @@ Contents:
    Recurrent Event Analysis
    Recurrent Event Regression Analysis
    Degradation Analysis
+   Multivariate Analysis
 
 .. toctree::
    :maxdepth: 2

--- a/docs/regression analysis.rst
+++ b/docs/regression analysis.rst
@@ -6,13 +6,15 @@ The time until some event happens will, almost certainly, be impacted by factors
 
 Regression analysis is the process of capturing the effect that covariates have on the item. That is, we use data on other factors to 'regress' onto the survival distribution. The purpose of this type of regression is so that you can ask, and answer, questions like "what effect will increasing X have on the survival time?"
 
-Surpyval covers three types of regression models, these are:
+Surpyval covers five families of regression model, distinguished by *how* the covariates act on the distribution:
 
- - Proportional Hazards,
- - Accelerated Time, and
- - Accelerated Life.
+ - Proportional Hazards (they multiply the hazard),
+ - Accelerated Failure Time (they scale the time axis),
+ - Accelerated Life (they scale the life parameter),
+ - Proportional Odds (they multiply the odds of failure), and
+ - Additive Hazards (they add to the hazard).
 
-There are special cases when these are the same, however, it is important to understand the difference between them in general. I detail the differences in the following sections.
+There are special cases when several of these coincide, however, it is important to understand the difference between them in general. I detail the differences in the following sections.
 
 Proportional Hazards Model
 --------------------------
@@ -53,7 +55,7 @@ Where
 
 In this case the proportional term is the e raised to the power of the cross product of X and beta. Using this as the covairate function is a very common choice. This is because it will not ever become negative. It can capture situations where a covariate will increase the hazard rate if it's coefficient, beta, is positive, and it will decrease the hazard rate it it's coefficient is negative. Also, the dot product can capture a varying number of covariates with ease. For these reasons the Cox model is a widely used. Although you can choose any function for your covariates there is already likely literature about your problem which might indicate which function to use.
 
-Surpyval uses MLE to estimate the parameters for proportional hazards models. This is a simple conversion from regulare MLE since we know the relationship between a baseline distribution and the proportional hazards version. These relationships are:
+For a *parametric* proportional hazards model (a known baseline such as the Weibull) surpyval uses MLE to estimate the parameters. This is a simple conversion from regular MLE since we know the relationship between a baseline distribution and the proportional hazards version. (The Cox model in the next section is *semi-parametric* — its baseline is left unspecified and its coefficients are estimated by *partial* likelihood, not full MLE.) These relationships are:
 
 .. math::
 
@@ -83,34 +85,34 @@ By far the most common of any regression model of any kind (parametric, non-para
 The Cox model is used in a wide variety of fields. It has been used in criminology to study the recidivism of parolees, in engineering to understand the factors affecting tire reliability, and in medical science to understand factors affecting cancer and other diseases, among many many other applications. The wide use of the model shows the utility the model has and the broad applicability to solve problems.
 
 
-Accelerated Time
-----------------
+Accelerated Failure Time
+------------------------
 
-An accelerated time model is very similar to a proportional hazards model. The difference is where the function is applied; instead of multiplying the hazard function, and accelerated time model multiplies the time by the function of covariates. The general definition is:
+An accelerated failure time (AFT) model is very similar to a proportional hazards model. The difference is where the function is applied; instead of multiplying the hazard function, an accelerated failure time model multiplies the time by the function of covariates. The general definition is:
 
 .. math::
 
-	f(t|X) = f(\phi(X)t)
+	f(t|X) = \phi(X)\, f_{0}(\phi(X)t)
 
-It is called an accelerated time since the time term is transformed by the covariates, i.e. time is 'accelerated' by the covariates.
+It is called accelerated failure time since the time term is transformed by the covariates, i.e. time is 'accelerated' by the covariates.
 
 .. math::
 
 	t_{a} = \phi(X)t
 
 
-Just like proportinal hazards, there are simple transofmations that apply 
+Just like proportional hazards, there are simple transformations that apply. Note the density carries an extra :math:`\phi(X)` factor — the Jacobian of the time change of variables — while the survival and CDF do not:
 
 
 .. math::
 
-	f(t|X) = f(\phi(X)t) \\
+	f(t|X) = \phi(X)\, f_{0}(\phi(X)t) \\
 	\\
-	F(t|X) = F(\phi(X)t) \\
+	F(t|X) = F_{0}(\phi(X)t) \\
 	\\
-	S(t|X) = S(\phi(X)t)
+	S(t|X) = S_{0}(\phi(X)t)
 
-Given the simple transofmation of the time term the MLE is feasible with an additional transformation step. This is how surpyval estimates the parameters.
+Given the simple transformation of the time term the MLE is feasible with an additional transformation step. This is how surpyval estimates the parameters.
 
 Accelerated Life
 ----------------
@@ -121,7 +123,7 @@ An accelerated life model is, in many cases, simply the inverse of an accelerate
 
 	F(t|X) = \Phi\left(\frac{\phi(X)t - \mu}{\sigma}\right) \\
 
-Where :math:`\Phi` is the CDF of the standard normal distribution. In this case :math:`\mu` is the expected life of the model, however, we may isntead be interested in determining what effect covariates have on the expected life of an item. In this case we can simply substitute the expected life:
+Where :math:`\Phi` is the CDF of the standard normal distribution. In this case :math:`\mu` is the expected life of the model, however, we may instead be interested in determining what effect covariates have on the expected life of an item. In this case we can simply substitute the expected life:
 
 .. math::
 
@@ -157,6 +159,33 @@ An accelerated life model is, therefore, simply a model where the life parameter
 
 Given the simple substitution into the life parameter, surpyval uses MLE to calculate the parameters.
 
+Proportional Odds
+-----------------
+
+A proportional odds model acts on the *odds* of having failed rather than on the hazard. Writing the odds of failure by time :math:`t` as :math:`F(t) / S(t)`, the model multiplies the baseline odds by a function of the covariates:
+
+.. math::
+
+    \frac{F(t \mid X)}{S(t \mid X)} = \phi(X)\, \frac{F_{0}(t)}{S_{0}(t)}.
+
+Its defining feature is that the covariate effect *decays* over time — two survival curves under a proportional odds model converge as :math:`t \to \infty` rather than staying a constant multiple apart. This makes it the natural choice when a treatment or covariate matters early but its influence fades, a pattern proportional hazards cannot represent.
+
+Additive Hazards
+----------------
+
+Where proportional hazards *multiplies* the baseline hazard, an additive hazards model *adds* to it:
+
+.. math::
+
+    h(t \mid X) = h_{0}(t) + \beta \cdot X.
+
+The covariate shifts the absolute hazard by a constant amount at every time, rather than scaling it. This is often the more natural scale for risk-difference questions (excess deaths per unit time attributable to an exposure), and, like Cox, the Lin-Ying form leaves the baseline hazard unspecified and admits a closed-form estimator for :math:`\beta`.
+
+Semi-Parametric — Buckley-James
+-------------------------------
+
+Cox leaves the baseline *hazard* unspecified; Buckley-James is the accelerated-failure-time counterpart that leaves the *error distribution* unspecified. It fits an AFT model by iterating between imputing the censored failure times from the current fit (using the Kaplan-Meier residual distribution) and re-estimating the coefficients by least squares on the completed data. The result is a semi-parametric AFT: covariate effects on the log-time scale without committing to a parametric family for the baseline.
+
 Checking a proportional hazards fit
 -----------------------------------
 
@@ -190,4 +219,4 @@ Information criteria (AIC, BIC) compare how well models fit the data they were t
 - The **Brier score** :math:`BS(t)` is the weighted mean squared error between the predicted survival :math:`S(t \mid Z)` and the survival indicator :math:`\mathbb{1}(T > t)`; the **integrated Brier score** averages it over a time grid. Lower is better, and a useful model scores below the marginal Kaplan-Meier reference.
 - The **time-dependent AUC** (Uno's cumulative/dynamic estimator) measures discrimination as a function of the horizon — the probability that a subject who has failed by :math:`t` was assigned a higher risk than one still event-free. 0.5 is chance, 1.0 is perfect.
 
-For examples on how to do regression analysis — including checking the proportional hazards assumption, robust and stratified fits, and validating predictions — see the entry in the SurPyval Modelling section of the docs.
+For worked examples on how to do regression analysis — including checking the proportional hazards assumption, robust and stratified fits, and validating predictions — see the :doc:`Regression Modelling with SurPyval` page.


### PR DESCRIPTION
Extends the theory/how-to separation (previously applied to the 0.16 features and Degradation) to **every** subject in the docs, and fixes a number of correctness and consistency issues found in a full audit of the theory pages against the `surpyval` source.

## Structure / harmonisation
- **New "Multivariate Analysis" theory page** — copulas, Sklar's theorem, the copula-family table, IFM vs full MLE, per-series censoring; the duplicated theory was removed from the Multivariate how-to and the new page added to the toctree.
- **Every theory ↔ how-to pair now cross-links both ways** with `:doc:` references instead of prose "see the Modelling section" pointers.
- Removed the remaining non-executed code blocks from the **Parametric Estimation** theory page and completed its dangling truncation section with the conditional-likelihood expression.
- Fixed a **title-level heading** in the Degradation how-to that made the stochastic-process section a second page title rather than a subsection, and a block-quote spacing warning in Recurrent Event Analysis.

## Correctness (audited against source)
- **Competing Risks** — corrected the class name to `ParametricCompetingRisks` and described its actual per-cause fit (each cause fitted independently, other causes right-censored); rewrote the identifiability explanation to the marginal-latent-distribution formulation.
- **Regression** — added the missing Jacobian factor to the AFT density `f(t|X)=φ(X)·f₀(φ(X)t)`; documented the Proportional Odds, Additive Hazards and Buckley-James families; corrected the model-family list.
- **Non-Parametric** — disambiguated the two "default" estimators (Nelson-Aalen as the parametric plotting position vs Fleming-Harrington as the recommended standalone estimator); corrected the Turnbull truncation/censoring capability statement.
- **Recurrent events** — removed a nonexistent NHPP model, corrected the `q < 0` virtual-age interpretation, fixed cumulative-intensity naming, and aligned covariate/coefficient notation (`Z`/`β`) between theory and how-to.
- **Parametric Estimation** — corrected the duplicated plotting-position heuristic row (Larsen → Tukey) and the list of bounded-support distributions; fixed the MPP/MPS method labelling in the how-to.

## Validation
Docs-only change. The documentation builds cleanly with Sphinx (no new warnings; all `:doc:` cross-references resolve). Class names and per-cause fit behaviour were verified directly against the `surpyval` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_