### PR TITLE
Serialise SurvivalTree and RandomSurvivalForest (#191)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -112,6 +112,24 @@ Regression
   Breslow and Efron already match what R's ``survival`` and lifelines use by
   default -- and correspondingly more expensive under heavy ties.
 
+Serialisation
+~~~~~~~~~~~~~
+
+- **Survival tree & forest serialisation** (#191). ``SurvivalTree`` and
+  ``RandomSurvivalForest`` now implement ``to_dict`` / ``from_dict`` (and
+  ``to_json`` / ``from_json``), completing the serialisation campaign that had
+  deferred them while the forest was crash-prone. A tree serialises as its
+  recursive node structure with each leaf stored as its own fitted model
+  (``Parametric`` / ``NonParametric``, or a sentinel for the empty
+  ``NeverOccurs`` leaf), so a restored tree predicts identically without
+  re-fitting; a forest is the ensemble settings plus its trees. Both carry a
+  ``"model"`` class tag and dispatch through the package-level
+  ``surpyval.from_dict`` / ``surpyval.from_json``, are schema-stamped, and are
+  BSON-native for MongoDB. In the course of this, a latent leak was fixed in
+  ``Parametric.to_dict``: ``_neg_ll`` (always) and ``gamma`` / ``p`` / ``f0``
+  (for offset / LFP / zero-inflated models) were emitted as NumPy scalars,
+  which MongoDB's BSON encoder rejects; they are now native floats.
+
 v0.15.2 (20 Jul 2026)
 ---------------------
 

--- a/surpyval/beta/ml/forest/forest.py
+++ b/surpyval/beta/ml/forest/forest.py
@@ -1,8 +1,12 @@
+import json
+from pathlib import Path
+
 import numpy as np
 from joblib import Parallel, delayed
 from numpy.typing import ArrayLike, NDArray
 
 from surpyval.beta.ml.forest.tree import SurvivalTree
+from surpyval.serialisation import stamp_schema
 from surpyval.utils.score import score
 from surpyval.utils.surpyval_data import SurpyvalData
 
@@ -191,3 +195,47 @@ class RandomSurvivalForest:
         """Harrell's concordance index of the forest's mortality scores."""
         scores: ArrayLike = self.mortality(x, Z)
         return score(x, c, scores, tie_tol)
+
+    def to_dict(self) -> dict:
+        """Serialise the fitted forest to a plain, JSON/BSON-safe dictionary:
+        the ensemble settings and every fitted tree. The training data is not
+        persisted -- a restored forest is a predictor, not re-fittable."""
+        return stamp_schema(
+            {
+                "model": "RandomSurvivalForest",
+                "kind": self.kind,
+                "n_trees": int(self.n_trees),
+                "bootstrap": bool(self.bootstrap),
+                "trees": [tree.to_dict() for tree in self.trees],
+            }
+        )
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "RandomSurvivalForest":
+        """Reconstruct a fitted forest from a :meth:`to_dict` dictionary."""
+        if model_dict.get("model") != "RandomSurvivalForest":
+            raise ValueError(
+                "Must create a RandomSurvivalForest from a "
+                "RandomSurvivalForest model dict"
+            )
+        forest = cls.__new__(cls)
+        forest.kind = model_dict["kind"]
+        forest.n_trees = model_dict["n_trees"]
+        forest.bootstrap = model_dict["bootstrap"]
+        # A restored forest predicts but is not re-fittable; it holds no data.
+        forest.data = None  # type: ignore[assignment]
+        forest.Z = None  # type: ignore[assignment]
+        forest.trees = [
+            SurvivalTree.from_dict(tree_dict)
+            for tree_dict in model_dict["trees"]
+        ]
+        return forest
+
+    def to_json(self, fp: str | Path) -> None:
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_json(cls, fp: str | Path) -> "RandomSurvivalForest":
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))

--- a/surpyval/beta/ml/forest/node.py
+++ b/surpyval/beta/ml/forest/node.py
@@ -12,6 +12,7 @@ from surpyval.beta.ml.forest.deviance_split import (
     needs_full_likelihood_split,
 )
 from surpyval.beta.ml.forest.log_rank_split import log_rank_split
+from surpyval.serialisation import to_native
 from surpyval.univariate.parametric import NeverOccurs
 from surpyval.utils.surpyval_data import SurpyvalData
 
@@ -26,6 +27,9 @@ class Node(ABC):
         x: int | float | ArrayLike,
         Z: NDArray,
     ) -> NDArray: ...
+
+    @abstractmethod
+    def to_dict(self) -> dict: ...
 
 
 class IntermediateNode(Node):
