### PR TITLE
Royston-Parmar: full arbitrary censoring and truncation support

### DIFF
--- a/docs/Parametric SurPyval Modelling.rst
+++ b/docs/Parametric SurPyval Modelling.rst
@@ -758,8 +758,10 @@ with its confidence band:
 The spline follows the two-component shape the single Weibull misses. Because
 the spline is linear beyond its boundary knots, the model extrapolates with a
 Weibull-like tail rather than a wild cubic — which is what makes it safe to read
-off a restricted-mean survival time or a far quantile. Right-censored, weighted,
-and left-truncated data are all supported (``c``, ``n``, ``tl``), and a fitted
+off a restricted-mean survival time or a far quantile. The full arbitrary
+censoring/truncation surface is supported — observed, right-, left- and
+interval-censored data (``c``, or ``xl`` / ``xr``), with left- and/or
+right-truncation and weights (``tl`` / ``tr`` / ``t``, ``n``) — and a fitted
 model serialises with ``to_dict`` / ``from_dict`` like any other.
 
 Discrete Distributions

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,8 +18,10 @@ v0.17.0 (unreleased)
   The fitted ``RoystonParmarModel`` exposes ``sf`` / ``ff`` / ``hf`` / ``Hf`` /
   ``df`` / ``qf`` / ``random`` / ``mean``, a linear-predictor confidence band
   (``cb``), ``aic`` / ``bic`` for choosing ``df``, and ``to_dict`` /
-  ``from_dict``. Observed, right-censored, weighted, and left-truncated data are
-  supported.
+  ``from_dict``. The likelihood supports the full arbitrary
+  censoring/truncation surface -- observed, right-, left- and interval-censored
+  observations (pass ``xl`` / ``xr`` or 2-element ``x`` rows), with left- and/or
+  right-truncation (``tl`` / ``tr`` / ``t``) and observation weights (``n``).
 - **Shared-frailty proportional-hazards models (Gamma frailty).** A new
   ``Frailty(distribution)`` factory (with pre-built ``WeibullFrailty``,
   ``ExponentialFrailty``, ``LogNormalFrailty``, ``GammaFrailty`` instances) fits

--- a/surpyval/tests/univariate/parametric/test_royston_parmar.py
+++ b/surpyval/tests/univariate/parametric/test_royston_parmar.py
@@ -107,7 +107,7 @@ def test_right_censoring_and_truncation():
     xc = np.minimum(x, 20.0)
     rp = RoystonParmar.fit(xc, c=c, df=3)
     assert rp.n_events == int((c == 0).sum())
-    tl = np.full_like(x, 1.0)
+    tl = np.full_like(x, x.min() / 2.0)
     rp_t = RoystonParmar.fit(x, tl=tl, df=2)
     assert np.isfinite(rp_t._neg_ll)
 
@@ -139,7 +139,85 @@ def test_guards():
         RoystonParmar.fit(x, scale="weird")
     with pytest.raises(ValueError, match="positive"):
         RoystonParmar.fit(np.array([-1.0, 2.0, 3.0]))
-    with pytest.raises(ValueError, match="right-censored"):
-        RoystonParmar.fit(np.array([1.0, 2.0, 3.0]), c=np.array([0, 2, 1]))
+    # Right-censored-only data is not identifiable.
     with pytest.raises(ValueError, match="event"):
         RoystonParmar.fit(np.array([1.0, 2.0, 3.0]), c=np.array([1, 1, 1]))
