### PR TITLE
Fix formula-fit regression models not round-tripping through serialisation (#244)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,18 @@ Changelog
 v0.17.0 (unreleased)
 --------------------
 
+- **Fixed: formula-fit regression models now round-trip through serialisation**
+  (#244). A regression model fit with ``fit_from_df(..., formula=...)`` using a
+  categorical term dropped its design-matrix transformer on ``to_dict`` /
+  ``from_dict``, so a restored model failed to evaluate from raw covariates
+  (``['sex[F]', 'sex[M]'] not in dataframe columns``). ``to_dict`` now persists
+  the categorical factor levels and numeric column names, and ``from_dict``
+  rebuilds an equivalent ``formulaic`` model spec, so a restored model expands
+  raw covariates identically to the original -- for the parametric families
+  (PH/AFT/PO/AH) and Cox. Data-dependent transforms (``scale()`` / ``center()``)
+  keep fitted statistics that cannot be restored from levels, so serialising
+  such a formula now raises early at ``to_dict`` rather than round-tripping to a
+  silently wrong encoding.
 - **Likelihood-ratio confidence bounds on model functions.** ``cb`` gains the
   same ``method`` argument: ``method="lr"`` returns a profile-likelihood band
   on ``sf`` / ``ff`` / ``Hf`` / ``hf`` / ``df``. At each time the bound is the

--- a/surpyval/tests/test_package_serialisation.py
+++ b/surpyval/tests/test_package_serialisation.py
@@ -95,6 +95,63 @@ def test_parametric_regression_dispatch():
     assert np.allclose(model.sf(t, Z=z), restored.sf(t, Z=z))
 
 
+def _formula_df(seed=0, n=200):
+    import pandas as pd
+
+    rng = np.random.default_rng(seed)
+    sex = rng.choice(["M", "F"], n)
+    age = rng.uniform(30, 70, n)
+    x = 10 * np.exp(-0.4 * (sex == "M")) * rng.weibull(2.0, n)
+    return pd.DataFrame(
+        {
+            "time": x,
+            "c": rng.integers(0, 2, n).astype(int),
+            "age": age,
+            "sex": sex,
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "formula", ["age + sex", "age + sex + age:sex", "np.log(age) + sex"]
+)
+def test_formula_regression_round_trips_with_raw_covariates(formula):
+    # #244: a formula fit with a categorical must round-trip so the restored
+    # model expands *raw* covariates (sex -> sex[F], sex[M]) identically.
+    import pandas as pd
+
+    df = _formula_df()
+    model = WeibullPH.fit_from_df(df, x_col="time", c_col="c", formula=formula)
+    restored = surpyval.from_dict(_rt(model.to_dict()))
+
+    raw_Z = pd.DataFrame({"age": [40.0, 55.0], "sex": ["M", "F"]})
+    t = np.array([5.0, 12.0])
+    assert np.allclose(model.sf(t, raw_Z), restored.sf(t, raw_Z))
+
+
+def test_formula_cox_round_trips_with_raw_covariates():
+    import pandas as pd
+
+    df = _formula_df(seed=2)
+    model = CoxPH.fit_from_df(df, x_col="time", c_col="c", formula="age + sex")
+    restored = surpyval.from_dict(_rt(model.to_dict()))
+
+    raw_Z = pd.DataFrame({"age": [40.0, 55.0], "sex": ["M", "F"]})
+    t = np.array([5.0, 12.0])
+    assert np.allclose(model.sf(t, raw_Z), restored.sf(t, raw_Z))
+
+
+def test_stateful_transform_formula_serialisation_raises():
+    df = _formula_df(seed=3)
+    model = WeibullPH.fit_from_df(
+        df, x_col="time", c_col="c", formula="scale(age) + sex"
+    )
+    # scale() keeps fitted stats that cannot be restored from levels; the
+    # failure is raised early (at to_dict) rather than a silently wrong encode.
+    with pytest.raises(NotImplementedError, match="data-dependent transform"):
+        model.to_dict()
+
+
 # -- tagged families (one representative per family) --------------------------
 
 

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -18,7 +18,11 @@ from ._bounds import (
     logit_sf_bound,
     numerical_hessian,
 )
-from .regression_data import prepare_Z
+from .regression_data import (
+    model_spec_to_meta,
+    prepare_Z,
+    rebuild_model_spec,
+)
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -194,7 +198,12 @@ class ParametricRegressionModel:
         if self.feature_names is not None:
             out["feature_names"] = list(self.feature_names)
         if self.formula is not None:
-            out["formula"] = self.formula
+            out["formula"] = str(self.formula)
+            # Persist the categorical levels / numeric columns needed to
+            # rebuild the formula's design-matrix transformer on load, so a
+            # restored model expands raw covariates the same way (#244).
+            if self._model_spec is not None:
+                out["formula_meta"] = model_spec_to_meta(self._model_spec)
 
         # Store the parameter covariance so the restored model can produce
         # confidence bounds without the original data. Only for data-fit
@@ -309,6 +318,13 @@ class ParametricRegressionModel:
         out.f0 = float(model_dict.get("f0", 0.0))
         out.feature_names = model_dict.get("feature_names")
         out.formula = model_dict.get("formula")
+
+        # Rebuild the formula's design-matrix transformer so the restored
+        # model expands raw covariates (e.g. categoricals) at prediction time
+        # exactly as the original did (#244).
+        formula_meta = model_dict.get("formula_meta")
+        if out.formula is not None and formula_meta is not None:
+            out._model_spec = rebuild_model_spec(out.formula, formula_meta)
 
         if "covariance" in model_dict:
             out._restored_covariance = np.array(

--- a/surpyval/univariate/regression/regression_data.py
+++ b/surpyval/univariate/regression/regression_data.py
@@ -133,6 +133,96 @@ def prepare_Z(
     )
 
 
+def model_spec_to_meta(model_spec: Any) -> dict:
+    """
+    Capture the JSON-safe state needed to rebuild a ``formulaic`` model spec.
+
+    A model fit with a ``formula`` carries a ``formulaic`` ``ModelSpec`` that
+    knows how to expand raw covariates into the fitted design matrix -- in
+    particular the levels of any categorical factor (``sex`` -> ``sex[F]``,
+    ``sex[M]``). That spec is not itself JSON-serialisable, so this extracts
+    the minimum needed to regenerate an equivalent one on load: the categorical
+    factor levels and the names of the numeric covariate columns. The formula
+    string is stored separately by the caller.
+
+    Data-dependent (stateful) transforms such as ``scale(x)`` or ``center(x)``
+    keep fitted statistics in the spec's ``transform_state`` that cannot be
+    recovered from levels alone; a formula using one raises
+    ``NotImplementedError`` rather than round-tripping to a silently wrong
+    encoding.
+    """
+    if getattr(model_spec, "transform_state", None):
+        raise NotImplementedError(
+            "Serialising a formula that uses a data-dependent transform "
+            "(e.g. scale() or center()) is not supported: its fitted "
+            "statistics cannot be restored. Refit with the covariate entered "
+            "directly (the baseline distribution absorbs location and scale), "
+            "or with a covariate list instead of a formula."
+        )
+
+    value_vars = {
+        str(v)
+        for v in model_spec.variables
+        if any(str(r).endswith("VALUE") for r in v.roles)
+    }
+
+    factor_levels: dict[str, list] = {}
+    for factor, (_kind, state) in model_spec.encoder_state.items():
+        if "categories" not in state:
+            continue
+        factor = str(factor)
+        if factor not in value_vars:
+            # A wrapped categorical such as ``C(sex)`` does not name a bare
+            # column, so the template below cannot type it. These are rare;
+            # fall back to Wald-free refitting rather than guess.
+            raise NotImplementedError(
+                "Serialising a wrapped categorical term "
+                f"('{factor}') is not yet supported; enter the column "
+                "directly (surpyval treats string / object columns as "
+                "categorical automatically)."
+            )
+        factor_levels[factor] = [str(c) for c in state["categories"]]
+
+    numeric_features = sorted(value_vars - set(factor_levels))
+    return {
+        "factor_levels": factor_levels,
+        "numeric_features": numeric_features,
+    }
+
+
+def rebuild_model_spec(formula: str, meta: dict) -> Any:
+    """
+    Reconstruct a ``formulaic`` model spec from a formula and stored metadata.
+
+    A small template DataFrame is built with each categorical column typed to
+    the stored levels and each numeric column a placeholder, then the same
+    ``"0 + " + formula`` is re-materialised against it. ``formulaic`` derives
+    an encoder state identical to fit time (the encoding depends on the formula
+    and the factor levels, not the row values), so the returned spec expands
+    raw covariates exactly as the original did.
+    """
+    formula = str(formula)
+    factor_levels = meta.get("factor_levels", {})
+    numeric_features = meta.get("numeric_features", [])
+
+    height = max((len(lv) for lv in factor_levels.values()), default=1)
+    template: dict[str, Any] = {}
+    for col, levels in factor_levels.items():
+        reps = (height + len(levels) - 1) // len(levels)
+        template[col] = pd.Categorical(
+            (list(levels) * reps)[:height], categories=list(levels)
+        )
+    for col in numeric_features:
+        # 1.0 (not 0.0) keeps log / reciprocal terms finite while the spec is
+        # derived; only the encoder structure is kept, not these values.
+        template[col] = np.ones(height)
+
+    model_matrix = Formula("0 + " + formula).get_model_matrix(
+        pd.DataFrame(template)
+    )
+    return model_matrix.model_spec
+
+
 class DataFrameRegressionMixin:
     """
     Mixin adding a ``fit_from_df`` method to a parametric regression fitter.

--- a/surpyval/univariate/regression/semi_parametric_regression_model.py
+++ b/surpyval/univariate/regression/semi_parametric_regression_model.py
@@ -8,7 +8,11 @@ import numpy.typing as npt
 from surpyval.serialisation import stamp_schema
 from surpyval.utils import _get_idx
 
-from .regression_data import prepare_Z
+from .regression_data import (
+    model_spec_to_meta,
+    prepare_Z,
+    rebuild_model_spec,
+)
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -127,7 +131,11 @@ class SemiParametricRegressionModel:
         if self.feature_names is not None:
             out["feature_names"] = list(self.feature_names)
         if self.formula is not None:
-            out["formula"] = self.formula
+            out["formula"] = str(self.formula)
+            # Persist the transformer state so a restored model expands raw
+            # covariates (e.g. categoricals) the same way (#244).
+            if self._model_spec is not None:
+                out["formula_meta"] = model_spec_to_meta(self._model_spec)
         return stamp_schema(out)
 
     def to_json(self, fp: "str | Path") -> None:
@@ -174,6 +182,12 @@ class SemiParametricRegressionModel:
             out._neg_log_like = float(model_dict["_neg_log_like"])
         out.feature_names = model_dict.get("feature_names")
         out.formula = model_dict.get("formula")
+
+        # Rebuild the formula's design-matrix transformer so the restored
+        # model expands raw covariates the same way (#244).
+        formula_meta = model_dict.get("formula_meta")
+        if out.formula is not None and formula_meta is not None:
+            out._model_spec = rebuild_model_spec(out.formula, formula_meta)
         return out
 
     @classmethod


### PR DESCRIPTION
Fixes #244.

## The bug
A regression model fit with `fit_from_df(..., formula=...)` using a **categorical** term dropped its design-matrix transformer on serialisation. `to_dict` persisted only the formula string + expanded `feature_names`, so `from_dict` rebuilt a model with `_model_spec = None`; predicting from **raw** covariates then failed:

```
m2.sf(10.0, pd.DataFrame({'age':[50], 'sex':['M']}))
# ValueError: ['sex[F]', 'sex[M]'] not in dataframe columns
```

Reproduced: `fitted has _model_spec: True` → `to_dict has model_spec: False` → `restored: False` → fails.

## The fix
`to_dict` now captures the JSON-safe state needed to regenerate an equivalent `formulaic` `ModelSpec` — the **categorical factor levels** and **numeric column names**, extracted from the fitted spec (`model_spec_to_meta`). `from_dict` rebuilds it by re-materialising `"0 + <formula>"` against a **template DataFrame** typed to those levels (`rebuild_model_spec`). formulaic derives an identical encoder state (encoding depends on the formula + factor levels, not row values), so a restored model expands raw covariates **exactly** as the original.

- Applied to both the parametric families (**PH/AFT/PO/AH**) and **Cox**.
- The stored `formula` is coerced to `str` so Cox's formulaic `Formula` object stays JSON-safe.
- **Data-dependent transforms** (`scale()`/`center()`) keep fitted statistics that can't be recovered from levels, so serialising such a formula raises `NotImplementedError` **early at `to_dict`** rather than round-tripping to a silently wrong encoding.

## Tests
Raw-covariate round-trip equality (through `json.dumps`/`loads`) for a plain categorical, an interaction (`age:sex`), and a stateless `np.log()` transform — across PH and Cox — plus the stateful-transform guard. `test_package_serialisation.py`: 26 passing. flake8/black clean.

Covariate-list (non-formula) fits and numeric-only formulas were already fine and remain so.

Targets `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_