@@ -86,6 +90,31 @@ class IntermediateNode(Node):
         if Z[self.split_feature_index] <= self.split_feature_value:
             return self.left_child.apply_model_function(function_name, x, Z)
         return self.right_child.apply_model_function(function_name, x, Z)
+
+    def to_dict(self) -> dict:
+        """Serialise the split rule and both child subtrees. The training
+        data is deliberately not stored -- a restored tree is a predictor,
+        rebuilt from its structure and its leaf models, not re-fitted."""
+        return {
+            "node": "intermediate",
+            "split_feature_index": int(self.split_feature_index),
+            "split_feature_value": float(self.split_feature_value),
+            "feature_indices_in": to_native(self.feature_indices_in),
+            "left": self.left_child.to_dict(),
+            "right": self.right_child.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, node_dict: dict) -> "IntermediateNode":
+        # Rebuild without re-running ``build_tree`` (which needs the data):
+        # the split rule and children fully determine prediction.
+        node = cls.__new__(cls)
+        node.split_feature_index = node_dict["split_feature_index"]
+        node.split_feature_value = node_dict["split_feature_value"]
+        node.feature_indices_in = np.asarray(node_dict["feature_indices_in"])
+        node.left_child = node_from_dict(node_dict["left"])
+        node.right_child = node_from_dict(node_dict["right"])
+        return node
 
 
 class TerminalNode(Node):
@@ -152,6 +181,49 @@ class TerminalNode(Node):
         _: NDArray,
     ) -> NDArray:
         return getattr(self.model, function_name)(x)
+
+    def to_dict(self) -> dict:
+        """Serialise the leaf as its *fitted* model rather than its data, so
+        the restored leaf predicts without re-fitting. ``NeverOccurs`` (the
+        empty / all-censored leaf) is a parameterless class, stored as a
+        string sentinel; every other leaf is a ``Parametric`` or
+        ``NonParametric`` model with its own ``to_dict``."""
+        model = self.model
+        if model is NeverOccurs:
+            leaf: str | dict = "NeverOccurs"
+        else:
+            leaf = model.to_dict()
+        return {"node": "terminal", "kind": self.kind, "leaf": leaf}
+
+    @classmethod
+    def from_dict(cls, node_dict: dict) -> "TerminalNode":
+        # Local import avoids any import cycle through the package-level
+        # serialisation dispatcher.
+        from surpyval.serialisation import from_dict as _restore_model
+
+        node = cls.__new__(cls)
+        node.kind = node_dict["kind"]
+        # A restored predictor carries no training data.
+        node.data = None  # type: ignore[assignment]
+        leaf = node_dict["leaf"]
+        model = NeverOccurs if leaf == "NeverOccurs" else _restore_model(leaf)
+        # ``model`` is a cached_property; seed the instance ``__dict__`` slot
+        # so the getter (which needs ``data``) never runs on a restored node.
+        node.__dict__["model"] = model
+        return node
+
+
+def node_from_dict(node_dict: dict) -> Node:
+    """Restore an ``IntermediateNode`` or ``TerminalNode`` from its dict."""
+    kind = node_dict.get("node")
+    if kind == "intermediate":
+        return IntermediateNode.from_dict(node_dict)
+    if kind == "terminal":
+        return TerminalNode.from_dict(node_dict)
+    raise ValueError(
+        f"Unrecognised tree node dict (node={kind!r}); expected "
+        "'intermediate' or 'terminal'."
+    )
 
 
 def build_tree(

--- a/surpyval/beta/ml/forest/tree.py
+++ b/surpyval/beta/ml/forest/tree.py
@@ -1,4 +1,6 @@
+import json
 from math import log2, sqrt
+from pathlib import Path
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -6,7 +8,8 @@ from numpy.typing import ArrayLike, NDArray
 from surpyval.beta.ml.forest.deviance_split import (
     needs_full_likelihood_split,
 )
-from surpyval.beta.ml.forest.node import build_tree
+from surpyval.beta.ml.forest.node import build_tree, node_from_dict
+from surpyval.serialisation import stamp_schema
 from surpyval.utils.surpyval_data import SurpyvalData
 
 
@@ -153,6 +156,49 @@ class SurvivalTree:
         self, x: int | float | ArrayLike, Z: ArrayLike | NDArray
     ) -> NDArray:
         return self.apply_model_function("Hf", x, Z)
