### PR TITLE
Harmonise the time-varying-covariate Cox input + add a timeline input

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -96,6 +96,25 @@ Correctness
 Regression
 ~~~~~~~~~~
 
+- **Timeline (xicnt-style) input for time-varying-covariate Cox.**
+  ``CoxPH.fit_tvc_timeline`` / ``fit_tvc_timeline_from_df`` accept a covariate
+  *timeline* -- one row per covariate change per subject (``i``, ``x``, ``Z``,
+  ``c``) with the terminal event / censoring on the subject's last row -- as an
+  alternative to writing explicit ``(xl, xr]`` intervals for ``fit_tvc``. Each
+  covariate value holds from its time until the subject's next row, the first
+  time is the (delayed-)entry time and the last is the exit; the timeline is
+  expanded to start-stop intervals and fitted identically, so it gives the same
+  fit as the equivalent ``fit_tvc`` data.
+- **Time-varying-covariate Cox input harmonised to the surpyval convention.**
+  The start-stop interface (``CoxPH.fit_tvc`` / ``fit_tvc_from_df`` /
+  ``predict_tvc`` and ``handle_tvc``) is renamed to match surpyval's
+  vocabulary: the subject id is ``i`` (was ``ident``), the interval bounds are
+  ``xl`` / ``xr`` (were ``start`` / ``stop``), and the status is ``c`` (was
+  ``event``). ``c`` now follows the standard surpyval censoring convention --
+  ``0`` = event at ``xr``, ``1`` = right-censored -- which is the *inverse* of
+  the old ``event`` flag (``event=1`` -> ``c=0``). The DataFrame entry point's
+  columns are named ``xl_col`` / ``xr_col`` / ``c_col`` accordingly. Positional
+  calls are unaffected; keyword calls and the ``event`` values need updating.
 - **Accelerated Life with an Exponential distribution now fits.**
   ``AcceleratedLife(Exponential, life_model).fit(...)`` raised
   ``KeyError: 'lambda'`` because the life-parameter map named the Exponential's

--- a/surpyval/tests/univariate/regression/test_semiparametric_serialisation.py
+++ b/surpyval/tests/univariate/regression/test_semiparametric_serialisation.py
@@ -80,21 +80,24 @@ def test_cox_tvc_round_trip():
     # contiguous intervals with a covariate that changes at the split.
     rng = np.random.default_rng(3)
     n = 40
-    ident, start, stop, event, Zrows = [], [], [], [], []
+    ident, xl, xr, c, Zrows = [], [], [], [], []
     for s in range(n):
         split = 3.0
         end = split + np.abs(rng.weibull(1.4)) * 6.0 + 0.5
         z0 = rng.normal(0, 1)
         ident += [s, s]
-        start += [0.0, split]
-        stop += [split, end]
-        event += [0, 1]  # event on the terminal interval
+        xl += [0.0, split]
+        xr += [split, end]
+        c += [
+            1,
+            0,
+        ]  # censored split, then event (c=0) on the terminal interval
         Zrows += [[z0], [z0 + 0.2]]
     model = CoxPH.fit_tvc(
         np.array(ident),
-        np.array(start),
-        np.array(stop),
-        np.array(event),
+        np.array(xl),
+        np.array(xr),
+        np.array(c),
         np.array(Zrows),
     )
     assert model.is_tvc

--- a/surpyval/tests/univariate/regression/test_tvc.py
+++ b/surpyval/tests/univariate/regression/test_tvc.py
@@ -26,18 +26,18 @@ def _split_dataset(seed=1, n=400):
     s = T * rng.uniform(0.3, 0.7, size=n)
 
     ident = np.repeat(np.arange(n), 2)
-    start = np.empty(2 * n)
-    stop = np.empty(2 * n)
-    event = np.zeros(2 * n, dtype=int)
+    xl = np.empty(2 * n)
+    xr = np.empty(2 * n)
+    c = np.ones(2 * n, dtype=int)  # right-censored (1) unless the event row
     Ztvc = np.empty((2 * n, 1))
-    start[0::2], stop[0::2], event[0::2], Ztvc[0::2] = 0.0, s, 0, Z
-    start[1::2], stop[1::2], event[1::2], Ztvc[1::2] = s, T, 1, Z
-    return (ident, start, stop, event, Ztvc), (Z, T)
+    xl[0::2], xr[0::2], c[0::2], Ztvc[0::2] = 0.0, s, 1, Z  # split, censored
+    xl[1::2], xr[1::2], c[1::2], Ztvc[1::2] = s, T, 0, Z  # terminal, event
+    return (ident, xl, xr, c, Ztvc), (Z, T)
 
 
 def test_fit_tvc_matches_episode_split_beta_and_baseline():
-    (ident, start, stop, event, Ztvc), (Z, T) = _split_dataset()
-    tvc = CoxPH.fit_tvc(ident, start, stop, event, Ztvc)
+    (ident, xl, xr, c, Ztvc), (Z, T) = _split_dataset()
+    tvc = CoxPH.fit_tvc(ident, xl, xr, c, Ztvc)
     c0 = np.zeros(T.size, dtype=int)
     ref = CoxPH.fit(x=T, Z=Z, c=c0, tl=np.zeros(T.size))
 
@@ -64,48 +64,48 @@ def test_fit_tvc_recovers_time_varying_effect():
     t2 = tau + rng.exponential(1 / (lam * np.exp(beta)), size=n)
     T = np.where(t1 > tau, t2, t1)
 
-    ids, s0, s1, ev, z = [], [], [], [], []
-    for i in range(n):
-        if T[i] <= tau[i]:
-            ids += [i]
+    ids, s0, s1, cc, z = [], [], [], [], []
+    for k in range(n):
+        if T[k] <= tau[k]:
+            ids += [k]
             s0 += [0.0]
