### PR TITLE
Regression serialisation/robustness and TVC alignment batch (#261, #259)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -105,6 +105,35 @@ v0.17.0 (unreleased)
   An explicit ``"0 + ..."`` formula opts back into full-rank coding. This
   also fixes the ``LinAlgError`` crash in Buckley-James formula fits with
   categoricals.
+- **Fixed: regression serialisation and robustness batch** (#261).
+  Buckley-James and Lin-Ying additive-hazards models now persist their
+  formula encoder state (the #244 treatment), so restored models predict
+  from DataFrames with transforms/categoricals; repeated save/load cycles of
+  a parametric regression model no longer silently drop the stored
+  covariance; ``ParametricRegressionModel.random`` (broken on every path —
+  it ignored ``Z``) now dispatches to the fitter's covariate-aware sampler;
+  the ``AcceleratedLife`` fitter is no longer stateful across fits, keeps
+  user-fixed parameters in ``model.fixed`` (SEs were reported for
+  constrained parameters), and accepts 1-D stress vectors; ``WeibullPH.fit``
+  accepts plain-list covariates; ``fit(init=<ndarray>)`` no longer crashes;
+  deserialised univariate models support ``bic``/``aic_c``/re-serialisation
+  and carry their support interval; interval/left-censored observations
+  below the distribution's support are rejected at validation instead of
+  producing a NaN likelihood and a silent initial-guess "fit" (whose
+  reported likelihood now matches its returned parameters); and invalid
+  ``cb``/``param_cb`` arguments raise ``ValueError`` instead of
+  ``UnboundLocalError``.
+- **Fixed: TVC prediction and alignment** (#259). Predicting along a
+  covariate schedule treated intervals as ``[xl, xr)``, so a baseline-hazard
+  jump exactly at a covariate-change time was weighted by the *new*
+  covariate while the fitted likelihood uses ``(xl, xr]`` — predictions now
+  match the fit, and a query time returns the same value regardless of the
+  other query points. Cluster-robust standard errors on start-stop (TVC)
+  fits now permute user-supplied per-row cluster labels into the internal
+  row order (previously silently misassigned unless the input was already
+  sorted), and default to clustering by subject. An exactly singular
+  information matrix now degrades to the pseudo-inverse/NaN path instead of
+  crashing.
 - **Royston-Parmar flexible parametric models.** ``RoystonParmar.fit(x, c=...,
   df=..., scale=...)`` fits a flexible parametric survival model that replaces
   the straight log-cumulative-hazard-vs-log-time line of a Weibull with a

--- a/surpyval/tests/univariate/regression/test_review_hardening.py
+++ b/surpyval/tests/univariate/regression/test_review_hardening.py
@@ -1,0 +1,219 @@
+"""
+Regression tests for the #261 serialisation/robustness batch and the
+#259 TVC prediction/alignment batch.
+"""
+
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import surpyval as surv
+from surpyval import Weibull, WeibullPH
+from surpyval.univariate.regression import (
+    AcceleratedLife,
+    BuckleyJames,
+    CoxPH,
+)
+from surpyval.univariate.regression.accelerated_life import Power
+from surpyval.univariate.regression.additive_hazards.additive_hazards import (
+    AdditiveHazards,
+)
+from surpyval.univariate.regression.proportional_hazards.diagnostics import (
+    robust_covariance,
+)
+
+
+def _df(seed=7, n=240):
+    rng = np.random.default_rng(seed)
+    sex = rng.choice(["M", "F"], n)
+    age = rng.normal(50, 10, n)
+    x = (
+        10
+        * np.exp(-0.3 * (sex == "M") + 0.01 * (age - 50))
+        * (-np.log(rng.uniform(size=n))) ** (1 / 2)
+    )
+    return pd.DataFrame(
+        {"time": x, "sex": sex, "age": age, "cens": np.zeros(n)}
+    )
+
+
+# -- #261: serialisation & robustness ---------------------------------------
+
+
+def test_buckley_james_formula_round_trip():
+    df = _df()
+    m = BuckleyJames.fit_from_df(
+        df, x_col="time", formula="age + I(age**2) + sex", c_col="cens"
+    )
+    restored = surv.from_dict(json.loads(json.dumps(m.to_dict())))
+    new = pd.DataFrame({"age": [55.0], "sex": ["M"]})
+    assert np.allclose(m.sf(5.0, new), restored.sf(5.0, new))
+
+
+def test_additive_hazards_formula_round_trip():
+    df = _df()
+    m = AdditiveHazards.fit_from_df(
+        df, x_col="time", formula="age + sex", c_col="cens"
+    )
+    restored = surv.from_dict(json.loads(json.dumps(m.to_dict())))
+    new = pd.DataFrame({"age": [55.0, 45.0], "sex": ["M", "F"]})
+    assert np.allclose(m.sf([5.0, 10.0], new), restored.sf([5.0, 10.0], new))
+
+
+def test_second_generation_serialisation_keeps_covariance():
+    np.random.seed(2)
+    x = Weibull.random(200, 10, 3)
+    Z = np.random.normal(size=(200, 1))
+    m = WeibullPH.fit(x, Z=Z)
+    gen1 = surv.from_dict(json.loads(json.dumps(m.to_dict())))
+    gen2 = surv.from_dict(json.loads(json.dumps(gen1.to_dict())))
+    cb = gen2.param_cb("beta_0")
+    assert np.all(np.isfinite(cb))
+
+
+def test_regression_random_dispatches_to_fitter():
+    np.random.seed(3)
+    x = Weibull.random(150, 10, 3)
+    Z = np.random.normal(size=(150, 1))
+    m = WeibullPH.fit(x, Z=Z)
+    out = m.random(20, Z[:1])
+    # The PH fitter's sampler returns (x, Z) arrays.
+    assert np.all(np.asarray(out[0]) > 0)
+
+
+def test_accelerated_life_refit_and_fixed():
+    np.random.seed(4)
+    stress = np.repeat([1.0, 2.0, 3.0, 4.0], 50)
+    x = (100 / stress) * (-np.log(np.random.uniform(size=len(stress)))) ** (
+        1 / 3
+    )
+    fitter = AcceleratedLife(Weibull, Power)
+    m1 = fitter.fit(x, Z=stress)  # 1-D stress vector (#261)
+    assert np.isfinite(np.atleast_1d(m1.sf([50.0], np.array([1.0])))).all()
+    # A second fit on the same fitter instance used to corrupt the
+    # parameter map; and user-fixed parameters were dropped from
+    # ``model.fixed`` so SEs were reported for constrained parameters.
+    m2 = fitter.fit(x, Z=stress, fixed={"beta": 3.0})
+    assert "beta" in m2.fixed
+    assert m2.params[1] == pytest.approx(3.0, abs=1e-9)
+
+
+def test_ph_fit_accepts_plain_list_Z():
+    np.random.seed(5)
+    x = Weibull.random(100, 10, 3)
+    Z = [[float(v)] for v in np.random.normal(size=100)]
+    m = WeibullPH.fit(x, Z=Z)
+    assert np.isfinite(m.params).all()
+
+
+def test_fit_accepts_ndarray_init():
+    np.random.seed(6)
+    x = Weibull.random(100, 10, 3)
+    m = Weibull.fit(x, init=np.array([10.0, 3.0]))
+    assert np.isfinite(m.params).all()
+
+
+def test_restored_parametric_model_bic_aicc_and_reserialisation():
+    np.random.seed(7)
+    x = Weibull.random(100, 10, 3)
+    m = Weibull.fit(x)
+    restored = surv.from_dict(
+        json.loads(json.dumps(m.to_dict(with_data=True)))
+    )
+    assert restored.bic() == pytest.approx(m.bic())
+    assert restored.aic_c() == pytest.approx(m.aic_c())
+    assert restored.support[0] == 0.0
+    # Re-serialising a restored model used to crash on list data.
+    again = restored.to_dict(with_data=True)
+    assert "data" in again
+
+
+def test_invalid_cb_arguments_raise_value_error():
+    np.random.seed(8)
+    m = Weibull.fit(Weibull.random(80, 10, 3))
+    with pytest.raises(ValueError):
+        m.cb([5.0], on="bogus")
+    with pytest.raises(ValueError):
+        m.param_cb("alpha", bound="both")
+
+
+def test_interval_bound_below_support_raises():
+    with pytest.raises(ValueError):
+        Weibull.fit(xl=np.array([-0.5, 1, 2]), xr=np.array([0.5, 2, 3]))
+    with pytest.raises(ValueError):
+        Weibull.fit(np.array([0.0, 1.0, 2.0, 5.0]), c=np.array([-1, 0, 0, 0]))
+
+
+# -- #259: TVC prediction and alignment -------------------------------------
+
+
+def _tvc_fit(seed=4, n=80):
+    rng = np.random.default_rng(seed)
+    rows_i, rows_xl, rows_xr, rows_c, rows_z = [], [], [], [], []
+    for i in range(n):
+        z1 = rng.normal()
+        t = rng.exponential(np.exp(-0.4 * z1)) * 4
+        change = min(3.0, 0.6 * t)
+        tend = min(t, 8.0)
+        rows_i += [i, i]
+        rows_xl += [0.0, change]
+        rows_xr += [change, tend]
+        rows_c += [1, 0 if t < 8.0 else 1]
+        rows_z += [[z1], [z1 + 1.0]]
+    return (
+        np.array(rows_i),
+        np.array(rows_xl),
+        np.array(rows_xr),
+        np.array(rows_c),
+        np.array(rows_z),
+    )
+
+
+def test_tvc_prediction_uses_old_covariate_at_change_time():
+    # (xl, xr] convention: a baseline jump exactly at a covariate change
+    # time belongs to the OLD covariate, matching the fitted likelihood.
+    i, xl, xr, c, Z = _tvc_fit()
+    m = CoxPH.fit_tvc(i, xl, xr, c, Z)
+    sched = m.Hf_tvc(
+        [3.0], Z=np.array([[0.0], [1.0]]), xl=np.array([0.0, 3.0])
+    )
+    const = m.Hf_tvc([3.0], Z=np.array([[0.0]]), xl=np.array([0.0]))
+    assert float(np.atleast_1d(sched)[0]) == pytest.approx(
+        float(np.atleast_1d(const)[0])
+    )
+
+
+def test_tvc_hf_query_independent_of_other_query_points():
+    i, xl, xr, c, Z = _tvc_fit()
+    m = CoxPH.fit_tvc(i, xl, xr, c, Z)
+    Zs = np.array([[0.0], [1.0]])
+    starts = np.array([0.0, 3.0])
+    single = float(np.atleast_1d(m.Hf_tvc([3.0], Z=Zs, xl=starts))[0])
+    paired = float(np.atleast_1d(m.Hf_tvc([3.0, 3.5], Z=Zs, xl=starts))[0])
+    assert single == pytest.approx(paired)
+
+
+def test_tvc_cluster_labels_aligned_after_internal_sort():
+    i, xl, xr, c, Z = _tvc_fit()
+    rng = np.random.default_rng(0)
+    perm = rng.permutation(len(i))
+    m_sorted = CoxPH.fit_tvc(i, xl, xr, c, Z)
+    m_shuffled = CoxPH.fit_tvc(i[perm], xl[perm], xr[perm], c[perm], Z[perm])
+    cov_sorted = robust_covariance(m_sorted, cluster=i)
+    cov_shuffled = robust_covariance(m_shuffled, cluster=i[perm])
+    assert np.allclose(cov_sorted, cov_shuffled)
+    # And a TVC fit defaults to clustering by subject.
+    assert np.allclose(robust_covariance(m_sorted), cov_sorted)
+
+
+def test_degenerate_tvc_fit_degrades_instead_of_crashing():
+    i = np.array([0, 0, 1, 1])
+    xl = np.array([0.0, 1.0, 0.0, 1.0])
+    xr = np.array([1.0, 2.0, 1.0, 2.0])
+    c = np.array([1, 0, 1, 0])
+    Z = np.array([[1.0], [1.0], [1.0], [1.0]])
+    m = CoxPH.fit_tvc(i, xl, xr, c, Z)
+    # Singular information: NaN p-values are the correct signal.
+    assert m.p_values is not None

--- a/surpyval/univariate/parametric/fitters/mle.py
+++ b/surpyval/univariate/parametric/fitters/mle.py
@@ -244,8 +244,16 @@ def mle(model):
 
         results["cov_matrix"] = cov_matrix
         results["hess_inv"] = hess_inv
-        results["_neg_ll"] = res["fun"]
-        results["log_likelihood"] = -res["fun"]
+        # On the fallback path the returned parameters are the initial
+        # guess, so the reported likelihood must be evaluated there — not
+        # taken from the failed optimizer (#261).
+        if use_initial:
+            with np.errstate(all="ignore"):
+                neg_ll_val = float(fun(init, offset, lfp, zi, True))
+        else:
+            neg_ll_val = float(res["fun"])
+        results["_neg_ll"] = neg_ll_val
+        results["log_likelihood"] = -neg_ll_val
         results["res"] = res
         results["optimizer"] = (
             best_method if best_method is not None else method

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -148,7 +148,10 @@ class Parametric(ParametricDistribution):
             )
         how = model_dict["how"]
         if "data" in model_dict:
-            data = model_dict["data"]
+            # Coerce the JSON lists back to arrays so downstream users
+            # (``bic``, ``aic_c``, re-serialisation with data) work on a
+            # restored model just as on a fitted one (#261).
+            data = {k: np.asarray(v) for k, v in model_dict["data"].items()}
         else:
             data = None
         offset = model_dict["offset"]
@@ -175,6 +178,10 @@ class Parametric(ParametricDistribution):
             out._neg_ll = model_dict["_neg_ll"]
 
         out.params = np.array(model_dict["params"])
+
+        # Restore the support interval, which fit-time construction sets via
+        # the fitter (#261).
+        dist._set_support(out, offset)
 
         return out
 
@@ -319,7 +326,14 @@ class Parametric(ParametricDistribution):
         else:
             idx = self.dist.param_map[name]
             p_hat = self.params[idx]
-            var = self.hess_inv[idx, idx]
+            hess_inv = getattr(self, "hess_inv", None)
+            if hess_inv is None:
+                raise ValueError(
+                    "Model carries no parameter covariance (the Hessian was "
+                    "singular at the optimum, or the model was not fit by "
+                    "MLE); confidence bounds are unavailable."
+                )
+            var = hess_inv[idx, idx]
             param_bounds = self.dist.bounds[idx]
 
         if bound == "two-sided":
@@ -331,6 +345,11 @@ class Parametric(ParametricDistribution):
         elif bound == "upper":
             alpha = alpha_ci
             bounds = np.array([1])
+        else:
+            raise ValueError(
+                "bound must be 'two-sided', 'lower' or 'upper'; got "
+                f"{bound!r}"
+            )
 
         if param_bounds == (0, None):
             exponent = z(alpha) * np.sqrt(var) / p_hat
@@ -1171,6 +1190,11 @@ class Parametric(ParametricDistribution):
                 cb = -np.log(self._cb_sf_bound(t, ctx, alpha_ci, bound))
             elif on in ["hf", "df"]:
                 cb = self._cb_rate_bound(t, ctx, alpha_ci, bound, on)
+            else:
+                raise ValueError(
+                    "'on' must be one of 'sf', 'R', 'ff', 'F', 'Hf', 'hf' "
+                    f"or 'df'; got {on!r}"
+                )
         finally:
             np.seterr(**old_err_state)
 
@@ -1324,8 +1348,15 @@ class Parametric(ParametricDistribution):
 
         cov = getattr(self, "cov_matrix", None)
         if cov is None:
+            hess_inv = getattr(self, "hess_inv", None)
+            if hess_inv is None:
+                raise ValueError(
+                    "Model carries no parameter covariance (the Hessian "
+                    "was singular at the optimum, or the model was not fit "
+                    "by MLE); confidence bounds are unavailable."
+                )
             cov = np.zeros((len(phi_hat), len(phi_hat)))
-            cov[:n_core, :n_core] = np.copy(self.hess_inv)
+            cov[:n_core, :n_core] = np.copy(hess_inv)
 
         return _CBContext(phi_hat=phi_hat, cov=cov, n_core=n_core)
 

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -420,6 +420,16 @@ class ParametricFitter:
                         lower=self.support[0], upper=self.support[1]
                     )
                     raise ValueError(detail)
+                elif (
+                    (surv_data.x[:, 0] < self.support[0]) & (surv_data.c == 2)
+                ).any():
+                    # An interval endpoint strictly below the support makes
+                    # the CDF evaluate outside its domain: NaN likelihood
+                    # everywhere and a silent initial-guess "fit" (#261).
+                    detail = detail_template.format(
+                        lower=self.support[0], upper=self.support[1]
+                    )
+                    raise ValueError(detail)
             else:
                 if (
                     (surv_data.x <= self.support[0]) & (surv_data.c == 0)
@@ -431,6 +441,17 @@ class ParametricFitter:
                 elif (
                     (surv_data.x >= self.support[1]) & (surv_data.c == 0)
                 ).any():
+                    detail = detail_template.format(
+                        lower=self.support[0], upper=self.support[1]
+                    )
+                    raise ValueError(detail)
+                elif (
+                    (surv_data.x <= self.support[0]) & (surv_data.c == -1)
+                ).any():
+                    # A left-censored point at or below the support start is
+                    # a zero-probability observation: the likelihood is
+                    # -inf/NaN everywhere and the optimiser silently
+                    # returns the initial guess (#261).
                     detail = detail_template.format(
                         lower=self.support[0], upper=self.support[1]
                     )
@@ -999,7 +1020,9 @@ class ParametricFitter:
             fitting_info["fixed_idx"] = fixed_idx
             fitting_info["not_fixed"] = not_fixed
 
-            if init == []:
+            # ``len``-based check: comparing an ndarray to ``[]`` raises a
+            # broadcast error (#261).
+            if init is None or len(np.atleast_1d(init)) == 0:
                 init = self._initial_guess(x, c, n, offset, zi, lfp, heuristic)
 
             init = np.atleast_1d(init)

--- a/surpyval/univariate/regression/accelerated_life/parameter_substitution.py
+++ b/surpyval/univariate/regression/accelerated_life/parameter_substitution.py
@@ -64,6 +64,10 @@ class ParameterSubstitutionFitter(DataFrameRegressionMixin):
             Z = np.ones_like(x) * Z
         else:
             Z = np.array(Z)
+        if Z.ndim == 1:
+            # A 1-D stress vector (one stress variable) becomes a single
+            # column so the per-stress masking below works (#261).
+            Z = Z.reshape(-1, 1)
 
         dist_params = np.array(params[0 : self.k_dist])
         phi_params = np.array(params[self.k_dist :])
@@ -91,6 +95,10 @@ class ParameterSubstitutionFitter(DataFrameRegressionMixin):
             Z = np.ones_like(x) * Z
         else:
             Z = np.array(Z)
+        if Z.ndim == 1:
+            # A 1-D stress vector (one stress variable) becomes a single
+            # column so the per-stress masking below works (#261).
+            Z = Z.reshape(-1, 1)
 
         dist_params = np.array(params[0 : self.k_dist])
         phi_params = np.array(params[self.k_dist :])
@@ -117,6 +125,10 @@ class ParameterSubstitutionFitter(DataFrameRegressionMixin):
             Z = np.ones_like(x) * Z
         else:
             Z = np.array(Z)
+        if Z.ndim == 1:
+            # A 1-D stress vector (one stress variable) becomes a single
+            # column so the per-stress masking below works (#261).
+            Z = Z.reshape(-1, 1)
         return self.hf(x, Z, *params) * np.exp(-self.Hf(x, Z, *params))
 
     def sf(self, x, Z, *params):
@@ -125,6 +137,10 @@ class ParameterSubstitutionFitter(DataFrameRegressionMixin):
             Z = np.ones_like(x) * Z
         else:
             Z = np.array(Z)
+        if Z.ndim == 1:
+            # A 1-D stress vector (one stress variable) becomes a single
+            # column so the per-stress masking below works (#261).
+            Z = Z.reshape(-1, 1)
         return np.exp(-self.Hf(x, Z, *params))
 
     def ff(self, x, Z, *params):
@@ -133,6 +149,10 @@ class ParameterSubstitutionFitter(DataFrameRegressionMixin):
             Z = np.ones_like(x) * Z
         else:
             Z = np.array(Z)
+        if Z.ndim == 1:
+            # A 1-D stress vector (one stress variable) becomes a single
+            # column so the per-stress masking below works (#261).
+            Z = Z.reshape(-1, 1)
         return -np.expm1(-self.Hf(x, Z, *params))
 
     def _parameter_initialiser_dist(self, x, c=None, n=None, t=None):
@@ -175,6 +195,9 @@ class ParameterSubstitutionFitter(DataFrameRegressionMixin):
         Z_out = []
         if isinstance(Z, tuple):
             Z = np.random.uniform(*Z, size)
+        Z = np.asarray(Z)
+        if Z.ndim == 1:
+            Z = Z.reshape(-1, 1)
 
         for stress in np.unique(Z, axis=0):
             life_param_mask = (
@@ -211,7 +234,12 @@ class ParameterSubstitutionFitter(DataFrameRegressionMixin):
     ) -> ParametricRegressionModel:
         x_arr: npt.NDArray = np.asarray(x)
         data = SurpyvalData(x=x, c=c, n=n, t=t, group_and_sort=False)
-        data.add_covariates(Z)
+        # A 1-D stress vector (one stress variable) becomes a single column
+        # so the per-stress masking in the initialiser works (#261).
+        Z_arr = np.asarray(Z)
+        if Z_arr.ndim == 1:
+            Z_arr = Z_arr.reshape(-1, 1)
+        data.add_covariates(Z_arr)
         life_parameter_idx = self.param_map[self.life_parameter]
         if fixed is None:
             fixed = {}
@@ -289,11 +317,13 @@ class ParameterSubstitutionFitter(DataFrameRegressionMixin):
         else:
             phi_param_map = self.life_model.phi_param_map
 
+        # Keep the merged map local: assigning it to ``self.param_map``
+        # mutated the fitter, so a second ``fit()`` re-merged on top of the
+        # already-merged map and produced out-of-range indices (#261).
         param_map = {
             **self.param_map,
             **{k: v + len(self.param_map) for k, v in phi_param_map.items()},
         }
-        self.param_map = param_map
 
         transform, inv_trans, const, fixed_idx, not_fixed = bounds_convert(
             x, bounds, fixed, param_map
@@ -335,7 +365,10 @@ class ParameterSubstitutionFitter(DataFrameRegressionMixin):
         model.phi_params = phi_params
         model.res = res
         model._neg_ll = res.fun
-        model.fixed = self.fixed
+        # Store the full merged fixed dict (baseline-derived + fitter-level +
+        # user-supplied), not just the fitter's own — otherwise standard
+        # errors are reported for parameters that were held fixed (#261).
+        model.fixed = fixed
         model.k_dist = self.k_dist
         model.fun = fun
 

--- a/surpyval/univariate/regression/additive_hazards/additive_hazards.py
+++ b/surpyval/univariate/regression/additive_hazards/additive_hazards.py
@@ -161,7 +161,14 @@ class AdditiveHazardsModel:
         if self.feature_names is not None:
             out["feature_names"] = list(self.feature_names)
         if self.formula is not None:
-            out["formula"] = self.formula
+            out["formula"] = str(self.formula)
+            # Persist the encoder state so a restored model expands raw
+            # covariates the same way (#244, applied to the Lin-Ying
+            # additive-hazards model in #261).
+            if getattr(self, "_model_spec", None) is not None:
+                from ..regression_data import model_spec_to_meta
+
+                out["formula_meta"] = model_spec_to_meta(self._model_spec)
         return stamp_schema(out)
 
     def to_json(self, fp: "str | Path") -> None:
@@ -196,6 +203,11 @@ class AdditiveHazardsModel:
             out.p_values = np.array(model_dict["p_values"], dtype=float)
         out.feature_names = model_dict.get("feature_names")
         out.formula = model_dict.get("formula")
+        formula_meta = model_dict.get("formula_meta")
+        if out.formula is not None and formula_meta is not None:
+            from ..regression_data import rebuild_model_spec
+
+            out._model_spec = rebuild_model_spec(out.formula, formula_meta)
         return out
 
     @classmethod

--- a/surpyval/univariate/regression/buckley_james/buckley_james.py
+++ b/surpyval/univariate/regression/buckley_james/buckley_james.py
@@ -220,7 +220,15 @@ class BuckleyJamesModel:
         if self.feature_names is not None:
             out["feature_names"] = list(self.feature_names)
         if self.formula is not None:
-            out["formula"] = self.formula
+            out["formula"] = str(self.formula)
+            # Persist the categorical levels / numeric columns needed to
+            # rebuild the formula's design-matrix transformer on load, so a
+            # restored model expands raw covariates the same way (#244,
+            # applied to Buckley-James in #261).
+            if getattr(self, "_model_spec", None) is not None:
+                from ..regression_data import model_spec_to_meta
+
+                out["formula_meta"] = model_spec_to_meta(self._model_spec)
         return stamp_schema(out)
 
     def to_json(self, fp):
@@ -261,6 +269,11 @@ class BuckleyJamesModel:
         )
         out.feature_names = model_dict.get("feature_names")
         out.formula = model_dict.get("formula")
+        formula_meta = model_dict.get("formula_meta")
+        if out.formula is not None and formula_meta is not None:
+            from ..regression_data import rebuild_model_spec
+
+            out._model_spec = rebuild_model_spec(out.formula, formula_meta)
         return out
 
     @classmethod

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -6,10 +6,9 @@ from typing import TYPE_CHECKING, Any
 import autograd.numpy as np
 import numpy.typing as npt
 from matplotlib import pyplot as plt
-from scipy.stats import norm, uniform
+from scipy.stats import norm
 
 from surpyval.serialisation import stamp_schema
-from surpyval.utils import fsli_to_xcnt
 
 from ._bounds import (
     bound_signs,
@@ -206,17 +205,20 @@ class ParametricRegressionModel:
                 out["formula_meta"] = model_spec_to_meta(self._model_spec)
 
         # Store the parameter covariance so the restored model can produce
-        # confidence bounds without the original data. Only for data-fit
-        # models whose covariance is finite (a boundary optimum gives nan).
+        # confidence bounds without the original data: from the fit when
+        # available, else the covariance restored from a previous dict so
+        # repeated save/load cycles do not silently lose it (#261).
         if hasattr(self, "data") and getattr(self, "res", None) is not None:
             try:
                 cov = self.covariance()
             except Exception:
                 cov = None
-            if cov is not None and np.all(np.isfinite(cov)):
-                out["covariance"] = np.asarray(cov, dtype=float).tolist()
-            if hasattr(self, "_neg_ll"):
-                out["_neg_ll"] = float(self._neg_ll)
+        else:
+            cov = getattr(self, "_restored_covariance", None)
+        if cov is not None and np.all(np.isfinite(cov)):
+            out["covariance"] = np.asarray(cov, dtype=float).tolist()
+        if hasattr(self, "_neg_ll"):
+            out["_neg_ll"] = float(self._neg_ll)
         return stamp_schema(out)
 
     def to_json(self, fp: "str | Path") -> None:
@@ -832,54 +834,21 @@ class ParametricRegressionModel:
         >>> np.random.seed(1)
         >>> model.random(1)
         array([8.14127103])
-        >>> model.random(10)
-        array([10.84103403,  0.48542084,  7.11387062,  5.41420125,  4.59286657,
-                5.90703589,  7.5124326 ,  7.96575225,  9.18134126,
-                8.16000438])
+        >>> from surpyval import WeibullPH
+        >>> np.random.seed(1)
+        >>> model = WeibullPH.fit(x, Z)
+        >>> x_rand, Z_rand = model.random(10, Z[:1])
         """
-        if (self.p == 1) and (self.f0 == 0):
-            return (
-                self.dist.qf(uniform.rvs(size=size), *self.params) + self.gamma
-            )
-        elif (self.p != 1) and (self.f0 == 0):
-            n_obs = np.random.binomial(size, self.p)
-
-            f = (
-                self.dist.qf(uniform.rvs(size=n_obs), *self.params)
-                + self.gamma
-            )
-            s = np.ones(np.array(size) - n_obs) * np.max(f) + 1
-
-            return fsli_to_xcnt(f, s)
-
-        elif (self.p == 1) and (self.f0 != 0):
-            n_doa = np.random.binomial(size, self.f0)
-
-            x0 = np.zeros(n_doa) + self.gamma
-            x = (
-                self.dist.qf(uniform.rvs(size=size - n_doa), *self.params)
-                + self.gamma
-            )
-            x = np.concatenate([x, x0])
-            np.random.shuffle(x)
-
-            return x
-        else:
-            N = np.random.multinomial(
-                1, [self.f0, self.p - self.f0, 1.0 - self.p], size
-            ).sum(axis=0)
-            N = np.atleast_2d(N)
-            n_doa, n_obs, n_cens = N[:, 0], N[:, 1], N[:, 2]
-            x0 = np.zeros(n_doa) + self.gamma
-            x = (
-                self.dist.qf(uniform.rvs(size=n_obs), *self.params)
-                + self.gamma
-            )
-            f = np.concatenate([x, x0])
-            s = np.ones(n_cens) * np.max(f) + 1
-            # raise NotImplementedError("Combo zero-inflated and lfp model not
-            # yet supported")
-            return fsli_to_xcnt(f, s)
+        # Dispatch to the regression fitter's own covariate-aware sampler
+        # (#261): the previous implementation ignored ``Z`` entirely and
+        # read LFP/ZI attributes regression fits never set, so it crashed
+        # on every path.
+        Z = self._prepare_Z(Z)
+        if hasattr(self.model, "random"):
+            return self.model.random(size, Z, *self.params)
+        raise NotImplementedError(
+            f"random() is not implemented for {self.kind} models."
+        )
 
     def neg_ll(self) -> float:
         r"""

--- a/surpyval/univariate/regression/proportional_hazards/cox_ph.py
+++ b/surpyval/univariate/regression/proportional_hazards/cox_ph.py
@@ -738,7 +738,12 @@ class CoxPH_:
             # Finds the p-value for the null hypothesis
             # that the coefficient is 0.
             hessian_matrix = jac(res.x)[1]
-            var = np.diag(inv(hessian_matrix))
+            # An exactly singular information matrix raises before the
+            # pseudo-inverse fallback can run (#259); route it there.
+            try:
+                var = np.diag(inv(hessian_matrix))
+            except np.linalg.LinAlgError:
+                var = np.full(len(np.atleast_1d(res.x)), -1.0)
             # Use the pseudo-inverse if the hessian does not have a
             # diagonal that is all positive.
             if np.any(var <= 0):
@@ -837,7 +842,11 @@ class CoxPH_:
                 res = fallback
 
         hessian_matrix = jac(res.x)[1]
-        var = np.diag(inv(hessian_matrix))
+        # Exactly singular -> route to the pseudo-inverse fallback (#259).
+        try:
+            var = np.diag(inv(hessian_matrix))
+        except np.linalg.LinAlgError:
+            var = np.full(len(np.atleast_1d(res.x)), -1.0)
         if np.any(var <= 0):
             var = np.diag(pinv(hessian_matrix))
         with np.errstate(invalid="ignore"):
@@ -987,11 +996,19 @@ class CoxPH_:
             semi_parametric_regression_model.SemiParametricRegressionModel.
             predict_tvc`.
         """
-        x, c, n_arr, tl, Z_arr, _ = handle_tvc(i, xl, xr, c, Z, n)
+        x, c, n_arr, tl, Z_arr, ident = handle_tvc(i, xl, xr, c, Z, n)
         model = self.fit(
             x=x, Z=Z_arr, c=c, n=n_arr, tl=tl, method=method, tol=tol
         )
         model.is_tvc = True
+        # Subject ids per *internal* (sorted) row, and the permutation from
+        # the caller's row order to the internal order: residuals and
+        # cluster-robust SEs align with the internal order, so user-supplied
+        # per-row labels must be permuted the same way (#259).
+        model.tvc_subject_ids = ident
+        model.tvc_row_order = np.lexsort(
+            (np.asarray(xl, dtype=float), np.asarray(i))
+        )
         return model
 
     def fit_tvc_from_df(

--- a/surpyval/univariate/regression/proportional_hazards/diagnostics.py
+++ b/surpyval/univariate/regression/proportional_hazards/diagnostics.py
@@ -255,6 +255,11 @@ def robust_covariance(
     dfbeta = compute_residuals(model, "dfbeta")  # (n_obs, p)
     n_obs = dfbeta.shape[0]
 
+    if cluster is None and getattr(model, "is_tvc", False):
+        # Start-stop rows of one subject are correlated by construction, so
+        # a TVC fit defaults to clustering by subject (#259).
+        cluster = getattr(model, "tvc_subject_ids", None)
+
     if cluster is None:
         grouped = dfbeta
     else:
@@ -264,6 +269,14 @@ def robust_covariance(
                 "`cluster` must have one label per observation "
                 f"({n_obs}); got {cluster.shape[0]}."
             )
+        row_order = getattr(model, "tvc_row_order", None)
+        if row_order is not None and not np.array_equal(
+            cluster, getattr(model, "tvc_subject_ids", None)
+        ):
+            # The residuals are in the internal (subject, entry)-sorted
+            # order; user labels arrive in the caller's original row order
+            # and must be permuted the same way (#259).
+            cluster = cluster[row_order]
         labels, inv_idx = np.unique(cluster, return_inverse=True)
         grouped = np.zeros((labels.size, dfbeta.shape[1]))
         np.add.at(grouped, inv_idx, dfbeta)

--- a/surpyval/univariate/regression/proportional_hazards/diagnostics.py
+++ b/surpyval/univariate/regression/proportional_hazards/diagnostics.py
@@ -270,8 +270,9 @@ def robust_covariance(
                 f"({n_obs}); got {cluster.shape[0]}."
             )
         row_order = getattr(model, "tvc_row_order", None)
-        if row_order is not None and not np.array_equal(
-            cluster, getattr(model, "tvc_subject_ids", None)
+        subject_ids = getattr(model, "tvc_subject_ids", None)
+        if row_order is not None and (
+            subject_ids is None or not np.array_equal(cluster, subject_ids)
         ):
             # The residuals are in the internal (subject, entry)-sorted
             # order; user labels arrive in the caller's original row order

--- a/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
+++ b/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
@@ -259,8 +259,14 @@ class ProportionalHazardsFitter(TVCFitMixin, DataFrameRegressionMixin):
 
         if init is None or len(init) == 0:  # type: ignore[arg-type]
             ps = self.dist.fit_from_surpyval_data(data).params
+            # Use the validated covariate array — the raw ``Z`` argument may
+            # be a plain list without a ``.shape`` (#261) — and fall back to
+            # zeros when no phi initialiser is configured (previously an
+            # unbound-name error).
             if callable(self.phi_init):
-                init_phi = self.phi_init(Z)
+                init_phi = self.phi_init(data.Z)
+            else:
+                init_phi = np.zeros(data.Z.shape[1])
 
             init = np.array([*ps, *init_phi])
         else:

--- a/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
+++ b/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
@@ -263,10 +263,11 @@ class ProportionalHazardsFitter(TVCFitMixin, DataFrameRegressionMixin):
             # be a plain list without a ``.shape`` (#261) — and fall back to
             # zeros when no phi initialiser is configured (previously an
             # unbound-name error).
+            Z_data = np.asarray(data.Z)
             if callable(self.phi_init):
-                init_phi = self.phi_init(data.Z)
+                init_phi = self.phi_init(Z_data)
             else:
-                init_phi = np.zeros(data.Z.shape[1])
+                init_phi = np.zeros(Z_data.shape[1])
 
             init = np.array([*ps, *init_phi])
         else:

--- a/surpyval/univariate/regression/semi_parametric_regression_model.py
+++ b/surpyval/univariate/regression/semi_parametric_regression_model.py
@@ -56,6 +56,11 @@ class SemiParametricRegressionModel:
     #: Per-observation training data (``x``/``c``/``n``/``Z``/``tl``) retained
     #: by ``CoxPH.fit`` for residuals and the proportional-hazards test.
     _fit_data: dict
+    #: For a TVC (start-stop) fit: subject id per *internal* (sorted) row,
+    #: and the permutation from the caller's row order to the internal order
+    #: (#259 — used to align user-supplied cluster labels).
+    tvc_subject_ids: "npt.NDArray | None" = None
+    tvc_row_order: "npt.NDArray | None" = None
 
     def __init__(self, kind: str, parameterization: str) -> None:
         self.kind = kind

--- a/surpyval/univariate/regression/semi_parametric_regression_model.py
+++ b/surpyval/univariate/regression/semi_parametric_regression_model.py
@@ -369,11 +369,14 @@ class SemiParametricRegressionModel:
         order = np.argsort(xl_a)
         xl_a, xr_a, Z_a = xl_a[order], xr_a[order], Z_a[order]
 
-        # The active interval at a baseline jump time u is the last interval
-        # whose xl is at or before u; times outside the path are clamped to
-        # the first/last interval (covariate held constant).
+        # The active interval at a baseline jump time u follows the fitted
+        # (xl, xr] convention: the interval with xl < u <= xr, i.e. the OLD
+        # covariate is still at risk at exactly its stop time (#259 —
+        # ``side="right"`` credited a jump at a change time to the NEW
+        # covariate, contradicting the likelihood). Times outside the path
+        # are clamped to the first/last interval (covariate held constant).
         base_t = self.x
-        active = np.searchsorted(xl_a, base_t, side="right") - 1
+        active = np.searchsorted(xl_a, base_t, side="left") - 1
         active = np.clip(active, 0, xl_a.shape[0] - 1)
         phi = np.exp(Z_a[active] @ self.beta)
         H_cum = np.cumsum(self.h0 * phi)
@@ -402,7 +405,9 @@ class SemiParametricRegressionModel:
         weighted by the multiplier of the covariate *active* at each jump.
         """
         base_t = self.x
-        active = np.searchsorted(starts, base_t, side="right") - 1
+        # (xl, xr] convention, matching the fit: the old covariate is at
+        # risk at exactly its stop time (#259).
+        active = np.searchsorted(starts, base_t, side="left") - 1
         active = np.clip(active, 0, starts.shape[0] - 1)
         phi = np.exp(Zseg[active] @ self.beta)
         H_cum = np.cumsum(self.h0 * phi)


### PR DESCRIPTION
Second hardening batch from the univariate deep review, closing #261 and #259. Every fix carries a regression test (14 new); univariate + serialisation suites green locally (1088 passed, 1 skipped).

## #261 — regression serialisation & robustness

- **Buckley-James and Lin-Ying additive-hazards** models now persist their formula encoder state (the #244 `formula_meta` treatment), so restored models predict from DataFrames with transforms/categoricals instead of raising.
- **Repeated save/load cycles** of a parametric regression model no longer silently drop the stored covariance (2nd-generation `to_dict` re-emits `_restored_covariance`).
- **`ParametricRegressionModel.random`** — which ignored `Z` and crashed on every path — now dispatches to the fitter's covariate-aware sampler (`NotImplementedError` for families without one).
- **`AcceleratedLife` fitter**: no longer mutates its param map across fits (second `fit()` on the same instance crashed); stores the merged fixed dict so SEs are no longer reported for constrained parameters; accepts 1-D stress vectors (the docstring example).
- **`WeibullPH.fit`** accepts plain-list covariates; missing phi initialiser falls back to zeros instead of an unbound name.
- **`fit(init=<ndarray>)`** no longer crashes on the `init == []` comparison.
- **Deserialised univariate models** coerce their data back to arrays (`bic`/`aic_c`/re-serialisation with data all work) and restore their `support` interval.
- **Validation**: interval/left-censored observations below the distribution's support are rejected up front instead of producing a NaN likelihood everywhere and a silent initial-guess "fit"; on the genuine fallback path the reported likelihood is now evaluated at the returned parameters.
- Invalid `cb(on=...)` / `param_cb(bound=...)` arguments raise `ValueError` instead of `UnboundLocalError`; missing covariance raises a clear error instead of `np.copy(None)`.

## #259 — TVC prediction & alignment

- **Schedule predictions follow the fitted `(xl, xr]` convention**: a baseline-hazard jump exactly at a covariate-change time belongs to the *old* covariate, matching the likelihood (previously the new covariate — predictions contradicted the fit). A query time's value is now independent of the other query points.
- **Cluster-robust SEs on start-stop fits**: user-supplied per-row cluster labels are permuted into the internal (subject, entry)-sorted order — previously silently misassigned unless the input was already sorted — and TVC fits default to clustering by subject (the statistically correct default for start-stop rows).
- **Exactly singular information matrices** route to the pseudo-inverse/NaN path instead of raising `LinAlgError`.

Remaining review items: #258, #260, #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_