+
+    def to_dict(self) -> dict:
+        """Serialise the fitted tree to a plain, JSON/BSON-safe dictionary.
+
+        Only what prediction needs is stored -- the tree ``kind``, the
+        resolved ``n_features_split`` and the recursive node structure with
+        its fitted leaf models. The training data and covariate matrix are
+        not persisted: a restored tree is a predictor, not a re-fittable
+        object.
+        """
+        return stamp_schema(
+            {
+                "model": "SurvivalTree",
+                "kind": self.kind,
+                "n_features_split": int(self.n_features_split),
+                "root": self._root.to_dict(),
+            }
+        )
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "SurvivalTree":
+        """Reconstruct a fitted tree from a :meth:`to_dict` dictionary."""
+        if model_dict.get("model") != "SurvivalTree":
+            raise ValueError(
+                "Must create a SurvivalTree from a SurvivalTree model dict"
+            )
+        tree = cls.__new__(cls)
+        tree.kind = model_dict["kind"]
+        tree.n_features_split = model_dict["n_features_split"]
+        # A restored tree predicts but is not re-fittable; it holds no data.
+        tree.data = None  # type: ignore[assignment]
+        tree.Z = None  # type: ignore[assignment]
+        tree._root = node_from_dict(model_dict["root"])
+        return tree
+
+    def to_json(self, fp: str | Path) -> None:
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_json(cls, fp: str | Path) -> "SurvivalTree":
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))
 
 
 def parse_n_features_split(

--- a/surpyval/serialisation.py
+++ b/surpyval/serialisation.py
@@ -73,6 +73,8 @@ _TAGGED_MODELS: dict[str, str] = {
     ),
     "WienerProcessModel": "surpyval.degradation.process_models",
     "GammaProcessModel": "surpyval.degradation.process_models",
+    "SurvivalTree": "surpyval.beta.ml.forest.tree",
+    "RandomSurvivalForest": "surpyval.beta.ml.forest.forest",
 }
 
 # ``"parameterization"`` value -> (defining module, class name), for

