### PR TITLE
CI: run on PRs into develop/master + pushes to master; adopt develop branch flow

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -2,7 +2,15 @@ name: actions
 
 run-name: SurPyval CI
 
-on: [push]
+# Run CI on pull requests into the integration branches and on pushes to
+# master (i.e. release merges + tags). Feature work accumulates on `develop`
+# via PRs; day-to-day pushes to feature branches no longer each trigger the
+# full suite. See docs/Contributing.rst for the branching / release flow.
+on:
+  pull_request:
+    branches: [develop, master]
+  push:
+    branches: [master]
 
 env:
   SRC: surpyval # Source directory to run jobs on

--- a/docs/Contributing.rst
+++ b/docs/Contributing.rst
@@ -6,6 +6,27 @@ If you want to contribute to SurPyval, please do! Please review the current open
 
 SurPyval is in the process of complying with the PEP8 standard so please make all contributions as per that standard.
 
+Branching and releases
+----------------------
+
+SurPyval uses a two-tier branch model to keep continuous integration and the
+documentation build from running on every change:
+
+* **master** is the release branch. It is only updated at a version release,
+  and pushing a ``v*`` tag to it publishes the package and rebuilds the hosted
+  documentation.
+* **develop** is the long-lived integration branch. Feature work is done on a
+  short-lived branch and opened as a pull request into ``develop``.
+* At release time ``develop`` is merged into ``master`` in a single pull
+  request and the new version is tagged.
+
+Continuous integration (``.github/workflows/actions.yml``) therefore runs on
+**pull requests into develop or master** and on **pushes to master**, rather
+than on every push to every branch. Read the Docs is configured to build
+``master`` and tags only. The net effect is that the full test suite and the
+documentation build run once per pull request and once per release, instead of
+once per intermediate commit.
+
 Documentation
 -------------
 


### PR DESCRIPTION
Reduces CI and Read the Docs churn by adopting a two-tier branch model.

## Change

`.github/workflows/actions.yml` trigger:

```yaml
# before
on: [push]

# after
on:
  pull_request:
    branches: [develop, master]
  push:
    branches: [master]
```

`on: [push]` ran the full lint + pytest (3.11/3.12/3.13, ~15 min) on **every push to every branch**, and every merge to `master` also rebuilt the hosted docs. Now the suite runs **once per pull request** (into `develop`/`master`) and **once on push to `master`** (release merges + tags), instead of once per intermediate commit.

## Branch model (documented in `docs/Contributing.rst`)

- **`master`** — release branch; only updated at a version release, and a `v*` tag publishes + rebuilds docs (`publish.yml` unchanged).
- **`develop`** — long-lived integration branch (created off `master`); feature PRs land here.
- At release: one PR `develop → master`, merge, tag.

## Companion setting (off-repo, maintainer action)

Read the Docs should be set to build **`master` + tags only** (deactivate `develop`/feature branches) so accumulation on `develop` doesn't trigger doc builds. That lever lives in the RTD project settings, not the repo.

Net effect: the full test suite and the docs build run **once per PR and once per release**, not once per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_