### PR TITLE
Shared-frailty proportional-hazards models with Gamma frailty (#149)

### DIFF
--- a/docs/Regression Modelling with SurPyval.rst
+++ b/docs/Regression Modelling with SurPyval.rst
@@ -927,6 +927,65 @@ survival curve into the future at all — which is why this scenario forecasting
 needs the parametric ``fit_tvc`` / ``sf_tvc`` pair.
 
 
+Shared-frailty models
+---------------------
+
+When your data come in **groups** — lots from the same supplier, units at the
+same site, repeated failures of one repairable machine — the members of a group
+tend to fail more alike than units from different groups, because they share
+something you did not measure. A **shared-frailty** model captures that with a
+random hazard multiplier ``u`` shared within each group, on top of a
+proportional-hazards baseline. Fit it with the :func:`~surpyval.Frailty`
+factory (or a pre-built instance like ``WeibullFrailty``), passing a ``groups``
+label per observation:
+
+.. jupyter-execute::
+
+    from surpyval import WeibullFrailty
+
+    rng = np.random.default_rng(1)
+    n_groups, per = 60, 6
+    rows_x, rows_c, rows_z, rows_g = [], [], [], []
+    for g in range(n_groups):
+        u = rng.gamma(1 / 0.6, 0.6)              # group frailty, mean 1
+        for _ in range(per):
+            z = rng.normal()
+            t = 20 * (-np.log(rng.uniform()) / (np.exp(0.8 * z) * u)) ** (1 / 1.8)
+            rows_x.append(min(t, 40)); rows_c.append(0 if t <= 40 else 1)
+            rows_z.append(z); rows_g.append(g)
+
+    model = WeibullFrailty.fit(
+        x=np.array(rows_x), c=np.array(rows_c),
+        Z=np.array(rows_z).reshape(-1, 1), groups=np.array(rows_g),
+    )
+    print(model.summary())
+    print("theta 95% CI:", np.round(model.param_cb("theta"), 3))
+
+The frailty variance ``theta`` quantifies the between-group spread; its
+confidence interval sitting clear of zero is evidence of real heterogeneity.
+The per-group posterior frailties — an empirical-Bayes estimate for each
+observed group, shrunk toward 1 — are on ``model.frailties``.
+
+Prediction comes in two flavours. The default is **marginal** (population
+averaged), the right curve for a *new* unit from an *unknown* group; passing
+``group=`` conditions on an observed group's posterior frailty, for another unit
+from a group you have already seen:
+
+.. jupyter-execute::
+
+    t = np.linspace(1, 40, 100)
+    z = np.array([0.0])
+    plt.plot(t, model.sf(t, z), 'k-', label='marginal (new group)')
+    g0 = model.group_labels[0]
+    plt.plot(t, model.sf(t, z, group=g0), 'b--',
+             label=f'conditional on group {g0}')
+    plt.legend(); plt.xlabel('Time'); plt.ylabel('S(t)')
+
+Omit ``Z`` entirely for a pure random-effects survival model (grouped data, no
+covariates). Only Gamma frailty is available for now, on observed and
+right-censored data.
+
+
 Confidence Bounds
 -----------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,24 @@ Changelog
 v0.17.0 (unreleased)
 --------------------
 
+- **Shared-frailty proportional-hazards models (Gamma frailty).** A new
+  ``Frailty(distribution)`` factory (with pre-built ``WeibullFrailty``,
+  ``ExponentialFrailty``, ``LogNormalFrailty``, ``GammaFrailty`` instances) fits
+  a proportional-hazards model with a random hazard multiplier shared within a
+  group -- ``h(t | Z, u) = u h0(t) exp(beta'Z)``, ``u`` drawn once per group
+  from a Gamma of mean 1 and variance ``theta``. ``.fit(x, Z, c, groups=...)``
+  and ``.fit_from_df(..., group_col=...)`` maximise the closed-form marginal
+  likelihood (the Gamma frailty integrates out per group), so it captures
+  unobserved between-group heterogeneity and the within-group correlation it
+  induces -- the conditional/random-effects complement to the cluster-robust
+  standard errors added in 0.16. The fitted ``FrailtyModel`` reports the frailty
+  variance ``theta`` (with a Wald CI), the per-group posterior (empirical-Bayes)
+  frailties, and predicts either **marginally** (population-averaged, the
+  default -- ``S = (1 + theta e^{beta'Z} H0)^{-1/theta}``) or **conditionally**
+  on an observed group or a supplied frailty value via ``sf(x, Z, group=...)`` /
+  ``sf(x, Z, frailty=...)``. Omitting ``Z`` gives a pure random-effects survival
+  model. Serialises with ``to_dict`` / ``from_dict``. Gamma frailty only for
+  now; log-normal, Cox, and nested/hierarchical frailty are planned.
 - **Fixed: formula-fit regression models now round-trip through serialisation**
   (#244). A regression model fit with ``fit_from_df(..., formula=...)`` using a
   categorical term dropped its design-matrix transformer on ``to_dict`` /

--- a/docs/regression analysis.rst
+++ b/docs/regression analysis.rst
@@ -206,6 +206,30 @@ The model-based standard errors assume every observation is independent. When th
 
 which reduces to the usual variance when there is one observation per cluster and there is no within-cluster correlation.
 
+Shared frailty
+--------------
+
+Cluster-robust errors *correct* for within-cluster correlation but do not *model* it. A **shared-frailty** model does the opposite: it introduces the correlation explicitly through an unobserved random effect. Each group :math:`g` (a manufacturing lot, a site, a repairable unit) is given a **frailty** :math:`u_g` — a random multiplier shared by every member of the group — acting on the hazard:
+
+.. math::
+
+    h\bigl(t \mid Z, u_g\bigr) = u_g \, h_0(t) \, e^{\beta' Z},
+
+with the frailties drawn once per group from a Gamma distribution of mean 1 and variance :math:`\theta`. The frailty is the survival analogue of a random intercept: it absorbs whatever unmeasured feature makes a whole group fail faster or slower than its covariates predict, and :math:`\theta` measures that between-group variability (:math:`\theta = 0` recovers ordinary proportional hazards). This is the *conditional* / random-effects counterpart of the *marginal* cluster-robust correction above — same within-group correlation, modelled rather than merely accounted for.
+
+Because the frailty multiplies the *cumulative* hazard, a Gamma frailty integrates out of a group's likelihood in closed form. Writing :math:`D_g` for the number of events in group :math:`g` and :math:`H_g = \sum_{j \in g} e^{\beta' z_j} H_0(t_j)` for the sum of its members' cumulative hazards, the group contributes
+
+.. math::
+
+    \sum_{\text{events}} \log\!\bigl(h_0 \, e^{\beta' Z}\bigr)
+    - \tfrac{1}{\theta}\log\theta - \log\Gamma\!\bigl(\tfrac{1}{\theta}\bigr)
+    + \log\Gamma\!\bigl(D_g + \tfrac{1}{\theta}\bigr)
+    - \bigl(D_g + \tfrac{1}{\theta}\bigr)\log\!\bigl(H_g + \tfrac{1}{\theta}\bigr)
+
+to the marginal log-likelihood, which is maximised jointly over the baseline parameters, :math:`\beta`, and :math:`\theta`. The same conjugacy makes the **posterior** frailty of an observed group a closed form, :math:`\hat u_g = (D_g + 1/\theta)/(H_g + 1/\theta)` — an empirical-Bayes estimate shrunk toward 1, larger for groups that fail early.
+
+The distinction between the two curves the model can draw matters. Integrating the frailty out gives the **marginal** (population-averaged) survival of a unit from an *unknown* group, :math:`S(t \mid Z) = (1 + \theta \, e^{\beta' Z} H_0(t))^{-1/\theta}` — a Laplace transform of the frailty distribution, and always heavier-tailed than the baseline. Conditioning on a value :math:`u` gives :math:`S(t \mid Z, u) = e^{-u \, e^{\beta' Z} H_0(t)}`, used with :math:`\hat u_g` to predict a *new* member of an *already-observed* group. A subtle consequence is that a mixture of groups makes the **population** hazard bend down over time even when every group's hazard rises, because the frail groups fail first and leave robust survivors — so an apparent decreasing hazard can be a heterogeneity artifact rather than a real one. Identification requires within-group replication: with a single group, or one observation per group, :math:`\theta` is confounded with the baseline shape and cannot be estimated.
+
 Stratification
 --------------
 

--- a/surpyval/serialisation.py
+++ b/surpyval/serialisation.py
@@ -36,6 +36,7 @@ _TAGGED_MODELS: dict[str, str] = {
     "SemiParametricRegressionModel": (
         "surpyval.univariate.regression.semi_parametric_regression_model"
     ),
+    "FrailtyModel": ("surpyval.univariate.regression.frailty.frailty_model"),
     "AdditiveHazardsModel": (
         "surpyval.univariate.regression.additive_hazards.additive_hazards"
     ),

--- a/surpyval/tests/univariate/regression/test_frailty.py
+++ b/surpyval/tests/univariate/regression/test_frailty.py
@@ -1,0 +1,201 @@
+"""Tests for the shared-frailty proportional-hazards model."""
+
+import json
+
+import numpy as np
+import pytest
+from scipy.integrate import quad
+from scipy.special import gammaln
+
+import surpyval as surv
+from surpyval import ExponentialFrailty, Frailty, Weibull, WeibullFrailty
+
+
+def _sim(seed=7, G=80, per=6, alpha=12.0, shape=1.8, beta=0.9, theta=0.6):
+    rng = np.random.default_rng(seed)
+    groups, x, c, Z = [], [], [], []
+    for g in range(G):
+        u = rng.gamma(1.0 / theta, theta)
+        for _ in range(per):
+            z = rng.normal(0, 1)
+            eta = np.exp(beta * z) * u
+            t = alpha * (-np.log(rng.uniform()) / eta) ** (1.0 / shape)
+            obs = min(t, 30.0)
+            groups.append(g)
+            x.append(obs)
+            c.append(0 if t <= 30.0 else 1)
+            Z.append(z)
+    return (
+        np.array(x),
+        np.array(c),
+        np.array(Z).reshape(-1, 1),
+        np.array(groups),
+    )
+
+
+def test_marginal_likelihood_matches_numerical_integration():
+    # Gold standard: the closed-form gamma-frailty group likelihood must equal
+    # brute-force integration of the conditional likelihood over the frailty.
+    rng = np.random.default_rng(0)
+    fitter = WeibullFrailty
+    dp = np.array([9.0, 1.8])
+    theta = 0.7
+    for _ in range(5):
+        m = rng.integers(2, 6)
+        x = np.abs(rng.weibull(2.0, m)) * 10 + 0.5
+        c = rng.integers(0, 2, m)
+        c[0] = 0  # ensure an event
+        eta = np.exp(rng.normal(0, 0.5, m))
+
+        H0 = Weibull.Hf(x, *dp)
+        h0 = Weibull.hf(x, *dp)
+        event = c == 0
+        D = int(event.sum())
+        H = float(np.sum(eta * H0))
+        it = 1.0 / theta
+        closed = (
+            np.sum(np.log(h0[event]) + np.log(eta[event]))
+            - it * np.log(theta)
+            - gammaln(it)
+            + gammaln(D + it)
+            - (D + it) * np.log(H + it)
+        )
+
+        prod_event = np.prod(h0[event] * eta[event])
+        logconst = it * np.log(theta) + gammaln(it)
+
+        def integrand(u):
+            cond = (u**D) * prod_event * np.exp(-u * H)
+            fu = np.exp((it - 1) * np.log(u) - u / theta - logconst)
+            return cond * fu
+
+        val, _ = quad(integrand, 0, np.inf, limit=200)
+        assert closed == pytest.approx(np.log(val), abs=1e-6)
+    assert fitter is WeibullFrailty  # keep the fixture referenced
+
+
+def test_recovers_known_parameters():
+    x, c, Z, groups = _sim()
+    m = WeibullFrailty.fit(x=x, Z=Z, c=c, groups=groups)
+    assert m.dist_params[0] == pytest.approx(12.0, rel=0.2)
+    assert m.dist_params[1] == pytest.approx(1.8, rel=0.2)
+    assert m.beta[0] == pytest.approx(0.9, abs=0.2)
+    assert m.theta == pytest.approx(0.6, abs=0.2)
+    assert m.n_groups == 80
+    # theta CI excludes 0 for this clearly-heterogeneous data
+    lo, hi = m.param_cb("theta")
+    assert 0 < lo < m.theta < hi
+
+
+def test_marginal_sf_is_gamma_laplace_transform():
+    x, c, Z, groups = _sim(seed=2)
+    m = WeibullFrailty.fit(x=x, Z=Z, c=c, groups=groups)
+    t = np.array([4.0, 9.0, 15.0])
+    z = np.array([0.3])
+    eta = np.exp(z @ m.beta)
+    H0 = Weibull.Hf(t, *m.dist_params)
+    expected = (1.0 + m.theta * eta * H0) ** (-1.0 / m.theta)
+    assert np.allclose(m.sf(t, z), expected)
+
+
+def test_posterior_frailty_mean_is_about_one():
+    x, c, Z, groups = _sim(seed=3)
+    m = WeibullFrailty.fit(x=x, Z=Z, c=c, groups=groups)
+    vals = np.array(list(m.frailties.values()))
+    assert vals.mean() == pytest.approx(1.0, abs=0.1)
+
+
+def test_conditional_orders_by_frailty():
+    x, c, Z, groups = _sim(seed=4)
+    m = WeibullFrailty.fit(x=x, Z=Z, c=c, groups=groups)
+    t = np.array([8.0])
+    z = np.array([0.0])
+    # a higher frailty means a higher hazard, hence lower survival
+    assert m.sf(t, z, frailty=2.0) < m.sf(t, z, frailty=0.5)
+
+
+def test_no_covariate_frailty():
+    rng = np.random.default_rng(5)
+    G, per, theta = 60, 8, 0.5
+    groups, x, c = [], [], []
+    for g in range(G):
+        u = rng.gamma(1.0 / theta, theta)
+        for _ in range(per):
+            t = 10.0 * (-np.log(rng.uniform()) / u) ** (1.0 / 2.0)
+            groups.append(g)
+            x.append(min(t, 25.0))
+            c.append(0 if t <= 25.0 else 1)
+    m = WeibullFrailty.fit(
+        x=np.array(x), c=np.array(c), groups=np.array(groups)
+    )
+    assert m.beta.size == 0
+    assert m.theta == pytest.approx(0.5, abs=0.2)
+    assert m.sf(np.array([8.0])).shape == (1,)
+
+
+def test_fit_from_df_formula_round_trips():
+    rng = np.random.default_rng(6)
+    n = 400
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {
+            "t": rng.weibull(1.8, n) * 10 + 0.5,
+            "c": rng.integers(0, 2, n),
+            "load": rng.uniform(1, 5, n),
+            "site": rng.choice(["A", "B", "C"], n),
+            "unit": rng.integers(0, 50, n),
+        }
+    )
+    m = WeibullFrailty.fit_from_df(
+        df, x_col="t", c_col="c", group_col="unit", formula="load + site"
+    )
+    restored = surv.from_dict(json.loads(json.dumps(m.to_dict())))
+    assert type(restored).__name__ == "FrailtyModel"
+    raw = pd.DataFrame({"load": [3.0, 2.0], "site": ["B", "A"]})
+    t = np.array([5.0, 10.0])
+    assert np.allclose(m.sf(t, raw), restored.sf(t, raw))
+    # a known group's conditional prediction round-trips too
+    g = m.group_labels[0]
+    assert np.allclose(
+        m.sf(t, raw.iloc[[0]], group=g),
+        restored.sf(t, raw.iloc[[0]], group=g),
+    )
+
+
+def test_serialisation_round_trip_arrays():
+    x, c, Z, groups = _sim(seed=8, G=40, per=5)
+    m = WeibullFrailty.fit(x=x, Z=Z, c=c, groups=groups)
+    restored = surv.from_dict(json.loads(json.dumps(m.to_dict())))
+    t = np.array([5.0, 12.0])
+    z = np.array([0.4])
+    assert np.allclose(m.sf(t, z), restored.sf(t, z))
+    assert restored.theta == pytest.approx(m.theta)
+    assert restored.frailties == m.frailties
+
+
+def test_guard_single_group():
+    x, c, Z, groups = _sim(seed=9, G=1, per=20)
+    with pytest.raises(ValueError, match="two groups"):
+        WeibullFrailty.fit(x=x, Z=Z, c=c, groups=groups)
+
+
+def test_guard_unsupported_censoring():
+    with pytest.raises(ValueError, match="right-censored"):
+        WeibullFrailty.fit(
+            x=np.array([1.0, 2.0, 3.0, 4.0]),
+            c=np.array([-1, 0, 0, 1]),
+            groups=np.array([0, 0, 1, 1]),
+        )
+
+
+def test_guard_unknown_family():
+    with pytest.raises(NotImplementedError):
+        Frailty(Weibull, family="lognormal")
+
+
+def test_exponential_frailty_available():
+    x, c, Z, groups = _sim(seed=10, G=50, per=5)
+    m = ExponentialFrailty.fit(x=x, Z=Z, c=c, groups=groups)
+    assert m.dist.name == "Exponential"
+    assert m.theta > 0

--- a/surpyval/univariate/regression/__init__.py
+++ b/surpyval/univariate/regression/__init__.py
@@ -38,6 +38,15 @@ from .additive_hazards import (
     WeibullAH,
 )
 from .buckley_james import BuckleyJames, BuckleyJamesModel
+from .frailty import (
+    ExponentialFrailty,
+    Frailty,
+    FrailtyFitter,
+    FrailtyModel,
+    GammaFrailty,
+    LogNormalFrailty,
+    WeibullFrailty,
+)
 from .parametric_regression_model import ParametricRegressionModel
 from .proportional_hazards import (
     PH,
@@ -69,6 +78,14 @@ __all__ = [
     # Result classes that hold to_dict / from_dict / to_json / from_json
     "ParametricRegressionModel",
     "SemiParametricRegressionModel",
+    "FrailtyModel",
+    # Shared-frailty proportional hazards (Gamma frailty)
+    "Frailty",
+    "FrailtyFitter",
+    "ExponentialFrailty",
+    "GammaFrailty",
+    "LogNormalFrailty",
+    "WeibullFrailty",
     # Time-varying-covariate step schedule for sf_tvc evaluation
     "StepSchedule",
     "StepValuedError",

--- a/surpyval/univariate/regression/frailty/__init__.py
+++ b/surpyval/univariate/regression/frailty/__init__.py
@@ -1,0 +1,57 @@
+from surpyval.univariate.parametric import (
+    Exponential,
+    Gamma,
+    LogNormal,
+    Weibull,
+)
+
+from .frailty_fitter import FrailtyFitter
+from .frailty_model import FrailtyModel
+
+
+def Frailty(distribution, family="gamma"):
+    """
+    Create a shared-frailty proportional-hazards fitter for a distribution.
+
+    A shared-frailty model adds a random hazard multiplier shared within a
+    group (a lot, site, or repairable unit) on top of a proportional-hazards
+    baseline, capturing unobserved between-group heterogeneity and the
+    within-group correlation it induces. The frailty family is Gamma (the only
+    one currently available), whose closed-form marginal likelihood keeps the
+    fit fast.
+
+    Parameters
+    ----------
+    distribution : ParametricFitter
+        A surpyval parametric distribution (e.g. ``Weibull``, ``Exponential``).
+    family : str, optional
+        The frailty distribution. Only ``"gamma"`` is currently supported.
+
+    Returns
+    -------
+    FrailtyFitter
+        A fitter with ``.fit(x, Z, c, groups=...)`` and ``.fit_from_df``.
+
+    Examples
+    --------
+    >>> from surpyval import Frailty, Weibull
+    >>> model = Frailty(Weibull).fit(x, Z=Z, c=c, groups=unit_id)
+    """
+    return FrailtyFitter.create(distribution, family)
+
+
+# Pre-built gamma-frailty instances -- one per distribution.
+ExponentialFrailty = FrailtyFitter.create(Exponential)
+WeibullFrailty = FrailtyFitter.create(Weibull)
+LogNormalFrailty = FrailtyFitter.create(LogNormal)
+GammaFrailty = FrailtyFitter.create(Gamma)
+
+__all__ = [
+    "ExponentialFrailty",
+    "Frailty",
+    "FrailtyFitter",
+    "FrailtyModel",
+    "GammaFrailty",
+    "LogNormalFrailty",
+    "WeibullFrailty",
+]

--- a/surpyval/univariate/regression/frailty/frailty_fitter.py
+++ b/surpyval/univariate/regression/frailty/frailty_fitter.py
@@ -1,0 +1,340 @@
+"""
+Fitter for shared-frailty proportional-hazards models (Gamma frailty).
+
+The frailty enters as a random multiplier on the hazard shared within a group,
+so the conditional cumulative hazard of an observation is ``u * eta * H0(t)``
+with ``eta = exp(beta'Z)``. A Gamma frailty of mean 1 and variance ``theta``
+integrates out of a group's likelihood in closed form. With ``D`` the number
+of events in a group and ``H`` the sum of ``eta * H0`` over its observations,
+the group log-likelihood is
+
+.. math::
+    \\sum_{\\text{events}} \\log(h_0 \\, \\eta)
+    - \\tfrac{1}{\\theta}\\log\\theta - \\log\\Gamma(\\tfrac{1}{\\theta})
+    + \\log\\Gamma(D + \\tfrac{1}{\\theta})
+    - (D + \\tfrac{1}{\\theta}) \\log(H + \\tfrac{1}{\\theta}),
+
+and the posterior frailty is ``(D + 1/theta) / (H + 1/theta)``. Only observed
+(``c = 0``) and right-censored (``c = 1``) data are supported -- the closed
+form relies on that split. The ordinary parametric MLE is not touched; this
+module
+maximises its own marginal likelihood on a fresh optimiser.
+"""
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from scipy.optimize import minimize
+from scipy.special import gammaln
+
+from ..regression_data import design_matrix_from_df
+from .frailty_model import FrailtyModel
+
+
+def _make_transforms(dist, k_dist):
+    """Per-parameter (natural <-> unconstrained) maps for the optimiser.
+
+    Baseline parameters follow the distribution's bounds (log for a positive
+    parameter, logit for a ``(0, 1)`` parameter, identity otherwise); the
+    coefficients are unconstrained; ``theta`` is positive, so log.
+    """
+    forms = []
+    for low, high in dist.bounds[:k_dist]:
+        if low == 0 and high is None:
+            forms.append("log")
+        elif (low, high) == (0, 1):
+            forms.append("logit")
+        else:
+            forms.append("id")
+
+    def to_unc(nat, n_beta):
+        out = []
+        for i, f in enumerate(forms):
+            v = nat[i]
+            if f == "log":
+                out.append(np.log(v))
+            elif f == "logit":
+                out.append(np.log(v / (1 - v)))
+            else:
+                out.append(v)
+        out.extend(nat[k_dist : k_dist + n_beta])  # beta: identity
+        out.append(np.log(nat[-1]))  # theta: log
+        return np.array(out, dtype=float)
+
+    def to_nat(unc, n_beta):
+        out = []
+        for i, f in enumerate(forms):
+            v = unc[i]
+            if f == "log":
+                out.append(np.exp(v))
+            elif f == "logit":
+                out.append(1.0 / (1.0 + np.exp(-v)))
+            else:
+                out.append(v)
+        out.extend(unc[k_dist : k_dist + n_beta])
+        out.append(np.exp(unc[-1]))
+        return np.array(out, dtype=float)
+
+    return to_unc, to_nat
+
+
+def _numerical_hessian(f, x, eps=1e-5):
+    """Finite-difference Hessian of scalar ``f`` at ``x``."""
+    n = len(x)
+    H = np.zeros((n, n))
+    steps = np.maximum(np.abs(x), 1.0) * eps
+    for i in range(n):
+        for j in range(i, n):
+            xi = x.copy()
+            xi[i] += steps[i]
+            xi[j] += steps[j]
+            fpp = f(xi)
+            xi = x.copy()
+            xi[i] += steps[i]
+            xi[j] -= steps[j]
+            fpm = f(xi)
+            xi = x.copy()
+            xi[i] -= steps[i]
+            xi[j] += steps[j]
+            fmp = f(xi)
+            xi = x.copy()
+            xi[i] -= steps[i]
+            xi[j] -= steps[j]
+            fmm = f(xi)
+            H[i, j] = H[j, i] = (fpp - fpm - fmp + fmm) / (
+                4 * steps[i] * steps[j]
+            )
+    return H
+
+
+class FrailtyFitter:
+    """Configured fitter for a shared-frailty PH model on one distribution."""
+
+    def __init__(self, name: str, dist: Any, family: str = "gamma") -> None:
+        if family != "gamma":
+            raise NotImplementedError(
+                "Only the 'gamma' frailty family is available; "
+                f"got {family!r}."
+            )
+        self.name = name
+        self.dist = dist
+        self.family = family
+        self.k_dist = len(dist.param_names)
+
+    @staticmethod
+    def create(distribution: Any, family: str = "gamma") -> "FrailtyFitter":
+        return FrailtyFitter(
+            f"{distribution.name}Frailty", distribution, family
+        )
+
+    # -- likelihood --------------------------------------------------------
+
+    def _neg_ll_natural(self, nat, x, c, w, eta_Z, inv, n_beta):
+        """Marginal negative log-likelihood in natural parameters.
+
+        ``eta_Z`` is the covariate matrix (n_obs x n_beta); ``inv`` maps each
+        observation to its group index; ``w`` are observation weights.
+        """
+        dist_params = nat[: self.k_dist]
+        beta = nat[self.k_dist : self.k_dist + n_beta]
+        theta = nat[-1]
+
+        H0 = self.dist.Hf(x, *dist_params)
+        h0 = self.dist.hf(x, *dist_params)
+        eta = np.exp(eta_Z @ beta) if n_beta else np.ones_like(x)
+
+        event = c == 0
+        it = 1.0 / theta
+        ll = np.sum(w[event] * (np.log(h0[event]) + np.log(eta[event])))
+
+        n_groups = inv.max() + 1
+        D = np.bincount(inv, weights=w * event, minlength=n_groups)
+        H = np.bincount(inv, weights=w * eta * H0, minlength=n_groups)
+        ll += np.sum(
+            -it * np.log(theta)
+            - gammaln(it)
+            + gammaln(D + it)
+            - (D + it) * np.log(H + it)
+        )
+        return -ll
+
+    # -- fit ---------------------------------------------------------------
+
+    def fit(
+        self,
+        x: Any,
+        Z: Any = None,
+        c: Any = None,
+        n: Any = None,
+        groups: Any = None,
+        init: Any = None,
+    ) -> FrailtyModel:
+        """Fit the shared-frailty model.
+
+        Parameters
+        ----------
+        x : array_like
+            Observed times.
+        Z : array_like, optional
+            Covariates ``(n_obs, p)``. Omit for a frailty model with no
+            covariates (a pure random-effects survival model).
+        c : array_like, optional
+            Censoring flags: ``0`` event, ``1`` right-censored (the only two
+            supported). Defaults to all events.
+        n : array_like, optional
+            Observation weights / counts. Defaults to 1.
+        groups : array_like
+            The group (cluster) label of each observation. Required.
+        init : array_like, optional
+            Optional initial natural parameters ``[*dist, *beta, theta]``.
+        """
+        x = np.asarray(x, dtype=float).ravel()
+        n_obs = x.shape[0]
+        c = (
+            np.zeros(n_obs, dtype=int)
+            if c is None
+            else np.asarray(c, dtype=int).ravel()
+        )
+        w = np.ones(n_obs) if n is None else np.asarray(n, dtype=float).ravel()
+        if groups is None:
+            raise ValueError("'groups' (a cluster label per row) is required.")
+        groups = np.asarray(groups).ravel()
+
+        if not np.all(np.isin(c, (0, 1))):
+            raise ValueError(
+                "Frailty fitting supports only observed (c=0) and "
+                "right-censored (c=1) data."
+            )
+        if int((c == 0).sum()) == 0:
+            raise ValueError("At least one event (c=0) is required.")
+
+        labels, inv = np.unique(groups, return_inverse=True)
+        n_groups = labels.shape[0]
+        if n_groups < 2:
+            raise ValueError(
+                "The frailty variance is not identifiable from a single "
+                "group; at least two groups are required."
+            )
+
+        if Z is None:
+            Zc = np.zeros((n_obs, 0))
+            n_beta = 0
+            feature_names = None
+        else:
+            Zc = np.atleast_2d(np.asarray(Z, dtype=float))
+            if Zc.shape[0] != n_obs:
+                Zc = Zc.T
+            n_beta = Zc.shape[1]
+            feature_names = None
+
+        to_unc, to_nat = _make_transforms(self.dist, self.k_dist)
+
+        if init is None:
+            base = self.dist.fit(x=x, c=c, n=w).params
+            init_nat = np.concatenate(
+                [np.asarray(base, float), np.zeros(n_beta), [0.5]]
+            )
+        else:
+            init_nat = np.asarray(init, dtype=float)
+
+        def obj_unc(u):
+            nat = to_nat(u, n_beta)
+            return self._neg_ll_natural(nat, x, c, w, Zc, inv, n_beta)
+
+        u0 = to_unc(init_nat, n_beta)
+        with np.errstate(all="ignore"):
+            res = minimize(
+                obj_unc,
+                u0,
+                method="Nelder-Mead",
+                options={"maxiter": 10000, "xatol": 1e-8, "fatol": 1e-8},
+            )
+            res = minimize(obj_unc, res.x, method="BFGS")
+        nat = to_nat(res.x, n_beta)
+
+        dist_params = nat[: self.k_dist]
+        beta = nat[self.k_dist : self.k_dist + n_beta]
+        theta = float(nat[-1])
+
+        # Posterior (empirical-Bayes) frailty per group.
+        H0 = self.dist.Hf(x, *dist_params)
+        eta = np.exp(Zc @ beta) if n_beta else np.ones_like(x)
+        it = 1.0 / theta
+        D = np.bincount(inv, weights=w * (c == 0), minlength=n_groups)
+        H = np.bincount(inv, weights=w * eta * H0, minlength=n_groups)
+        post = (D + it) / (H + it)
+
+        # Covariance of the natural parameters via a numerical Hessian.
+        param_names = list(self.dist.param_names)
+        param_names += [f"beta_{i}" for i in range(n_beta)]
+        param_names += ["theta"]
+
+        def nll_nat(v):
+            return self._neg_ll_natural(v, x, c, w, Zc, inv, n_beta)
+
+        covariance = None
+        with np.errstate(all="ignore"):
+            try:
+                Hmat = _numerical_hessian(nll_nat, nat)
+                cov = np.linalg.inv(Hmat)
+                if np.all(np.isfinite(cov)):
+                    covariance = cov
+            except np.linalg.LinAlgError:
+                covariance = None
+
+        model = FrailtyModel()
+        model.family = self.family
+        model.dist = self.dist
+        model.dist_params = np.asarray(dist_params, float)
+        model.beta = np.asarray(beta, float)
+        model.theta = theta
+        model.k_dist = self.k_dist
+        model.feature_names = feature_names
+        model.group_labels = list(labels)
+        model.frailties = {str(lab): float(u) for lab, u in zip(labels, post)}
+        model.covariance = covariance
+        model.param_names = param_names
+        model.n_obs = n_obs
+        model.n_events = int((c == 0).sum())
+        model.n_groups = n_groups
+        model._neg_ll = float(res.fun)
+        return model
+
+    def fit_from_df(
+        self,
+        df: pd.DataFrame,
+        x_col: str,
+        group_col: str,
+        Z_cols: "str | list[str] | None" = None,
+        c_col: "str | None" = None,
+        n_col: "str | None" = None,
+        formula: "str | None" = None,
+        init: Any = None,
+    ) -> FrailtyModel:
+        """Fit from a :class:`pandas.DataFrame` naming the columns.
+
+        Either ``Z_cols`` or ``formula`` describes the covariates (or neither,
+        for a no-covariate frailty model); ``group_col`` names the cluster
+        column. Covariate names / the formula transformer are retained so the
+        fitted model predicts from raw-covariate DataFrames.
+        """
+        x = df[x_col].values
+        c = None if c_col is None else df[c_col].values
+        n = None if n_col is None else df[n_col].values
+        groups = df[group_col].values
+
+        feature_names = None
+        model_spec = None
+        if Z_cols is None and formula is None:
+            Z = None
+        else:
+            Z, feature_names, model_spec = design_matrix_from_df(
+                df, Z_cols=Z_cols, formula=formula
+            )
+
+        model = self.fit(x, Z=Z, c=c, n=n, groups=groups, init=init)
+        model.feature_names = feature_names
+        model.formula = formula
+        model._model_spec = model_spec
+        return model

--- a/surpyval/univariate/regression/frailty/frailty_model.py
+++ b/surpyval/univariate/regression/frailty/frailty_model.py
@@ -1,0 +1,312 @@
+"""
+The fitted shared-frailty model returned by :class:`FrailtyFitter`.
+
+A shared-frailty model is a proportional-hazards model with an extra random
+multiplier ``u`` on the hazard that is *shared* by every observation in a
+group (a lot, a site, a repairable unit):
+
+.. math::
+    h(t \\mid Z, u) = u \\, h_0(t) \\, e^{\\beta' Z},
+
+with the frailties drawn once per group from a Gamma distribution of mean 1 and
+variance :math:`\\theta` (``theta``). ``theta`` measures the unexplained
+between-group variability; ``theta = 0`` recovers an ordinary parametric PH
+model.
+
+Because the frailty enters multiplicatively on the *cumulative* hazard, a Gamma
+frailty integrates out of a group's likelihood in closed form, and the same
+conjugacy gives each group's posterior frailty in closed form -- so prediction
+comes in two flavours:
+
+* **marginal** (population-averaged), integrating the frailty out --
+  ``S(t \\mid Z) = (1 + \\theta\\, e^{\\beta'Z} H_0(t))^{-1/\\theta}`` -- the
+  right curve for a new unit from an unknown group; and
+* **conditional**, on a supplied frailty value or on an *observed* group's
+  posterior frailty ``S(t \\mid Z, u) = e^{-u e^{\\beta'Z} H_0(t)}``.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from scipy.special import ndtri as _z
+
+from surpyval.serialisation import stamp_schema, to_native
+
+from ..regression_data import (
+    model_spec_to_meta,
+    prepare_Z,
+    rebuild_model_spec,
+)
+
+
+class FrailtyModel:
+    """A fitted shared-frailty proportional-hazards model.
+
+    See :class:`FrailtyFitter` for how one is produced. Prediction methods
+    (:meth:`sf`, :meth:`ff`, :meth:`hf`, :meth:`Hf`, :meth:`df`) return the
+    *marginal* (population) curve by default; pass ``group=`` to condition on
+    an observed group's posterior frailty, or ``frailty=`` to condition on a
+    supplied frailty value.
+    """
+
+    def __init__(self) -> None:
+        self.kind = "Frailty"
+        self.family = "gamma"
+        self.dist: Any = None
+        self.dist_params: np.ndarray = np.array([])
+        self.beta: np.ndarray = np.array([])
+        self.theta: float = 0.0
+        self.k_dist: int = 0
+        self.feature_names: "list[str] | None" = None
+        self.formula: "str | None" = None
+        self._model_spec: Any = None
+        self.group_labels: list = []
+        self.frailties: dict = {}
+        self.covariance: "np.ndarray | None" = None
+        self.param_names: "list[str]" = []
+        self.n_obs: int = 0
+        self.n_events: int = 0
+        self.n_groups: int = 0
+        self._neg_ll: float = 0.0
+
+    # -- covariate / frailty resolution ------------------------------------
+
+    def _eta(self, Z: Any) -> np.ndarray:
+        """The hazard multiplier ``exp(beta'Z)`` for a covariate setting."""
+        if self.beta.size == 0:
+            return np.array(1.0)
+        if Z is None:
+            raise ValueError(
+                "This model was fit with covariates; 'Z' is required."
+            )
+        Zp = prepare_Z(Z, self.feature_names, self._model_spec)
+        Zp = np.atleast_2d(np.asarray(Zp, dtype=float))
+        eta = np.exp(Zp @ self.beta)
+        return eta[0] if eta.shape[0] == 1 else eta
+
+    def _resolve_frailty(self, group: Any, frailty: Any) -> "float | None":
+        """Return the frailty value to condition on, or ``None`` (marginal)."""
+        if group is not None and frailty is not None:
+            raise ValueError("Pass at most one of 'group' or 'frailty'.")
+        if frailty is not None:
+            return float(frailty)
+        if group is not None:
+            key = group
+            if key not in self.frailties:
+                key = str(group)
+            if key not in self.frailties:
+                raise KeyError(
+                    f"Unknown group {group!r}; known groups are "
+                    f"{list(self.frailties)[:8]}..."
+                )
+            return float(self.frailties[key])
+        return None
+
+    # -- prediction --------------------------------------------------------
+
+    def Hf(
+        self, x: Any, Z: Any = None, group: Any = None, frailty: Any = None
+    ) -> np.ndarray:
+        """Cumulative hazard (marginal, or conditional on a frailty)."""
+        x = np.asarray(x, dtype=float)
+        eta = self._eta(Z)
+        H0 = self.dist.Hf(x, *self.dist_params)
+        s = eta * H0
+        u = self._resolve_frailty(group, frailty)
+        if u is None:
+            out = np.log1p(self.theta * s) / self.theta
+        else:
+            out = u * s
+        return out
+
+    def sf(
+        self, x: Any, Z: Any = None, group: Any = None, frailty: Any = None
+    ) -> np.ndarray:
+        """Survival function (marginal by default)."""
+        return np.exp(-self.Hf(x, Z, group=group, frailty=frailty))
+
+    def ff(
+        self, x: Any, Z: Any = None, group: Any = None, frailty: Any = None
+    ) -> np.ndarray:
+        """CDF / failure function."""
+        return 1.0 - self.sf(x, Z, group=group, frailty=frailty)
+
+    def hf(
+        self, x: Any, Z: Any = None, group: Any = None, frailty: Any = None
+    ) -> np.ndarray:
+        """Hazard function (marginal by default)."""
+        x = np.asarray(x, dtype=float)
+        eta = self._eta(Z)
+        H0 = self.dist.Hf(x, *self.dist_params)
+        h0 = self.dist.hf(x, *self.dist_params)
+        u = self._resolve_frailty(group, frailty)
+        if u is None:
+            return eta * h0 / (1.0 + self.theta * eta * H0)
+        return u * eta * h0
+
+    def df(
+        self, x: Any, Z: Any = None, group: Any = None, frailty: Any = None
+    ) -> np.ndarray:
+        """Density function."""
+        return self.hf(x, Z, group=group, frailty=frailty) * self.sf(
+            x, Z, group=group, frailty=frailty
+        )
+
+    # -- inference ---------------------------------------------------------
+
+    @property
+    def frailty_variance(self) -> float:
+        """The estimated frailty variance :math:`\\hat\\theta`."""
+        return float(self.theta)
+
+    def standard_errors(self) -> "dict[str, float]":
+        """Wald standard errors for each parameter, keyed by name."""
+        if self.covariance is None:
+            raise ValueError("No covariance was stored for this model.")
+        se = np.sqrt(np.diag(self.covariance))
+        return {name: float(s) for name, s in zip(self.param_names, se)}
+
+    def param_cb(
+        self,
+        name: str,
+        alpha_ci: float = 0.05,
+        bound: str = "two-sided",
+    ) -> np.ndarray:
+        """Wald confidence bound on a named parameter.
+
+        The bound is formed on a scale chosen from the parameter's support (log
+        for the positive baseline parameters and ``theta``, natural for the
+        unbounded coefficients) so the interval stays valid.
+        """
+        if self.covariance is None:
+            raise ValueError("No covariance was stored for this model.")
+        idx = self.param_names.index(name)
+        est = self._param_vector()[idx]
+        se = float(np.sqrt(self.covariance[idx, idx]))
+        positive = name == "theta" or (
+            idx < self.k_dist and self.dist.bounds[idx][0] == 0
+        )
+        if bound == "two-sided":
+            q = _z(1 - alpha_ci / 2)
+            signs = np.array([-1.0, 1.0])
+        elif bound == "lower":
+            q = _z(1 - alpha_ci)
+            signs = np.array([-1.0])
+        elif bound == "upper":
+            q = _z(1 - alpha_ci)
+            signs = np.array([1.0])
+        else:
+            raise ValueError("bound must be 'two-sided', 'lower' or 'upper'")
+        if positive:
+            return est * np.exp(signs * q * se / est)
+        return est + signs * q * se
+
+    def _param_vector(self) -> np.ndarray:
+        return np.concatenate([self.dist_params, self.beta, [self.theta]])
+
+    def summary(self) -> str:
+        """A short text summary of the fit."""
+        lines = [
+            "Shared-Frailty Regression SurPyval Model",
+            "========================================",
+            f"Distribution        : {self.dist.name}",
+            f"Frailty             : {self.family}",
+            f"Groups              : {self.n_groups}"
+            f"  (observations {self.n_obs}, events {self.n_events})",
+            "Baseline            :",
+        ]
+        for name, val in zip(self.dist.param_names, self.dist_params):
+            lines.append(f"    {name:>8} : {val:.6g}")
+        if self.beta.size:
+            lines.append("Coefficients        :")
+            for i, b in enumerate(self.beta):
+                lines.append(f"    beta_{i:<4}: {b:.6g}")
+        lines.append(f"Frailty variance    : theta = {self.theta:.6g}")
+        return "\n".join(lines)
+
+    def __repr__(self) -> str:
+        return self.summary()
+
+    # -- serialisation -----------------------------------------------------
+
+    def to_dict(self) -> dict:
+        """Serialise to a plain, JSON-serialisable ``dict``."""
+        out: dict[str, Any] = {
+            "model": "FrailtyModel",
+            "kind": self.kind,
+            "family": self.family,
+            "distribution": self.dist.name,
+            "dist_params": np.asarray(self.dist_params, float).tolist(),
+            "beta": np.asarray(self.beta, float).tolist(),
+            "theta": float(self.theta),
+            "k_dist": int(self.k_dist),
+            "param_names": list(self.param_names),
+            "group_labels": [str(g) for g in self.group_labels],
+            "frailties": {str(k): float(v) for k, v in self.frailties.items()},
+            "n_obs": int(self.n_obs),
+            "n_events": int(self.n_events),
+            "n_groups": int(self.n_groups),
+            "_neg_ll": to_native(self._neg_ll),
+        }
+        if self.covariance is not None:
+            out["covariance"] = np.asarray(self.covariance, float).tolist()
+        if self.feature_names is not None:
+            out["feature_names"] = list(self.feature_names)
+        if self.formula is not None:
+            out["formula"] = str(self.formula)
+            if self._model_spec is not None:
+                out["formula_meta"] = model_spec_to_meta(self._model_spec)
+        return stamp_schema(out)
+
+    def to_json(self, fp: "str | Path") -> None:
+        with open(fp, "w+") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, model_dict: dict) -> "FrailtyModel":
+        """Rebuild a model from a :meth:`to_dict` dictionary."""
+        import surpyval as surv
+        from surpyval.univariate.parametric.parametric_fitter import (
+            ParametricFitter,
+        )
+
+        if model_dict.get("model") != "FrailtyModel":
+            raise ValueError("Must create a FrailtyModel from its own dict")
+
+        dist = getattr(surv, model_dict["distribution"], None)
+        if not isinstance(dist, ParametricFitter):
+            raise ValueError(
+                f"Unknown distribution '{model_dict['distribution']}'"
+            )
+
+        out = cls()
+        out.family = model_dict.get("family", "gamma")
+        out.dist = dist
+        out.dist_params = np.array(model_dict["dist_params"], dtype=float)
+        out.beta = np.array(model_dict["beta"], dtype=float)
+        out.theta = float(model_dict["theta"])
+        out.k_dist = int(model_dict["k_dist"])
+        out.param_names = list(model_dict["param_names"])
+        out.group_labels = list(model_dict.get("group_labels", []))
+        out.frailties = {
+            k: float(v) for k, v in model_dict.get("frailties", {}).items()
+        }
+        out.n_obs = int(model_dict.get("n_obs", 0))
+        out.n_events = int(model_dict.get("n_events", 0))
+        out.n_groups = int(model_dict.get("n_groups", 0))
+        out._neg_ll = float(model_dict.get("_neg_ll", 0.0))
+        if "covariance" in model_dict:
+            out.covariance = np.array(model_dict["covariance"], dtype=float)
+        out.feature_names = model_dict.get("feature_names")
+        out.formula = model_dict.get("formula")
+        formula_meta = model_dict.get("formula_meta")
+        if out.formula is not None and formula_meta is not None:
+            out._model_spec = rebuild_model_spec(out.formula, formula_meta)
+        return out
+
+    @classmethod
+    def from_json(cls, fp: "str | Path") -> "FrailtyModel":
+        with open(fp, "r") as f:
+            return cls.from_dict(json.load(f))


### PR DESCRIPTION
Implements shared-frailty models (#149) — the flagship 0.17 item, and the conditional / random-effects complement to the cluster-robust standard errors added in 0.16.

## API
```python
from surpyval import Frailty, WeibullFrailty, Weibull

m = WeibullFrailty.fit(x=x, Z=Z, c=c, groups=unit_id)     # or Frailty(Weibull)
m = WeibullFrailty.fit_from_df(df, x_col="t", c_col="c",
                               group_col="unit", formula="load + site")
```
Mirrors the `PH(dist)` / `WeibullPH` pattern. A random hazard multiplier `u` is shared within each group: `h(t|Z,u) = u·h0(t)·exp(β'Z)`, `u ~ Gamma(mean 1, var θ)`.

## Why gamma-on-PH
The frailty multiplies the **cumulative** hazard, so a Gamma frailty integrates out of each group's likelihood in **closed form** (fast, no quadrature), and the posterior frailty is closed-form too. The fit maximises that marginal likelihood on a fresh optimiser — **the ordinary parametric MLE is untouched** (same isolation as the AFT-TVC work).

## `FrailtyModel`
- `frailty_variance` (θ) with a Wald CI (`param_cb("theta")`); per-group posterior (empirical-Bayes) `frailties`; `summary()`.
- **Marginal** prediction (default) `S = (1 + θ e^{β'Z} H0)^{-1/θ}` — for a new unit from an unknown group; **conditional** via `sf(x, Z, group=…)` (an observed group's posterior frailty) or `sf(x, Z, frailty=…)`.
- Omit `Z` → pure random-effects survival model. Serialises via `to_dict`/`from_dict` (reuses the #244 formula fix).

## Scope / guards
Gamma frailty, observed (`c=0`) + right-censored (`c=1`) data, ≥2 groups (θ unidentifiable otherwise). Raises for a single group, unsupported censoring, and non-gamma families. Log-normal, Cox, and nested/hierarchical frailty are planned follow-ups.

## Verification
The marginal-likelihood formula is checked **against brute-force numerical integration** of the conditional likelihood over the frailty (to 1e-6) — the gold-standard math anchor. Other tests: parameter recovery on simulated clustered data, the marginal-sf Laplace-transform form, the posterior-frailty formula, marginal-vs-conditional ordering, the no-covariate model, `fit_from_df` formula round-trip, serialisation, and the guards. 12 tests; flake8/mypy/black clean.

Docs: theory section (regression analysis) + how-to with an executed example (Regression Modelling) + changelog under v0.17.0.

Depends on #246 (merged) for the formula-serialisation helpers. Targets `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_