--- a/surpyval/tests/beta/ml/forest/test_forest_serialisation.py
+++ b/surpyval/tests/beta/ml/forest/test_forest_serialisation.py
@@ -1,0 +1,173 @@
+"""Serialisation round-trips for the survival tree and forest (issue #191).
+
+The tree/forest were deliberately excluded from the original serialisation
+campaign while the forest was crash-prone. These tests lock in that a fitted
+tree or forest survives ``to_dict``/``from_dict`` (and the JSON/BSON forms)
+with byte-for-byte identical predictions, dispatches through the package-level
+``surpyval.from_dict``, and stays BSON-native.
+"""
+
+import json
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+import surpyval
+from surpyval import Weibull
+from surpyval.beta.ml.forest.forest import RandomSurvivalForest
+from surpyval.beta.ml.forest.node import TerminalNode, node_from_dict
+from surpyval.beta.ml.forest.tree import SurvivalTree
+from surpyval.serialisation import SCHEMA_VERSION
+from surpyval.univariate.parametric import NeverOccurs
+from surpyval.utils.surpyval_data import SurpyvalData
+
+
+def _data(seed=0, n=80):
+    rng = np.random.default_rng(seed)
+    Z = rng.normal(size=(n, 3))
+    lin = Z @ np.array([0.9, -0.6, 0.3])
+    x = rng.exponential(np.exp(-lin)) * 15 + 1
+    c = (rng.uniform(size=n) < 0.2).astype(int)
+    return x, Z, c
+
+
+def _assert_bson_native(obj, path="$"):
+    """Every key a str, every value a BSON-encodable native type."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            assert isinstance(k, str), f"non-string key {k!r} at {path}"
+            _assert_bson_native(v, f"{path}.{k}")
+    elif isinstance(obj, (list, tuple)):
+        for j, v in enumerate(obj):
+            _assert_bson_native(v, f"{path}[{j}]")
+    else:
+        assert obj is None or isinstance(
+            obj, (str, bool, int, float)
+        ), f"non-native {type(obj).__name__} at {path}"
+        assert not isinstance(obj, np.generic), f"numpy scalar at {path}"
+
+
+KINDS = ["weibull", "exponential", "non-parametric"]
+
+
+@pytest.mark.parametrize("kind", KINDS)
+def test_tree_round_trip_predictions(kind):
+    x, Z, c = _data()
+    np.random.seed(1)
+    tree = SurvivalTree.fit(x=x, Z=Z, c=c, kind=kind, max_depth=4)
+
+    restored = SurvivalTree.from_dict(tree.to_dict())
+
+    xq = np.linspace(1, 30, 12)
+    for zq in ([0.5, -0.5, 0.2], [-1.0, 1.0, 0.0]):
+        for fn in ("sf", "ff", "Hf"):
+            a = getattr(tree, fn)(xq, zq)
+            b = getattr(restored, fn)(xq, zq)
+            assert np.allclose(a, b, equal_nan=True)
+
+
+@pytest.mark.parametrize("kind", KINDS)
+def test_tree_dict_is_bson_native(kind):
+    x, Z, c = _data(seed=3)
+    np.random.seed(2)
+    tree = SurvivalTree.fit(x=x, Z=Z, c=c, kind=kind, max_depth=4)
+    d = tree.to_dict()
+    _assert_bson_native(d)
+    assert d["model"] == "SurvivalTree"
+    assert d["schema"] == SCHEMA_VERSION
+
+
+def test_tree_json_file_round_trip():
+    x, Z, c = _data(seed=4)
+    np.random.seed(3)
+    tree = SurvivalTree.fit(x=x, Z=Z, c=c, kind="weibull", max_depth=4)
+    fp = tempfile.mktemp(suffix=".json")
+    try:
+        tree.to_json(fp)
+        restored = SurvivalTree.from_json(fp)
+    finally:
+        if os.path.exists(fp):
+            os.remove(fp)
+    xq = np.linspace(1, 30, 10)
+    assert np.allclose(
+        tree.sf(xq, [0.3, 0.3, 0.3]),
+        restored.sf(xq, [0.3, 0.3, 0.3]),
+        equal_nan=True,
+    )
+
+
+def test_forest_round_trip_predictions():
+    x, Z, c = _data(seed=5)
+    np.random.seed(4)
+    forest = RandomSurvivalForest.fit(
+        x=x, Z=Z, c=c, n_trees=8, kind="weibull", max_depth=4
+    )
+    d = forest.to_dict()
+    _assert_bson_native(d)
+    restored = RandomSurvivalForest.from_dict(json.loads(json.dumps(d)))
+
+    xq = np.linspace(1, 30, 12)
+    for zq in ([0.5, -0.5, 0.2], [-1.0, 1.0, 0.0]):
+        assert np.allclose(forest.sf(xq, zq), restored.sf(xq, zq))
+        assert np.allclose(forest.Hf(xq, zq), restored.Hf(xq, zq))
+    assert restored.n_trees == forest.n_trees
+    assert len(restored.trees) == len(forest.trees)
+
+
+def test_package_from_dict_dispatch():
+    x, Z, c = _data(seed=6)
+    np.random.seed(5)
+    tree = SurvivalTree.fit(x=x, Z=Z, c=c, kind="weibull", max_depth=3)
+    forest = RandomSurvivalForest.fit(
+        x=x, Z=Z, c=c, n_trees=4, kind="exponential", max_depth=3
+    )
+
+    assert isinstance(surpyval.from_dict(tree.to_dict()), SurvivalTree)
+    assert isinstance(
+        surpyval.from_dict(forest.to_dict()), RandomSurvivalForest
+    )
+
+
+def test_never_occurs_leaf_round_trip():
+    # An all-censored leaf carries no event information, so its model is the
+    # parameterless NeverOccurs; it must serialise as a sentinel and restore
+    # to the same degenerate leaf.
+    data = SurpyvalData(
+        x=[5.0, 6.0, 7.0], c=[1, 1, 1], n=[1, 1, 1], group_and_sort=False
+    )
+    leaf = TerminalNode(data, kind="weibull")
+    assert leaf.model is NeverOccurs
+
+    d = leaf.to_dict()
+    assert d["leaf"] == "NeverOccurs"
+    _assert_bson_native(d)
+
+    restored = node_from_dict(d)
+    assert restored.model is NeverOccurs
+    xq = np.array([1.0, 2.0, 3.0])
+    assert np.allclose(
+        leaf.apply_model_function("sf", xq, None),
+        restored.apply_model_function("sf", xq, None),
+    )
+
+
+def test_from_dict_rejects_tag_mismatch():
+    with pytest.raises(ValueError, match="SurvivalTree"):
+        SurvivalTree.from_dict({"model": "RandomSurvivalForest"})
+    with pytest.raises(ValueError, match="RandomSurvivalForest"):
+        RandomSurvivalForest.from_dict({"model": "SurvivalTree"})
+    with pytest.raises(ValueError, match="node"):
+        node_from_dict({"node": "not-a-node"})
+
+
+def test_parametric_offset_to_dict_is_bson_native():
+    # Regression guard for the leak surfaced by the forest work: an offset
+    # Weibull's ``gamma`` and every model's ``_neg_ll`` were stored as numpy
+    # scalars, which MongoDB's BSON encoder rejects.
+    for model in (
+        Weibull.fit([3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),
+        Weibull.fit([3.0, 4.0, 5.0, 6.0, 7.0, 8.0], offset=True),
+    ):
+        _assert_bson_native(model.to_dict())

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -20,12 +20,13 @@ if TYPE_CHECKING:
 
     from surpyval.utils.surpyval_data import SurpyvalData
 
+from surpyval.serialisation import stamp_schema, to_native
+
 from .probability_plotting import (
     adjust_heuristic,
     draw_probability_plot,
     probability_plot_data,
 )
-from surpyval.serialisation import stamp_schema
 
 # Shared inputs for the confidence-bound computations: the fitted parameter
 # vector ``phi_hat`` (core params plus any LFP/ZI parameters), its covariance
@@ -194,22 +195,22 @@ class Parametric(ParametricDistribution):
                 out["data"] = data_dict
 
         out["params"] = np.array(self.params).tolist()
-        out["lfp"] = self.lfp
+        out["lfp"] = bool(self.lfp)
 
         if self.lfp:
-            out["p"] = self.p
+            out["p"] = to_native(self.p)
         else:
             out["p"] = 1.0
 
-        out["zi"] = self.zi
+        out["zi"] = bool(self.zi)
         if self.zi:
-            out["f0"] = self.f0
+            out["f0"] = to_native(self.f0)
         else:
             out["f0"] = 0.0
 
-        out["offset"] = self.offset
+        out["offset"] = bool(self.offset)
         if self.offset:
-            out["gamma"] = self.gamma
+            out["gamma"] = to_native(self.gamma)
         else:
             out["gamma"] = 0.0
 
@@ -221,7 +222,7 @@ class Parametric(ParametricDistribution):
         if getattr(self, "cov_matrix", None) is not None:
             out["cov_matrix"] = self.cov_matrix.tolist()
         if hasattr(self, "_neg_ll"):
-            out["_neg_ll"] = self._neg_ll
+            out["_neg_ll"] = to_native(self._neg_ll)
 
         return stamp_schema(out)
 


### PR DESCRIPTION
Closes #191.

Completes the serialisation campaign (#179–#184), which had deliberately deferred the tree/forest while the forest was crash-prone. After #185 they're stable and worth persisting — forests are exactly the kind of expensive fit users want to save.

## What's added

- **Nodes** (`node.py`): `IntermediateNode.to_dict`/`from_dict` (split rule + recursive children) and `TerminalNode.to_dict`/`from_dict`. Each leaf is serialised as its **fitted model** — `Parametric`/`NonParametric` via their own `to_dict`, restored through the package-level `surpyval.from_dict`; the parameterless `NeverOccurs` (empty / all-censored leaf) is a string sentinel. A `node_from_dict` dispatcher and an abstract `to_dict` on the `Node` base round it out. Restored nodes carry no training data — a restored tree is a predictor, not a re-fittable object — and the leaf model is injected into the `cached_property` slot so it predicts without re-fitting.
- **`SurvivalTree`** (`tree.py`): `to_dict`/`from_dict`/`to_json`/`from_json`; `from_dict` bypasses the tree-building `__init__` via `__new__`.
- **`RandomSurvivalForest`** (`forest.py`): `to_dict`/`from_dict`/`to_json`/`from_json` — ensemble settings + serialised trees.
- **Dispatch**: both registered in `serialisation.py`'s `_TAGGED_MODELS` with `"model"` class tags; schema-stamped; `from_dict` refuses a tag mismatch.

## Fix surfaced along the way

`Parametric.to_dict` emitted `_neg_ll` (always) and `gamma`/`p`/`f0` (for offset / LFP / zero-inflated models) as **NumPy scalars**, which MongoDB's BSON encoder rejects — a latent gap from the earlier BSON-safety pass that only the tree leaves exercised. Now wrapped with `to_native`, and guarded by a regression test.

## Validation

- Round-trip **prediction equality** (`sf`/`ff`/`Hf`) for all three tree `kind`s and the forest, incl. through JSON.
- `surpyval.from_dict` package dispatch restores the right class.
- The `NeverOccurs` empty-leaf sentinel round-trips.
- **BSON-native** assertions over the full nested dict; `to_json`/`from_json` file round-trip; tag-mismatch rejection; schema stamp present.
- Regression guard for the offset-`Parametric` leak.

New `test_forest_serialisation.py` (12 tests) plus the existing forest, MongoDB, package- and regression-serialisation suites all pass (147 in the combined run); flake8/black/isort/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_