-            s1 += [T[i]]
-            ev += [1]
+            s1 += [T[k]]
+            cc += [0]  # event
             z += [0.0]
         else:
-            ids += [i, i]
-            s0 += [0.0, tau[i]]
-            s1 += [tau[i], T[i]]
-            ev += [0, 1]
+            ids += [k, k]
+            s0 += [0.0, tau[k]]
+            s1 += [tau[k], T[k]]
+            cc += [1, 0]  # censored change, then event
             z += [0.0, 1.0]
     model = CoxPH.fit_tvc(
         np.array(ids),
         np.array(s0),
         np.array(s1),
-        np.array(ev),
+        np.array(cc),
         np.array(z).reshape(-1, 1),
     )
     assert abs(model.beta[0] - beta) < 0.15
 
 
 def test_fit_tvc_from_df_matches_arrays():
-    (ident, start, stop, event, Ztvc), _ = _split_dataset()
-    arrays = CoxPH.fit_tvc(ident, start, stop, event, Ztvc)
+    (ident, xl, xr, c, Ztvc), _ = _split_dataset()
+    arrays = CoxPH.fit_tvc(ident, xl, xr, c, Ztvc)
     df = pd.DataFrame(
         {
             "id": ident,
-            "t0": start,
-            "t1": stop,
-            "ev": event,
+            "t0": xl,
+            "t1": xr,
+            "cc": c,
             "z": Ztvc[:, 0],
         }
     )
     from_df = CoxPH.fit_tvc_from_df(
         df,
         id_col="id",
-        start_col="t0",
-        stop_col="t1",
-        event_col="ev",
+        xl_col="t0",
+        xr_col="t1",
+        c_col="cc",
         Z_cols="z",
     )
     assert np.isclose(arrays.beta[0], from_df.beta[0])
@@ -113,8 +113,8 @@ def test_fit_tvc_from_df_matches_arrays():
 
 
 def test_predict_tvc_constant_reduces_to_sf():
-    (ident, start, stop, event, Ztvc), _ = _split_dataset()
-    model = CoxPH.fit_tvc(ident, start, stop, event, Ztvc)
+    (ident, xl, xr, c, Ztvc), _ = _split_dataset()
+    model = CoxPH.fit_tvc(ident, xl, xr, c, Ztvc)
     z = np.array([0.5])
     t = np.array([0.3, 0.7, 1.2])
     # a single constant interval spanning the times must equal sf(t, Z)
@@ -124,11 +124,11 @@ def test_predict_tvc_constant_reduces_to_sf():
 
 
 def test_predict_tvc_changing_covariate_is_monotone_and_responds():
-    (ident, start, stop, event, Ztvc), _ = _split_dataset()
-    model = CoxPH.fit_tvc(ident, start, stop, event, Ztvc)
+    (ident, xl, xr, c, Ztvc), _ = _split_dataset()
+    model = CoxPH.fit_tvc(ident, xl, xr, c, Ztvc)
 
     times, sf, _ = model.predict_tvc(
-        start=[0.0, 0.5], stop=[0.5, 5.0], Z=[[-1.0], [1.5]]
+        xl=[0.0, 0.5], xr=[0.5, 5.0], Z=[[-1.0], [1.5]]
     )
     # survival is a proper (non-increasing) curve
     assert np.all(np.diff(sf) <= 1e-12)
@@ -136,7 +136,7 @@ def test_predict_tvc_changing_covariate_is_monotone_and_responds():
     # switching to a higher-hazard covariate late must leave survival below
     # the all-low-covariate path at the final time
     _, sf_low, _ = model.predict_tvc(
-        start=[0.0], stop=[5.0], Z=[[-1.0]], times=times[-1:]
+        xl=[0.0], xr=[5.0], Z=[[-1.0]], times=times[-1:]
     )
     assert sf[-1] < sf_low[-1]
 
@@ -146,50 +146,50 @@ def test_predict_tvc_changing_covariate_is_monotone_and_responds():
     [
         # overlapping intervals
         dict(
-            ident=[1, 1],
-            start=[0, 1],
-            stop=[3, 4],
-            event=[0, 1],
+            i=[1, 1],
+            xl=[0, 1],
+            xr=[3, 4],
+            c=[1, 0],
             Z=[[0.1], [0.2]],
         ),
         # more than one event
         dict(
-            ident=[1, 1],
-            start=[0, 2],
-            stop=[2, 4],
-            event=[1, 1],
+            i=[1, 1],
+            xl=[0, 2],
+            xr=[2, 4],
+            c=[0, 0],
             Z=[[0.1], [0.2]],
         ),
         # event on a non-final interval
         dict(
-            ident=[1, 1],
-            start=[0, 2],
-            stop=[2, 4],
-            event=[1, 0],
+            i=[1, 1],
+            xl=[0, 2],
+            xr=[2, 4],
+            c=[0, 1],
             Z=[[0.1], [0.2]],
         ),
-        # start >= stop
+        # xl >= xr
         dict(
-            ident=[1, 1],
-            start=[0, 4],
-            stop=[2, 4],
-            event=[0, 1],
+            i=[1, 1],
+            xl=[0, 4],
+            xr=[2, 4],
+            c=[1, 0],
             Z=[[0.1], [0.2]],
         ),
         # length mismatch
         dict(
-            ident=[1, 1],
-            start=[0, 2],
-            stop=[2, 4],
-            event=[0],
+            i=[1, 1],
+            xl=[0, 2],
+            xr=[2, 4],
+            c=[1],
             Z=[[0.1], [0.2]],
         ),
-        # bad event value
+        # bad c value
         dict(
-            ident=[1],
-            start=[0],
-            stop=[2],
-            event=[2],
+            i=[1],
+            xl=[0],
+            xr=[2],
+            c=[2],
             Z=[[0.1]],
         ),
     ],
