### PR TITLE
AFT-TVC coverage validation + frailty theta->0 limit (#258, #262)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -144,6 +144,12 @@ v0.17.0 (unreleased)
   conditioning would require the unobserved pre-entry covariate path, so
   rather than guess it the fit raises an informative error pointing to Cox
   TVC (``CoxPH.fit_tvc``), which handles delayed entry and gaps exactly.
+- **Fixed: frailty models handle the ``theta -> 0`` (no-frailty) limit**
+  (#262). A frailty variance that underflows to zero — frailty-free data, or
+  a restored model — gave NaN marginal predictions (division by ``theta``)
+  and a NaN/crashing Wald interval; the marginal now takes the well-defined
+  proportional-hazards limit ``eta * H0``, and a boundary estimate returns a
+  zero-width interval instead of dividing by zero.
 - **Royston-Parmar flexible parametric models.** ``RoystonParmar.fit(x, c=...,
   df=..., scale=...)`` fits a flexible parametric survival model that replaces
   the straight log-cumulative-hazard-vs-log-time line of a Weibull with a

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -134,6 +134,16 @@ v0.17.0 (unreleased)
   sorted), and default to clustering by subject. An exactly singular
   information matrix now degrades to the pseudo-inverse/NaN path instead of
   crashing.
+- **Fixed: AFT time-varying-covariate fits now refuse delayed entry and
+  observation gaps instead of silently dropping the missing exposure**
+  (#258). The accumulated accelerated age ``psi(T)`` integrates the covariate
+  path from time 0; a subject entering observation late (or with gaps) has
+  unobserved covariates over the uncovered window, and the likelihood
+  previously treated that time as contributing zero ageing — shifting every
+  subject's window by +5 returned bit-identical parameters. Correct
+  conditioning would require the unobserved pre-entry covariate path, so
+  rather than guess it the fit raises an informative error pointing to Cox
+  TVC (``CoxPH.fit_tvc``), which handles delayed entry and gaps exactly.
 - **Royston-Parmar flexible parametric models.** ``RoystonParmar.fit(x, c=...,
   df=..., scale=...)`` fits a flexible parametric survival model that replaces
   the straight log-cumulative-hazard-vs-log-time line of a Weibull with a

--- a/surpyval/tests/univariate/regression/test_aft_tvc_fit.py
+++ b/surpyval/tests/univariate/regression/test_aft_tvc_fit.py
@@ -17,6 +17,7 @@ These tests pin the properties that make that likelihood correct:
 """
 
 import numpy as np
+import pytest
 
 from surpyval import WeibullAFT, WeibullPH
 from surpyval.univariate.regression.accelerated_failure_time import (
@@ -193,3 +194,50 @@ def test_core_mle_unchanged():
 def test_ph_has_no_custom_aft_likelihood():
     # AFT's fit_tvc must not leak onto PH/AH (they use the reshape mixin).
     assert aft_tvc_fit.AFTTVCFitMixin not in type(WeibullPH).__mro__
+
+
+def _contiguous_tvc_data(seed=3, n=60):
+    rng = np.random.default_rng(seed)
+    rows_i, rows_xl, rows_xr, rows_c, rows_z = [], [], [], [], []
+    for i in range(n):
+        z = rng.normal()
+        t = rng.exponential(np.exp(0.3 * z)) * 5
+        change = 0.5 * t
+        rows_i += [i, i]
+        rows_xl += [0.0, change]
+        rows_xr += [change, t]
+        rows_c += [1, 0]
+        rows_z += [[z], [z + 0.5]]
+    return (
+        np.array(rows_i),
+        np.array(rows_xl),
+        np.array(rows_xr),
+        np.array(rows_c),
+        np.array(rows_z),
+    )
+
+
+def test_delayed_entry_is_refused():
+    # The accumulated-age likelihood integrates the covariate path from 0;
+    # pre-entry covariates are unobserved, and the fit used to silently
+    # drop the missing exposure (shifting every window by +5 returned
+    # bit-identical parameters, #258).
+    i, xl, xr, c, Z = _contiguous_tvc_data()
+    with pytest.raises(ValueError, match="enters observation"):
+        WeibullAFT.fit_tvc(i, xl + 5.0, xr + 5.0, c, Z)
+
+
+def test_gapped_intervals_are_refused():
+    i, xl, xr, c, Z = _contiguous_tvc_data()
+    xl_gap = xl.copy()
+    # Open a gap before each subject's second interval.
+    second = np.arange(1, len(xl), 2)
+    xl_gap[second] = xl_gap[second] + 0.25 * (xr[second] - xl[second])
+    with pytest.raises(ValueError, match="gap between observation"):
+        WeibullAFT.fit_tvc(i, xl_gap, xr, c, Z)
+
+
+def test_contiguous_from_zero_still_fits():
+    i, xl, xr, c, Z = _contiguous_tvc_data()
+    m = WeibullAFT.fit_tvc(i, xl, xr, c, Z)
+    assert np.all(np.isfinite(m.params))

--- a/surpyval/tests/univariate/regression/test_frailty.py
+++ b/surpyval/tests/univariate/regression/test_frailty.py
@@ -9,6 +9,9 @@ from scipy.special import gammaln
 
 import surpyval as surv
 from surpyval import ExponentialFrailty, Frailty, Weibull, WeibullFrailty
+from surpyval.univariate.regression.frailty.frailty_model import (
+    FrailtyModel,
+)
 
 
 def _sim(seed=7, G=80, per=6, alpha=12.0, shape=1.8, beta=0.9, theta=0.6):
@@ -199,3 +202,22 @@ def test_exponential_frailty_available():
     m = ExponentialFrailty.fit(x=x, Z=Z, c=c, groups=groups)
     assert m.dist.name == "Exponential"
     assert m.theta > 0
+
+
+def test_theta_zero_gives_ph_limit_not_nan():
+    # theta -> 0 is the no-frailty PH limit: Hf = eta * H0. Dividing by a
+    # zero theta (frailty-free data, or a restored model) gave NaN (#262).
+    m = FrailtyModel.__new__(FrailtyModel)
+    m.dist = Weibull
+    m.dist_params = np.array([10.0, 3.0])
+    m.beta = np.array([])
+    m.theta = 0.0
+    m.family = "gamma"
+    m._frailties = {}
+    m.feature_names = None
+    m.formula = None
+    m._model_spec = None
+
+    x = np.array([2.0, 5.0, 10.0])
+    assert np.allclose(m.Hf(x), Weibull.Hf(x, 10.0, 3.0))
+    assert np.all(np.isfinite(m.sf(x)))

--- a/surpyval/univariate/regression/accelerated_failure_time/aft_tvc_fit.py
+++ b/surpyval/univariate/regression/accelerated_failure_time/aft_tvc_fit.py
@@ -42,6 +42,47 @@ from surpyval.utils.surpyval_data import SurpyvalData
 from ..parametric_regression_model import ParametricRegressionModel
 
 
+def _validate_full_coverage(x, tl, ident):
+    """
+    Require each subject's episodes to tile ``(0, T]`` completely: first
+    entry at 0 and no gaps between consecutive episodes.
+
+    The accumulated accelerated age ``psi(T) = sum_k phi_k (b_k - a_k)``
+    implements the integral from 0, so uncovered time would silently
+    contribute *zero* accelerated ageing — shifting every subject's window
+    by +5 used to return bit-identical parameters (#258). Conditioning a
+    delayed-entry AFT fit correctly needs ``psi`` over the unobserved
+    pre-entry window, i.e. covariate values the data does not contain, so
+    rather than guess them the fit refuses. Cox TVC (``CoxPH.fit_tvc``)
+    handles delayed entry and gaps exactly, because its risk-set partial
+    likelihood never needs the unobserved history.
+    """
+    uniq, starts, counts = np.unique(
+        ident, return_index=True, return_counts=True
+    )
+    for u, f, cnt in zip(uniq, starts, counts):
+        s_tl = tl[f : f + cnt]
+        s_x = x[f : f + cnt]
+        if s_tl[0] > 1e-12:
+            raise ValueError(
+                "subject {} enters observation at {} > 0: the accelerated "
+                "failure time TVC likelihood integrates the covariate path "
+                "from time 0, and the pre-entry covariates are unobserved. "
+                "Start each subject's first interval at 0, or use Cox TVC "
+                "(CoxPH.fit_tvc), which handles delayed entry "
+                "exactly.".format(u, s_tl[0])
+            )
+        if cnt > 1 and np.any(np.abs(s_tl[1:] - s_x[:-1]) > 1e-9):
+            raise ValueError(
+                "subject {} has a gap between observation intervals: the "
+                "accelerated failure time TVC likelihood needs the covariate "
+                "path over the subject's whole life, and the in-gap "
+                "covariates are unobserved. Make each subject's intervals "
+                "contiguous, or use Cox TVC (CoxPH.fit_tvc), which handles "
+                "gaps exactly.".format(u)
+            )
+
+
 def _grouped_episodes(x, c, n, tl, ident):
     """
     From the (subject-contiguous, entry-sorted) episode arrays returned by
@@ -189,6 +230,7 @@ class AFTTVCFitMixin:
         if Z.shape[0] == 1 and x.shape[0] != 1:
             Z = Z.reshape(-1, 1)
         p = Z.shape[1]
+        _validate_full_coverage(x, tl, ident)
         grp = _grouped_episodes(x, c, n, tl, ident)
 
         # Result fitter: a fresh AFTFitter (so all ordinary prediction

--- a/surpyval/univariate/regression/frailty/frailty_model.py
+++ b/surpyval/univariate/regression/frailty/frailty_model.py
@@ -116,7 +116,14 @@ class FrailtyModel:
         s = eta * H0
         u = self._resolve_frailty(group, frailty)
         if u is None:
-            out = np.log1p(self.theta * s) / self.theta
+            if self.theta < 1e-12:
+                # theta -> 0 is the no-frailty PH limit
+                # log(1 + theta s)/theta -> s; dividing by a zero theta
+                # (e.g. frailty-free data, or a restored model) gave NaN
+                # (#262).
+                out = s
+            else:
+                out = np.log1p(self.theta * s) / self.theta
         else:
             out = u * s
         return out
@@ -200,6 +207,11 @@ class FrailtyModel:
         else:
             raise ValueError("bound must be 'two-sided', 'lower' or 'upper'")
         if positive:
+            if est <= 0:
+                # A boundary estimate (theta -> 0: no detectable frailty)
+                # has no log-scale Wald interval; dividing by zero gave
+                # NaN/ZeroDivision (#262).
+                return np.zeros_like(signs, dtype=float)
             return est * np.exp(signs * q * se / est)
         return est + signs * q * se
 


### PR DESCRIPTION
Final small batch from the univariate deep review.

## #258 — AFT-TVC refuses delayed entry and observation gaps

The accumulated accelerated age `psi(T) = Σ φ_k (b_k − a_k)` implements the integral of the covariate path **from time 0**. A subject entering observation late, or with gaps between intervals, had the uncovered time silently contribute *zero* ageing — shifting every subject's window by +5 returned bit-identical parameters, with no left-truncation conditioning. Correct conditioning would need the covariate path over the unobserved window — information the data does not contain — so rather than guess it, the fit now validates that each subject's intervals tile `(0, T]` and raises an informative error pointing to Cox TVC (`CoxPH.fit_tvc`), which handles delayed entry and gaps exactly. (A future `pre_entry=` assumption-based extension remains possible; tracked in #258.)

## #262 (frailty half) — well-defined theta → 0 limit

A frailty variance that underflows to zero (frailty-free data, or a restored model) produced NaN marginal predictions (division by θ) and a NaN/crashing Wald interval. The marginal cumulative hazard now takes the proportional-hazards limit `η·H0` for θ < 1e-12, and a boundary estimate returns a zero-width interval.

The PH-test convention item in #262 (per-covariate statistic differs from R/lifelines) is deliberately **not** included — it changes reported statistics and awaits an explicit decision; #262 stays open for it.

## Tests

Four new tests; regression dir green locally (298 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_