+
+
+def test_left_censoring_recovers_baseline():
+    # Left-censoring a chunk of the smallest times should still recover a
+    # baseline close to fitting the fully-observed data.
+    np.random.seed(20)
+    x = Weibull.random(800, 10.0, 1.8)
+    thresh = 4.0
+    c = np.where(x < thresh, -1, 0)
+    xc = np.where(x < thresh, thresh, x)
+    rp = RoystonParmar.fit(xc, c=c, df=3)
+    full = RoystonParmar.fit(x, df=3)
+    t = np.array([6.0, 10.0, 16.0, 24.0])
+    assert np.allclose(rp.sf(t), full.sf(t), atol=4e-2)
+
+
+def test_interval_censoring_recovers_baseline():
+    # Round each event down/up to an inspection grid: interval-censored data
+    # should recover a survival curve close to the exact-data fit.
+    np.random.seed(21)
+    x = Weibull.random(800, 10.0, 1.6)
+    grid = np.arange(0.0, 60.0, 2.0)
+    idx = np.searchsorted(grid, x)
+    xl = grid[idx - 1]
+    xr = grid[idx]
+    keep = xl > 0
+    rp = RoystonParmar.fit(xl=xl[keep], xr=xr[keep], df=3)
+    full = RoystonParmar.fit(x[keep], df=3)
+    t = np.array([6.0, 10.0, 16.0, 24.0])
+    assert np.allclose(rp.sf(t), full.sf(t), atol=4e-2)
+    assert rp.n_events == 0  # all interval-censored
+
+
+def test_right_truncation_correction():
+    # Right-truncated sampling (only failures before ``tr`` are seen) is
+    # corrected by conditioning on T <= tr; the fit should be finite and the
+    # correction should move the estimate relative to ignoring truncation.
+    np.random.seed(22)
+    x = Weibull.random(2000, 10.0, 1.8)
+    tr_val = 12.0
+    seen = x <= tr_val
+    xs = x[seen]
+    corrected = RoystonParmar.fit(xs, tr=tr_val, df=2, scale="hazard")
+    naive = RoystonParmar.fit(xs, df=2, scale="hazard")
+    full = RoystonParmar.fit(x, df=2, scale="hazard")
+    assert np.isfinite(corrected._neg_ll)
+    # The truncation-corrected mean should sit closer to the true full-data
+    # mean than the biased naive fit that ignores the sampling.
+    assert abs(corrected.mean() - full.mean()) < abs(
+        naive.mean() - full.mean()
+    )
+
+
+def test_mixed_censoring_and_truncation_fits():
+    # A single dataset combining observed, right-, left- and interval-censored
+    # rows with left-truncation must fit and give a valid survival curve.
+    np.random.seed(23)
+    base = Weibull.random(600, 10.0, 1.6)
+    x_list: list = []
+    c_list: list = []
+    for v in base:
+        if v < 3.0:  # left-censored
+            x_list.append(3.0)
+            c_list.append(-1)
+        elif v > 25.0:  # right-censored
+            x_list.append(25.0)
+            c_list.append(1)
+        elif 8.0 < v < 12.0:  # interval-censored into a coarse window
+            x_list.append([8.0, 12.0])
+            c_list.append(2)
+        else:  # exactly observed
+            x_list.append(float(v))
+            c_list.append(0)
+    rp = RoystonParmar.fit(x=x_list, c=c_list, tl=1.0, df=2)
+    assert np.isfinite(rp._neg_ll)
+    t = np.array([2.0, 5.0, 10.0, 20.0])
+    s = rp.sf(t)
+    assert np.all((s >= 0) & (s <= 1))
+    assert np.all(np.diff(s) <= 1e-9)

--- a/surpyval/univariate/parametric/royston_parmar.py
+++ b/surpyval/univariate/parametric/royston_parmar.py
@@ -27,6 +27,12 @@ knots at their extremes, the internal knots at equally-spaced centiles. Beyond
 the boundary knots the spline is linear (the "restricted" part), so the model
 extrapolates with a Weibull-like tail. The number of knots -- set through
 ``df`` -- is the modelling choice; compare a few by AIC / BIC.