@@ -201,21 +201,125 @@ def test_handle_tvc_validation(kwargs):
 
 def test_handle_tvc_maps_columns():
     x, c, n, tl, Z, ident = handle_tvc(
-        ident=[1, 1, 2],
-        start=[0, 2, 0],
-        stop=[2, 4, 3],
-        event=[0, 1, 0],
+        i=[1, 1, 2],
+        xl=[0, 2, 0],
+        xr=[2, 4, 3],
+        c=[1, 0, 1],
         Z=[[0.1], [0.2], [0.3]],
     )
-    assert np.array_equal(x, [2.0, 4.0, 3.0])
-    assert np.array_equal(c, [1, 0, 1])  # event -> c=0, else c=1
-    assert np.array_equal(tl, [0.0, 2.0, 0.0])
+    assert np.array_equal(x, [2.0, 4.0, 3.0])  # x = xr
+    assert np.array_equal(c, [1, 0, 1])  # 0 event, 1 censored
+    assert np.array_equal(tl, [0.0, 2.0, 0.0])  # tl = xl
 
 
 def test_predict_tvc_input_validation():
-    (ident, start, stop, event, Ztvc), _ = _split_dataset()
-    model = CoxPH.fit_tvc(ident, start, stop, event, Ztvc)
+    (ident, xl, xr, c, Ztvc), _ = _split_dataset()
+    model = CoxPH.fit_tvc(ident, xl, xr, c, Ztvc)
     with pytest.raises(ValueError):
-        model.predict_tvc(start=[0.0, 1.0], stop=[1.0], Z=[[0.1], [0.2]])
+        model.predict_tvc(xl=[0.0, 1.0], xr=[1.0], Z=[[0.1], [0.2]])
     with pytest.raises(ValueError):
