### PR TITLE
Turnbull variance from observed counts; standard (entry, exit] risk-set convention (#260)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -150,6 +150,29 @@ v0.17.0 (unreleased)
   and a NaN/crashing Wald interval; the marginal now takes the well-defined
   proportional-hazards limit ``eta * H0``, and a boundary estimate returns a
   zero-width interval instead of dividing by zero.
+- **Fixed: Turnbull confidence intervals and the delayed-entry risk-set
+  convention** (#260). On plain right-censored data (where Turnbull reduces
+  exactly to Kaplan-Meier) the variance was computed from the EM's
+  *expected*-count ladder, which redistributes censored mass as fractional
+  later events and silently understated it — confidence intervals were
+  anti-conservative (e.g. Var(H) 0.47 vs the correct Greenwood 0.63). The
+  variance now uses the observed-count ladder in that regime and matches
+  Kaplan-Meier's Greenwood intervals exactly; genuinely interval-censored
+  data keeps the expected-count approximation (use ``bootstrap_cb`` for
+  calibrated intervals there).
+
+  **Convention change:** delayed-entry risk sets now follow the standard
+  ``(entry, exit]`` convention (R ``survival`` / lifelines): a subject
+  entering observation exactly at an event time is *not* at risk for that
+  event. Kaplan-Meier/Nelson-Aalen previously counted it, disagreeing with
+  Turnbull's NPMLE on identical data; the two now agree. Fits only change
+  where an entry time exactly ties an event time. Consistently, a value at
+  exactly its own left-truncation time (a zero-length observation window)
+  is now rejected at validation instead of silently distorting the
+  estimate, and ``Turnbull.fit(..., max_iter=0)`` raises instead of
+  crashing. The truncated-fit degeneracy detector now inspects only the
+  identifiable region, so partial collapses are reported as degenerate
+  rather than as generic non-convergence.
 - **Royston-Parmar flexible parametric models.** ``RoystonParmar.fit(x, c=...,
   df=..., scale=...)`` fits a flexible parametric survival model that replaces
   the straight log-cumulative-hazard-vs-log-time line of a Weibull with a

--- a/surpyval/tests/univariate/nonparametric/test_turnbull.py
+++ b/surpyval/tests/univariate/nonparametric/test_turnbull.py
@@ -325,7 +325,9 @@ def test_km_entry_tie_uses_strict_entry_convention():
     x = np.array([2.0, 3.0, 3.0, 4.0, 5.0, 6.0])
     tl = np.array([0.0, 0.0, 1.0, 1.0, 2.0, 2.0])
     km_model = surpyval.KaplanMeier.fit(x, tl=tl)
-    tb_model = surpyval.Turnbull.fit(x, tl=tl, turnbull_estimator="Kaplan-Meier")
+    tb_model = surpyval.Turnbull.fit(
+        x, tl=tl, turnbull_estimator="Kaplan-Meier"
+    )
     assert float(np.ravel(km_model.sf(2.0))[0]) == pytest.approx(0.75)
     assert float(np.ravel(tb_model.sf(2.0))[0]) == pytest.approx(
         0.75, abs=1e-6

--- a/surpyval/tests/univariate/nonparametric/test_turnbull.py
+++ b/surpyval/tests/univariate/nonparametric/test_turnbull.py
@@ -295,3 +295,59 @@ def test_turnbull_untruncated_default_is_unchanged():
     ]
     assert np.allclose(model.R, expected, atol=1e-6)
     assert model.degenerate is False
+
+
+def test_untruncated_censored_variance_matches_greenwood():
+    # The estimation ladder redistributes right-censored mass as fractional
+    # expected events, silently understating the variance (#260). On data
+    # where Turnbull reduces exactly to KM, the confidence intervals must
+    # now match Greenwood's exactly.
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    c = np.array([0, 0, 1, 0, 1])
+    km_model = surpyval.KaplanMeier.fit(x, c=c)
+    tb_model = surpyval.Turnbull.fit(x, c=c, turnbull_estimator="Kaplan-Meier")
+    km_g = dict(zip(km_model.x, km_model.greenwood))
+    tb_g = {}
+    for xx, g in zip(tb_model.x, tb_model.greenwood):
+        tb_g[xx] = g
+    for xx, g in km_g.items():
+        assert g == pytest.approx(tb_g[xx], abs=1e-12)
+    assert np.allclose(
+        km_model.cb([2.5, 4.0]), tb_model.cb([2.5, 4.0]), atol=1e-9
+    )
+
+
+def test_km_entry_tie_uses_strict_entry_convention():
+    # (entry, exit] risk intervals (R survival / lifelines): a subject
+    # entering exactly at an event time is not at risk for that event.
+    # KM previously counted it (sf(2) = 0.8333) and disagreed with the
+    # Turnbull NPMLE on identical data (#260).
+    x = np.array([2.0, 3.0, 3.0, 4.0, 5.0, 6.0])
+    tl = np.array([0.0, 0.0, 1.0, 1.0, 2.0, 2.0])
+    km_model = surpyval.KaplanMeier.fit(x, tl=tl)
+    tb_model = surpyval.Turnbull.fit(x, tl=tl, turnbull_estimator="Kaplan-Meier")
+    assert float(np.ravel(km_model.sf(2.0))[0]) == pytest.approx(0.75)
+    assert float(np.ravel(tb_model.sf(2.0))[0]) == pytest.approx(
+        0.75, abs=1e-6
+    )
+
+
+def test_value_at_own_truncation_time_rejected():
+    # A value at exactly its own left-truncation time has a zero-length
+    # observation window under (entry, exit]; it previously slipped
+    # through and silently distorted the Turnbull estimate (#260).
+    with pytest.raises(ValueError, match="strictly less"):
+        surpyval.Turnbull.fit(
+            np.array([2.0, 3.0, 4.0]), tl=np.array([2.0, 1.0, 1.0])
+        )
+    with pytest.raises(ValueError, match="strictly less"):
+        surpyval.KaplanMeier.fit(
+            np.array([2.0, 3.0, 4.0]), tl=np.array([2.0, 1.0, 1.0])
+        )
+
+
+def test_max_iter_zero_raises():
+    with pytest.raises(ValueError, match="max_iter"):
+        surpyval.Turnbull.fit(
+            np.array([1.0, 2.0, 3.0]), c=np.array([0, 1, 0]), max_iter=0
+        )

--- a/surpyval/univariate/nonparametric/turnbull.py
+++ b/surpyval/univariate/nonparametric/turnbull.py
@@ -26,7 +26,27 @@ def turnbull(
     per-observation weights over ranges (difference arrays). Each
     iteration is O(N + M) in both time and memory.
     """
+    if max_iter < 1:
+        raise ValueError(f"max_iter must be at least 1; got {max_iter}")
     any_truncated = np.isfinite(t).any()
+    # Exact + right-censored (possibly weighted) untruncated data is the
+    # regime where Turnbull reduces exactly to Kaplan-Meier; keep the raw
+    # inputs so the variance can use the *observed* count ladder rather
+    # than the EM's expected-count ladder, which redistributes censored
+    # mass as fractional later events and silently understates the
+    # variance (#260).
+    km_reducible = (
+        (not any_truncated)
+        and np.asarray(x).ndim == 1
+        and not np.isin(c, (-1, 2)).any()
+    )
+    if km_reducible:
+        x_raw, c_raw, n_raw, t_raw = (
+            np.asarray(x).copy(),
+            np.asarray(c).copy(),
+            np.asarray(n).copy(),
+            np.asarray(t).copy(),
+        )
     # Find all unique bounding points
     bounds = np.unique(np.concatenate([np.unique(x), np.unique(t)]))
     # Add the times at which there was an observation again since
@@ -207,8 +227,25 @@ def turnbull(
     # non-identifiable degenerate state, not a real estimate.
     if not degenerate and R.size > 2:
         reported = R[:-2]
+        if any_truncated:
+            # Only inspect the identifiable region: positions before the
+            # earliest entry time are pinned at 1.0 and previously masked
+            # every partial collapse from the detector (#260).
+            min_tl = (
+                np.min(tl[np.isfinite(tl)])
+                if np.isfinite(tl).any()
+                else -np.inf
+            )
+            idx0 = int(
+                np.searchsorted(
+                    bounds[: reported.shape[0]], min_tl, side="right"
+                )
+            )
+            inspect = reported[idx0:] if idx0 < reported.shape[0] else reported
+        else:
+            inspect = reported
         if not np.all(np.isfinite(reported)) or (
-            any_truncated and np.nanmax(reported) < 1e-8
+            any_truncated and inspect.size > 0 and np.nanmax(inspect) < 1e-8
         ):
             degenerate = True
 
@@ -295,6 +332,31 @@ def turnbull(
     if any_truncated:
         out["var_r"] = r_var[1:-1]
         out["var_d"] = d_var[1:-1]
+    elif km_reducible:
+        # Variance from the observed counts (the Greenwood ladder): the
+        # estimation ladder redistributes each right-censored observation
+        # as fractional expected events at later times, inflating the
+        # information and giving silently narrower intervals (#260). Only
+        # positions with observed events contribute to the variance sum.
+        from surpyval.utils import xcnt_to_xrd
+
+        xg, rg, dg = xcnt_to_xrd(x_raw, c_raw, n_raw, t_raw)
+        ladder_x = bounds[1:-1]
+        var_d = np.zeros(ladder_x.shape[0])
+        var_r = np.ones(ladder_x.shape[0])
+        pos = np.searchsorted(xg, ladder_x)
+        ok = pos < xg.shape[0]
+        ok[ok] = np.isclose(xg[pos[ok]], ladder_x[ok])
+        var_r[ok] = rg[pos[ok]]
+        # Exact times appear twice on the bounds ladder (the zero-width
+        # [x, x] interval trick); credit each event count once so the
+        # cumulative variance steps once per event time.
+        first = np.ones(ladder_x.shape[0], dtype=bool)
+        first[1:] = ladder_x[1:] != ladder_x[:-1]
+        take = ok & first
+        var_d[take] = dg[pos[take]]
+        out["var_r"] = var_r
+        out["var_d"] = var_d
     out["R"] = R[0:-2]
     out["F"] = 1 - R[0:-2]
     out["R_upper"] = R[0:-2]

--- a/surpyval/utils/__init__.py
+++ b/surpyval/utils/__init__.py
@@ -626,10 +626,15 @@ def xcnt_handler(
                 + " respective observed values"
             )
     else:
-        if (t[:, 0] > x).any():
+        # Strictly less: under the (entry, exit] risk-interval convention a
+        # value at exactly its own left-truncation time has a zero-length
+        # observation window — contradictory data that previously slipped
+        # through and silently distorted the Turnbull estimate (#260).
+        if ((t[:, 0] >= x) & np.isfinite(t[:, 0])).any():
             raise ValueError(
-                "All left truncated values must be less than the respective"
-                + " observed values"
+                "All left truncated values must be strictly less than the"
+                + " respective observed values: a value at its own left"
+                + " truncation time has a zero-length observation window."
             )
         elif (t[:, 1] < x).any():
             raise ValueError(
@@ -826,8 +831,13 @@ def xcnt_to_xrd(x, c=None, n=None, t=None, **kwargs):
     d = np.bincount(idx, weights=n * (1 - c))
     # do is drop outs - i.e right censored
     do = np.bincount(idx, weights=n * c)
-    # e is the number of items that have entered observation by each x
-    e = ((tl[:, np.newaxis] <= x[np.newaxis, :]) * n[:, np.newaxis]).sum(0)
+    # e is the number of items that have entered observation *before* each
+    # x: the standard (entry, exit] risk-interval convention (R survival /
+    # lifelines) — a subject entering exactly at an event time is not at
+    # risk for that event. The previous inclusive comparison put surpyval's
+    # KM on the nonstandard side and made it disagree with Turnbull's NPMLE
+    # at exact entry/event ties (#260).
+    e = ((tl[:, np.newaxis] < x[np.newaxis, :]) * n[:, np.newaxis]).sum(0)
     # r is the number of people at risk at each x
     r = e + d - d.cumsum() + do - do.cumsum()
     # change to correct data types


### PR DESCRIPTION
Closes #260, the last substantive item from the univariate deep review.

## Anti-conservative Turnbull confidence intervals

On plain right-censored data — where Turnbull reduces exactly to Kaplan-Meier — the variance was computed from the EM's *expected*-count ladder, which redistributes each censored observation's mass as fractional later events. Feeding those expected counts to Greenwood's formula inflated the information: Var(H) 0.47 vs the correct 0.63 on the reference example, i.e. silently overconfident intervals. The variance now uses the observed-count ladder (via `xcnt_to_xrd`) in the KM-reducible regime and **matches Kaplan-Meier's Greenwood intervals to machine precision** (verified: identical variance ladders and `cb` output). Genuinely interval-censored data keeps the expected-count approximation, with `bootstrap_cb` documented as the calibrated route.

## Convention change: standard (entry, exit] risk sets

Delayed-entry risk sets now follow the convention used by R `survival` and lifelines: a subject entering observation **exactly at** an event time is *not* at risk for that event. `xcnt_to_xrd` previously counted it (`tl <= x`), which put KM/NA on the nonstandard side and made KM disagree with Turnbull's NPMLE on identical data (sf(2) = 0.833 vs the true 0.75 on the tie example). The two now agree exactly. Fits only change where an entry time exactly ties an event time — a measure-zero coincidence for continuous data, relevant for discretised times.

Consistently:
- A value at exactly its own left-truncation time (a zero-length observation window under the strict convention) is **rejected at validation** instead of being silently warped by the Turnbull EM.
- `Turnbull.fit(..., max_iter=0)` raises a clear `ValueError` instead of an `UnboundLocalError`.
- The truncated-fit degeneracy detector now inspects only the identifiable region (positions after the earliest entry), so partial collapses are reported as degenerate rather than generic non-convergence.

## Tests

Five new tests (Greenwood equality, KM≡NPMLE at entry ties, zero-length-window rejection on both estimators, max_iter guard). **Full suite green locally: 1782 passed, 1 skipped** — the convention change altered no other test in the package.

This completes the review: all thirteen issues (#250–#262) are now resolved except the PH-test statistic convention half of #262, which awaits an explicit decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_