+
+The likelihood supports the full SurpyvalData censoring/truncation surface:
+observed, right-, left- and interval-censored observations, with left- and/or
+right-truncation. Right-censored contribute ``log S``, left-censored
+``log(1 - S)``, interval-censored ``log(S(l) - S(r))``, and truncation divides
+each observation's contribution by ``S(t_l) - S(t_r)``.
 """
 
 import json
@@ -105,6 +111,22 @@ def _sf_from_eta(eta: np.ndarray, scale: str) -> np.ndarray:
     if scale == "odds":
         return 1.0 / (1.0 + np.exp(eta))
     return norm.sf(eta)
+
+
+def _sf_at(times: np.ndarray, knots: np.ndarray, gamma: np.ndarray, scale: str):
+    """Survival at arbitrary times, with the boundary conventions the
+    censoring/truncation likelihoods need: ``S = 1`` at times ``<= 0`` (and
+    ``-inf``) and ``S = 0`` at ``+inf``. Finite positive times go through the
+    spline as usual.
+    """
+    times = np.asarray(times, dtype=float)
+    out = np.empty(times.shape, dtype=float)
+    pos = np.isfinite(times) & (times > 0.0)
+    if np.any(pos):
+        eta = _rcs_basis(np.log(times[pos]), knots) @ gamma
+        out[pos] = _sf_from_eta(eta, scale)
+    out[~pos] = np.where(np.isposinf(times[~pos]), 0.0, 1.0)
+    return out
 
 
 class RoystonParmarModel:
@@ -343,27 +365,43 @@ class RoystonParmar_:
 
     def fit(
         self,
-        x: Any,
+        x: Any = None,
         c: Any = None,
         n: Any = None,
+        t: Any = None,
+        xl: Any = None,
+        xr: Any = None,
         tl: Any = None,
+        tr: Any = None,
         df: int = 3,
         scale: str = "hazard",
         knots: Any = None,
     ) -> RoystonParmarModel:
         """Fit a Royston-Parmar model by maximum likelihood.
 
+        Accepts the full SurpyvalData censoring/truncation surface: observed,
+        right-, left- and interval-censored observations, with left- and/or
+        right-truncation (delayed entry and right-truncated sampling).
+
         Parameters
         ----------
         x : array_like
-            Observed times (all strictly positive).
+            Observed times (strictly positive). For interval-censored rows the
+            entry is a 2-element ``[left, right]`` pair (see ``c``).
         c : array_like, optional
-            Censoring flags: ``0`` event, ``1`` right-censored. Default all
-            events.
+            Censoring flags: ``0`` event, ``1`` right-censored, ``-1``
+            left-censored, ``2`` interval-censored. Default all events.
         n : array_like, optional
             Observation weights / counts. Default 1.
