### PR TITLE
Fix Accelerated Life fit for the Exponential distribution

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -96,6 +96,14 @@ Correctness
 Regression
 ~~~~~~~~~~
 
+- **Accelerated Life with an Exponential distribution now fits.**
+  ``AcceleratedLife(Exponential, life_model).fit(...)`` raised
+  ``KeyError: 'lambda'`` because the life-parameter map named the Exponential's
+  parameter ``"lambda"`` while the distribution actually calls it
+  ``"failure_rate"``. The name is corrected (the ``life <-> rate`` transforms
+  were already right), so Exponential accelerated-life models fit, predict and
+  serialise; a guard test now checks every distribution's declared life
+  parameter is a real parameter of that distribution.
 - **Exact and Kalbfleisch-Prentice tie handling for Cox** (#142). ``CoxPH.fit``
   gains two further ``method`` choices beyond ``'breslow'`` and ``'efron'``:
   ``'exact'`` (the average-over-orderings exact partial likelihood, for ties

--- a/surpyval/tests/univariate/regression/test_accelerated_life.py
+++ b/surpyval/tests/univariate/regression/test_accelerated_life.py
@@ -1,0 +1,91 @@
+"""Accelerated Life (parameter-substitution) fitting.
+
+Guards the life-parameter map that couples each distribution to its
+stress-relationship life model, and checks that an Exponential Accelerated
+Life model fits and recovers the underlying stress-life relationship (a
+regression: its life parameter was mis-named ``"lambda"`` where the
+distribution actually calls it ``"failure_rate"``, so the fit raised
+``KeyError: 'lambda'``).
+"""
+
+import numpy as np
+
+import surpyval
+from surpyval import AcceleratedLife, Exponential, Power, Weibull
+from surpyval.univariate.regression.accelerated_life.accelerated_life import (
+    _LIFE_PARAM_MAP,
+)
+
+
+def test_life_param_map_names_a_real_parameter():
+    # Every distribution's declared life parameter must be one of that
+    # distribution's actual parameters, or ``fit`` fails when it looks the
+    # index up in ``param_map``.
+    for dist_name, (life_param, _, _) in _LIFE_PARAM_MAP.items():
+        dist = getattr(surpyval, dist_name)
+        assert life_param in dist.param_names, (
+            f"{dist_name} life parameter {life_param!r} is not in "
+            f"{dist.param_names}"
+        )
+
+
+def _al_stress_data(phi, stresses, per=400, seed=0):
+    rng = np.random.default_rng(seed)
+    xs, Zs = [], []
+    for s in stresses:
+        xs.append(rng.exponential(phi(s), per))
+        Zs.append(np.full(per, s))
+    x = np.concatenate(xs)
+    Z = np.concatenate(Zs).reshape(-1, 1)
+    return x, Z
+
+
+def test_exponential_accelerated_life_fits_and_recovers():
+    # Exponential lifetimes whose mean life follows a power law in the stress.
+    stresses = [1.0, 2.0, 4.0, 8.0]
+
+    def true_life(s):
+        return 2000.0 * s**-1.5
+
+    x, Z = _al_stress_data(true_life, stresses)
+
+    # Must not raise (previously KeyError: 'lambda').
+    model = AcceleratedLife(Exponential, Power).fit(x=x, Z=Z)
+
+    # The fitted model's mean life at each stress (= 1 / failure_rate) should
+    # recover the true power-law life within sampling error.
+    for s in stresses:
+        rate = np.ravel(
+            model.model.param_transform(
+                model.reg_model.phi(np.array([[s]]), *model.phi_params)
+            )
+        )[0]
+        assert np.isclose(1.0 / rate, true_life(s), rtol=0.15)
+
+
+def test_exponential_accelerated_life_round_trips():
+    stresses = [1.0, 2.0, 4.0, 8.0]
+    x, Z = _al_stress_data(lambda s: 2000.0 * s**-1.5, stresses, seed=1)
+    model = AcceleratedLife(Exponential, Power).fit(x=x, Z=Z)
+
+    restored = surpyval.from_dict(model.to_dict())
+    xq = np.linspace(1.0, 500.0, 10)
+    Zq = np.full((xq.size, 1), 2.0)
+    assert np.allclose(model.sf(xq, Zq), restored.sf(xq, Zq), equal_nan=True)
+
+
+def test_weibull_accelerated_life_still_fits():
+    # A guard that the fix did not disturb the other (already-working)
+    # distributions.
+    stresses = [1.0, 2.0, 4.0, 8.0]
+    rng = np.random.default_rng(2)
+    xs, Zs = [], []
+    for s in stresses:
+        life = 500.0 * s**-1.0
+        xs.append(life * rng.weibull(2.2, 200))
+        Zs.append(np.full(200, s))
+    x = np.concatenate(xs)
+    Z = np.concatenate(Zs).reshape(-1, 1)
+
+    model = AcceleratedLife(Weibull, Power).fit(x=x, Z=Z)
+    assert np.all(np.isfinite(model.params))

--- a/surpyval/univariate/regression/accelerated_life/accelerated_life.py
+++ b/surpyval/univariate/regression/accelerated_life/accelerated_life.py
@@ -6,7 +6,10 @@ from .parameter_substitution import ParameterSubstitutionFitter
 # transforms needed to convert between the life-model output space and
 # the distribution's native parameter space.
 _LIFE_PARAM_MAP = {
-    "Exponential": ("lambda", lambda x: 1.0 / x, lambda x: 1.0 / x),
+    # The Exponential's native parameter is ``failure_rate`` (the rate,
+    # lambda); the life model produces a characteristic *life* (mean time), so
+    # the two transforms convert life <-> rate via ``1 / x``.
+    "Exponential": ("failure_rate", lambda x: 1.0 / x, lambda x: 1.0 / x),
     "Normal": ("mu", None, None),
     "Weibull": ("alpha", None, None),
     "Gumbel": ("mu", None, None),


### PR DESCRIPTION
`AcceleratedLife(Exponential, life_model).fit(...)` raised `KeyError: 'lambda'` — no Exponential accelerated-life model could be fit at all. (Surfaced while adding AL serialisation in #231.)

## Root cause

`_LIFE_PARAM_MAP` names the Exponential's life parameter `"lambda"`, but the distribution's actual parameter is `"failure_rate"`. The fitter looks that name up in the distribution's `param_map` to find the life-parameter index, so the lookup `KeyError`'d.

Only the **name** was wrong — the `life ↔ rate` transforms (`1/x` both ways, since `failure_rate = 1 / mean-life`) were already correct. Renaming `"lambda"` → `"failure_rate"` fixes it.

## Verification

- The model now fits and **recovers the true stress-life relationship** (Exponential lifetimes with a power-law mean life `2000·s^-1.5` → estimated within sampling error), predicts, and serialises through the round-trip added in #231.
- All other supported distributions (Weibull, LogNormal, Normal, Gumbel, Logistic, Gamma) were already correct — checked and unchanged.

## Tests

New `test_accelerated_life.py`:
- Exponential-Power fits and recovers the power-law life (regression test).
- Exponential AL round-trips through `surpyval.from_dict`.
- Weibull AL still fits (guard against disturbing the working path).
- **A guard that every `_LIFE_PARAM_MAP` entry names a real parameter of its distribution**, so this class of mismatch cannot silently return.

flake8/black/isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_