-        model.predict_tvc(start=[2.0], stop=[1.0], Z=[[0.1]])
+        model.predict_tvc(xl=[2.0], xr=[1.0], Z=[[0.1]])
+
+
+# ---------------------------------------------------------------------------
+# Timeline / xicnt-style TVC input (fit_tvc_timeline)
+# ---------------------------------------------------------------------------
+
+from surpyval.univariate.regression.proportional_hazards.tvc import (  # noqa: E402,E501
+    handle_tvc_timeline,
+)
+
+
+def _timeline_and_startstop(seed=3, nsub=150):
+    """Build the same TVC data in both the timeline and start-stop layouts:
+    each subject has a covariate that steps once, then an event/censor."""
+    rng = np.random.default_rng(seed)
+    ss = {"ident": [], "xl": [], "xr": [], "c": [], "Z": []}
+    tl = {"i": [], "x": [], "Z": [], "c": []}
+    for s in range(nsub):
+        z0 = rng.normal()
+        z1 = z0 + 0.5 * rng.normal()
+        change = rng.uniform(1.0, 4.0)
+        exit_t = change + rng.uniform(0.5, 5.0)
+        died = int(rng.uniform() < 0.7)
+
+        ss["ident"] += [s, s]
+        ss["xl"] += [0.0, change]
+        ss["xr"] += [change, exit_t]
+        ss["c"] += [1, 0 if died else 1]
+        ss["Z"] += [[z0], [z1]]
+
+        tl["i"] += [s, s, s]
+        tl["x"] += [0.0, change, exit_t]
+        tl["Z"] += [[z0], [z1], [z1]]  # terminal Z ignored
+        tl["c"] += [-1, -1, 0 if died else 1]
+    return ss, tl
+
+
+def test_fit_tvc_timeline_matches_start_stop():
+    ss, tl = _timeline_and_startstop()
+    m_ss = CoxPH.fit_tvc(
+        i=ss["ident"],
+        xl=ss["xl"],
+        xr=ss["xr"],
+        c=ss["c"],
+        Z=np.array(ss["Z"]),
+    )
+    m_tl = CoxPH.fit_tvc_timeline(
+        i=tl["i"], x=tl["x"], Z=np.array(tl["Z"]), c=tl["c"]
+    )
+    assert np.allclose(m_ss.beta, m_tl.beta, atol=1e-8)
+    assert m_tl.is_tvc
+
+
+def test_handle_tvc_timeline_carries_covariate_forward():
+    # Two rows -> one interval; a change -> two intervals; entry = first x.
+    i_out, xl, xr, c, Z, n = handle_tvc_timeline(
+        i=[1, 1, 1],
+        x=[2.0, 5.0, 8.0],
+        Z=[[0.0], [1.0], [9.9]],  # terminal 9.9 is dropped
+        c=[-1, -1, 0],
+    )
+    assert list(xl) == [2.0, 5.0]  # entry is the first x (delayed entry)
+    assert list(xr) == [5.0, 8.0]
+    assert list(c) == [1, 0]  # event (c=0) on the last interval
+    assert Z.ravel().tolist() == [0.0, 1.0]
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        (dict(i=[1], x=[3.0], Z=[[0.5]], c=[0]), "single timeline row"),
+        (
+            dict(i=[1, 1], x=[5.0, 5.0], Z=[[0.0], [0.0]], c=[-1, 0]),
+            "non-increasing",
+        ),
+        (
+            dict(i=[1, 1], x=[0.0, 5.0], Z=[[0.0], [0.0]], c=[-1, 2]),
+            "terminal status",
+        ),
+    ],
+)
+def test_handle_tvc_timeline_validation(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        handle_tvc_timeline(**kwargs)
+
+
+def test_fit_tvc_timeline_from_df_matches_arrays():
+    ss, tl = _timeline_and_startstop(seed=5, nsub=120)
+    df = pd.DataFrame(
+        {
+            "subj": tl["i"],
+            "t": tl["x"],
+            "z": [row[0] for row in tl["Z"]],
+            "cc": tl["c"],
+        }
+    )
+    m_df = CoxPH.fit_tvc_timeline_from_df(
+        df, id_col="subj", time_col="t", Z_cols="z", c_col="cc"
+    )
+    m_arr = CoxPH.fit_tvc_timeline(
+        i=tl["i"], x=tl["x"], Z=np.array(tl["Z"]), c=tl["c"]
+    )
+    assert np.allclose(m_df.beta, m_arr.beta)
+    assert m_df.feature_names == ["z"]

--- a/surpyval/univariate/regression/proportional_hazards/cox_ph.py
+++ b/surpyval/univariate/regression/proportional_hazards/cox_ph.py
@@ -30,7 +30,7 @@ from surpyval.univariate.nonparametric import (
 from surpyval.utils import validate_coxph, validate_coxph_df_inputs
 
 from ..semi_parametric_regression_model import SemiParametricRegressionModel
-from .tvc import handle_tvc
+from .tvc import handle_tvc, handle_tvc_timeline
 
 nonparametric_dists = {
     "Nelson-Aalen": NelsonAalen,
@@ -976,10 +976,10 @@ class CoxPH_:
 
     def fit_tvc(
         self,
-        ident: npt.ArrayLike,
-        start: npt.ArrayLike,
-        stop: npt.ArrayLike,
-        event: npt.ArrayLike,
+        i: npt.ArrayLike,
+        xl: npt.ArrayLike,
+        xr: npt.ArrayLike,
+        c: npt.ArrayLike,
         Z: npt.ArrayLike,
         n: npt.ArrayLike | None = None,
         method: str = "efron",
@@ -988,18 +988,21 @@ class CoxPH_:
         """
         Fit a Cox model with time-varying covariates in start-stop format.
 
-        Each row is one interval ``(start, stop]`` of a subject (identified by
-        ``ident``) on which the covariate row ``Z`` is constant; ``event`` is 1
-        only on the interval that ends at the subject's event. The rows are
-        validated (see :func:`~surpyval.univariate.regression.
-        proportional_hazards.tvc.handle_tvc`) and fitted as delayed-entry
-        observations -- exact for the Cox partial likelihood.
+        Each row is one observation interval ``(xl, xr]`` of a subject
+        (identified by ``i``) on which the covariate row ``Z`` is constant;
+        ``c`` is ``0`` (event) only on the interval that ends at the subject's
+        event and ``1`` (right-censored) otherwise. The rows are validated (see
+        :func:`~surpyval.univariate.regression.proportional_hazards.tvc.
+        handle_tvc`) and fitted as delayed-entry observations -- exact for the
+        Cox partial likelihood.
 
         Parameters
         ----------
-        ident, start, stop, event, Z : array_like
-            The start-stop interval data (subject id, entry time, exit time,
-            terminal-event flag, and per-interval covariates).
+        i, xl, xr, c, Z : array_like
+            The start-stop interval data: subject id, interval entry time
+            ``xl``, exit time ``xr``, censoring flag ``c`` (``0`` event at
+            ``xr``, ``1`` right-censored -- surpyval's convention), and the
+            per-interval covariates.
         n : array_like, optional
             Count weight per interval row.
         method : {'efron', 'breslow'}, optional
@@ -1015,7 +1018,7 @@ class CoxPH_:
             semi_parametric_regression_model.SemiParametricRegressionModel.
             predict_tvc`.
         """
-        x, c, n_arr, tl, Z_arr, _ = handle_tvc(ident, start, stop, event, Z, n)
+        x, c, n_arr, tl, Z_arr, _ = handle_tvc(i, xl, xr, c, Z, n)
         model = self.fit(
             x=x, Z=Z_arr, c=c, n=n_arr, tl=tl, method=method, tol=tol
         )
@@ -1026,9 +1029,9 @@ class CoxPH_:
         self,
         df: "pd.DataFrame",
         id_col: str,
-        start_col: str,
-        stop_col: str,
-        event_col: str,
+        xl_col: str,
+        xr_col: str,
+        c_col: str,
         Z_cols: str | list[str],
         n_col: str | None = None,
         method: str = "efron",
@@ -1037,15 +1040,105 @@ class CoxPH_:
         Fit a time-varying-covariate Cox model from a start-stop DataFrame.
 
         See :meth:`fit_tvc`; ``Z_cols`` names the covariate column(s) and the
-        remaining arguments name the id / start / stop / event columns.
+        remaining arguments name the id / ``xl`` / ``xr`` / ``c`` columns.
         """
         cols = [Z_cols] if isinstance(Z_cols, str) else list(Z_cols)
         model = self.fit_tvc(
-            ident=df[id_col].to_numpy(),
-            start=df[start_col].to_numpy(),
-            stop=df[stop_col].to_numpy(),
-            event=df[event_col].to_numpy(),
+            i=df[id_col].to_numpy(),
+            xl=df[xl_col].to_numpy(),
+            xr=df[xr_col].to_numpy(),
+            c=df[c_col].to_numpy(),
             Z=df[cols].to_numpy(),
+            n=None if n_col is None else df[n_col].to_numpy(),
+            method=method,
+        )
+        model.feature_names = cols
+        return model
+
+    def fit_tvc_timeline(
+        self,
+        i: npt.ArrayLike,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        c: npt.ArrayLike,
+        n: npt.ArrayLike | None = None,
+        method: str = "efron",
+        tol: float = 1e-10,
+    ) -> SemiParametricRegressionModel:
+        """
+        Fit a time-varying-covariate Cox model from a covariate *timeline*.
+
+        This is the timeline / ``xicnt``-style alternative to
+        :meth:`fit_tvc`'s explicit ``(start, stop]`` intervals. Each subject's
+        rows give its covariate history: a covariate value ``Z`` takes effect
+        at time ``x`` and holds until the subject's next row, with the terminal
+        event / censoring marked on the last row's ``c``. The timeline is
+        expanded to start-stop intervals (see
+        :func:`~surpyval.univariate.regression.proportional_hazards.tvc.
+        handle_tvc_timeline`) and fitted exactly as :meth:`fit_tvc`, so it
+        gives an identical fit to the equivalent start-stop data.
+
+        Parameters
+        ----------
+        i : array_like
+            Subject identifier for each timeline row (the ``xicnt`` item id).
+        x : array_like
+            The time each row's covariate value takes effect. Strictly
+            increasing within a subject; the first is the entry
+            (delayed-entry) time, the last is the event / censoring time.
+        Z : array_like
+            The covariate vector effective from this row's ``x``. The value on
+            a subject's terminal (last) row is ignored.
+        c : array_like
+            Censoring status; only each subject's last row is read (``0``
+            event, ``1`` right-censored).
+        n : array_like, optional
+            Per-subject count weight (read from the terminal row).
+        method : {'efron', 'breslow'}, optional
+            Tie-handling method. Default ``'efron'``.
+        tol : float, optional
+            Optimiser tolerance.
+
+        Returns
+        -------
+        SemiParametricRegressionModel
+            The fitted model, with ``is_tvc`` set.
+        """
+        i_ss, xl, xr, c_ss, Z_ss, n_ss = handle_tvc_timeline(i, x, Z, c, n)
+        return self.fit_tvc(
+            i=i_ss,
+            xl=xl,
+            xr=xr,
+            c=c_ss,
+            Z=Z_ss,
+            n=n_ss,
+            method=method,
+            tol=tol,
+        )
+
+    def fit_tvc_timeline_from_df(
+        self,
+        df: "pd.DataFrame",
+        id_col: str,
+        time_col: str,
+        Z_cols: str | list[str],
+        c_col: str,
+        n_col: str | None = None,
+        method: str = "efron",
+    ) -> SemiParametricRegressionModel:
+        """
+        Fit a timeline TVC Cox model from a DataFrame.
+
+        See :meth:`fit_tvc_timeline`; ``time_col`` names the change-point time
+        column, ``Z_cols`` the covariate column(s) and ``c_col`` the terminal
+        event / censoring column (``0`` event, ``1`` censored).
+        """
+        cols = [Z_cols] if isinstance(Z_cols, str) else list(Z_cols)
+        model = self.fit_tvc_timeline(
+            i=df[id_col].to_numpy(),
+            x=df[time_col].to_numpy(),
+            Z=df[cols].to_numpy(),
+            c=df[c_col].to_numpy(),
             n=None if n_col is None else df[n_col].to_numpy(),
             method=method,
         )

--- a/surpyval/univariate/regression/proportional_hazards/tvc.py
+++ b/surpyval/univariate/regression/proportional_hazards/tvc.py
@@ -18,24 +18,27 @@ intervals with the same covariates gives the same fit as the unsplit subject.
 import numpy as np
 
 
-def handle_tvc(ident, start, stop, event, Z, n=None):
+def handle_tvc(i, xl, xr, c, Z, n=None):
     """
     Validate start-stop time-varying-covariate data and map it to the arrays
     the Cox partial likelihood fits.
 
     Parameters
     ----------
-    ident : array_like
+    i : array_like
         Subject identifier for each interval row. Rows sharing an identifier
         are the successive observation intervals of one subject.
-    start, stop : array_like
-        The open-closed interval ``(start, stop]`` each row is observed over.
-        ``start`` is the delayed-entry (left-truncation) time.
-    event : array_like
-        1 if the subject's terminal event occurs at ``stop`` on this interval,
-        0 otherwise (interval end is an administrative censoring / covariate
-        change). A subject has at most one ``event = 1`` row, and it must be
-        its last interval.
+    xl, xr : array_like
+        The open-closed observation interval ``(xl, xr]`` each row covers.
+        ``xl`` is the delayed-entry (left-truncation) time; ``xr`` is the exit
+        time. (These follow surpyval's ``xl``/``xr`` interval naming.)
+    c : array_like
+        Censoring flag at ``xr``, in surpyval's convention: ``0`` if the
+        subject's terminal event occurs at ``xr`` on this interval, ``1`` if
+        the interval end is right-censoring (administrative end / covariate
+        change). A subject has at most one ``c = 0`` (event) row, and it must
+        be its last interval. Note this is the *inverse* of the previous
+        ``event`` flag.
     Z : array_like
         Covariate matrix, one row per interval, constant on that interval.
     n : array_like, optional
@@ -44,14 +47,14 @@ def handle_tvc(ident, start, stop, event, Z, n=None):
     Returns
     -------
     x, c, n, tl, Z, ident : ndarray
-        ``x = stop``, ``c = 1 - event`` (0 event, 1 right-censored),
-        ``tl = start``, and the (sorted-within-subject) covariate rows and
-        identifiers, ready for ``CoxPH.fit(x=x, Z=Z, c=c, n=n, tl=tl)``.
+        ``x = xr``, ``c`` (0 event, 1 right-censored), ``tl = xl``, and the
+        (sorted-within-subject) covariate rows and identifiers, ready for
+        ``CoxPH.fit(x=x, Z=Z, c=c, n=n, tl=tl)``.
     """
-    ident = np.asarray(ident)
-    start = np.asarray(start, dtype=float)
-    stop = np.asarray(stop, dtype=float)
-    event = np.asarray(event)
+    ident = np.asarray(i)
+    xl = np.asarray(xl, dtype=float)
+    xr = np.asarray(xr, dtype=float)
+    c = np.asarray(c)
     Z = np.asarray(Z, dtype=float)
     if Z.ndim == 1:
         Z = Z.reshape(-1, 1)
@@ -59,45 +62,43 @@ def handle_tvc(ident, start, stop, event, Z, n=None):
 
     nrow = ident.shape[0]
     for name, arr in (
-        ("start", start),
-        ("stop", stop),
-        ("event", event),
+        ("xl", xl),
+        ("xr", xr),
+        ("c", c),
         ("n", n),
     ):
         if arr.shape[0] != nrow:
             raise ValueError(
-                "ident, start, stop, event, Z and n must have the same "
-                "length; {} has {} rows, expected {}".format(
-                    name, arr.shape[0], nrow
-                )
+                "i, xl, xr, c, Z and n must have the same length; {} has {} "
+                "rows, expected {}".format(name, arr.shape[0], nrow)
             )
     if Z.shape[0] != nrow:
         raise ValueError(
-            "Z must have one row per interval (same length as ident); got "
+            "Z must have one row per interval (same length as i); got "
             "{} rows, expected {}".format(Z.shape[0], nrow)
         )
     if nrow == 0:
         raise ValueError("no interval rows were supplied")
-    if not (np.isfinite(start).all() and np.isfinite(stop).all()):
-        raise ValueError("start and stop must be finite")
-    if np.any(start >= stop):
+    if not (np.isfinite(xl).all() and np.isfinite(xr).all()):
+        raise ValueError("xl and xr must be finite")
+    if np.any(xl >= xr):
         raise ValueError(
-            "every interval must have start < stop (an interval covers the "
-            "open-closed window (start, stop])"
+            "every interval must have xl < xr (an interval covers the "
+            "open-closed window (xl, xr])"
         )
-    if not np.isin(event, [0, 1]).all():
-        raise ValueError("event must be 0 or 1")
+    if not np.isin(c, [0, 1]).all():
+        raise ValueError("c must be 0 (event) or 1 (right-censored)")
     if not np.isfinite(Z).all():
         raise ValueError("Z must contain only finite values")
 
-    # Reassemble in subject-contiguous, start-sorted order so the returned
+    # Reassemble in subject-contiguous, entry-sorted order so the returned
     # arrays are tidy and the per-subject checks are simple.
-    order = np.lexsort((start, ident))
-    ident, start, stop, event, n = (
+    order = np.lexsort((xl, ident))
+    ident, xl, xr, c, n = (
         ident[order],
-        start[order],
-        stop[order],
-        event[order],
+        xl[order],
+        xr[order],
+        c[order],
         n[order],
     )
     Z = Z[order]
@@ -106,32 +107,166 @@ def handle_tvc(ident, start, stop, event, Z, n=None):
         ident, return_index=True, return_counts=True
     )
     for u, f, cnt in zip(uniq, first, counts):
-        s_start = start[f : f + cnt]
-        s_stop = stop[f : f + cnt]
-        s_event = event[f : f + cnt]
+        s_xl = xl[f : f + cnt]
+        s_xr = xr[f : f + cnt]
+        s_c = c[f : f + cnt]
         # Non-overlapping: each interval must start at or after the previous
-        # interval's stop (touching intervals are contiguous, which is the
+        # interval's exit (touching intervals are contiguous, which is the
         # usual case; a gap is allowed -- the subject is simply not at risk in
         # the gap).
-        if cnt > 1 and np.any(s_start[1:] < s_stop[:-1] - 1e-12):
+        if cnt > 1 and np.any(s_xl[1:] < s_xr[:-1] - 1e-12):
             raise ValueError(
-                "subject {!r} has overlapping intervals; start-stop rows for "
-                "a subject must not overlap".format(u)
+                "subject {!r} has overlapping intervals; (xl, xr] rows for a "
+                "subject must not overlap".format(u)
             )
-        n_events = int((s_event == 1).sum())
+        n_events = int((s_c == 0).sum())
         if n_events > 1:
             raise ValueError(
-                "subject {!r} has more than one event=1 interval; a subject "
-                "may experience at most one terminal event".format(u)
+                "subject {!r} has more than one event (c=0) interval; a "
+                "subject may experience at most one terminal event".format(u)
             )
-        if n_events == 1 and s_event[-1] != 1:
+        if n_events == 1 and s_c[-1] != 0:
             raise ValueError(
-                "subject {!r} has event=1 on a non-final interval; the event "
-                "must terminate observation (it can only fall on the interval "
-                "with the largest stop time)".format(u)
+                "subject {!r} has an event (c=0) on a non-final interval; the "
+                "event must terminate observation (it can only fall on the "
+                "interval with the largest xr)".format(u)
             )
 
-    x = stop
-    c = np.where(event == 1, 0, 1).astype(int)
-    tl = start
+    x = xr
+    c = c.astype(int)
+    tl = xl
     return x, c, n, tl, Z, ident
+
+
+def handle_tvc_timeline(i, x, Z, c, n=None):
+    """
+    Convert a per-subject covariate *timeline* into the start-stop intervals
+    that :func:`handle_tvc` (and ``CoxPH.fit_tvc``) consume.
+
+    This is the timeline / ``xicnt``-style alternative to writing the
+    ``(start, stop]`` intervals by hand: instead of one row per interval, give
+    each subject's covariate history as a sequence of change-points in time,
+    with the subject's terminal event / censoring marked on its last row.
+
+    Parameters
+    ----------
+    i : array_like
+        Subject identifier for each timeline row (the ``xicnt`` item id). Rows
+        sharing an identifier are one subject's covariate history.
+    x : array_like
+        The time each row's covariate value *takes effect*. Within a subject
+        the times must be strictly increasing; the subject's **first** time is
+        its entry (delayed-entry / left-truncation) time and its **last** time
+        is the event / censoring time.
+    Z : array_like
+        The covariate vector effective from this row's ``x`` until the
+        subject's next row. The value on a subject's **last** (terminal) row is
+        ignored -- that row only marks the exit time and status -- so it may be
+        a repeat or a placeholder.
+    c : array_like
+        Censoring status. Only the value on each subject's **last** row is
+        read: ``0`` for an event at that time, ``1`` for right-censored. The
+        ``c`` on earlier (covariate-change) rows is ignored.
+    n : array_like, optional
+        Count weight per subject, read from the subject's terminal row.
+        Defaults to 1.
+
+    Returns
+    -------
+    i, xl, xr, c, Z, n : ndarray
+        Start-stop interval arrays, ready for ``CoxPH.fit_tvc`` /
+        :func:`handle_tvc`. A subject with ``m`` timeline rows yields ``m - 1``
+        contiguous intervals ``(xl_k, xr_k]`` carrying covariate ``Z_k``, and
+        the terminal status (``c = 0`` event) falls on the last interval.
+
+    Notes
+    -----
+    A subject needs at least two rows (an entry row and a terminal row) to
+    define one interval. Because times are strictly increasing within a
+    subject, a covariate change and the terminal event cannot share an instant;
+    put the change on the interval that ends at the event.
+    """
+    ident = np.asarray(i)
+    x = np.asarray(x, dtype=float)
+    c = np.asarray(c)
+    Z = np.asarray(Z, dtype=float)
+    if Z.ndim == 1:
+        Z = Z.reshape(-1, 1)
+    nrow = ident.shape[0]
+    n = np.ones(nrow) if n is None else np.asarray(n, dtype=float)
+
+    for name, arr in (("x", x), ("c", c), ("n", n)):
+        if arr.shape[0] != nrow:
+            raise ValueError(
+                "i, x, Z, c and n must have the same length; {} has {} "
+                "rows, expected {}".format(name, arr.shape[0], nrow)
+            )
+    if Z.shape[0] != nrow:
+        raise ValueError(
+            "Z must have one row per timeline entry (same length as i); "
+            "got {} rows, expected {}".format(Z.shape[0], nrow)
+        )
+    if nrow == 0:
+        raise ValueError("no timeline rows were supplied")
+    if not np.isfinite(x).all():
+        raise ValueError("x (timeline times) must be finite")
+
+    # Sort into subject-contiguous, time-increasing order.
+    order = np.lexsort((x, ident))
+    ident, x, c, n = ident[order], x[order], c[order], n[order]
+    Z = Z[order]
+
+    ids_out, xl_out, xr_out, c_out, n_out = [], [], [], [], []
+    Z_out = []
+    uniq, first, counts = np.unique(
+        ident, return_index=True, return_counts=True
+    )
+    for u, f, cnt in zip(uniq, first, counts):
+        if cnt < 2:
+            raise ValueError(
+                "subject {!r} has a single timeline row; a subject needs at "
+                "least an entry row and a terminal (event/censoring) row to "
+                "define one interval".format(u)
+            )
+        sx = x[f : f + cnt]
+        sc = c[f : f + cnt]
+        sZ = Z[f : f + cnt]
+        sn = n[f : f + cnt]
+        if np.any(np.diff(sx) <= 0):
+            raise ValueError(
+                "subject {!r} has non-increasing timeline times; each "
+                "subject's rows must have strictly increasing x".format(u)
+            )
+        terminal = sc[-1]
+        if terminal not in (0, 1):
+            raise ValueError(
+                "subject {!r} has a terminal status c={!r}; the last row's c "
+                "must be 0 (event) or 1 (right-censored)".format(u, terminal)
+            )
+        subject_weight = sn[-1]
+        # m rows -> m-1 intervals (xl_k, xr_k] carrying Z_k; the terminal
+        # status attaches to the last interval, which ends at the exit time.
+        # c follows surpyval's convention (0 event, 1 right-censored).
+        for k in range(cnt - 1):
+            ids_out.append(u)
+            xl_out.append(sx[k])
+            xr_out.append(sx[k + 1])
+            is_last = k == cnt - 2
+            c_out.append(0 if (is_last and terminal == 0) else 1)
+            Z_out.append(sZ[k])
+            n_out.append(subject_weight)
+
+    Z_arr = np.array(Z_out)
+    if not np.isfinite(Z_arr).all():
+        raise ValueError(
+            "Z must contain only finite values on every non-terminal timeline "
+            "row (each covariate segment must have a defined value)"
+        )
+    return (
+        np.array(ids_out),
+        np.array(xl_out, dtype=float),
+        np.array(xr_out, dtype=float),
+        np.array(c_out, dtype=int),
+        Z_arr,
+        np.array(n_out, dtype=float),
+    )

--- a/surpyval/univariate/regression/semi_parametric_regression_model.py
+++ b/surpyval/univariate/regression/semi_parametric_regression_model.py
@@ -304,8 +304,8 @@ class SemiParametricRegressionModel:
 
     def predict_tvc(
         self,
-        start: npt.ArrayLike,
-        stop: npt.ArrayLike,
+        xl: npt.ArrayLike,
+        xr: npt.ArrayLike,
         Z: npt.ArrayLike,
         times: "npt.ArrayLike | None" = None,
     ) -> "tuple[npt.NDArray, npt.NDArray, npt.NDArray]":
@@ -325,10 +325,10 @@ class SemiParametricRegressionModel:
 
         Parameters
         ----------
-        start, stop : array_like
-            The subject's covariate-path intervals ``(start, stop]``, one per
-            row (as given to :meth:`~...CoxPH.fit_tvc`). Usually contiguous
-            from ``0``.
+        xl, xr : array_like
+            The subject's covariate-path intervals ``(xl, xr]``, one per row
+            (as given to :meth:`~...CoxPH.fit_tvc`). Usually contiguous from
+            ``0``.
         Z : array_like
             The covariate row active on each interval, one row per interval.
         times : array_like, optional
@@ -342,32 +342,30 @@ class SemiParametricRegressionModel:
             of the subject along its covariate path. Outside the supplied path
             the nearest interval's covariate is held constant.
         """
-        start_a = np.atleast_1d(np.asarray(start, dtype=float))
-        stop_a = np.atleast_1d(np.asarray(stop, dtype=float))
+        xl_a = np.atleast_1d(np.asarray(xl, dtype=float))
+        xr_a = np.atleast_1d(np.asarray(xr, dtype=float))
         Z_a = np.asarray(Z, dtype=float)
         if Z_a.ndim == 1:
             Z_a = Z_a.reshape(-1, 1)
-        if not (start_a.shape[0] == stop_a.shape[0] == Z_a.shape[0]):
-            raise ValueError(
-                "start, stop and Z must have the same number of rows"
-            )
-        if np.any(start_a >= stop_a):
-            raise ValueError("every interval must have start < stop")
+        if not (xl_a.shape[0] == xr_a.shape[0] == Z_a.shape[0]):
+            raise ValueError("xl, xr and Z must have the same number of rows")
+        if np.any(xl_a >= xr_a):
+            raise ValueError("every interval must have xl < xr")
 
-        order = np.argsort(start_a)
-        start_a, stop_a, Z_a = start_a[order], stop_a[order], Z_a[order]
+        order = np.argsort(xl_a)
+        xl_a, xr_a, Z_a = xl_a[order], xr_a[order], Z_a[order]
 
         # The active interval at a baseline jump time u is the last interval
-        # whose start is at or before u; times outside the path are clamped to
+        # whose xl is at or before u; times outside the path are clamped to
         # the first/last interval (covariate held constant).
         base_t = self.x
-        active = np.searchsorted(start_a, base_t, side="right") - 1
-        active = np.clip(active, 0, start_a.shape[0] - 1)
+        active = np.searchsorted(xl_a, base_t, side="right") - 1
+        active = np.clip(active, 0, xl_a.shape[0] - 1)
         phi = np.exp(Z_a[active] @ self.beta)
         H_cum = np.cumsum(self.h0 * phi)
 
         if times is None:
-            within = (base_t > start_a[0]) & (base_t <= stop_a[-1])
+            within = (base_t > xl_a[0]) & (base_t <= xr_a[-1])
             query = base_t[within]
         else:
             query = np.atleast_1d(np.asarray(times, dtype=float))


### PR DESCRIPTION
Two related changes to the time-varying-covariate (TVC) Cox interface: a new **timeline input**, and a **harmonisation of the start-stop interface to surpyval's convention**.

## 1. Harmonised start-stop interface

`CoxPH.fit_tvc` / `fit_tvc_from_df` / `predict_tvc` (and `handle_tvc`) are renamed to match surpyval's vocabulary:

| old | new |
|---|---|
| `ident` | `i` (the `xicnt` item id) |
| `start` | `xl` (interval entry) |
| `stop` | `xr` (interval exit) |
| `event` | `c` |

`c` now follows the standard surpyval censoring convention — **`0` = event at `xr`, `1` = right-censored** — which is the **inverse** of the old `event` flag (`event=1` → `c=0`). The DataFrame entry point's columns are `xl_col` / `xr_col` / `c_col`. Positional calls are unaffected; keyword calls and the `event`→`c` values need updating.

## 2. Timeline (`xicnt`-style) input

`CoxPH.fit_tvc_timeline(i, x, Z, c, …)` / `fit_tvc_timeline_from_df(…)` accept a covariate **history** — one row per covariate change per subject — instead of pre-cut `(xl, xr]` intervals:

| col | meaning |
|---|---|
| `i` | subject id |
| `x` | time this covariate value takes effect; strictly increasing per subject |
| `Z` | covariate effective from `x` until the subject's next row (terminal row's `Z` ignored) |
| `c` | read on the subject's **last** row only: `0` event, `1` censored |
| `n` | optional per-subject count weight |

The first `x` is the (delayed-)entry time; the last is the exit. A subject with `m` rows expands to `m − 1` contiguous `(x_k, x_{k+1}]` intervals carrying `Z_k`.

```
i   x   Z     c              i  xl  xr  c    Z
1   0   0.0   —              1  0   5   1    0.0
1   5   1.0   —      ──▶      1  5   8   0    1.0
1   8   —     0              2  0   6   1    0.3
2   0   0.3   —
2   6   —     1
```

A new `handle_tvc_timeline` converter validates the timeline and expands it to start-stop arrays, fed through the **existing** `fit_tvc` / `handle_tvc` path — so a timeline fit is byte-identical to the equivalent start-stop fit, and it inherits the delayed-entry baseline and `predict_tvc`.

## Validation & tests

- Timeline fit **reproduces the start-stop `beta` exactly** (equivalence test over 150 subjects); the genuine time-varying-effect recovery test still passes, confirming the `c` inversion is correct.
- Covariates carried forward; delayed entry from the first time; terminal `Z` may be a placeholder / `NaN`.
- DataFrame variants match the array API and record `feature_names`.
- Validation rejects single-row subjects, non-increasing times, overlapping intervals, multiple events, an event on a non-final interval, and bad `c` values.

Full `tests/univariate/regression/` suite (203 tests) passes; flake8/black/isort/mypy clean.

Note: Cox-only, matching the existing `fit_tvc`. The same layout is the natural input to reuse if TVC fitting is extended to the parametric families (#150).

🤖 Generated with [Claude Code](https://claude.com/claude-code)