-        tl : array_like or scalar, optional
-            Left-truncation (delayed-entry) time per observation.
+        t : array_like, optional
+            ``(m, 2)`` array of ``[left, right]`` truncation bounds per row.
+            Mutually exclusive with ``tl`` / ``tr``.
+        xl, xr : array_like, optional
+            Left/right interval bounds for interval-censored data, as an
+            alternative to passing 2-element ``x`` rows.
+        tl, tr : array_like or scalar, optional
+            Left- and right-truncation bounds. A scalar truncates every
+            observation at that value.
         df : int, optional
             Degrees of freedom = number of spline terms beyond the intercept;
             ``df - 1`` internal knots. ``df = 1`` is a Weibull (``scale`` =
@@ -376,62 +414,79 @@ class RoystonParmar_:
         """
         if scale not in _SCALES:
             raise ValueError(f"scale must be one of {_SCALES}; got {scale!r}")
-        x = np.asarray(x, dtype=float).ravel()
-        if np.any(x <= 0):
+
+        from surpyval.utils.surpyval_data import SurpyvalData
+
+        data = SurpyvalData(
+            x=x, c=c, n=n, t=t, xl=xl, xr=xr, tl=tl, tr=tr,
+            group_and_sort=True,
+        )
+
+        if np.any(data.x_min <= 0):
             raise ValueError(
                 "Royston-Parmar requires strictly positive times."
             )
-        c = (
-            np.zeros(x.shape[0], dtype=int)
-            if c is None
-            else np.asarray(c, dtype=int).ravel()
-        )
-        if not np.all(np.isin(c, (0, 1))):
-            raise ValueError(
-                "Royston-Parmar supports observed (c=0) and right-censored "
-                "(c=1) data only."
-            )
-        w = (
-            np.ones(x.shape[0])
-            if n is None
-            else np.asarray(n, dtype=float).ravel()
-        )
-        if tl is not None:
-            tl = np.broadcast_to(np.asarray(tl, dtype=float), x.shape).copy()
 
-        event = c == 0
-        if int(event.sum()) == 0:
-            raise ValueError("At least one event (c=0) is required.")
+        # Per-type times and weights.
+        x_o, n_o = data.x_o, data.n_o.astype(float)
+        x_r, n_r = data.x_r, data.n_r.astype(float)
+        x_l, n_l = data.x_l, data.n_l.astype(float)
+        x_il, x_ir, n_i = data.x_il, data.x_ir, data.n_i.astype(float)
+        x_tl, x_tr, n_t = data.x_tl, data.x_tr, data.n_t.astype(float)
+
+        # Right-censored-only data carries no finite MLE: at least one
+        # observed event, left- or interval-censored row is needed to identify
+        # the baseline.
+        if (x_o.size + x_l.size + x_il.size) == 0:
+            raise ValueError(
+                "Royston-Parmar requires at least one event (or left- or "
+                "interval-censored) observation; right-censored-only data is "
+                "not identifiable."
+            )
+
+        # Knots go on the exactly-observed event log-times when there are any,
+        # else on whatever finite failure information the data provide.
+        event_times = x_o
+        if event_times.size == 0:
+            event_times = np.concatenate([x_il, x_ir, x_l])
+            event_times = event_times[np.isfinite(event_times)]
 
         if knots is None:
             n_internal = max(int(df) - 1, 0)
-            knots = _place_knots(x[event], n_internal)
+            knots = _place_knots(event_times, n_internal)
         else:
             knots = np.asarray(knots, dtype=float)
         n_params = len(knots)  # [1, x] + (len(knots) - 2) internal terms
 
-        lx = np.log(x)
-        B = _rcs_basis(lx, knots)
-        Bd = _rcs_deriv(lx, knots)
-        B_tl = None if tl is None else _rcs_basis(np.log(tl), knots)
+        lx_o = np.log(x_o) if x_o.size else x_o
+        B_o = _rcs_basis(lx_o, knots) if x_o.size else None
+        Bd_o = _rcs_deriv(lx_o, knots) if x_o.size else None
+        B_r = _rcs_basis(np.log(x_r), knots) if x_r.size else None
+        B_l = _rcs_basis(np.log(x_l), knots) if x_l.size else None
+        B_il = _rcs_basis(np.log(x_il), knots) if x_il.size else None
+        B_ir = _rcs_basis(np.log(x_ir), knots) if x_ir.size else None
 
         def neg_ll(g):
-            eta = B @ g
-            sp = Bd @ g
-            log_S, log_negdS = _scale_terms(eta, scale)
-            ll = np.sum(w * log_S)  # log S for everyone
-            ll += np.sum(
-                w[event]
-                * (
-                    log_negdS[event]
-                    + np.log(sp[event])
-                    - lx[event]
-                    - log_S[event]
-                )
-            )  # events: swap log S -> log f = log(-dS) + log s' - log t
-            if B_tl is not None:
-                log_S_tl, _ = _scale_terms(B_tl @ g, scale)
-                ll -= np.sum(w * log_S_tl)  # condition on survival to tl
+            ll = 0.0
+            if B_o is not None:  # events: log f = log(-dS) + log s' - log t
+                eta = B_o @ g
+                sp = Bd_o @ g
+                _, log_negdS = _scale_terms(eta, scale)
+                ll += np.sum(n_o * (log_negdS + np.log(sp) - lx_o))
+            if B_r is not None:  # right-censored: log S
+                log_S_r, _ = _scale_terms(B_r @ g, scale)
+                ll += np.sum(n_r * log_S_r)
+            if B_l is not None:  # left-censored: log F = log(1 - S)
+                log_S_l, _ = _scale_terms(B_l @ g, scale)
+                ll += np.sum(n_l * np.log1p(-np.exp(log_S_l)))
+            if B_il is not None:  # interval-censored: log(S(l) - S(r))
+                S_il = _sf_from_eta(B_il @ g, scale)
+                S_ir = _sf_from_eta(B_ir @ g, scale)
+                ll += np.sum(n_i * np.log(S_il - S_ir))
+            if x_tl.size:  # truncation: divide by P(entry <= T <= exit)
+                S_tl = _sf_at(x_tl, knots, g, scale)
+                S_tr = _sf_at(x_tr, knots, g, scale)
+                ll -= np.sum(n_t * np.log(S_tl - S_tr))
             return -ll
 
         # Initialise from the Weibull/log-normal that the no-knot model is.
@@ -461,8 +516,14 @@ class RoystonParmar_:
         model.knots = knots
         model.params = gamma
         model.covariance = covariance
-        model.n = int(x.shape[0])
-        model.n_events = int(event.sum())
+        model.n = int(
+            round(
+                float(
+                    n_o.sum() + n_r.sum() + n_l.sum() + n_i.sum()
+                )
+            )
+        )
+        model.n_events = int(round(float(n_o.sum())))
         model._neg_ll = float(res.fun)
         return model
 

--- a/surpyval/univariate/parametric/royston_parmar.py
+++ b/surpyval/univariate/parametric/royston_parmar.py
@@ -113,7 +113,9 @@ def _sf_from_eta(eta: np.ndarray, scale: str) -> np.ndarray:
     return norm.sf(eta)
 
 
-def _sf_at(times: np.ndarray, knots: np.ndarray, gamma: np.ndarray, scale: str):
+def _sf_at(
+    times: np.ndarray, knots: np.ndarray, gamma: np.ndarray, scale: str
+):
     """Survival at arbitrary times, with the boundary conventions the
     censoring/truncation likelihoods need: ``S = 1`` at times ``<= 0`` (and
     ``-inf``) and ``S = 0`` at ``+inf``. Finite positive times go through the
@@ -418,7 +420,14 @@ class RoystonParmar_:
         from surpyval.utils.surpyval_data import SurpyvalData
 
         data = SurpyvalData(
-            x=x, c=c, n=n, t=t, xl=xl, xr=xr, tl=tl, tr=tr,
+            x=x,
+            c=c,
+            n=n,
+            t=t,
+            xl=xl,
+            xr=xr,
+            tl=tl,
+            tr=tr,
             group_and_sort=True,
         )
 
@@ -517,11 +526,7 @@ class RoystonParmar_:
         model.params = gamma
         model.covariance = covariance
         model.n = int(
-            round(
-                float(
-                    n_o.sum() + n_r.sum() + n_l.sum() + n_i.sum()
-                )
-            )
+            round(float(n_o.sum() + n_r.sum() + n_l.sum() + n_i.sum()))
         )
         model.n_events = int(round(float(n_o.sum())))
         model._neg_ll = float(res.fun)


### PR DESCRIPTION
## What

Extends the Royston-Parmar flexible parametric fitter from *observed + right-censored + left-truncated* data to the **full SurpyvalData censoring/truncation surface**, matching surpyval's "arbitrary combinations" brand across the rest of the library.

## How

`RoystonParmar.fit` now routes its inputs through `SurpyvalData` and builds the log-likelihood from the per-type splits:

- **Observed** (`c=0`): `log f = log(-dS/dη) + log s'(t) - log t`
- **Right-censored** (`c=1`): `log S`
- **Left-censored** (`c=-1`): `log(1 - S)`
- **Interval-censored** (`c=2`, via `xl`/`xr` or 2-element `x` rows): `log(S(l) - S(r))`
- **Truncation** (`tl`/`tr`/`t`, scalar or array): each contribution divided by `S(t_l) - S(t_r)`

A new `_sf_at` helper evaluates survival at arbitrary times with the boundary conventions the censoring/truncation terms need (`S=1` at times ≤ 0 / −∞, `S=0` at +∞). Observation weights (`n`) are respected throughout.

Guard change: right-censored-**only** data (no finite MLE) now raises early; the previous "right-censored only supported" guard is removed since the other types are now handled.

## Tests

Four new tests: left-censoring and interval-censoring each recover a baseline close to the exact-data fit; right-truncation correction pulls the estimate toward the true full-data mean vs. the naive fit; and a single mixed observed/right/left/interval + left-truncated dataset fits to a valid, monotone survival curve. The existing truncation test updated for proper `tl ≤ x` validation now that inputs flow through `SurpyvalData`.

Full suite green locally: **1720 passed, 1 skipped**.

## Docs

Module docstring, `docs/changelog.rst` (v0.17.0 entry), and the Royston-Parmar section of the parametric guide updated to describe the broadened data support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_