### PR TITLE
Time-varying-covariate evaluation across families: sf_tvc + StepSchedule (#170)

### DIFF
--- a/docs/Regression Modelling with SurPyval.rst
+++ b/docs/Regression Modelling with SurPyval.rst
@@ -223,15 +223,19 @@ format directly — splitting a subject into intervals with the same covariates
 leaves the fit unchanged.
 
 Use :meth:`CoxPH.fit_tvc` (arrays) or :meth:`CoxPH.fit_tvc_from_df` (a
-start-stop ``DataFrame``). In the example below a covariate ``stress`` switches
-from 0 to 1 at a random time for each unit and genuinely raises the hazard once
-it turns on; units that fail before the switch contribute a single interval,
-those that survive it contribute two:
+start-stop ``DataFrame``). The interval bounds follow surpyval's ``xl`` / ``xr``
+naming and the status column ``c`` follows surpyval's censoring convention —
+``c = 0`` for the terminal event, ``c = 1`` for a right-censored interval end
+(a covariate change or administrative end). In the example below a covariate
+``stress`` switches from 0 to 1 at a random time for each unit and genuinely
+raises the hazard once it turns on; units that fail before the switch
+contribute a single interval, those that survive it contribute two:
 
 .. jupyter-execute::
 
     import pandas as pd
     from surpyval import CoxPH
+    from surpyval.univariate.regression import StepSchedule
 
     rng = np.random.default_rng(0)
     n, lam, beta = 2000, 0.5, 1.0
@@ -243,40 +247,63 @@ those that survive it contribute two:
     rows = []
     for i in range(n):
         if T[i] <= switch[i]:                    # failed before the switch
-            rows.append((i, 0.0, T[i], 1, 0.0))
+            rows.append((i, 0.0, T[i], 0, 0.0))     # c=0: event on one interval
         else:                                    # survived it: two intervals
-            rows.append((i, 0.0, switch[i], 0, 0.0))
-            rows.append((i, switch[i], T[i], 1, 1.0))
-    df = pd.DataFrame(rows, columns=['id', 'start', 'stop', 'event', 'stress'])
+            rows.append((i, 0.0, switch[i], 1, 0.0))  # c=1: covariate change
+            rows.append((i, switch[i], T[i], 0, 1.0)) # c=0: terminal event
+    df = pd.DataFrame(rows, columns=['id', 'xl', 'xr', 'c', 'stress'])
 
     model = CoxPH.fit_tvc_from_df(
-        df, id_col='id', start_col='start', stop_col='stop',
-        event_col='event', Z_cols='stress',
+        df, id_col='id', xl_col='xl', xr_col='xr', c_col='c', Z_cols='stress',
     )
     model
 
 The fitted coefficient recovers the simulated log-hazard-ratio of the stress
 (:math:`\beta \approx 1`) — a plain Cox fit that ignored the timing of the
-switch could not.
+switch could not. (A covariate *timeline* — one row per change per subject —
+can be given instead of explicit intervals with
+:meth:`CoxPH.fit_tvc_timeline`.)
 
 Because survival now depends on the *whole* covariate path, evaluate it with
-:meth:`~surpyval.univariate.regression.semi_parametric_regression_model.SemiParametricRegressionModel.predict_tvc`,
-passing a subject's intervals. It returns the times, survival and cumulative
-hazard along that path; with a single constant interval it reduces exactly to
-``sf``. Here a unit stressed from ``t = 1`` onward has visibly lower survival
-than one never stressed:
+``sf_tvc``, describing the path as a :class:`StepSchedule` (or ``(xl, Z)``
+arrays). This is the same ``sf_tvc`` interface every regression family exposes
+(see :ref:`tvc-parametric`); with a single constant segment it reduces exactly
+to ``sf``. Here a unit stressed from ``t = 1`` onward has visibly lower
+survival than one never stressed:
 
 .. jupyter-execute::
 
-    t_never, s_never, _ = model.predict_tvc(start=[0.0], stop=[3.0], Z=[[0.0]])
-    t_late, s_late, _ = model.predict_tvc(
-        start=[0.0, 1.0], stop=[1.0, 3.0], Z=[[0.0], [1.0]]
-    )
-    plt.step(t_never, s_never, where='post', label='never stressed')
-    plt.step(t_late, s_late, where='post', label='stressed after t=1')
+    t = np.linspace(0.01, 3.0, 100)
+    never = StepSchedule.constant([0.0])
+    late = StepSchedule.from_changepoints([0.0, 1.0], [[0.0], [1.0]])
+    plt.plot(t, model.sf_tvc(t, never), label='never stressed')
+    plt.plot(t, model.sf_tvc(t, late), label='stressed after t=1')
     plt.legend()
     plt.xlabel('Time')
     plt.ylabel('S(t)')
+
+The older interval-oriented
+:meth:`~surpyval.univariate.regression.semi_parametric_regression_model.SemiParametricRegressionModel.predict_tvc`
+— which returns the survival and cumulative hazard at the baseline jump times
+along a subject's ``(xl, xr]`` intervals — remains available and agrees with
+``sf_tvc`` exactly.
+
+.. note::
+
+   **Predicting along a future covariate path.** Some packages (lifelines, for
+   one) deliberately *refuse* to produce a survival curve from a
+   time-varying-covariate Cox model, reasoning that a subject's future
+   covariate values are unknown: you cannot know :math:`Z(u)` for :math:`u` up
+   to a future time :math:`t`, so an *observed* subject's survival past its
+   last record is undefined. SurPyval takes a different view because ``sf_tvc``
+   answers a different question. You *supply* the covariate path as a plan or a
+   hypothesis — mission phases, a periodic duty cycle, a scheduled load
+   increase — and given that stated :math:`Z(\cdot)` the survival
+   :math:`S(t \mid Z(\cdot))` is exactly defined. This is scenario / what-if
+   evaluation under an assumed trajectory, not a claim to know the future; the
+   answer is only ever as good as the covariate plan you feed it. When the
+   future schedule is genuinely unknown, that is a reason not to specify one —
+   not a reason for the model to refuse an otherwise well-posed question.
 
 Only left-truncation / delayed entry is available for Cox (supply a 1-D ``tl``
 to :meth:`CoxPH.fit`); right or interval truncation is rejected, because the
@@ -683,6 +710,85 @@ The ``PO`` factory accepts any distribution:
 A practical rule of thumb: if the Kaplan-Meier curves for different covariate
 groups converge at long times (rather than remaining parallel on the log-hazard
 scale), PO is likely a better fit than PH.
