### PR TITLE
check_ph: adopt the Grambsch-Therneau per-covariate statistic (#262)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -173,6 +173,19 @@ v0.17.0 (unreleased)
   crashing. The truncated-fit degeneracy detector now inspects only the
   identifiable region, so partial collapses are reported as degenerate
   rather than as generic non-convergence.
+- **Changed: the proportional-hazards test now uses the standard
+  Grambsch-Therneau forms** (#262). The per-covariate statistic is
+  ``d (Vu)_j^2 / (Sgc2 V_jj)`` with ``V`` the inverse information — the form
+  used by R's ``cox.zph`` and lifelines — replacing the previous
+  information-diagonal variant (both are valid chi-square screens, but they
+  weight cross-covariate information differently, so surpyval could flag a
+  different covariate than R/lifelines on the same data). The ``"km"`` time
+  transform is now the true ``1 - KM(t)`` fit on the full data (censoring
+  included) rather than the censoring-blind ECDF of event times.
+  ``check_ph`` now matches lifelines to numerical precision (verified
+  against lifelines 0.30.3); reported per-covariate statistics change for
+  multi-covariate models. The global test was already the standard form and
+  is unchanged.
 - **Royston-Parmar flexible parametric models.** ``RoystonParmar.fit(x, c=...,
   df=..., scale=...)`` fits a flexible parametric survival model that replaces
   the straight log-cumulative-hazard-vs-log-time line of a Weibull with a

--- a/surpyval/tests/univariate/regression/test_cox_diagnostics.py
+++ b/surpyval/tests/univariate/regression/test_cox_diagnostics.py
@@ -187,3 +187,33 @@ def test_per_covariate_names_from_dataframe():
     ph = m.check_ph()
     names = [e.get("covariate") for e in ph["per_covariate"]]
     assert names == ["temp", "volt"]
+
+
+def _ph_test_dataset():
+    # Correlated covariates with a time-varying effect on the first, so
+    # the per-covariate statistics genuinely differ between conventions.
+    np.random.seed(11)
+    n = 200
+    Z = np.random.normal(size=(n, 2))
+    Z[:, 1] = 0.5 * Z[:, 0] + np.random.normal(size=n)
+    u = np.random.uniform(size=n)
+    x = -np.log(u) / (0.1 * np.exp(0.8 * Z[:, 0]))
+    cut = np.quantile(x, 0.8)
+    c = (x > cut).astype(int)
+    return np.minimum(x, cut), Z, c
+
+
+def test_check_ph_matches_lifelines_convention():
+    # Grambsch-Therneau per-covariate statistic d (Vu)_j^2 / (Sgc2 V_jj)
+    # with the km transform as 1 - KM(t) (#262). Reference values computed
+    # with lifelines 0.30.3 ``proportional_hazard_test(time_transform="km")``
+    # on this exact dataset.
+    x, Z, c = _ph_test_dataset()
+    model = sp.CoxPH.fit(x=x, Z=Z, c=c)
+    res = model.check_ph(transform="km")
+    stats = [e["statistic"] for e in res["per_covariate"]]
+    assert stats[0] == pytest.approx(0.178375, abs=2e-4)
+    assert stats[1] == pytest.approx(0.182189, abs=2e-4)
+    pvals = [e["p_value"] for e in res["per_covariate"]]
+    assert pvals[0] == pytest.approx(0.672773, abs=2e-4)
+    assert pvals[1] == pytest.approx(0.669498, abs=2e-4)

--- a/surpyval/univariate/regression/proportional_hazards/diagnostics.py
+++ b/surpyval/univariate/regression/proportional_hazards/diagnostics.py
@@ -313,7 +313,9 @@ def robust_summary(
     return out
 
 
-def _transform_times(t: np.ndarray, transform: str) -> np.ndarray:
+def _transform_times(
+    t: np.ndarray, transform: str, fit_data: "dict | None" = None
+) -> np.ndarray:
     if transform == "identity":
         return t.astype(float)
     if transform == "log":
@@ -321,8 +323,25 @@ def _transform_times(t: np.ndarray, transform: str) -> np.ndarray:
     if transform == "rank":
         return np.argsort(np.argsort(t)).astype(float)
     if transform == "km":
-        # Scale-free transform (Grambsch-Therneau default): the empirical
-        # CDF of the event times, a monotone stand-in for 1 - KM(t).
+        # Scale-free transform (Grambsch-Therneau default): 1 - KM(t) with
+        # the Kaplan-Meier estimate fit on the *full* data, so censoring
+        # weighs in — the previous censoring-blind ECDF of event times
+        # deviated from the R/lifelines convention (#262).
+        if fit_data is not None:
+            from surpyval.utils import xcnt_to_xrd
+
+            x_all = np.asarray(fit_data["x"], dtype=float)
+            c_all = np.asarray(fit_data["c"], dtype=int)
+            n_all = np.asarray(fit_data["n"], dtype=float)
+            tl_all = np.asarray(fit_data.get("tl", None), dtype=float)
+            t_mat = np.column_stack([tl_all, np.full(x_all.shape[0], np.inf)])
+            xk, rk, dk = xcnt_to_xrd(x_all, c_all, n_all, t_mat)
+            with np.errstate(all="ignore"):
+                surv = np.cumprod(1.0 - dk / rk)
+            idx = np.searchsorted(xk, t, side="right") - 1
+            g = np.where(idx >= 0, 1.0 - surv[np.clip(idx, 0, None)], 0.0)
+            return g.astype(float)
+        # Without the fit data fall back to the ECDF of the event times.
         ranks = np.searchsorted(np.sort(t), t, side="right")
         return ranks.astype(float) / t.size
     raise ValueError(
@@ -358,10 +377,9 @@ def check_ph(
 
     Notes
     -----
-    Per-covariate tests use the information diagonal (a marginal working
-    covariance) and so do not adjust for non-proportionality in the *other*
-    covariates; the global test uses the full information and does. For a
-    single covariate the two coincide.
+    Both the global and per-covariate statistics follow the
+    Grambsch-Therneau forms used by R's ``cox.zph`` and lifelines, so the
+    results are directly comparable across packages (#262).
     """
     _require_cox(model)
     if transform not in _TRANSFORMS:
@@ -377,7 +395,7 @@ def check_ph(
     t_events = x[event_rows]
     w_events = n[event_rows]  # count weight per event record
 
-    g = _transform_times(t_events, transform)
+    g = _transform_times(t_events, transform, fit_data=data)
     g_bar = np.average(g, weights=w_events)
     gc = g - g_bar
 
@@ -404,12 +422,18 @@ def check_ph(
     global_stat = float((n_events / Sgc2) * (u @ V @ u))
     global_p = float(chi2.sf(global_stat, df=p))
 
-    # Per-covariate marginal test: T_j = d u_j^2 / (Sgc2 * I_jj) ~ chi2_1.
-    info_diag = np.diag(info)
+    # Per-covariate test, Grambsch-Therneau / cox.zph / lifelines form:
+    # T_j = d (V u)_j^2 / (Sgc2 * V_jj) ~ chi2_1, with V = I^{-1}. The
+    # previous d u_j^2 / (Sgc2 * I_jj) form is also a valid chi2_1 screen
+    # but weights cross-covariate information differently, so users
+    # cross-checking against R / lifelines saw different covariates
+    # flagged (#262).
+    Vu = V @ u
+    V_diag = np.diag(V)
     names = getattr(model, "feature_names", None)
     per_cov = []
     for j in range(p):
-        stat_j = float(n_events * u[j] ** 2 / (Sgc2 * info_diag[j]))
+        stat_j = float(n_events * Vu[j] ** 2 / (Sgc2 * V_diag[j]))
         entry = {
             "statistic": stat_j,
             "df": 1,


### PR DESCRIPTION
## Summary

Completes #262 (the remaining half — the frailty θ→0 fix merged in #265) by aligning `CoxPH.check_ph` with the standard Grambsch-Therneau proportional-hazards test as implemented by R's `cox.zph` and lifelines:

- **Per-covariate statistic**: now `d·(Vu)ⱼ² / (Σ(g−ḡ)²·Vⱼⱼ)` with `V = I⁻¹` — the score is premultiplied by the full inverse information before squaring, so correlated covariates are handled the way `cox.zph`/lifelines do. Previously each covariate was tested with only its own diagonal element, which gives different (and non-standard) values for multi-covariate models.
- **`km` transform**: now the true `1 − KM(t)` computed from the full fitted data (censored rows included, via `xcnt_to_xrd`), rather than an ECDF of event times only.

## Verification

- Per-covariate statistics/p-values match lifelines 0.30.3 to 6 significant figures on a correlated two-covariate dataset: stats (0.178375, 0.182189), p-values (0.672773, 0.669498). The reference values are hard-coded in `test_check_ph_matches_lifelines_convention` (lifelines is not a CI dependency, matching the repo's precomputed-reference pattern).
- 18 diagnostics tests and the full 299-test regression suite pass locally; `mypy` clean.

Closes #262 — and with it, the last item of the univariate deep-dive review (#250–#262).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_