+
+
+.. _tvc-parametric:
+
+Time-varying covariates across families
+---------------------------------------
+
+The counting-process machinery shown for Cox is not unique to it. Wherever the
+cumulative hazard is *additive over disjoint time intervals*, a
+time-varying-covariate subject factorises exactly into one left-truncated
+observation per constant-covariate interval — so the parametric proportional
+hazards (``PH``) and additive hazards (``AH``) families fit start-stop data
+with the same ``fit_tvc`` / ``fit_tvc_timeline`` (and ``_from_df``) methods and
+the same ``i`` / ``xl`` / ``xr`` / ``c`` convention as Cox:
+
+.. jupyter-execute::
+
+    from surpyval import WeibullPH
+
+    ph = WeibullPH.fit_tvc_from_df(
+        df, id_col='id', xl_col='xl', xr_col='xr', c_col='c', Z_cols='stress',
+    )
+    ph.params
+
+**Evaluating a covariate path.** Every family that has a closed form along a
+step path — Cox, parametric ``PH`` and ``AH``, and accelerated failure time
+(``AFT``) — exposes the same ``sf_tvc(x, Z, xl=None, given=None)`` (plus the
+matching ``Hf_tvc``). Pass either ``(xl, Z)`` arrays or a :class:`StepSchedule`,
+and ``given=`` for conditional survival :math:`S(x \mid \text{survived to } g)`.
+Proportional and additive hazards accumulate a cumulative hazard over the
+segments; AFT instead accumulates an *accelerated age*
+:math:`\psi(x) = \sum e^{\beta'z}\,(b - a)` and evaluates the baseline once at
+:math:`\psi`. Proportional odds has no such closed form yet, and raises.
+
+Describing the covariate path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A :class:`StepSchedule` is a piecewise-constant covariate path. The covariate
+*must* be a step function — that is precisely what keeps each family's
+cumulative form exact — so a schedule can be built structurally (change-points,
+explicit intervals, or a repeating duty cycle) or from a step-valued expression
+in ``t``:
+
+.. jupyter-execute::
+
+    # structural
+    StepSchedule.from_changepoints([0.0, 500.0], [[0.0], [1.0]])   # a switch
+    StepSchedule.cyclic([0, 8], [[1.0], [0.0]], period=24)         # 8-on/16-off
+
+    # expression in t, materialised to a horizon
+    duty = StepSchedule.from_expression("1.0 if t % 24 < 8 else 0.0",
+                                        horizon=96)
+    trend = StepSchedule.from_expression("0.3 * 2 ** floor(t / 1000)",
+                                         horizon=5000)
+    trend
+
+An expression is proved piecewise-constant *statically*, from its syntax tree,
+before it is ever evaluated: ``t`` may reach the value only through a quantizer
+(``floor``, ``ceil``, ``//``) or a comparison. A genuinely continuous covariate
+(``0.3 + 1e-4 * t``, ``sin(t)``) is rejected with ``StepValuedError`` rather
+than silently returning a wrong answer — a covariate that varies continuously
+would break the exactness of the segment sum. (surpyval owns only this
+step-valued guarantee; sandboxing an *untrusted* expression string is the
+calling application's responsibility.)
+
+Evaluating the fitted parametric model along a path is then identical to the
+Cox case:
+
+.. jupyter-execute::
+
+    t = np.linspace(0.1, 3.0, 100)
+    never = ph.sf_tvc(t, StepSchedule.constant([0.0]))
+    late = ph.sf_tvc(t, StepSchedule.from_changepoints([0.0, 1.0],
+                                                       [[0.0], [1.0]]))
+    plt.plot(t, never, label='never stressed')
+    plt.plot(t, late, label='stressed after t=1')
+    plt.legend()
+    plt.xlabel('Time')
+    plt.ylabel('S(t)')
 
 
 Confidence Bounds

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -96,6 +96,25 @@ Correctness
 Regression
 ~~~~~~~~~~
 
+- **Evaluate a fitted PH / AH model along a time-varying covariate path**
+  (#170). A fitted ``WeibullPH`` (any ``PH(dist)``) or ``WeibullAH`` (any
+  ``AH(dist)``) gains ``sf_tvc`` (and ``Hf_tvc``): given a piecewise-constant
+  covariate schedule ``Z(t)`` it returns the resulting survival ``S(t)``, with
+  an optional ``given=`` age for conditional survival. Because the cumulative
+  hazard is additive over disjoint intervals, the survival along a step path is
+  the exact sum of the per-segment increments and reduces to ordinary ``sf``
+  for a constant covariate. The covariate path is described by a new
+  ``StepSchedule``, built structurally (``from_changepoints`` / ``from_intervals``
+  / ``cyclic`` for duty cycles) or from a step-valued expression string in
+  ``t`` (``from_expression``, e.g. ``"0.9 if t % 24 < 8 else 0.3"`` or
+  ``"0.3 * 2 ** floor(t / 1000)"``). Expressions are *proved* piecewise-constant
+  from their syntax tree before evaluation -- ``t`` may reach the value only
+  through a quantizer (``floor`` / ``ceil`` / ``//``) or a comparison -- so a
+  continuously-varying covariate (``0.3 + 1e-4 * t``, ``sin(t)``) is rejected
+  with ``StepValuedError`` rather than silently returning a wrong answer.
+  ``sf_tvc`` may be given ``(xl, Z)`` arrays directly or a ``StepSchedule``.
+  Accelerated failure time (needs an accumulated accelerated age) and
+  proportional odds (no additive hazard) do not compose this way and raise.
 - **Time-varying covariates for the parametric PH and additive-hazards
   families** (#150). ``WeibullPH`` (and every ``PH(dist)``) and ``WeibullAH``
   (every ``AH(dist)``) gain ``fit_tvc`` / ``fit_tvc_timeline`` and the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -96,14 +96,18 @@ Correctness
 Regression
 ~~~~~~~~~~
 
-- **Evaluate a fitted PH / AH model along a time-varying covariate path**
-  (#170). A fitted ``WeibullPH`` (any ``PH(dist)``) or ``WeibullAH`` (any
-  ``AH(dist)``) gains ``sf_tvc`` (and ``Hf_tvc``): given a piecewise-constant
-  covariate schedule ``Z(t)`` it returns the resulting survival ``S(t)``, with
-  an optional ``given=`` age for conditional survival. Because the cumulative
-  hazard is additive over disjoint intervals, the survival along a step path is
-  the exact sum of the per-segment increments and reduces to ordinary ``sf``
-  for a constant covariate. The covariate path is described by a new
+- **Evaluate a fitted regression model along a time-varying covariate path**
+  (#170). A fitted ``WeibullPH`` (any ``PH(dist)``), ``WeibullAH`` (any
+  ``AH(dist)``) or ``WeibullAFT`` (any ``AFT(dist)``) gains ``sf_tvc`` (and
+  ``Hf_tvc``): given a piecewise-constant covariate schedule ``Z(t)`` it
+  returns the resulting survival ``S(t)``, with an optional ``given=`` age for
+  conditional survival. For proportional and additive hazards the cumulative
+  hazard is additive over disjoint intervals, so the survival along a step path
+  is the exact sum of the per-segment increments; for accelerated failure time
+  the path instead accumulates an *accelerated age*
+  ``ψ(x) = Σ exp(β'z)·(b − a)`` fed once through the baseline. Either way it
+  reduces to ordinary ``sf`` for a constant covariate. The covariate path is
+  described by a new
   ``StepSchedule``, built structurally (``from_changepoints`` / ``from_intervals``
   / ``cyclic`` for duty cycles) or from a step-valued expression string in
   ``t`` (``from_expression``, e.g. ``"0.9 if t % 24 < 8 else 0.3"`` or
@@ -116,9 +120,8 @@ Regression
   The semi-parametric ``CoxPH`` gains the same ``sf_tvc`` / ``Hf_tvc`` and
   ``StepSchedule`` convention (summing the fitted baseline-hazard jumps along
   the path); the existing interval-oriented ``predict_tvc`` is unchanged and
-  ``sf_tvc`` agrees with it exactly. Accelerated failure time (needs an
-  accumulated accelerated age) and proportional odds (no additive hazard) do
-  not compose this way and raise.
+  ``sf_tvc`` agrees with it exactly. Only proportional odds does not yet
+  expose a time-varying-covariate evaluation and raises.
 - **Time-varying covariates for the parametric PH and additive-hazards
   families** (#150). ``WeibullPH`` (and every ``PH(dist)``) and ``WeibullAH``
   (every ``AH(dist)``) gain ``fit_tvc`` / ``fit_tvc_timeline`` and the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -113,8 +113,12 @@ Regression
   continuously-varying covariate (``0.3 + 1e-4 * t``, ``sin(t)``) is rejected
   with ``StepValuedError`` rather than silently returning a wrong answer.
   ``sf_tvc`` may be given ``(xl, Z)`` arrays directly or a ``StepSchedule``.
-  Accelerated failure time (needs an accumulated accelerated age) and
-  proportional odds (no additive hazard) do not compose this way and raise.
+  The semi-parametric ``CoxPH`` gains the same ``sf_tvc`` / ``Hf_tvc`` and
+  ``StepSchedule`` convention (summing the fitted baseline-hazard jumps along
+  the path); the existing interval-oriented ``predict_tvc`` is unchanged and
+  ``sf_tvc`` agrees with it exactly. Accelerated failure time (needs an
+  accumulated accelerated age) and proportional odds (no additive hazard) do
+  not compose this way and raise.
 - **Time-varying covariates for the parametric PH and additive-hazards
   families** (#150). ``WeibullPH`` (and every ``PH(dist)``) and ``WeibullAH``
   (every ``AH(dist)``) gain ``fit_tvc`` / ``fit_tvc_timeline`` and the

--- a/docs/regression/cox_ph.rst
+++ b/docs/regression/cox_ph.rst
@@ -13,8 +13,12 @@ Fitted model
 
 The object returned by :meth:`CoxPH.fit` / :meth:`CoxPH.fit_tvc`. It exposes
 the usual survival functions at a covariate vector (``sf``, ``ff``, ``df``,
-``hf``, ``Hf``) and, for models fitted from time-varying-covariate (start-stop)
-data, ``predict_tvc`` for the survival of a subject along a covariate path.
+``hf``, ``Hf``) and, for a time-varying covariate, the survival along a
+covariate path: ``sf_tvc`` / ``Hf_tvc`` take a piecewise-constant
+:class:`~surpyval.univariate.regression.tvc_schedule.StepSchedule` (or
+``(xl, Z)`` arrays), the same interface the parametric families use, while the
+older interval-oriented ``predict_tvc`` returns the survival at the baseline
+jump times along a subject's ``(xl, xr]`` intervals.
 
 .. autoclass:: surpyval.univariate.regression.semi_parametric_regression_model.SemiParametricRegressionModel
    :members:

--- a/docs/regression/parametric.rst
+++ b/docs/regression/parametric.rst
@@ -13,6 +13,16 @@ All parametric regression models use :math:`\phi(Z) = e^{\beta'Z}` (log-linear
 covariates) except Accelerated Life models, which use domain-specific stress
 functions.
 
+**Time-varying covariates.** Where the cumulative hazard is additive over
+disjoint intervals, the proportional-hazards and additive-hazards families
+(``WeibullPH`` / ``PH(dist)`` and ``WeibullAH`` / ``AH(dist)``) also *fit*
+start-stop time-varying-covariate data with ``fit_tvc`` / ``fit_tvc_timeline``,
+reusing the ordinary maximum-likelihood fit. A fitted PH, AH or AFT model can
+then be *evaluated* along a piecewise-constant covariate path with ``sf_tvc`` /
+``Hf_tvc``, describing the path as a
+:class:`~surpyval.univariate.regression.tvc_schedule.StepSchedule`. See
+:ref:`tvc-parametric` in the how-to guide.
+
 
 Proportional Hazards (PH)
 --------------------------
@@ -118,4 +128,17 @@ Custom life models can be created by subclassing ``LifeModel``::
     :members: fit
 
 .. autoclass:: surpyval.univariate.regression.accelerated_life.lifemodel.LifeModel
+    :members:
+
+
+Time-varying covariate schedules
+--------------------------------
+
+A ``StepSchedule`` describes a piecewise-constant covariate path ``Z(t)`` for
+``sf_tvc`` / ``Hf_tvc`` evaluation. Build one structurally
+(``from_changepoints`` / ``from_intervals`` / ``cyclic`` / ``constant``) or from
+a step-valued expression string in ``t`` (``from_expression``); see
+:ref:`tvc-parametric` for worked examples.
+
+.. autoclass:: surpyval.univariate.regression.tvc_schedule.StepSchedule
     :members:

--- a/surpyval/tests/univariate/regression/test_tvc_evaluation.py
+++ b/surpyval/tests/univariate/regression/test_tvc_evaluation.py
@@ -143,7 +143,7 @@ def _fit(F, seed=0, n=300):
     return F.fit(x=x, Z=Z, c=c)
 
 
-@pytest.mark.parametrize("F", [WeibullPH, WeibullAH])
+@pytest.mark.parametrize("F", [WeibullPH, WeibullAH, WeibullAFT])
 def test_constant_schedule_reduces_to_sf(F):
     m = _fit(F)
     z = 0.7
@@ -153,7 +153,7 @@ def test_constant_schedule_reduces_to_sf(F):
     assert np.allclose(a, b)
 
 
-@pytest.mark.parametrize("F", [WeibullPH, WeibullAH])
+@pytest.mark.parametrize("F", [WeibullPH, WeibullAH, WeibullAFT])
 def test_array_form_matches_schedule(F):
     m = _fit(F)
     xl = np.array([0.0, 4.0])
@@ -179,13 +179,31 @@ def test_hf_tvc_equals_manual_telescoping(F):
     assert np.isclose(got, manual)
 
 
-@pytest.mark.parametrize("F", [WeibullPH, WeibullAH])
+@pytest.mark.parametrize("F", [WeibullPH, WeibullAH, WeibullAFT])
 def test_conditional_survival(F):
     m = _fit(F)
     sched = StepSchedule.from_changepoints([0.0, 4.0], [[0.2], [0.9]])
     cond = m.sf_tvc([6.0], sched, given=3.0)
     manual = m.sf_tvc([6.0], sched) / m.sf_tvc([3.0], sched)
     assert np.allclose(cond, manual)
+
+
+def test_aft_hf_tvc_equals_accumulated_accelerated_age():
+    # AFT rescales time: each segment contributes phi(z) * width of accelerated
+    # age, then the baseline cumulative hazard is evaluated once at the total.
+    m = _fit(WeibullAFT)
+    xl = np.array([0.0, 4.0])
+    Z = np.array([[0.2], [0.9]])
+    beta = np.asarray(m.params[m.k_dist :])
+    dist_params = m.params[: m.k_dist]
+    psi = np.exp(0.2 * beta[0]) * 4.0 + np.exp(0.9 * beta[0]) * (6.0 - 4.0)
+    manual = float(
+        np.asarray(
+            m.model.Hf_dist(np.array([psi]), *dist_params), dtype=float
+        ).ravel()[0]
+    )
+    got = m.Hf_tvc([6.0], Z, xl=xl)[0]
+    assert np.isclose(got, manual)
 
 
 def test_sf_tvc_survival_decreasing_and_bounded():
@@ -197,10 +215,9 @@ def test_sf_tvc_survival_decreasing_and_bounded():
     assert np.all(np.diff(s) <= 1e-12)  # monotone non-increasing
 
 
-@pytest.mark.parametrize("F", [WeibullAFT, WeibullPO])
-def test_aft_po_reject_tvc_evaluation(F):
-    m = _fit(F)
-    with pytest.raises(NotImplementedError, match="proportional-hazards"):
+def test_po_rejects_tvc_evaluation():
+    m = _fit(WeibullPO)
+    with pytest.raises(NotImplementedError, match="proportional-odds"):
         m.sf_tvc([2.0], StepSchedule.constant([0.5]))
 
 

--- a/surpyval/tests/univariate/regression/test_tvc_evaluation.py
+++ b/surpyval/tests/univariate/regression/test_tvc_evaluation.py
@@ -18,7 +18,11 @@ import numpy as np
 import pytest
 
 from surpyval import WeibullAFT, WeibullAH, WeibullPH, WeibullPO
-from surpyval.univariate.regression import StepSchedule, StepValuedError
+from surpyval.univariate.regression import (
+    CoxPH,
+    StepSchedule,
+    StepValuedError,
+)
 
 # -- StepSchedule (structural) --------------------------------------------
 
@@ -228,3 +232,93 @@ def test_end_to_end_fit_tvc_then_sf_tvc():
     s = model.sf_tvc([2.0, 5.0, 8.0], sched)
     assert s.shape == (3,)
     assert np.all((s >= 0) & (s <= 1)) and s[0] >= s[-1]
+
+
+# -- sf_tvc on the semi-parametric Cox model ------------------------------
+#
+# Cox shares the sf_tvc / StepSchedule convention with the parametric
+# families; sf_tvc is the schedule-oriented counterpart of the existing
+# interval-oriented predict_tvc, and the two must agree.
+
+
+def _fit_cox_tvc(seed=3, n=40):
+    rng = np.random.default_rng(seed)
+    ident, xl, xr, c, Z = [], [], [], [], []
+    for s in range(n):
+        split = 3.0
+        end = split + np.abs(rng.weibull(1.4)) * 6.0 + 0.5
+        z0 = rng.normal(0, 1)
+        ident += [s, s]
+        xl += [0.0, split]
+        xr += [split, end]
+        c += [1, 0]
+        Z += [[z0], [z0 + 0.2]]
+    return CoxPH.fit_tvc(
+        np.array(ident), np.array(xl), np.array(xr), np.array(c), np.array(Z)
+    )
+
+
+def test_cox_sf_tvc_matches_predict_tvc():
+    m = _fit_cox_tvc()
+    xl = np.array([0.0, 3.0])
+    xr = np.array([3.0, 8.0])
+    Z = np.array([[0.5], [0.7]])
+    times = np.array([2.0, 5.0, 7.5])
+    _, sf_pred, _ = m.predict_tvc(xl, xr, Z, times=times)
+    sf_new = m.sf_tvc(times, StepSchedule.from_intervals(xl, xr, Z))
+    assert np.allclose(sf_new, sf_pred)
+
+
+def test_cox_array_form_matches_schedule():
+    m = _fit_cox_tvc()
+    times = np.array([2.0, 5.0, 7.5])
+    a = m.sf_tvc(times, np.array([[0.5], [0.7]]), xl=np.array([0.0, 3.0]))
+    b = m.sf_tvc(times, StepSchedule.from_changepoints([0.0, 3.0], [0.5, 0.7]))
+    assert np.allclose(a, b)
+
+
+def test_cox_constant_reduces_to_sf_above_first_event():
+    # Cox's sf clamps the left tail (via _get_idx) to the first jump, so the
+    # constant reduction holds at/above the first event time, where the
+    # Breslow baseline is well defined.
+    m = _fit_cox_tvc()
+    z = 0.6
+    t = m.x[m.x > 0][:5]
+    a = m.sf_tvc(t, StepSchedule.constant([z]))
+    b = np.asarray(m.sf(t, np.array([z])), dtype=float).ravel()
+    assert np.allclose(a, b)
+
+
+def test_cox_conditional_survival():
+    m = _fit_cox_tvc()
+    sched = StepSchedule.from_intervals([0.0, 3.0], [3.0, 8.0], [[0.5], [0.7]])
+    cond = m.sf_tvc([7.5], sched, given=2.0)
+    manual = m.sf_tvc([7.5], sched) / m.sf_tvc([2.0], sched)
+    assert np.allclose(cond, manual)
+
+
+def test_cox_expression_schedule():
+    m = _fit_cox_tvc()
+    es = StepSchedule.from_expression(
+        "0.9 if t < 3 else 0.3", horizon=8, resolution=0.5
+    )
+    s = m.sf_tvc([2.0, 6.0], es)
+    assert np.all((s >= 0) & (s <= 1)) and s[0] >= s[1]
+
+
+def test_cox_covariate_count_checked():
+    m = _fit_cox_tvc()  # one covariate
+    with pytest.raises(ValueError, match="covariate"):
+        m.sf_tvc([2.0], StepSchedule.constant([0.5, 0.5]))
+
+
+def test_cox_stratified_rejects_sf_tvc():
+    rng = np.random.default_rng(0)
+    n = 120
+    Z = rng.normal(0, 1, (n, 1))
+    x = np.abs(rng.weibull(1.5, n) * 10) + 0.5
+    c = np.zeros(n)
+    strata = (Z[:, 0] > 0).astype(int)
+    m = CoxPH.fit(x=x, Z=Z, c=c, strata=strata)
+    with pytest.raises(NotImplementedError, match="stratified"):
+        m.sf_tvc([2.0], StepSchedule.constant([0.5]))

--- a/surpyval/tests/univariate/regression/test_tvc_evaluation.py
+++ b/surpyval/tests/univariate/regression/test_tvc_evaluation.py
@@ -1,0 +1,230 @@
+r"""
+Time-varying-covariate *evaluation*: ``StepSchedule`` and ``sf_tvc`` (#170).
+
+Where ``fit_tvc`` (#150) reshapes start-stop data to *fit* a proportional- or
+additive-hazards model, ``sf_tvc`` evaluates an *already-fitted* model along a
+piecewise-constant covariate path ``Z(t)``. The covariate path is described by
+a :class:`StepSchedule`, built either structurally (change-points, intervals, a
+cyclic pattern) or from a step-valued expression string whose step-ness is
+proved statically before it is evaluated.
+
+The evaluation is exact for these families because the cumulative hazard is
+additive over disjoint segments, so along a step path it is the sum of the
+per-segment increments -- and therefore collapses to the ordinary ``sf`` when
+the covariate is constant.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval import WeibullAFT, WeibullAH, WeibullPH, WeibullPO
+from surpyval.univariate.regression import StepSchedule, StepValuedError
+
+# -- StepSchedule (structural) --------------------------------------------
+
+
+def test_constant_schedule_is_single_segment():
+    s = StepSchedule.constant([0.5])
+    starts, ends, Z = s.segments(10.0)
+    assert starts.tolist() == [0.0]
+    assert ends.tolist() == [10.0]
+    assert Z.tolist() == [[0.5]]
+    assert s.p == 1
+
+
+def test_from_changepoints_segments():
+    s = StepSchedule.from_changepoints([0, 500, 800], [0.3, 0.9, 0.3])
+    starts, ends, Z = s.segments(1000.0)
+    assert starts.tolist() == [0.0, 500.0, 800.0]
+    assert ends.tolist() == [500.0, 800.0, 1000.0]
+    assert Z.ravel().tolist() == [0.3, 0.9, 0.3]
+
+
+def test_from_intervals_matches_changepoints():
+    a = StepSchedule.from_intervals([0, 4], [4, 10], [[0.2], [0.9]])
+    b = StepSchedule.from_changepoints([0, 4], [[0.2], [0.9]])
+    for sa, sb in zip(a.segments(8.0), b.segments(8.0)):
+        assert np.allclose(sa, sb)
+
+
+def test_from_intervals_rejects_gaps():
+    with pytest.raises(ValueError, match="contiguous"):
+        StepSchedule.from_intervals([0, 5], [4, 10], [[0.2], [0.9]])
+
+
+def test_cyclic_duty_cycle_repeats_to_horizon():
+    # 8 "on" (0.9) then 16 "off" (0.3), period 24.
+    s = StepSchedule.cyclic([0, 8], [[0.9], [0.3]], 24)
+    starts, ends, Z = s.segments(50.0)
+    assert starts.tolist() == [0.0, 8.0, 24.0, 32.0, 48.0]
+    assert ends.tolist() == [8.0, 24.0, 32.0, 48.0, 50.0]
+    assert Z.ravel().tolist() == [0.9, 0.3, 0.9, 0.3, 0.9]
+
+
+def test_multivariate_schedule():
+    s = StepSchedule.from_changepoints([0, 5], [[0.1, 1.0], [0.2, 2.0]])
+    assert s.p == 2
+    starts, ends, Z = s.segments(10.0)
+    assert Z.tolist() == [[0.1, 1.0], [0.2, 2.0]]
+
+
+def test_schedule_validation():
+    with pytest.raises(ValueError, match="strictly increasing"):
+        StepSchedule(np.array([0.0, 0.0, 1.0]), np.array([[1.0], [2.0]]))
+    with pytest.raises(ValueError, match="one more entry"):
+        StepSchedule(np.array([0.0, 1.0]), np.array([[1.0], [2.0]]))
+
+
+# -- StepSchedule (expression + step guard) -------------------------------
+
+
+def test_expression_duty_cycle_matches_cyclic():
+    expr = StepSchedule.from_expression(
+        "0.9 if t % 24 < 8 else 0.3", horizon=50, resolution=1.0
+    )
+    cyc = StepSchedule.cyclic([0, 8], [[0.9], [0.3]], 24)
+    se, _, ze = expr.segments(50.0)
+    sc, _, zc = cyc.segments(50.0)
+    assert np.allclose(se, sc)
+    assert np.allclose(ze.ravel(), zc.ravel())
+
+
+def test_expression_stepped_doubling():
+    s = StepSchedule.from_expression(
+        "0.3 * 2 ** floor(t / 1000)", horizon=3500, resolution=1.0
+    )
+    starts, ends, Z = s.segments(3500.0)
+    assert starts.tolist() == [0.0, 1000.0, 2000.0, 3000.0]
+    assert np.allclose(Z.ravel(), [0.3, 0.6, 1.2, 2.4])
+
+
+def test_expression_multivariate():
+    s = StepSchedule.from_expression(
+        ["0.3 if t < 10 else 0.9", "1.0"], horizon=20, resolution=1.0
+    )
+    assert s.p == 2
+    _, _, Z = s.segments(20.0)
+    # second covariate constant at 1.0 throughout
+    assert np.allclose(Z[:, 1], 1.0)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "0.3 + 1e-4 * t",  # continuous ramp
+        "0.3 * 2 ** (t / 1000)",  # smooth doubling
+        "sin(t)",  # unknown / continuous fn
+        "t",  # bare t
+    ],
+)
+def test_expression_rejects_continuous(bad):
+    with pytest.raises(StepValuedError):
+        StepSchedule.from_expression(bad, horizon=100, resolution=1.0)
+
+
+def test_expression_accepts_constant_and_phase():
+    # both are step-valued and must be accepted
+    StepSchedule.from_expression("0.3", horizon=10)
+    StepSchedule.from_expression("0.3 if t < 500 else 0.9", horizon=1000)
+
+
+# -- sf_tvc on fitted PH / AH models --------------------------------------
+
+
+def _fit(F, seed=0, n=300):
+    rng = np.random.default_rng(seed)
+    Z = rng.normal(0, 1, (n, 1))
+    x = np.abs(rng.weibull(1.6, n) * 10 * np.exp(-0.4 * Z[:, 0])) + 0.5
+    c = np.zeros(n)
+    return F.fit(x=x, Z=Z, c=c)
+
+
+@pytest.mark.parametrize("F", [WeibullPH, WeibullAH])
+def test_constant_schedule_reduces_to_sf(F):
+    m = _fit(F)
+    z = 0.7
+    x = np.array([2.0, 5.0, 9.0])
+    a = m.sf_tvc(x, StepSchedule.constant([z]))
+    b = np.asarray(m.sf(x, np.array([[z]])), dtype=float).ravel()
+    assert np.allclose(a, b)
+
+
+@pytest.mark.parametrize("F", [WeibullPH, WeibullAH])
+def test_array_form_matches_schedule(F):
+    m = _fit(F)
+    xl = np.array([0.0, 4.0])
+    Z = np.array([[0.2], [0.9]])
+    a = m.sf_tvc([3.0, 6.0], Z, xl=xl)
+    b = m.sf_tvc([3.0, 6.0], StepSchedule.from_changepoints(xl, Z))
+    assert np.allclose(a, b)
+
+
+@pytest.mark.parametrize("F", [WeibullPH, WeibullAH])
+def test_hf_tvc_equals_manual_telescoping(F):
+    m = _fit(F)
+    xl = np.array([0.0, 4.0])
+    Z = np.array([[0.2], [0.9]])
+    # H(6) = [Hf(4, z0) - 0] + [Hf(6, z1) - Hf(4, z1)]
+    Hf = lambda t, z: float(  # noqa: E731
+        np.asarray(
+            m.model.Hf(np.array([t]), np.array([z]), *m.params)
+        ).ravel()[0]
+    )
+    manual = (Hf(4.0, [0.2]) - 0.0) + (Hf(6.0, [0.9]) - Hf(4.0, [0.9]))
+    got = m.Hf_tvc([6.0], Z, xl=xl)[0]
+    assert np.isclose(got, manual)
+
+
+@pytest.mark.parametrize("F", [WeibullPH, WeibullAH])
+def test_conditional_survival(F):
+    m = _fit(F)
+    sched = StepSchedule.from_changepoints([0.0, 4.0], [[0.2], [0.9]])
+    cond = m.sf_tvc([6.0], sched, given=3.0)
+    manual = m.sf_tvc([6.0], sched) / m.sf_tvc([3.0], sched)
+    assert np.allclose(cond, manual)
+
+
+def test_sf_tvc_survival_decreasing_and_bounded():
+    m = _fit(WeibullPH)
+    sched = StepSchedule.cyclic([0, 8], [[0.0], [1.5]], 24)
+    x = np.linspace(1, 100, 50)
+    s = m.sf_tvc(x, sched)
+    assert np.all(s <= 1.0) and np.all(s >= 0.0)
+    assert np.all(np.diff(s) <= 1e-12)  # monotone non-increasing
+
+
+@pytest.mark.parametrize("F", [WeibullAFT, WeibullPO])
+def test_aft_po_reject_tvc_evaluation(F):
+    m = _fit(F)
+    with pytest.raises(NotImplementedError, match="proportional-hazards"):
+        m.sf_tvc([2.0], StepSchedule.constant([0.5]))
+
+
+def test_schedule_covariate_count_checked():
+    m = _fit(WeibullPH)  # one covariate
+    two = StepSchedule.constant([0.5, 0.5])
+    with pytest.raises(ValueError, match="covariate"):
+        m.sf_tvc([2.0], two)
+
+
+def test_end_to_end_fit_tvc_then_sf_tvc():
+    # Fit on time-varying start-stop data, then evaluate survival along a path.
+    rng = np.random.default_rng(7)
+    n = 200
+    i, xl, xr, c, Z = [], [], [], [], []
+    for s in range(n):
+        split = 3.0
+        end = split + np.abs(rng.weibull(1.4)) * 6.0 + 0.5
+        z0 = rng.normal(0, 1)
+        i += [s, s]
+        xl += [0.0, split]
+        xr += [split, end]
+        c += [1, 0]
+        Z += [[z0], [z0 + 0.3]]
+    model = WeibullPH.fit_tvc(
+        np.array(i), np.array(xl), np.array(xr), np.array(c), np.array(Z)
+    )
+    sched = StepSchedule.from_changepoints([0.0, 3.0], [[0.0], [0.3]])
+    s = model.sf_tvc([2.0, 5.0, 8.0], sched)
+    assert s.shape == (3,)
+    assert np.all((s >= 0) & (s <= 1)) and s[0] >= s[-1]

--- a/surpyval/univariate/regression/__init__.py
+++ b/surpyval/univariate/regression/__init__.py
@@ -9,7 +9,6 @@ from .accelerated_failure_time import (
     NormalAFT,
     WeibullAFT,
 )
-from .buckley_james import BuckleyJames, BuckleyJamesModel
 from .accelerated_life import (
     AcceleratedLife,
     DualExponential,
@@ -38,6 +37,8 @@ from .additive_hazards import (
     NormalAH,
     WeibullAH,
 )
+from .buckley_james import BuckleyJames, BuckleyJamesModel
+from .parametric_regression_model import ParametricRegressionModel
 from .proportional_hazards import (
     PH,
     CoxPH,
@@ -50,8 +51,6 @@ from .proportional_hazards import (
     ProportionalHazardsFitter,
     WeibullPH,
 )
-from .parametric_regression_model import ParametricRegressionModel
-from .semi_parametric_regression_model import SemiParametricRegressionModel
 from .proportional_odds import (
     PO,
     ExponentialPO,
@@ -63,11 +62,16 @@ from .proportional_odds import (
     ProportionalOddsFitter,
     WeibullPO,
 )
+from .semi_parametric_regression_model import SemiParametricRegressionModel
+from .tvc_schedule import StepSchedule, StepValuedError
 
 __all__ = [
     # Result classes that hold to_dict / from_dict / to_json / from_json
     "ParametricRegressionModel",
     "SemiParametricRegressionModel",
+    # Time-varying-covariate step schedule for sf_tvc evaluation
+    "StepSchedule",
+    "StepValuedError",
     # Buckley-James semi-parametric AFT
     "BuckleyJames",
     "BuckleyJamesModel",

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -427,13 +427,18 @@ class ParametricRegressionModel:
         Z = self._prepare_Z(Z)
         return self.model.sf(x, Z, *self.params)
 
-    # Families whose cumulative hazard is additive over disjoint time
-    # intervals, so a step-valued covariate path factorises exactly into a sum
-    # over its segments (the same structure that lets ``fit_tvc`` reshape TVC
-    # data). Accelerated failure time (covariate rescales time -> needs an
-    # accumulated accelerated age) and proportional odds (no additive form) do
-    # not compose this way and are refused below.
-    _TVC_EVALUABLE_KINDS = ("Proportional Hazard", "Additive Hazard")
+    # Families whose survival along a step-valued covariate path has an exact
+    # closed form. Proportional and additive hazards accumulate a *cumulative
+    # hazard* additively over the segments; accelerated failure time instead
+    # accumulates an *accelerated age* over the segments and then evaluates the
+    # baseline once. Proportional odds has neither structure (its time-varying
+    # odds form is not yet implemented) and is refused below.
+    _TVC_ADDITIVE_KINDS = ("Proportional Hazard", "Additive Hazard")
+    _TVC_EVALUABLE_KINDS = (
+        "Proportional Hazard",
+        "Additive Hazard",
+        "Accelerated Failure Time",
+    )
 
     def _tvc_segments(self, schedule, t_max):
         """
@@ -476,11 +481,14 @@ class ParametricRegressionModel:
 
         .. math::
             H\bigl(x \mid Z(\cdot)\bigr)
-            = \sum_{\text{seg } (a, b]} \bigl[\,H(b, z) - H(a, z)\,\bigr],
+            = \sum_{\text{seg } (a, b]} \bigl[\,H(b, z) - H(a, z)\,\bigr] .
 
-        each increment evaluated with the model's own ``Hf`` at the covariate
-        ``z`` active on that segment (the last segment clipped at ``x``). With
-        a single constant segment this reduces exactly to ``Hf(x, Z)``.
+        For accelerated failure time the covariate rescales time, so the path
+        accumulates an *accelerated age*
+        :math:`\psi(x) = \sum_{\text{seg}} e^{\beta' z}\,(b - a)` and the
+        cumulative hazard is the baseline evaluated there,
+        :math:`H(x \mid Z(\cdot)) = H_0(\psi(x))`. Either way a single constant
+        segment reduces exactly to ``Hf(x, Z)``.
 
         Parameters
         ----------
@@ -500,14 +508,11 @@ class ParametricRegressionModel:
         """
         if self.kind not in self._TVC_EVALUABLE_KINDS:
             raise NotImplementedError(
-                "time-varying-covariate evaluation is only defined for the "
-                "proportional-hazards and additive-hazards families (this "
-                "model is '{}'). Accelerated failure time needs an "
-                "accumulated accelerated age and proportional odds has no "
-                "additive hazard "
-                "form; neither factorises over covariate segments.".format(
-                    self.kind
-                )
+                "time-varying-covariate evaluation is defined for the "
+                "proportional-hazards, additive-hazards and "
+                "accelerated-failure-time families (this model is '{}'). The "
+                "proportional-odds time-varying form is not yet "
+                "implemented.".format(self.kind)
             )
         xq = np.atleast_1d(np.asarray(x, dtype=float))
         schedule = self._to_schedule(Z, xl)
@@ -516,6 +521,16 @@ class ParametricRegressionModel:
             raise ValueError("x must contain a positive time")
         starts, ends, Zseg = self._tvc_segments(schedule, t_max)
 
+        if self.kind in self._TVC_ADDITIVE_KINDS:
+            return self._tvc_hf_additive(xq, starts, ends, Zseg)
+        return self._tvc_hf_aft(xq, starts, ends, Zseg)
+
+    def _tvc_hf_additive(self, xq, starts, ends, Zseg):
+        """
+        Cumulative hazard along a step path for the additive-cumulative-hazard
+        families (PH, AH): telescoping sum of the model's ``Hf`` increment on
+        each segment, the last clipped at the query time.
+        """
         H = np.zeros(xq.shape[0], dtype=float)
         for a, b, z in zip(starts, ends, Zseg):
             zrow = np.asarray(z, dtype=float).reshape(1, -1)
@@ -529,6 +544,32 @@ class ParametricRegressionModel:
             H = H + (hi - lo)
         return H
 
+    def _tvc_hf_aft(self, xq, starts, ends, Zseg):
+        r"""
+        Cumulative hazard along a step path for accelerated failure time.
+
+        The covariate rescales time by ``phi(z) = exp(beta'z)``, so each
+        segment contributes ``phi(z) * (width)`` of *accelerated age*. The
+        accumulated age ``psi(x)`` is then fed once through the baseline
+        cumulative hazard ``H0``. This is exact for a step covariate and
+        reduces to ``Hf(x, Z)`` for a single constant segment.
+        """
+        dist_params = self.params[: self.k_dist]
+        phi_params = self.params[self.k_dist :]
+        psi = np.zeros(xq.shape[0], dtype=float)
+        for a, b, z in zip(starts, ends, Zseg):
+            zrow = np.asarray(z, dtype=float).reshape(1, -1)
+            phi_seg = float(
+                np.asarray(
+                    self.model._phi(zrow, *phi_params), dtype=float
+                ).ravel()[0]
+            )
+            width = np.clip(xq, a, b) - a
+            psi = psi + phi_seg * width
+        return np.asarray(
+            self.model.Hf_dist(psi, *dist_params), dtype=float
+        ).ravel()
+
     def sf_tvc(
         self,
         x: npt.ArrayLike,
@@ -541,11 +582,13 @@ class ParametricRegressionModel:
         schedule ``Z(t)``.
 
         With a time-varying covariate the survival depends on the whole
-        covariate path, not one fixed vector. For the proportional- and
-        additive-hazards families this is exact along a step path:
-        ``S(x) = exp(-H(x))`` where ``H`` is the segment sum in
-        :meth:`Hf_tvc`. Only these families compose this way -- accelerated
-        failure time and proportional odds raise ``NotImplementedError``.
+        covariate path, not one fixed vector. This is exact along a step path
+        for the proportional-hazards, additive-hazards and
+        accelerated-failure-time families: ``S(x) = exp(-H(x))`` with ``H`` the
+        per-segment accumulation in :meth:`Hf_tvc` (a cumulative-hazard sum for
+        PH/AH, an accelerated-age sum fed through the baseline for AFT). Only
+        proportional odds does not yet compose this way and raises
+        ``NotImplementedError``.
 
         Parameters
         ----------

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -427,6 +427,184 @@ class ParametricRegressionModel:
         Z = self._prepare_Z(Z)
         return self.model.sf(x, Z, *self.params)
 
+    # Families whose cumulative hazard is additive over disjoint time
+    # intervals, so a step-valued covariate path factorises exactly into a sum
+    # over its segments (the same structure that lets ``fit_tvc`` reshape TVC
+    # data). Accelerated failure time (covariate rescales time -> needs an
+    # accumulated accelerated age) and proportional odds (no additive form) do
+    # not compose this way and are refused below.
+    _TVC_EVALUABLE_KINDS = ("Proportional Hazard", "Additive Hazard")
+
+    def _tvc_segments(self, schedule, t_max):
+        """
+        Materialise ``schedule`` to ``t_max`` and return ``(starts, ends, Z)``
+        with the first segment held back to the time origin, so the cumulative
+        hazard is measured from ``0`` (unconditional survival).
+        """
+        starts, ends, Z = schedule.segments(t_max)
+        if starts[0] > 0:
+            # Hold the first covariate back to the origin (matches the Cox
+            # ``predict_tvc`` clamp): survival is measured from t = 0.
+            starts = starts.copy()
+            starts[0] = 0.0
+        return starts, ends, Z
+
+    def _to_schedule(self, Z, xl):
+        """
+        Coerce the ``sf_tvc`` covariate argument into a
+        :class:`~...tvc_schedule.StepSchedule`.
+
+        ``Z`` is either a ready-made schedule, or an array of per-segment
+        covariate rows whose segment start times are given in ``xl``.
+        """
+        from .tvc_schedule import StepSchedule
+
+        if isinstance(Z, StepSchedule):
+            if xl is not None:
+                raise ValueError(
+                    "xl must not be given when Z is already a StepSchedule"
+                )
+            schedule = Z
+        else:
+            if xl is None:
+                raise ValueError(
+                    "for the array form pass xl (the segment start times) "
+                    "alongside Z (one covariate row per segment); or pass a "
+                    "StepSchedule"
+                )
+            schedule = StepSchedule.from_changepoints(xl, Z)
+
+        n_cov = self.params.shape[0] - self.k_dist
+        if schedule.p != n_cov:
+            raise ValueError(
+                "the schedule has {} covariate(s) but the model was fit with "
+                "{}".format(schedule.p, n_cov)
+            )
+        return schedule
+
+    def Hf_tvc(
+        self,
+        x: npt.ArrayLike,
+        Z: "npt.ArrayLike | Any",
+        xl: "npt.ArrayLike | None" = None,
+    ) -> npt.NDArray:
+        r"""
+        Cumulative hazard for a covariate following a step schedule ``Z(t)``.
+
+        For the proportional- and additive-hazards families the cumulative
+        hazard is additive over disjoint intervals, so along a piecewise
+        constant path it is exactly the sum of the per-segment increments
+
+        .. math::
+            H\bigl(x \mid Z(\cdot)\bigr)
+            = \sum_{\text{seg } (a, b]} \bigl[\,H(b, z) - H(a, z)\,\bigr],
+
+        each increment evaluated with the model's own ``Hf`` at the covariate
+        ``z`` active on that segment (the last segment clipped at ``x``). With
+        a single constant segment this reduces exactly to ``Hf(x, Z)``.
+
+        Parameters
+        ----------
+        x : array_like
+            Times at which to evaluate the cumulative hazard.
+        Z : StepSchedule or array_like
+            The covariate path -- either a
+            :class:`~...tvc_schedule.StepSchedule`, or an array of per-segment
+            covariate rows (with ``xl`` giving the segment start times).
+        xl : array_like, optional
+            Segment start times, required only when ``Z`` is an array.
+
+        Returns
+        -------
+        ndarray
+            The cumulative hazard at each ``x``.
+        """
+        if self.kind not in self._TVC_EVALUABLE_KINDS:
+            raise NotImplementedError(
+                "time-varying-covariate evaluation is only defined for the "
+                "proportional-hazards and additive-hazards families (this "
+                "model is '{}'). Accelerated failure time needs an "
+                "accumulated accelerated age and proportional odds has no "
+                "additive hazard "
+                "form; neither factorises over covariate segments.".format(
+                    self.kind
+                )
+            )
+        xq = np.atleast_1d(np.asarray(x, dtype=float))
+        schedule = self._to_schedule(Z, xl)
+        t_max = float(np.max(xq))
+        if t_max <= 0:
+            raise ValueError("x must contain a positive time")
+        starts, ends, Zseg = self._tvc_segments(schedule, t_max)
+
+        H = np.zeros(xq.shape[0], dtype=float)
+        for a, b, z in zip(starts, ends, Zseg):
+            zrow = np.asarray(z, dtype=float).reshape(1, -1)
+            upper = np.clip(xq, a, b)
+            hi = np.asarray(
+                self.model.Hf(upper, zrow, *self.params), dtype=float
+            ).ravel()
+            lo = np.asarray(
+                self.model.Hf(np.array([a]), zrow, *self.params), dtype=float
+            ).ravel()
+            H = H + (hi - lo)
+        return H
+
+    def sf_tvc(
+        self,
+        x: npt.ArrayLike,
+        Z: "npt.ArrayLike | Any",
+        xl: "npt.ArrayLike | None" = None,
+        given: "float | None" = None,
+    ) -> npt.NDArray:
+        r"""
+        Survival for a covariate that follows a step (piecewise-constant)
+        schedule ``Z(t)``.
+
+        With a time-varying covariate the survival depends on the whole
+        covariate path, not one fixed vector. For the proportional- and
+        additive-hazards families this is exact along a step path:
+        ``S(x) = exp(-H(x))`` where ``H`` is the segment sum in
+        :meth:`Hf_tvc`. Only these families compose this way -- accelerated
+        failure time and proportional odds raise ``NotImplementedError``.
+
+        Parameters
+        ----------
+        x : array_like
+            Times at which to evaluate survival.
+        Z : StepSchedule or array_like
+            The covariate path. Either a
+            :class:`~...tvc_schedule.StepSchedule` (built from change-points,
+            intervals, a cyclic pattern, or a step-valued expression) or an
+            array of per-segment covariate rows with ``xl`` giving the segment
+            start times.
+        xl : array_like, optional
+            Segment start times, required only when ``Z`` is an array.
+        given : float, optional
+            If supplied, return the *conditional* survival given the item has
+            survived to age ``given``:
+            ``S(x | given) = exp(-(H(x) - H(given)))``.
+
+        Returns
+        -------
+        ndarray
+            Survival at each ``x`` (conditional on ``given`` when supplied).
+
+        Examples
+        --------
+        >>> from surpyval import WeibullPH
+        >>> from surpyval.univariate.regression import StepSchedule
+        >>> # ... model = WeibullPH.fit(...)
+        >>> sched = StepSchedule.from_changepoints([0, 500], [[0.0], [1.0]])
+        >>> model.sf_tvc([250, 750], sched)          # doctest: +SKIP
+        """
+        H = self.Hf_tvc(x, Z, xl)
+        if given is not None:
+            given = float(given)
+            if given > 0:
+                H = H - self.Hf_tvc(given, Z, xl)[0]
+        return np.exp(-H)
+
     def ff(
         self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"
     ) -> npt.NDArray:

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -437,43 +437,22 @@ class ParametricRegressionModel:
 
     def _tvc_segments(self, schedule, t_max):
         """
-        Materialise ``schedule`` to ``t_max`` and return ``(starts, ends, Z)``
-        with the first segment held back to the time origin, so the cumulative
-        hazard is measured from ``0`` (unconditional survival).
+        Materialise ``schedule`` to ``t_max`` with the first segment held back
+        to the time origin (survival measured from ``0``).
         """
-        starts, ends, Z = schedule.segments(t_max)
-        if starts[0] > 0:
-            # Hold the first covariate back to the origin (matches the Cox
-            # ``predict_tvc`` clamp): survival is measured from t = 0.
-            starts = starts.copy()
-            starts[0] = 0.0
-        return starts, ends, Z
+        from .tvc_schedule import segments_from_origin
+
+        return segments_from_origin(schedule, t_max)
 
     def _to_schedule(self, Z, xl):
         """
         Coerce the ``sf_tvc`` covariate argument into a
-        :class:`~...tvc_schedule.StepSchedule`.
-
-        ``Z`` is either a ready-made schedule, or an array of per-segment
-        covariate rows whose segment start times are given in ``xl``.
+        :class:`~...tvc_schedule.StepSchedule` and check its covariate count
+        against the fitted model.
         """
-        from .tvc_schedule import StepSchedule
+        from .tvc_schedule import as_step_schedule
 
-        if isinstance(Z, StepSchedule):
-            if xl is not None:
-                raise ValueError(
-                    "xl must not be given when Z is already a StepSchedule"
-                )
-            schedule = Z
-        else:
-            if xl is None:
-                raise ValueError(
-                    "for the array form pass xl (the segment start times) "
-                    "alongside Z (one covariate row per segment); or pass a "
-                    "StepSchedule"
-                )
-            schedule = StepSchedule.from_changepoints(xl, Z)
-
+        schedule = as_step_schedule(Z, xl)
         n_cov = self.params.shape[0] - self.k_dist
         if schedule.p != n_cov:
             raise ValueError(

--- a/surpyval/univariate/regression/semi_parametric_regression_model.py
+++ b/surpyval/univariate/regression/semi_parametric_regression_model.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING, Any, Callable
 import autograd.numpy as np
 import numpy.typing as npt
 
+from surpyval.serialisation import stamp_schema
 from surpyval.utils import _get_idx
 
 from .regression_data import prepare_Z
-from surpyval.serialisation import stamp_schema
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -374,3 +374,120 @@ class SemiParametricRegressionModel:
         last = H_cum.shape[0] - 1
         Hf = np.where(idx >= 0, H_cum[np.clip(idx, 0, last)], 0.0)
         return query, np.exp(-Hf), Hf
+
+    def _tvc_cumhaz(self, query, starts, Zseg):
+        r"""
+        Cumulative hazard of the fitted baseline at each ``query`` time for a
+        covariate that takes value ``Zseg[i]`` on the segment starting at
+        ``starts[i]``:
+
+        .. math::
+            H(t) = \sum_{u_j \le t} h_0(u_j)\, e^{\beta' Z(u_j)},
+
+        summing the baseline-hazard jumps ``h0`` at the fitted event times
+        weighted by the multiplier of the covariate *active* at each jump.
+        """
+        base_t = self.x
+        active = np.searchsorted(starts, base_t, side="right") - 1
+        active = np.clip(active, 0, starts.shape[0] - 1)
+        phi = np.exp(Zseg[active] @ self.beta)
+        H_cum = np.cumsum(self.h0 * phi)
+        idx = np.searchsorted(base_t, query, side="right") - 1
+        last = H_cum.shape[0] - 1
+        return np.where(idx >= 0, H_cum[np.clip(idx, 0, last)], 0.0)
+
+    def Hf_tvc(
+        self,
+        x: npt.ArrayLike,
+        Z: "npt.ArrayLike | Any",
+        xl: "npt.ArrayLike | None" = None,
+    ) -> npt.NDArray:
+        r"""
+        Cumulative hazard for a covariate following a step schedule ``Z(t)``.
+
+        The Cox analogue of :meth:`predict_tvc` written to the shared
+        time-varying-covariate convention used by the parametric families:
+        ``Z`` is either a :class:`~...tvc_schedule.StepSchedule` or an array of
+        per-segment covariate rows with ``xl`` giving the segment start times.
+        The cumulative hazard sums the fitted baseline-hazard jumps weighted by
+        the covariate active at each jump (see :meth:`_tvc_cumhaz`).
+
+        Parameters
+        ----------
+        x : array_like
+            Times at which to evaluate the cumulative hazard.
+        Z : StepSchedule or array_like
+            The covariate path -- a
+            :class:`~...tvc_schedule.StepSchedule`, or per-segment covariate
+            rows (with ``xl`` giving the segment start times).
+        xl : array_like, optional
+            Segment start times, required only when ``Z`` is an array.
+        """
+        if self.is_stratified:
+            raise NotImplementedError(
+                "time-varying-covariate evaluation is not defined for a "
+                "stratified Cox fit (each stratum carries its own baseline "
+                "hazard); pick a stratum's model first"
+            )
+        from .tvc_schedule import as_step_schedule, segments_from_origin
+
+        schedule = as_step_schedule(Z, xl)
+        n_cov = np.asarray(self.beta).shape[0]
+        if schedule.p != n_cov:
+            raise ValueError(
+                "the schedule has {} covariate(s) but the model was fit with "
+                "{}".format(schedule.p, n_cov)
+            )
+        xq = np.atleast_1d(np.asarray(x, dtype=float))
+        t_max = float(np.max(xq))
+        if t_max <= 0:
+            raise ValueError("x must contain a positive time")
+        starts, _, Zseg = segments_from_origin(schedule, t_max)
+        return self._tvc_cumhaz(xq, starts, Zseg)
+
+    def sf_tvc(
+        self,
+        x: npt.ArrayLike,
+        Z: "npt.ArrayLike | Any",
+        xl: "npt.ArrayLike | None" = None,
+        given: "float | None" = None,
+    ) -> npt.NDArray:
+        r"""
+        Survival for a covariate following a step (piecewise-constant) schedule
+        ``Z(t)``.
+
+        The Cox counterpart of the parametric ``sf_tvc``: ``S(x) = exp(-H(x))``
+        with ``H`` the baseline-jump sum of :meth:`Hf_tvc`, so every regression
+        family -- parametric proportional/additive hazards and semi-parametric
+        Cox -- shares one calling convention. ``predict_tvc`` remains for the
+        interval-oriented ``(xl, xr, Z)`` form and returning the baseline jump
+        times.
+
+        Parameters
+        ----------
+        x : array_like
+            Times at which to evaluate survival.
+        Z : StepSchedule or array_like
+            The covariate path. Either a
+            :class:`~...tvc_schedule.StepSchedule` (change-points, intervals, a
+            cyclic pattern, or a step-valued expression) or an array of
+            per-segment covariate rows with ``xl`` giving the segment start
+            times.
+        xl : array_like, optional
+            Segment start times, required only when ``Z`` is an array.
+        given : float, optional
+            If supplied, return the *conditional* survival given the item has
+            survived to age ``given``:
+            ``S(x | given) = exp(-(H(x) - H(given)))``.
+
+        Returns
+        -------
+        ndarray
+            Survival at each ``x`` (conditional on ``given`` when supplied).
+        """
+        H = self.Hf_tvc(x, Z, xl)
+        if given is not None:
+            given = float(given)
+            if given > 0:
+                H = H - self.Hf_tvc(given, Z, xl)[0]
+        return np.exp(-H)

--- a/surpyval/univariate/regression/tvc_schedule.py
+++ b/surpyval/univariate/regression/tvc_schedule.py
@@ -1,0 +1,555 @@
+r"""
+Piecewise-constant (step) covariate schedules for time-varying-covariate
+*evaluation*.
+
+Where :mod:`...tvc_fit` reshapes time-varying-covariate data to *fit* a model,
+this module describes a covariate path so an already-fitted model can be
+*evaluated* along it: given a fitted proportional- or additive-hazards model
+and a step schedule ``Z(t)``, ``model.sf_tvc`` returns the survival ``S(t)``
+that results from the covariate following that schedule.
+
+The covariate is constrained to be **piecewise-constant** (a "step" function):
+flat on each segment, jumping at change-points. This is not a stylistic choice
+-- each family's cumulative-hazard form is exact *only* when ``Z`` is constant
+on each segment (the cumulative hazard is then additive over the segments). A
+continuously-varying ``Z`` would silently give a wrong answer, so this class
+owns the step-valued guarantee two ways:
+
+* the **structural** constructors (:meth:`StepSchedule.from_changepoints`,
+  :meth:`~StepSchedule.from_intervals`, :meth:`~StepSchedule.cyclic`) can only
+  ever describe a step function -- there is no way to express a continuous
+  ramp; and
+* the **expression** constructor (:meth:`~StepSchedule.from_expression`)
+  accepts a string in ``t`` but first proves, statically from the syntax tree,
+  that ``t`` can only reach the value through a *quantizer* (``floor``,
+  ``ceil``, ``//`` or a comparison) -- anything continuous is rejected before
+  it is ever evaluated.
+
+Whatever the construction, the one thing the family math consumes is
+:meth:`~StepSchedule.segments`, which materialises the schedule up to a horizon
+into concrete ``(start, end, Z)`` triples.
+"""
+
+import ast
+import math
+
+import numpy as np
+
+__all__ = ["StepSchedule", "StepValuedError"]
+
+
+# Functions that turn a continuous input into a piecewise-constant output. Once
+# ``t`` passes through one of these, later arithmetic keeps the result stepped
+# (any pure function of a step function is still a step function).
+_QUANTIZERS = {"floor", "ceil", "round", "trunc"}
+
+# Names an expression may reference besides the free variable ``t``.
+_CONSTANTS = {"pi": math.pi, "e": math.e, "tau": math.tau, "inf": math.inf}
+
+# Callables an expression may use. Kept to quantizers plus a few pure helpers
+# that cannot smuggle in continuous variation on their own.
+_FUNCTIONS = {
+    "floor": math.floor,
+    "ceil": math.ceil,
+    "round": round,
+    "trunc": math.trunc,
+    "abs": abs,
+    "min": min,
+    "max": max,
+}
+
+
+class StepValuedError(ValueError):
+    """
+    Raised when an expression covariate schedule is not provably step-valued.
+
+    The message points at the sub-expression through which ``t`` reaches the
+    output continuously (e.g. a bare ``t`` or ``sin(t)``), so the offending
+    term can be quantized (``floor(t / dt)``) or replaced.
+    """
+
+
+def _varies_continuously(node):
+    """
+    Return ``True`` if the AST ``node`` lets the free variable ``t`` influence
+    its value *continuously* (rather than only through a quantizer/comparison).
+
+    Sound -- never returns ``False`` for a genuinely continuous function -- and
+    conservative: a few things that algebraically reduce to a constant (e.g.
+    ``t - t``) are still reported as continuous. Decidable purely from syntax;
+    no sampling.
+    """
+    if isinstance(node, ast.Constant):
+        return False
+    if isinstance(node, ast.Name):
+        # ``t`` reaching here unquantized is the continuous case; named
+        # constants (pi, e, ...) are fine.
+        return node.id == "t"
+    if isinstance(node, (ast.Compare, ast.BoolOp)):
+        # A boolean is two-valued -> stepped, regardless of its operands.
+        return False
+    if isinstance(node, ast.IfExp):
+        # test only selects a branch (it is a comparison/boolean); the value
+        # is continuous iff a selectable branch is.
+        return _varies_continuously(node.body) or _varies_continuously(
+            node.orelse
+        )
+    if isinstance(node, ast.UnaryOp):
+        return _varies_continuously(node.operand)
+    if isinstance(node, ast.BinOp):
+        # ``t // k`` is a step; every other binary op is continuous in an
+        # operand that is itself continuous in ``t``.
+        if isinstance(node.op, ast.FloorDiv):
+            return False
+        return _varies_continuously(node.left) or _varies_continuously(
+            node.right
+        )
+    if isinstance(node, ast.Call):
+        fname = getattr(node.func, "id", None)
+        if fname in _QUANTIZERS:
+            return False
+        # Non-quantizing call (e.g. abs, min, max, or -- once rejected -- a
+        # trig function): continuous iff any argument is.
+        return any(_varies_continuously(a) for a in node.args)
+    # Anything unrecognised (attribute access, comprehensions, ...) is treated
+    # as continuous; it is rejected here and would also fail the safe eval.
+    return True
+
+
+def _safe_eval(node, t):
+    """
+    Evaluate a validated expression AST at a single time ``t``.
+
+    Only the node types the step-guard understands are supported, so this can
+    never execute arbitrary code -- unknown syntax raises. It is a plain
+    interpreter, not ``eval``.
+    """
+    if isinstance(node, ast.Expression):
+        return _safe_eval(node.body, t)
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, bool) or not isinstance(
+            node.value, (int, float)
+        ):
+            raise StepValuedError(
+                "only numeric constants are allowed in a schedule expression"
+            )
+        return float(node.value)
+    if isinstance(node, ast.Name):
+        if node.id == "t":
+            return t
+        if node.id in _CONSTANTS:
+            return _CONSTANTS[node.id]
+        raise StepValuedError(
+            "unknown name {!r} in schedule expression (allowed: t, "
+            "{})".format(node.id, ", ".join(sorted(_CONSTANTS)))
+        )
+    if isinstance(node, ast.UnaryOp):
+        val = _safe_eval(node.operand, t)
+        if isinstance(node.op, ast.UAdd):
+            return +val
+        if isinstance(node.op, ast.USub):
+            return -val
+        if isinstance(node.op, ast.Not):
+            return not val
+        raise StepValuedError("unsupported unary operator in expression")
+    if isinstance(node, ast.BinOp):
+        left = _safe_eval(node.left, t)
+        right = _safe_eval(node.right, t)
+        op = node.op
+        if isinstance(op, ast.Add):
+            return left + right
+        if isinstance(op, ast.Sub):
+            return left - right
+        if isinstance(op, ast.Mult):
+            return left * right
+        if isinstance(op, ast.Div):
+            return left / right
+        if isinstance(op, ast.FloorDiv):
+            return left // right
+        if isinstance(op, ast.Mod):
+            return left % right
+        if isinstance(op, ast.Pow):
+            return left**right
+        raise StepValuedError("unsupported binary operator in expression")
+    if isinstance(node, ast.BoolOp):
+        vals = [_safe_eval(v, t) for v in node.values]
+        if isinstance(node.op, ast.And):
+            return all(vals)
+        return any(vals)
+    if isinstance(node, ast.Compare):
+        left = _safe_eval(node.left, t)
+        result = True
+        for op, comparator in zip(node.ops, node.comparators):
+            right = _safe_eval(comparator, t)
+            if isinstance(op, ast.Lt):
+                ok = left < right
+            elif isinstance(op, ast.LtE):
+                ok = left <= right
+            elif isinstance(op, ast.Gt):
+                ok = left > right
+            elif isinstance(op, ast.GtE):
+                ok = left >= right
+            elif isinstance(op, ast.Eq):
+                ok = left == right
+            elif isinstance(op, ast.NotEq):
+                ok = left != right
+            else:
+                raise StepValuedError("unsupported comparison in expression")
+            result = result and ok
+            left = right
+        return result
+    if isinstance(node, ast.IfExp):
+        return (
+            _safe_eval(node.body, t)
+            if _safe_eval(node.test, t)
+            else _safe_eval(node.orelse, t)
+        )
+    if isinstance(node, ast.Call):
+        fname = getattr(node.func, "id", None)
+        if fname not in _FUNCTIONS:
+            raise StepValuedError(
+                "unknown function {!r} in schedule expression (allowed: "
+                "{})".format(fname, ", ".join(sorted(_FUNCTIONS)))
+            )
+        args = [_safe_eval(a, t) for a in node.args]
+        return float(_FUNCTIONS[fname](*args))
+    raise StepValuedError(
+        "unsupported syntax in schedule expression: {}".format(
+            type(node).__name__
+        )
+    )
+
+
+def _coalesce(times, values):
+    """
+    Collapse a fine grid of ``(time, value-row)`` samples into the minimal set
+    of step segments, merging consecutive samples that share a covariate row.
+
+    ``times`` is the strictly-increasing left edge of each sample; ``values``
+    is ``(len(times), p)``. Returns ``(edges, Z)`` where ``edges`` has one more
+    entry than ``Z`` has rows (the trailing edge is the horizon).
+    """
+    times = np.asarray(times, dtype=float)
+    values = np.asarray(values, dtype=float)
+    keep = [0]
+    for i in range(1, values.shape[0]):
+        if not np.array_equal(values[i], values[i - 1]):
+            keep.append(i)
+    starts = times[keep]
+    Z = values[keep]
+    return starts, Z
+
+
+class StepSchedule:
+    r"""
+    A piecewise-constant covariate path ``Z(t)`` for time-varying-covariate
+    evaluation.
+
+    The canonical form is a set of ``edges`` (segment boundaries) and a ``Z``
+    matrix with one covariate row per segment: segment ``i`` covers
+    ``[edges[i], edges[i + 1])`` and carries covariate ``Z[i]``. Beyond the
+    last edge the final segment's covariate is held constant (or, when
+    ``period`` is set, the pattern repeats). ``Z`` is always two-dimensional,
+    so a schedule is multivariate for free (a single covariate is ``p = 1``).
+
+    Construct one with a class method rather than the raw constructor:
+
+    * :meth:`constant` -- a fixed covariate (reduces to the ordinary ``sf``);
+    * :meth:`from_changepoints` -- ``(time, value)`` pairs, the value taking
+      effect at each time;
+    * :meth:`from_intervals` -- explicit ``(xl, xr]`` interval rows, matching
+      the ``fit_tvc`` start-stop layout;
+    * :meth:`cyclic` -- a within-period pattern repeated to a horizon;
+    * :meth:`from_expression` -- a step-valued expression string in ``t``.
+
+    All the family math needs is :meth:`segments`.
+    """
+
+    def __init__(self, edges, Z, period=None):
+        edges = np.asarray(edges, dtype=float)
+        Z = np.asarray(Z, dtype=float)
+        if Z.ndim == 1:
+            Z = Z.reshape(-1, 1)
+        if edges.ndim != 1:
+            raise ValueError("edges must be one-dimensional")
+        if edges.shape[0] != Z.shape[0] + 1:
+            raise ValueError(
+                "edges must have exactly one more entry than Z has rows "
+                "(got {} edges for {} segments)".format(
+                    edges.shape[0], Z.shape[0]
+                )
+            )
+        if Z.shape[0] == 0:
+            raise ValueError("a schedule needs at least one segment")
+        if not np.all(np.diff(edges) > 0):
+            raise ValueError("edges must be strictly increasing")
+        if not np.isfinite(edges[:-1]).all():
+            raise ValueError("every edge except the last must be finite")
+        if not np.isfinite(Z).all():
+            raise ValueError("Z must contain only finite values")
+        if period is not None:
+            period = float(period)
+            if not (period > 0):
+                raise ValueError("period must be positive")
+            if not np.isfinite(edges[-1]):
+                raise ValueError(
+                    "a cyclic schedule needs a finite final edge (the pattern "
+                    "length); use cyclic() to build one"
+                )
+            if edges[-1] - edges[0] > period + 1e-12:
+                raise ValueError("the pattern spans longer than one period")
+        self.edges = edges
+        self.Z = Z
+        self.period = period
+
+    @property
+    def p(self):
+        """Number of covariates (columns of ``Z``)."""
+        return self.Z.shape[1]
+
+    # -- structural constructors ------------------------------------------
+
+    @classmethod
+    def constant(cls, Z):
+        """
+        A constant covariate ``Z`` over all time. Evaluating a model on it is
+        identical to ``model.sf(x, Z)``.
+        """
+        Z = np.asarray(Z, dtype=float).reshape(1, -1)
+        return cls(np.array([0.0, np.inf]), Z)
+
+    @classmethod
+    def from_changepoints(cls, times, values):
+        """
+        Build a schedule from ``(time, value)`` change-points.
+
+        ``values[i]`` is the covariate row in effect from ``times[i]`` until
+        the next change-point; the last value is held to the horizon.
+        ``times`` must be strictly increasing; ``times[0]`` is the path's
+        start (usually ``0``).
+
+        Parameters
+        ----------
+        times : array_like, shape (m,)
+            The instants at which the covariate takes each value.
+        values : array_like, shape (m,) or (m, p)
+            The covariate row active from each time.
+        """
+        times = np.atleast_1d(np.asarray(times, dtype=float))
+        values = np.asarray(values, dtype=float)
+        if values.ndim == 1:
+            values = values.reshape(-1, 1)
+        if times.shape[0] != values.shape[0]:
+            raise ValueError(
+                "times and values must have the same length ({} vs {})".format(
+                    times.shape[0], values.shape[0]
+                )
+            )
+        edges = np.concatenate([times, [np.inf]])
+        return cls(edges, values)
+
+    @classmethod
+    def from_intervals(cls, xl, xr, Z):
+        """
+        Build a schedule from explicit ``(xl, xr]`` interval rows -- the same
+        layout ``fit_tvc`` consumes.
+
+        The intervals must be contiguous (each ``xr`` equals the next ``xl``);
+        the covariate beyond the final ``xr`` is held constant. Rows may be
+        given in any order and are sorted by ``xl``.
+        """
+        xl = np.atleast_1d(np.asarray(xl, dtype=float))
+        xr = np.atleast_1d(np.asarray(xr, dtype=float))
+        Z = np.asarray(Z, dtype=float)
+        if Z.ndim == 1:
+            Z = Z.reshape(-1, 1)
+        if not (xl.shape[0] == xr.shape[0] == Z.shape[0]):
+            raise ValueError("xl, xr and Z must have the same number of rows")
+        order = np.argsort(xl)
+        xl, xr, Z = xl[order], xr[order], Z[order]
+        if np.any(xl >= xr):
+            raise ValueError("every interval must have xl < xr")
+        if np.any(np.abs(xl[1:] - xr[:-1]) > 1e-9):
+            raise ValueError(
+                "intervals must be contiguous (each xr must equal the next "
+                "xl); a step schedule cannot have gaps or overlaps"
+            )
+        edges = np.concatenate([xl, [xr[-1]]])
+        return cls(edges, Z)
+
+    @classmethod
+    def cyclic(cls, pattern_times, pattern_values, period):
+        """
+        A within-period covariate pattern repeated indefinitely.
+
+        ``pattern_times`` are the change-points *within* one period (starting
+        at ``0`` and all ``< period``); ``pattern_values`` the covariate on
+        each. The pattern repeats every ``period`` and is materialised up to
+        whatever horizon :meth:`segments` is asked for -- for duty cycles.
+
+        Parameters
+        ----------
+        pattern_times : array_like, shape (m,)
+            Change-points within one period, ``0 <= t < period``, strictly
+            increasing (the first should be ``0``).
+        pattern_values : array_like, shape (m,) or (m, p)
+            The covariate row active from each within-period change-point.
+        period : float
+            The repetition period.
+        """
+        pattern_times = np.atleast_1d(np.asarray(pattern_times, dtype=float))
+        pattern_values = np.asarray(pattern_values, dtype=float)
+        if pattern_values.ndim == 1:
+            pattern_values = pattern_values.reshape(-1, 1)
+        period = float(period)
+        if pattern_times.shape[0] != pattern_values.shape[0]:
+            raise ValueError(
+                "pattern_times and pattern_values must have the same length"
+            )
+        if pattern_times[0] != 0.0:
+            raise ValueError("the first pattern time must be 0")
+        if np.any(pattern_times < 0) or np.any(pattern_times >= period):
+            raise ValueError("pattern times must satisfy 0 <= t < period")
+        edges = np.concatenate([pattern_times, [period]])
+        return cls(edges, pattern_values, period=period)
+
+    # -- expression constructor -------------------------------------------
+
+    @classmethod
+    def from_expression(cls, expr, horizon, resolution=1.0, t0=0.0):
+        r"""
+        Build a schedule from a step-valued expression string (or list of
+        strings) in the free variable ``t``.
+
+        The expression is parsed and *proved* piecewise-constant before it is
+        ever evaluated: ``t`` may reach the value only through a quantizer
+        (``floor``, ``ceil``, ``//``) or a comparison. A continuously-varying
+        expression (``0.3 + 1e-4 * t``, ``sin(t)``) raises
+        :class:`StepValuedError`.
+
+        The (guaranteed stepped) expression is then materialised by sampling on
+        a grid of spacing ``resolution`` over ``[t0, horizon]`` and coalescing
+        runs of equal value into segments, so ``resolution`` must be no
+        coarser than the narrowest step (e.g. ``1`` hour for an
+        ``8``-on/``16``-off duty cycle).
+
+        Parameters
+        ----------
+        expr : str or list of str
+            A scalar covariate (``p = 1``) or, for a multivariate covariate,
+            one expression per covariate.
+        horizon : float
+            Materialise the schedule out to this time.
+        resolution : float, optional
+            Grid spacing for sampling. Default ``1.0``.
+        t0 : float, optional
+            Start of the path. Default ``0.0``.
+
+        Examples
+        --------
+        >>> StepSchedule.from_expression("0.9 if t % 24 < 8 else 0.3", 96)
+        >>> StepSchedule.from_expression("0.3 * 2 ** floor(t / 1000)", 5000)
+        """
+        exprs = [expr] if isinstance(expr, str) else list(expr)
+        if len(exprs) == 0:
+            raise ValueError("at least one expression is required")
+        horizon = float(horizon)
+        resolution = float(resolution)
+        if not (resolution > 0):
+            raise ValueError("resolution must be positive")
+        if not (horizon > t0):
+            raise ValueError("horizon must be greater than t0")
+
+        trees = []
+        for e in exprs:
+            try:
+                tree = ast.parse(e, mode="eval")
+            except SyntaxError as exc:
+                raise StepValuedError(
+                    "could not parse schedule expression {!r}: {}".format(
+                        e, exc
+                    )
+                )
+            if _varies_continuously(tree.body):
+                raise StepValuedError(
+                    "expression {!r} is not step-valued: t reaches the "
+                    "value continuously. Quantize it (e.g. floor(t / dt)) "
+                    "or use a comparison so the covariate stays "
+                    "piecewise-constant.".format(e)
+                )
+            trees.append(tree)
+
+        n = int(math.floor((horizon - t0) / resolution)) + 1
+        grid = t0 + resolution * np.arange(n)
+        # Ensure the horizon itself is represented as a left edge so the final
+        # step is not truncated early.
+        if grid[-1] < horizon:
+            grid = np.append(grid, horizon)
+        values = np.empty((grid.shape[0], len(trees)), dtype=float)
+        for j, tree in enumerate(trees):
+            for i, tv in enumerate(grid):
+                values[i, j] = float(_safe_eval(tree, float(tv)))
+
+        starts, Z = _coalesce(grid, values)
+        edges = np.concatenate([starts, [np.inf]])
+        return cls(edges, Z)
+
+    # -- consumption ------------------------------------------------------
+
+    def segments(self, t_max):
+        """
+        Materialise the schedule up to ``t_max`` into concrete step segments.
+
+        Returns ``(starts, ends, Z)`` with one row per segment, contiguous and
+        covering ``[edges[0], t_max]``. The final segment (or, for a cyclic
+        schedule, every repetition) is clipped so ``ends[-1] == t_max``. This
+        is the sole interface the family cumulative-hazard math consumes.
+
+        Parameters
+        ----------
+        t_max : float
+            The horizon to materialise to (typically the largest query time).
+        """
+        t_max = float(t_max)
+        if t_max <= self.edges[0]:
+            raise ValueError(
+                "t_max ({}) must be greater than the schedule start "
+                "({})".format(t_max, self.edges[0])
+            )
+
+        if self.period is None:
+            edges = self.edges.copy()
+            # Held-constant tail: replace an infinite (or short) final edge
+            # with the horizon.
+            edges[-1] = t_max if not np.isfinite(edges[-1]) else edges[-1]
+            Z = self.Z
+        else:
+            # Repeat the within-period pattern until it covers t_max.
+            pattern_starts = self.edges[:-1]
+            base = self.edges[0]
+            reps = int(math.ceil((t_max - base) / self.period))
+            starts = []
+            Zrows = []
+            for k in range(reps):
+                offset = k * self.period
+                for s, z in zip(pattern_starts, self.Z):
+                    starts.append(s + offset)
+                    Zrows.append(z)
+            starts = np.asarray(starts, dtype=float)
+            edges = np.concatenate([starts, [starts[0] + reps * self.period]])
+            Z = np.asarray(Zrows, dtype=float)
+
+        # Clip to [start, t_max]: drop segments that begin at or after t_max
+        # and trim the final edge.
+        within = edges[:-1] < t_max
+        starts = edges[:-1][within]
+        Z = Z[within]
+        ends = np.concatenate([starts[1:], [t_max]])
+        ends = np.minimum(ends, t_max)
+        return starts, ends, Z
+
+    def __repr__(self):
+        kind = "cyclic" if self.period is not None else "step"
+        return "StepSchedule({}, {} segment(s), p={})".format(
+            kind, self.Z.shape[0], self.p
+        )

--- a/surpyval/univariate/regression/tvc_schedule.py
+++ b/surpyval/univariate/regression/tvc_schedule.py
@@ -553,3 +553,45 @@ class StepSchedule:
         return "StepSchedule({}, {} segment(s), p={})".format(
             kind, self.Z.shape[0], self.p
         )
+
+
+# -- shared helpers for the model ``sf_tvc`` / ``Hf_tvc`` methods ----------
+#
+# These give every regression family (parametric PH/AH and the semi-parametric
+# Cox) the same time-varying-covariate calling convention: pass either a
+# ready-made StepSchedule, or ``(xl, Z)`` arrays (segment start times plus one
+# covariate row per segment).
+
+
+def as_step_schedule(Z, xl=None):
+    """
+    Coerce a model ``sf_tvc`` covariate argument into a :class:`StepSchedule`.
+
+    ``Z`` is either a ready-made schedule (then ``xl`` must be ``None``), or an
+    array of per-segment covariate rows whose segment start times are ``xl``.
+    """
+    if isinstance(Z, StepSchedule):
+        if xl is not None:
+            raise ValueError(
+                "xl must not be given when Z is already a StepSchedule"
+            )
+        return Z
+    if xl is None:
+        raise ValueError(
+            "for the array form pass xl (the segment start times) alongside "
+            "Z (one covariate row per segment); or pass a StepSchedule"
+        )
+    return StepSchedule.from_changepoints(xl, Z)
+
+
+def segments_from_origin(schedule, t_max):
+    """
+    Materialise ``schedule`` to ``t_max``, holding the first segment back to
+    the time origin so cumulative hazard is measured from ``0`` (unconditional
+    survival). Returns ``(starts, ends, Z)``.
+    """
+    starts, ends, Z = schedule.segments(t_max)
+    if starts[0] > 0:
+        starts = starts.copy()
+        starts[0] = 0.0
+    return starts, ends, Z


### PR DESCRIPTION
Implements the **evaluation** half of #170 — the counterpart to the TVC **fitting** shipped in #150. A fitted regression model can now return the survival produced by a covariate that follows a piecewise-constant path `Z(t)`.

## What's added

`sf_tvc(x, Z, xl=None, given=None)` (and `Hf_tvc`) on every family whose survival has an exact closed form along a step path — **parametric PH, AH, AFT, and semi-parametric Cox**:

```python
from surpyval.univariate.regression import StepSchedule

sched = StepSchedule.from_changepoints([0, 500], [[0.0], [1.0]])   # a switch
model.sf_tvc([250, 750], sched)
model.sf_tvc([750], sched, given=500)                             # conditional
model.sf_tvc([3, 6], Z=[[0.2], [0.9]], xl=[0.0, 4.0])            # (xl, Z) arrays
```

Covered families and the exact per-family form:

| Family | Accumulation along the step path |
|---|---|
| **PH / AH / Cox** | cumulative hazard is additive: `H = Σ_seg [H(b,z) − H(a,z)]` |
| **AFT** | accumulate accelerated age `ψ = Σ exp(β'z)(b−a)`, then `S₀(ψ)` |
| **PO** | no closed form yet → raises (tracked in #236) |

All reduce exactly to ordinary `sf(x, Z)` for a single constant segment. For Cox, `sf_tvc` agrees exactly with the existing interval-oriented `predict_tvc` (which is unchanged).

## The covariate path: `StepSchedule`

`sf_tvc` takes a `StepSchedule` or `(xl, Z)` arrays. A schedule is built:

- **structurally** — `from_changepoints`, `from_intervals` (the `fit_tvc` layout), `cyclic` (duty cycles), `constant`; step-valued *by construction*.
- **from an expression** in `t` — `"0.9 if t % 24 < 8 else 0.3"`, `"0.3 * 2 ** floor(t / 1000)"`.

Expressions are **proved piecewise-constant statically** from their syntax tree before evaluation (`t` may reach the value only through a quantizer `floor`/`ceil`/`//` or a comparison); a continuous covariate (`0.3 + 1e-4*t`, `sin(t)`) is rejected with `StepValuedError` rather than silently returning a wrong answer. A tiny AST interpreter (not `eval`) materialises the schedule — no new dependency. surpyval owns only the step-valued guarantee; the untrusted-text sandbox stays with the calling app.

## Docs

- Fixed the Cox TVC how-to example, which still used the pre-#233 API (`start_col`/`event_col`, `predict_tvc(start=…)`); it now uses the `i`/`xl`/`xr`/`c` convention and `sf_tvc`.
- New "Time-varying covariates across families" section covering `fit_tvc` (PH/AH) and `sf_tvc` (PH/AH/AFT/Cox), the `StepSchedule` constructors, and the step-valued guard.
- A note on **why, unlike lifelines, surpyval predicts along a future covariate path**: `sf_tvc` evaluates survival under a *supplied* covariate plan (mission phases, duty cycle, scheduled load) — a well-posed what-if, not a claim to know the future.
- `sf_tvc` noted in the Cox and parametric theory pages; `StepSchedule` autodoc'd.

## Validation

`test_tvc_evaluation.py` (38 tests): schedule constructors and the step guard; `sf_tvc` reducing to `sf` for a constant covariate; the telescoping identity (PH/AH) and accelerated-age identity (AFT); Cox `sf_tvc` matching `predict_tvc`; the `(xl, Z)` array form matching the schedule form; conditional survival; covariate-count, stratified-Cox and PO rejection; and an end-to-end `fit_tvc → sf_tvc`. Full `tests/univariate/regression/` suite (248) passes; flake8 / black / isort / mypy clean; all `jupyter-execute` doc cells run.

Remaining #170 gap: proportional-odds evaluation, split out to #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_