### PR TITLE
Round-2 review fixes: estimators, truncation, covariance, diagnostics (#268-#282)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,66 @@ Changelog
 v0.17.0 (unreleased)
 --------------------
 
+- **Fixed: Cox residuals, ``check_ph`` and robust standard errors now
+  apply the Efron tie correction for Efron fits** (#279). All residuals
+  used plain Breslow risk-set means and increments regardless of the tie
+  method, so heavily tied Efron fits (the ``fit_from_df`` default)
+  disagreed with R/lifelines — ``check_ph`` km statistic 0.36 vs 0.72,
+  robust SEs ~20% small. Schoenfeld residuals and ``check_ph`` (km,
+  identity, log transforms) now match lifelines to 6+ figures under
+  heavy ties; martingale and score residual sums vanish at the MLE for
+  both tie methods; dfbeta correlates 0.999 with exact leave-one-out
+  influence. The ``"rank"`` transform now uses average ranks for ties
+  (R's ``cox.zph`` convention; lifelines' cumulative-count variant is
+  nonstandard).
+- **Fixed: the concordance index credited 0.5 to a discordant
+  event/censored pair tied in time** (#276). Harrell's C treats the
+  censored subject as having outlived the tied event, so the pair is
+  fully comparable: 1/0.5/0 by score order. Tie-heavy data was biased
+  toward 0.5; results now match lifelines up to the (documented)
+  both-events-tied-time convention difference.
+- **Fixed: Lin-Ying additive-hazards ``hf``/``df`` added the baseline
+  *jump* to a hazard *rate*** (#277) — dimensionally incoherent, and as
+  n grows the baseline vanished entirely (``hf -> beta'Z``). The
+  baseline rate is now a kernel-smoothed (Ramlau-Hansen, Epanechnikov)
+  estimate from the corrected cumulative-baseline increments, with a
+  ``bandwidth`` argument. ``phi()`` on additive-hazards models now
+  raises a clear ``NotImplementedError`` (the covariate effect is
+  additive, not a multiplier) instead of an ``AttributeError``.
+- **Fixed: competing-risks CIFs could exceed 1 with the default
+  Nelson-Aalen method** (#278). The Aalen-Johansen increment paired the
+  discrete hazard ``d/r`` with the exponential survival ``exp(-H)``;
+  only the product-limit survival satisfies the telescoping identity,
+  so total incidence reached 1.22-1.31 in small samples. Increments now
+  always use the product-limit ``S(t-)``; the reported ``sf`` keeps the
+  requested estimator.
+- **Fixed: distribution edge cases** (#280). LogLogistic: ``sf``/``ff``
+  are defined at ``x = 0`` (previously ``ZeroDivisionError``/NaN) and
+  ``log_sf``/``log_ff`` use a ``logaddexp`` form that no longer
+  overflows to ``-inf`` for large ``alpha**beta``. Beta4: ``df``/``hf``
+  are 0 outside the support instead of arbitrary/negative/NaN values.
+  Rayleigh, Gamma and Exponential custom probability-plotting paths now
+  forward truncation bounds (previously silently dropped), and Rayleigh
+  masks plotting positions at F = 1 (the ECDF heuristic returned NaN
+  parameters). Uniform's closed-form MLE rejects interval-censored data
+  with a clear error instead of a cryptic ``IndexError``.
+- **Fixed: ``xrd_to_xcnt`` silently corrupted late-entry data** (#281).
+  A risk set that grows between observation times (left truncation)
+  cannot be represented in xcnt output; the ``np.abs`` of the risk-set
+  differences masked the increase and returned a different study. It
+  now raises an informative ``ValueError``.
+- **Fixed: container and robustness batch** (#282). ``SurpyvalData``:
+  scalar indexing on interval-censored data no longer flattens the
+  interval row (IndexError), slicing carries covariates ``Z`` through,
+  and ``to_xrd`` caches per estimator instead of returning the first
+  call's result for every later estimator. Nonparametric models: scalar
+  ``hf``/``df`` return the step's hazard increment instead of always
+  NaN, and confidence bounds fall back to the point estimate when no
+  point on the curve has a finite variance (single-observation fits
+  returned NaN bounds). ``check_ph`` no longer emits a spurious
+  "ignoring left truncated values" warning for models fit with a
+  constant entry column (``tl = 0``), and the stale pre-#260
+  ``xcnt_to_xrd`` docstring example was updated.
 - **Fixed: the MPS estimator returned wrong parameters for censored,
   tied, truncated, and offset-truncated data** (#268). Four defects: the
   censored/ties block was divided by a different count than the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,19 @@ Changelog
 v0.17.0 (unreleased)
 --------------------
 
+- **Fixed: censored/truncated Gamma and Beta fits had a silently corrupted
+  Wald covariance** (#270). The autograd shims for the incomplete
+  gamma/beta functions stripped the derivative trace in their
+  shape-parameter VJPs, zeroing every second-derivative contribution
+  through a shape parameter: the stored covariance was wrong (12x the
+  true sampling variance in one repro) and not even symmetric, corrupting
+  ``param_cb``, ``cb``, plot bands and the serialised covariance while
+  the point estimates were fine. The shape derivatives are now traced
+  primitives with numerical second-derivative VJPs, so autograd Hessians
+  match the true observed information (verified against numerical
+  differentiation to ~1e-6 for censored Gamma and Beta, including offset
+  fits); ``mle`` additionally validates Hessian symmetry and falls back
+  to a numerical Hessian if a corrupted one ever reappears.
 - **Fixed: Turnbull excluded the right endpoint of interval- and
   left-censored observations from their support** (#272). An interval
   ``(l, r]`` whose right endpoint coincided with an exactly observed event

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,21 @@ Changelog
 v0.17.0 (unreleased)
 --------------------
 
+- **Fixed: the MPS estimator returned wrong parameters for censored,
+  tied, truncated, and offset-truncated data** (#268). Four defects: the
+  censored/ties block was divided by a different count than the
+  spacings, making the estimator inconsistent even without truncation
+  (integer-tied Weibull data fit as ``(13.7, 1.52)`` vs the true
+  ``(10, 2)``); censored survivor/CDF terms were not conditioned on the
+  truncation window (truncated + censored fits biased to
+  ``(11.7, 4.36)``); offset fits passed unshifted truncation bounds to
+  the shifted distribution (objective infinite at the true parameters);
+  and interval-censored input crashed deep in ``np.hstack`` instead of a
+  clear validation error. The objective is now the Cheng-Amin sum form
+  (spacings + tie densities + conditional censored terms in one sum),
+  bounds are shifted with the data (clamped at the support), and
+  interval data raises an informative ``ValueError``. All four scenarios
+  now track MLE to within ~2%.
 - **Fixed: censored/truncated Gamma and Beta fits had a silently corrupted
   Wald covariance** (#270). The autograd shims for the incomplete
   gamma/beta functions stripped the derivative trace in their

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,34 @@ Changelog
 v0.17.0 (unreleased)
 --------------------
 
+- **Fixed: Turnbull excluded the right endpoint of interval- and
+  left-censored observations from their support** (#272). An interval
+  ``(l, r]`` whose right endpoint coincided with an exactly observed event
+  time was forbidden from having failed at ``r`` (and a left-censored
+  observation from having failed at its own bound), pushing its mass onto
+  earlier atoms — ``sf`` between the atoms was 0.45 where the (l, r]
+  NPMLE (Turnbull 1976, lifelines, icenReg) gives 0.83. Supports now
+  include the atom at the right endpoint, matching the (entry, exit]
+  convention adopted in #260.
+- **Fixed: Turnbull under truncation — variance ladder, support windows,
+  and degenerate-interval inputs** (#273). (1) The truncated variance
+  ladder redistributed right-censored mass as fractional later events and
+  kept censored items at risk via conditional tail probabilities — the
+  anti-conservative mechanism #260 removed for untruncated data — and at
+  the last event produced huge *negative* Greenwood increments that
+  passed the finiteness guard. It now uses observed counts (events at
+  exact atoms, censored items leave at censoring), reducing exactly to
+  the delayed-entry Kaplan-Meier Greenwood ladder for exact +
+  right-censored data. (2) Each observation's support is now intersected
+  with its own truncation window: mass can no longer be redistributed to
+  times where the observed event provably cannot be, which previously
+  drove the EM to a degenerate all-zero fixed point on valid
+  left-censored + delayed-entry data — including the original #203
+  reproduction, which now converges to a healthy estimate. An empty
+  intersection raises an informative ``ValueError``. (3) The KM-reducible
+  variance branch now recognises exact + right-censored data expressed as
+  degenerate intervals (``xl == xr`` / ``xr = inf``), which previously
+  fell back to the anti-conservative expected-count ladder.
 - **Fixed: LFP fits with left truncation maximised an unbounded likelihood
   and returned degenerate parameters with optimiser success** (#269). The
   truncation normaliser used ``(p - f0) * (1 - F0(tl))`` — dropping the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,36 @@ Changelog
 v0.17.0 (unreleased)
 --------------------
 
+- **Fixed: LFP fits with left truncation maximised an unbounded likelihood
+  and returned degenerate parameters with optimiser success** (#269). The
+  truncation normaliser used ``(p - f0) * (1 - F0(tl))`` — dropping the
+  never-failing mass from the survival at entry — instead of the mixture
+  survival ``1 - f0 - (p - f0) * F0(tl)``. ``Weibull.fit(x, c, tl=...,
+  lfp=True)`` returned ``alpha ~ 1e-42`` on healthy data; it now recovers
+  the true parameters. Finite-bound windows (interval censoring, double
+  truncation) are algebraically unchanged.
+- **Fixed: parametric PH ``random()`` sampled the wrong distribution and
+  crashed with two or more covariates** (#271). The sampler inverted
+  ``qf(U ** phi)`` where PH requires ``qf(1 - U ** (1 / phi))``, so every
+  draw with a non-zero covariate effect came from the wrong distribution
+  (empirical SF 0.67 vs model 0.89 in the repro); the covariate broadcast
+  also raised ``ValueError`` for multi-covariate models. Draws now
+  reproduce the model's own ``sf`` and the returned covariates have shape
+  ``(size, p)``.
+- **Fixed: Royston-Parmar silently returned NaN models** (#274). The BFGS
+  polish replaced the finite Nelder-Mead result even when it diverged
+  (e.g. on doubly-truncated data); it is now kept only when finite and
+  better, and a non-finite final likelihood raises. Quantile knot
+  placement over too-few or tied event times produced coincident knots
+  and an all-NaN model with no warning; ``fit`` now validates that the
+  data contain at least ``df + 1`` distinct event times and that knots
+  are distinct, raising an informative ``ValueError``.
+- **Fixed: numeric MOM fits stopped far from the moment-matching
+  solution** (#275). The optimiser ran with ``tol=1e-1`` and no
+  convergence check, so ``how="MOM"`` with ``offset=True`` or ``fixed``
+  returned e.g. ``beta ~ 3-4`` for true ``beta = 2`` silently. The path
+  now optimises tightly, polishes with Nelder-Mead when needed, and warns
+  if the sample moments remain unmatched.
 - **Fixed: Cox delayed-entry / start-stop (TVC) fits had corrupted scores and
   Hessians whenever any covariate value was negative** (#250). The
   left-truncation risk-set adjustment was forward-filled with

--- a/surpyval/tests/univariate/nonparametric/test_turnbull.py
+++ b/surpyval/tests/univariate/nonparametric/test_turnbull.py
@@ -225,13 +225,27 @@ def _degenerate_case():
     return x, c, n, tl
 
 
-def test_turnbull_degenerate_state_is_flagged_and_warns():
+def test_turnbull_previously_degenerate_case_now_identifiable():
+    # The #203 reproduction collapsed because left-censored and
+    # entry-spanning interval supports extended below the observation
+    # windows. With each support intersected with its own truncation
+    # window (#273) the data are identifiable and the EM converges to a
+    # healthy estimate instead of the all-zero fixed point.
     x, c, n, tl = _degenerate_case()
-    with pytest.warns(UserWarning, match="degenerate"):
-        model = surpyval.Turnbull.fit(x=x, c=c, n=n, tl=tl)
-    # The degenerate direction is detected and surfaced, rather than a
-    # silent all-zero survival curve being returned as if converged.
-    assert model.degenerate is True
+    model = surpyval.Turnbull.fit(x=x, c=c, n=n, tl=tl, max_iter=200000)
+    assert model.degenerate is False
+    assert model.converged is True
+    R = np.asarray(model.R)
+    assert R[-1] < 0.1  # survival still falls essentially to zero
+    assert np.nanmax(R) == pytest.approx(1.0)
+    assert np.all(np.diff(R) <= 1e-12)  # monotone non-increasing
+
+
+def test_turnbull_non_convergence_still_warns():
+    # The same case stopped early must warn rather than return silently.
+    x, c, n, tl = _degenerate_case()
+    with pytest.warns(UserWarning, match="did not converge"):
+        surpyval.Turnbull.fit(x=x, c=c, n=n, tl=tl, max_iter=100)
 
 
 def test_turnbull_healthy_truncated_fit_is_not_flagged():

--- a/surpyval/tests/univariate/nonparametric/test_turnbull_round2.py
+++ b/surpyval/tests/univariate/nonparametric/test_turnbull_round2.py
@@ -1,0 +1,131 @@
+"""
+Regression tests for the round-2 Turnbull fixes:
+
+- #272: interval/left-censored observations follow the (l, r] convention —
+  the exact-time atom at the right endpoint is inside the support.
+- #273: under truncation the variance ladder uses observed counts (no
+  negative variances, reduces to delayed-entry KM Greenwood), supports are
+  intersected with truncation windows, and degenerate-interval inputs use
+  the KM-reducible variance.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval import KaplanMeier, Turnbull
+
+
+class TestIntervalEndpointConvention:
+    def test_right_endpoint_tie_matches_npmle(self):
+        # 272: exact {2} x1, {3} x5, interval (1, 3] x5. The (l, r] NPMLE
+        # puts mass 1/6 at 2 and 5/6 at 3 (lifelines NPMLE agrees), so
+        # S(2.5) = 5/6. The old support excluded the atom at 3 and gave
+        # S(2.5) = 5/11.
+        tb = Turnbull.fit(
+            x=[2] * 1 + [3] * 5 + [[1, 3]] * 5,
+            c=[0] * 6 + [2] * 5,
+            turnbull_estimator="Kaplan-Meier",
+        )
+        sf25 = float(np.ravel(tb.sf(2.5))[0])
+        assert sf25 == pytest.approx(5 / 6, abs=1e-6)
+
+    def test_left_censored_at_event_time(self):
+        # 272: left-censored at 3 means "failed at or before 3": with
+        # exact {3} x5 + left-censored-at-3 x5 all mass sits at 3.
+        tb = Turnbull.fit(
+            x=[3.0] * 5 + [3.0] * 5,
+            c=[0] * 5 + [-1] * 5,
+            turnbull_estimator="Kaplan-Meier",
+        )
+        R = np.asarray(tb.R)
+        # Survival is 1 before 3 and 0 at/after 3.
+        assert R[-1] == pytest.approx(0.0, abs=1e-9)
+
+    def test_generic_intervals_unchanged(self):
+        # Non-coinciding endpoints were already correct; sanity-pin one.
+        x = np.array([[1, 5], [2, 3], [3, 6], [1, 8], [9, 10]])
+        model = Turnbull.fit(x)
+        R = np.asarray(model.R)
+        assert np.all(np.isfinite(R))
+        assert np.all(np.diff(R) <= 1e-12)
+
+
+class TestTruncatedVariance:
+    def test_variance_matches_delayed_entry_km(self):
+        # 273: exact + right-censored + left-truncated reduces to
+        # delayed-entry KM — including the Greenwood ladder, which used
+        # to produce a -1.5e15 increment at the last event.
+        x = [2, 3, 4, 5, 6, 7, 8]
+        c = [0, 0, 1, 0, 0, 0, 0]
+        tl = [0, 1, 1, 2, 3, 0, 5]
+        tb = Turnbull.fit(x=x, c=c, tl=tl, turnbull_estimator="Kaplan-Meier")
+        km = KaplanMeier.fit(x=x, c=c, tl=tl)
+
+        tb_x = np.asarray(tb.x)
+        tb_gw = np.asarray(tb.greenwood)
+        km_x = np.asarray(km.x)
+        km_gw = np.asarray(km.greenwood)
+        # Compare at each KM event time (TB's ladder has doubled bounds;
+        # take the last TB position at or before each KM time).
+        for xv, gv in zip(km_x, km_gw):
+            idx = np.searchsorted(tb_x, xv, side="right") - 1
+            if np.isnan(gv):
+                assert np.isnan(tb_gw[idx])
+            else:
+                assert tb_gw[idx] == pytest.approx(gv, abs=1e-10)
+        # No negative variance anywhere on the ladder.
+        finite = tb_gw[np.isfinite(tb_gw)]
+        assert np.all(finite >= 0)
+
+    def test_survival_still_matches_delayed_entry_km(self):
+        x = [2, 3, 4, 5, 6, 7, 8]
+        c = [0, 0, 1, 0, 0, 0, 0]
+        tl = [0, 1, 1, 2, 3, 0, 5]
+        tb = Turnbull.fit(x=x, c=c, tl=tl, turnbull_estimator="Kaplan-Meier")
+        km = KaplanMeier.fit(x=x, c=c, tl=tl)
+        t_eval = [2.5, 3.5, 5.5, 6.5, 7.5]
+        np.testing.assert_allclose(
+            np.ravel(tb.sf(t_eval)), np.ravel(km.sf(t_eval)), atol=1e-9
+        )
+
+
+class TestSupportWindowIntersection:
+    def test_left_censored_with_entry_converges(self):
+        # 273: valid left-censored + delayed-entry data used to hit the
+        # degenerate all-zero fixed point because the (-inf, x] support
+        # was not intersected with the (tl, inf) window.
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            tb = Turnbull.fit(
+                x=[3, 4, 5, 6, 7],
+                c=[0, -1, 0, 0, 0],
+                tl=[1, 2, 2, 3, 1],
+                turnbull_estimator="Kaplan-Meier",
+            )
+        R = np.asarray(tb.R)
+        assert np.all(np.isfinite(R))
+        assert np.nanmax(R) == pytest.approx(1.0)
+
+
+class TestDegenerateIntervalReducibility:
+    def test_degenerate_intervals_match_1d_form(self):
+        # 273: the same exact + right-censored data in degenerate-interval
+        # form must give identical survival and Greenwood variance to the
+        # 1-D form (both on the KM-reducible observed-count ladder).
+        x1 = [1, 2, 3, 4, 5, 6]
+        c1 = [0, 0, 1, 0, 1, 0]
+        x2 = [[v, v] if cc == 0 else [v, np.inf] for v, cc in zip(x1, c1)]
+        t1 = Turnbull.fit(x=x1, c=c1, turnbull_estimator="Kaplan-Meier")
+        t2 = Turnbull.fit(x=x2, turnbull_estimator="Kaplan-Meier")
+        np.testing.assert_allclose(
+            np.asarray(t1.greenwood),
+            np.asarray(t2.greenwood),
+            atol=1e-12,
+        )
+        km = KaplanMeier.fit(x=x1, c=c1)
+        t_eval = [1.5, 2.5, 3.5, 4.5, 5.5]
+        np.testing.assert_allclose(
+            np.ravel(t2.sf(t_eval)), np.ravel(km.sf(t_eval)), atol=1e-8
+        )

--- a/surpyval/tests/univariate/parametric/test_censored_hessian.py
+++ b/surpyval/tests/univariate/parametric/test_censored_hessian.py
@@ -1,0 +1,99 @@
+"""
+Regression tests for #270: censored/truncated Gamma and Beta fits used to
+get a silently corrupted (even asymmetric) Wald covariance because the
+autograd shims for the incomplete gamma/beta functions stripped the trace
+in their shape-parameter VJPs, zeroing every second-derivative
+contribution through a shape parameter.
+"""
+
+import numpy as np
+import pytest
+from scipy.stats import beta as sbeta
+from scipy.stats import gamma as sgamma
+
+from surpyval import Beta, Gamma, Weibull
+
+
+def _numerical_inv_information(nll, params):
+    import numdifftools as nd  # type: ignore
+
+    return np.linalg.inv(nd.Hessian(nll)(params))
+
+
+class TestCensoredGammaCovariance:
+    def test_covariance_matches_observed_information(self):
+        np.random.seed(7)
+        n = 150
+        x0 = np.random.gamma(3, 2.0, n)
+        cens = 6.0
+        c = (x0 > cens).astype(int)
+        x = np.minimum(x0, cens)
+        m = Gamma.fit(x=x, c=c)
+        H = np.array(m.hess_inv)
+
+        def nll(p):
+            a, b = p
+            return -(
+                sgamma.logpdf(x[c == 0], a, scale=1 / b).sum()
+                + sgamma.logsf(x[c == 1], a, scale=1 / b).sum()
+            )
+
+        ref = _numerical_inv_information(nll, m.params)
+        # Was 12.5x off and 29% asymmetric before the fix.
+        np.testing.assert_allclose(H, ref, rtol=1e-3)
+        assert abs(H[0, 1] - H[1, 0]) <= 1e-4 * abs(H[0, 1])
+
+    def test_offset_censored_gamma_covariance_finite(self):
+        # The mixed d2/dadx path flows through the offset parameter.
+        np.random.seed(9)
+        x0 = 5.0 + np.random.gamma(3, 2.0, 3000)
+        c = (x0 > 11.0).astype(int)
+        x = np.minimum(x0, 11.0)
+        m = Gamma.fit(x=x, c=c, offset=True)
+        assert np.all(np.isfinite(m.hess_inv))
+        H = np.array(m.hess_inv)
+        assert np.allclose(H, H.T, rtol=1e-3, atol=1e-10)
+
+
+class TestCensoredBetaCovariance:
+    def test_covariance_matches_observed_information(self):
+        np.random.seed(8)
+        x0 = np.random.beta(2.0, 5.0, 200)
+        c = (x0 > 0.4).astype(int)
+        x = np.minimum(x0, 0.4)
+        m = Beta.fit(x=x, c=c)
+        H = np.array(m.hess_inv)
+
+        def nll(p):
+            a, b = p
+            return -(
+                sbeta.logpdf(x[c == 0], a, b).sum()
+                + sbeta.logsf(x[c == 1], a, b).sum()
+            )
+
+        ref = _numerical_inv_information(nll, m.params)
+        np.testing.assert_allclose(H, ref, rtol=1e-3)
+
+
+class TestControls:
+    def test_censored_weibull_unaffected(self):
+        # Weibull never touches the incomplete-gamma shims; its Hessian
+        # must stay exactly symmetric.
+        np.random.seed(7)
+        x0 = 10 * np.random.weibull(2, 200)
+        c = (x0 > 12.0).astype(int)
+        x = np.minimum(x0, 12.0)
+        m = Weibull.fit(x=x, c=c)
+        H = np.array(m.hess_inv)
+        assert abs(H[0, 1] - H[1, 0]) < 1e-12
+
+    def test_uncensored_gamma_unchanged(self):
+        # The uncensored likelihood is analytic; parameter CIs must be
+        # unchanged and tight around the truth for a large sample.
+        np.random.seed(10)
+        x = np.random.gamma(3, 2.0, 2000)
+        m = Gamma.fit(x=x)
+        H = np.array(m.hess_inv)
+        assert np.allclose(H, H.T, atol=1e-12)
+        se_alpha = np.sqrt(H[0, 0])
+        assert m.params[0] == pytest.approx(3.0, abs=4 * se_alpha)

--- a/surpyval/tests/univariate/parametric/test_mps_round2.py
+++ b/surpyval/tests/univariate/parametric/test_mps_round2.py
@@ -1,0 +1,72 @@
+"""
+Regression tests for #268: the MPS estimator was wrong under truncation,
+censoring, ties, and offset — the censored/ties block was scaled by a
+different count than the spacings (inconsistent even without truncation),
+censored terms were not conditioned on the truncation window, and offset
+fits passed unshifted truncation bounds to the shifted distribution.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval import Weibull
+
+
+class TestMPSTies:
+    def test_tied_data_tracks_mle(self):
+        # Was (13.7, 1.52) vs MLE (10.07, 2.01).
+        np.random.seed(13)
+        x = np.round(10 * np.random.weibull(2, 3000))
+        x = x[x > 0]
+        mps = Weibull.fit(x=x, how="MPS")
+        mle = Weibull.fit(x=x, how="MLE")
+        np.testing.assert_allclose(mps.params, mle.params, rtol=0.02)
+
+
+class TestMPSCensoring:
+    def test_censored_data_recovers_parameters(self):
+        # The old block weighting converged to (9.46, 2.07) as n grew.
+        np.random.seed(14)
+        t = 10 * np.random.weibull(2, 20000)
+        c = (t > 13).astype(int)
+        x = np.minimum(t, 13.0)
+        mps = Weibull.fit(x=x, c=c, how="MPS")
+        assert mps.params[0] == pytest.approx(10.0, rel=0.02)
+        assert mps.params[1] == pytest.approx(2.0, rel=0.02)
+
+
+class TestMPSTruncation:
+    def test_truncated_censored_data_recovers_parameters(self):
+        # Was (11.7, 4.36) with optimiser success.
+        np.random.seed(14)
+        t = 10 * np.random.weibull(2, 90000)
+        t = t[t > 8][:15000]
+        c = (t > 13).astype(int)
+        x = np.minimum(t, 13.0)
+        mps = Weibull.fit(x=x, c=c, tl=8.0, how="MPS")
+        mle = Weibull.fit(x=x, c=c, tl=8.0, how="MLE")
+        np.testing.assert_allclose(mps.params, mle.params, rtol=0.02)
+
+    def test_offset_truncated_recovers_parameters(self):
+        # The unshifted bound made the objective infinite at the truth;
+        # the fit returned gamma=104, alpha=6.1, beta=1.3.
+        np.random.seed(31)
+        T = 100 + 10 * np.random.weibull(2, 60000)
+        x = T[T > 103][:5000]
+        m = Weibull.fit(x=x, tl=103.0, how="MPS", offset=True)
+        assert m.gamma == pytest.approx(100.0, abs=1.0)
+        assert m.params[0] == pytest.approx(10.0, rel=0.1)
+        assert m.params[1] == pytest.approx(2.0, rel=0.1)
+
+
+class TestMPSValidation:
+    def test_interval_censored_raises_clearly(self):
+        with pytest.raises(ValueError, match="interval-censored"):
+            Weibull.fit(x=[[1, 2], [2, 4], [3, 5]], how="MPS")
+
+    def test_plain_fit_unchanged(self):
+        np.random.seed(15)
+        x = 10 * np.random.weibull(2, 2000)
+        m = Weibull.fit(x=x, how="MPS")
+        assert m.params[0] == pytest.approx(10.0, rel=0.05)
+        assert m.params[1] == pytest.approx(2.0, rel=0.05)

--- a/surpyval/tests/univariate/parametric/test_offset_divergence.py
+++ b/surpyval/tests/univariate/parametric/test_offset_divergence.py
@@ -84,23 +84,22 @@ def test_mpp_offset_gamma_parameters_recovered():
     assert s["wasserstein_frac_std"] < 0.05
 
 
-def test_mom_offset_rayleigh_biased_but_central_predictions_hold():
-    """MOM offset on Rayleigh biases gamma low and, unlike the Gamma
-    case, the divergence is *modest, not negligible*: the spread is
-    visibly wrong even though the central predictions stay accurate."""
+def test_mom_offset_rayleigh_parameters_recovered():
+    """MOM offset on Rayleigh used to stop far from the moment-matching
+    solution (the numeric path ran with tol=1e-1 and no convergence
+    check), biasing gamma low and the spread high. #275 tightened the
+    optimisation, so the parameters are now recovered too."""
     s = _summary(Rayleigh, (3.0,), how="MOM")
 
-    # gamma is biased away from the truth.
-    assert abs(s["fit"].gamma - TRUE_GAMMA) > 0.4
+    # The parameters are now close to the truth.
+    assert abs(s["fit"].gamma - TRUE_GAMMA) < 0.5, s["fit"].gamma
+    assert s["max_param_rel_err"] < 0.10  # within 10%
 
-    # Central predictions remain trustworthy...
+    # ...and the distribution matches.
     assert s["mean_rel_err"] < 0.02  # mean within 2%
     assert s["median_rel_err"] < 0.02  # median within 2%
-
-    # ...but the distribution is genuinely off in its spread: this is the
-    # "modest, not negligible" caveat made concrete.
-    assert s["std_rel_err"] > 0.10  # std off by more than 10%
-    assert 0.02 < s["kl_nats"] < 0.15  # small, but not zero
+    assert s["std_rel_err"] < 0.10  # spread within 10%
+    assert s["kl_nats"] < 0.02
 
 
 def test_mle_offset_is_the_accurate_baseline():

--- a/surpyval/tests/univariate/test_round2_fixes_a.py
+++ b/surpyval/tests/univariate/test_round2_fixes_a.py
@@ -1,0 +1,117 @@
+"""
+Regression tests for the round-2 review fix batch A:
+
+- #271: parametric PH ``random()`` samples the model's own distribution and
+  supports multi-covariate models.
+- #269: LFP + left truncation uses the mixture survival in the truncation
+  normaliser (the old form was unbounded above).
+- #274: Royston-Parmar keeps the best finite optimiser result and validates
+  knot placement.
+- #275: the numeric MOM path optimises to convergence.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval import RoystonParmar, Weibull, WeibullPH
+
+
+class TestPHRandom:
+    def test_random_matches_model_sf(self):
+        # 271: draws must come from S(x|Z) = S0(x)^phi.
+        np.random.seed(1)
+        u = np.random.uniform(size=3000)
+        Z = np.random.binomial(1, 0.5, 3000).reshape(-1, 1)
+        phi = np.exp(1.0 * Z[:, 0])
+        t = 10 * (-np.log(u) / phi) ** 0.5
+        m = WeibullPH.fit(x=t, Z=Z)
+
+        np.random.seed(2)
+        xs, zs = m.random(100_000, np.array([[1.0]]))
+        for tt in (2.0, 4.0, 6.0):
+            emp = (np.asarray(xs) > tt).mean()
+            mod = float(np.ravel(m.sf(tt, np.array([[1.0]])))[0])
+            assert emp == pytest.approx(mod, abs=0.01)
+
+    def test_random_two_covariates(self):
+        # 271: used to raise a broadcast ValueError for >= 2 covariates.
+        np.random.seed(3)
+        t = 10 * np.random.weibull(2, 500)
+        Z = np.hstack(
+            [
+                np.random.binomial(1, 0.5, 500).reshape(-1, 1),
+                np.random.normal(size=(500, 1)),
+            ]
+        )
+        m = WeibullPH.fit(x=t, Z=Z)
+        x, z_out = m.random(7, np.array([[1.0, 0.5]]))
+        assert np.shape(x) == (7,)
+        assert np.shape(z_out) == (7, 2)
+        assert np.all(np.isfinite(x))
+
+
+class TestLFPTruncation:
+    def test_lfp_left_truncated_recovers_parameters(self):
+        # 269: the old normaliser (p - f0) * (1 - F0(tl)) made the
+        # likelihood unbounded; the fit returned alpha ~ 1e-42.
+        np.random.seed(11)
+        N = 30000
+        is_mortal = np.random.uniform(size=N) < 0.6
+        t = np.where(is_mortal, 10 * np.random.weibull(2, N), np.inf)
+        entry = 3.0
+        t_seen = t[t > entry]
+        observed = t_seen < 20
+        x = np.where(observed, t_seen, 20.0)
+        c = (~observed).astype(int)
+
+        model = Weibull.fit(x=x, c=c, tl=np.full(len(x), entry), lfp=True)
+        alpha, beta = model.params
+        assert alpha == pytest.approx(10.0, rel=0.05)
+        assert beta == pytest.approx(2.0, rel=0.05)
+        assert model.p == pytest.approx(0.6, abs=0.03)
+
+    def test_plain_interval_likelihood_unchanged(self):
+        # The f0 terms cancel for finite bounds: a plain interval-censored
+        # fit must be unaffected by the 269 change.
+        np.random.seed(12)
+        t = 10 * np.random.weibull(2, 2000)
+        xl = np.floor(t)
+        xr = xl + 1.0
+        model = Weibull.fit(x=np.column_stack([xl, xr]), c=np.full(2000, 2))
+        assert model.params[0] == pytest.approx(10.0, rel=0.05)
+        assert model.params[1] == pytest.approx(2.0, rel=0.1)
+
+
+class TestRoystonParmarGuards:
+    def test_double_truncation_returns_finite_model(self):
+        # 274: the unguarded BFGS polish used to replace the finite
+        # Nelder-Mead result with NaN on doubly-truncated data.
+        np.random.seed(21)
+        t = 10 * np.random.weibull(2, 20000)
+        x = t[(t > 3) & (t < 15)][:2000]
+        m = RoystonParmar.fit(x=x, tl=3, tr=15, df=1)
+        assert np.isfinite(m.neg_ll())
+        sf10 = float(np.ravel(m.sf(10))[0])
+        # True Weibull(10, 2) survival at 10 is exp(-1).
+        assert sf10 == pytest.approx(np.exp(-1), abs=0.05)
+
+    def test_too_few_distinct_events_raises(self):
+        # 274: one event + censored rows at the default df=3 used to
+        # return a silent NaN model.
+        with pytest.raises(ValueError, match="distinct event times"):
+            RoystonParmar.fit(x=[5.0, 6.0, 7.0, 8.0], c=[0, 1, 1, 1])
+
+    def test_tied_events_raise_instead_of_nan(self):
+        with pytest.raises(ValueError, match="distinct event times|distinct"):
+            RoystonParmar.fit(x=[1.0] * 10 + [2.0] * 10, df=3)
+
+
+class TestMOMNumericPath:
+    def test_mom_offset_recovers_parameters(self):
+        # 275: tol=1e-1 used to stop the optimiser at beta ~ 3-4.
+        np.random.seed(12)
+        T = 50 + 10 * np.random.weibull(2, 5000)
+        m = Weibull.fit(x=T, how="MOM", offset=True)
+        assert m.gamma == pytest.approx(50.0, abs=1.0)
+        assert m.params[0] == pytest.approx(10.0, rel=0.1)
+        assert m.params[1] == pytest.approx(2.0, rel=0.1)

--- a/surpyval/tests/univariate/test_round2_fixes_e.py
+++ b/surpyval/tests/univariate/test_round2_fixes_e.py
@@ -1,0 +1,253 @@
+"""
+Regression tests for the round-2 medium/low batch (#276-#282):
+
+- #276 concordance-index tie handling (see test_score.py for unit cases)
+- #277 Lin-Ying hf/df baseline rate; phi() on additive models
+- #278 Aalen-Johansen CIF uses product-limit weights (CIF <= 1)
+- #279 Efron tie corrections in Cox residuals / check_ph / robust SEs
+- #280 distribution edge cases (see also test_distribution_fixes.py)
+- #281 xrd_to_xcnt late-entry guard
+- #282 container/robustness batch
+"""
+
+import numpy as np
+import pytest
+
+import surpyval
+from surpyval import (
+    AdditiveHazards,
+    Beta4,
+    CoxPH,
+    ExponentialAH,
+    KaplanMeier,
+    LogLogistic,
+    NelsonAalen,
+    Rayleigh,
+    Uniform,
+)
+from surpyval.univariate.competing_risks.nonparametric.competing_risks import (
+    CompetingRisks,
+)
+from surpyval.univariate.regression.proportional_hazards.diagnostics import (
+    check_ph,
+    compute_residuals,
+)
+from surpyval.utils import xrd_to_xcnt
+from surpyval.utils.surpyval_data import SurpyvalData
+
+
+class TestLinYingHazardRate:
+    def test_hf_df_on_hazard_scale(self):
+        # 277: hf used to return ~beta'Z (the baseline jump vanishes as
+        # n grows); it must estimate h0(t) + beta'Z.
+        np.random.seed(2)
+        n = 20000
+        Z = np.random.uniform(size=(n, 1))
+        t = np.random.exponential(1 / (0.5 + 0.7 * Z[:, 0]))
+        m = AdditiveHazards.fit(x=t, Z=Z)
+        z = np.array([0.5])
+        hf = np.ravel(m.hf([0.5, 1.0, 1.5], z))
+        assert np.all(np.abs(hf - 0.85) < 0.12)
+        df = float(np.ravel(m.df([1.0], z))[0])
+        assert df == pytest.approx(0.85 * np.exp(-0.85), rel=0.15)
+
+    def test_parametric_ah_phi_raises_not_implemented(self):
+        np.random.seed(4)
+        Z = np.random.uniform(size=(300, 1))
+        t = np.random.exponential(1 / (0.5 + 0.7 * Z[:, 0]))
+        m = ExponentialAH.fit(x=t, Z=Z)
+        with pytest.raises(NotImplementedError, match="additive"):
+            m.phi(np.array([0.5]))
+
+
+class TestCIFProductLimit:
+    def test_na_method_cif_sums_to_one(self):
+        # 278: default Nelson-Aalen method paired d/r with exp(-H) and
+        # the total incidence exceeded 1 (1.216 here).
+        cr = CompetingRisks.fit(
+            x=[1, 1, 1, 2, 2, 3], e=["a", "a", "b", "a", "b", "a"]
+        )
+        total = float(np.ravel(cr.cif(3, "a"))[0]) + float(
+            np.ravel(cr.cif(3, "b"))[0]
+        )
+        assert total == pytest.approx(1.0, abs=1e-12)
+
+    def test_extreme_case_capped_at_one(self):
+        cr = CompetingRisks.fit(x=[1] * 9 + [2], e=["a"] * 10)
+        assert float(np.ravel(cr.cif(2, "a"))[0]) == pytest.approx(1.0)
+
+
+class TestEfronDiagnostics:
+    @staticmethod
+    def _tied_fit():
+        np.random.seed(11)
+        n = 120
+        Z = np.column_stack(
+            [np.random.binomial(1, 0.5, n), np.random.normal(size=n)]
+        )
+        u = np.random.uniform(size=n)
+        t = -np.log(u) / (0.3 * np.exp(0.7 * Z[:, 0] - 0.4 * Z[:, 1]))
+        x = np.ceil(np.clip(t, 0.5, 6)).astype(float)
+        c = (np.random.uniform(size=n) < 0.2).astype(int)
+        return x, c, Z
+
+    def test_residual_sums_vanish_at_mle(self):
+        # 279: these identities only hold when the residuals use the
+        # same tie handling as the fitted likelihood.
+        x, c, Z = self._tied_fit()
+        for method in ("efron", "breslow"):
+            m = CoxPH.fit(x=x, Z=Z, c=c, method=method)
+            assert compute_residuals(m, "martingale").sum() == pytest.approx(
+                0.0, abs=1e-8
+            )
+            assert np.abs(
+                compute_residuals(m, "score").sum(axis=0)
+            ).max() == pytest.approx(0.0, abs=1e-8)
+
+    def test_check_ph_matches_lifelines_under_ties(self):
+        # Reference values from lifelines 0.30.3 on this exact dataset
+        # (km transform; identity and log also agree — lifelines is not
+        # a CI dependency, so the values are pinned).
+        x, c, Z = self._tied_fit()
+        m = CoxPH.fit(x=x, Z=Z, c=c, method="efron")
+        res = check_ph(m, transform="km")
+        stats = [e["statistic"] for e in res["per_covariate"]]
+        assert stats[0] == pytest.approx(1.3936, abs=2e-3)
+        assert stats[1] == pytest.approx(0.0013, abs=2e-3)
+
+    def test_dfbeta_tracks_exact_leave_one_out(self):
+        x, c, Z = self._tied_fit()
+        m = CoxPH.fit(x=x, Z=Z, c=c, method="efron")
+        dfb = compute_residuals(m, "dfbeta")
+        # Spot-check 15 rows of exact leave-one-out influence.
+        rows = np.arange(0, 120, 8)
+        loo = np.zeros((rows.size, 2))
+        for r, i in enumerate(rows):
+            keep = np.ones(120, dtype=bool)
+            keep[i] = False
+            mi = CoxPH.fit(x=x[keep], Z=Z[keep], c=c[keep], method="efron")
+            loo[r] = m.beta - mi.beta
+        corr = np.corrcoef(dfb[rows, 0], loo[:, 0])[0, 1]
+        assert corr > 0.99
+
+
+class TestDistributionEdges:
+    def test_loglogistic_at_zero(self):
+        assert LogLogistic.sf(0.0, 3, 4) == pytest.approx(1.0)
+        assert LogLogistic.ff(0.0, 3, 4) == pytest.approx(0.0)
+        vals = LogLogistic.sf(np.array([0.0, 1.0]), 3, 4)
+        assert np.all(np.isfinite(vals))
+
+    def test_loglogistic_log_sf_no_overflow(self):
+        from scipy.stats import fisk
+
+        got = float(
+            np.ravel(LogLogistic.log_sf(np.array([1e41]), 1e40, 10))[0]
+        )
+        want = float(fisk.logsf(1e41, 10, scale=1e40))
+        assert got == pytest.approx(want, rel=1e-6)
+
+    def test_beta4_density_zero_outside_support(self):
+        vals = Beta4.df(np.array([1.0, 2.5, 6.0]), 3, 4, 2, 5)
+        assert vals[0] == 0.0
+        assert vals[2] == 0.0
+        assert vals[1] > 0
+        assert Beta4.df(1.0, 2.5, 4, 2, 5) == 0.0  # fractional alpha
+
+    def test_rayleigh_mpp_uses_truncation(self):
+        np.random.seed(3)
+        x = 3 * np.sqrt(-2 * np.log(np.random.uniform(size=6000)))
+        tl = np.random.uniform(0, 2, 6000)
+        keep = x > tl
+        x_obs, tl_obs = x[keep][:3000], tl[keep][:3000]
+        with_tl = Rayleigh.fit(x_obs, tl=tl_obs, how="MPP").params
+        without = Rayleigh.fit(x_obs, how="MPP").params
+        assert not np.allclose(with_tl, without)
+        assert with_tl[0] == pytest.approx(3.0, rel=0.05)
+
+    def test_rayleigh_mpp_ecdf_finite(self):
+        np.random.seed(3)
+        x = 3 * np.sqrt(-2 * np.log(np.random.uniform(size=1000)))
+        params = Rayleigh.fit(x, how="MPP", heuristic="ECDF").params
+        assert np.all(np.isfinite(params))
+
+    def test_uniform_interval_clear_error(self):
+        with pytest.raises(ValueError, match="interval-censored"):
+            Uniform.fit(x=[1.0, 2.0, [2, 4], 3.5, [3, 5]], c=[0, 0, 2, 0, 2])
+
+
+class TestDataHandling:
+    def test_xrd_to_xcnt_rejects_late_entry(self):
+        # 281: np.abs silently converted late-entry data into a
+        # different study.
+        with pytest.raises(ValueError, match="risk set increases"):
+            xrd_to_xcnt(
+                np.array([1.0, 2, 3, 4]),
+                np.array([2, 3, 2, 1]),
+                np.array([1, 1, 1, 1]),
+            )
+
+    def test_xrd_to_xcnt_monotone_unchanged(self):
+        x, c, n, t = xrd_to_xcnt(
+            np.array([1.0, 2, 3, 4]),
+            np.array([4, 3, 2, 1]),
+            np.array([1, 1, 1, 1]),
+        )
+        assert np.asarray(x).tolist() == [1.0, 2.0, 3.0, 4.0]
+        assert np.asarray(c).tolist() == [0, 0, 0, 0]
+
+    def test_surpyval_data_scalar_interval_index(self):
+        d = SurpyvalData([1, 2, [2, 5], 3, 6], c=[0, 1, 2, 0, 0])
+        row = d[2]
+        assert row.x.ndim == 2  # keeps the interval row structure
+
+    def test_surpyval_data_slice_keeps_covariates(self):
+        d = SurpyvalData([3, 1, 2], Z=[[1], [2], [3]])
+        assert d[0:2].Z is not None
+        assert d[0:2].Z.shape == (2, 1)
+
+    def test_to_xrd_cache_respects_estimator(self):
+        d = SurpyvalData([1, 2, 3, 4], c=[1, 0, 0, 0])
+        a = d.to_xrd(estimator="Nelson-Aalen")
+        b = d.to_xrd(estimator="Kaplan-Meier")
+        assert a is not b
+
+
+class TestNonParametricScalars:
+    def test_scalar_hf_df_finite(self):
+        na = NelsonAalen.fit([1.0, 2, 3, 4, 5])
+        assert float(np.ravel(na.hf(2.5))[0]) == pytest.approx(0.25)
+        assert np.isfinite(float(np.ravel(na.df(2.5))[0]))
+        # Matches what the array path returns for the same point.
+        grid = np.ravel(na.hf([1.5, 2.5]))
+        assert float(np.ravel(na.hf(2.5))[0]) == pytest.approx(grid[1])
+
+    def test_single_observation_cb_drawable(self):
+        km = KaplanMeier.fit([5.0])
+        cb = np.asarray(km.cb([5.0], on="sf"), dtype=float)
+        assert np.all(np.isfinite(cb))
+
+    def test_check_ph_no_spurious_truncation_warning(self):
+        import warnings as _w
+
+        np.random.seed(7)
+        x = np.random.exponential(2.0, 60)
+        Z = np.random.normal(size=(60, 1))
+        m = CoxPH.fit(x=x, Z=Z, tl=np.zeros(60))
+        with _w.catch_warnings():
+            _w.simplefilter("error")
+            check_ph(m)
+
+
+def test_concordance_discordant_tied_pair_scores_zero():
+    # 276 (unit cases in tests/utils/test_score.py; pinned here too).
+    from surpyval.utils.score import score
+
+    assert score([5.0, 5.0], [0, 1], [1.0, 2.0]) == 0.0
+    assert score([5.0, 5.0], [0, 1], [2.0, 1.0]) == 1.0
+
+
+def test_surpyval_namespace_unchanged():
+    # Guard: the fixes must not have removed public names.
+    for name in ("AdditiveHazards", "CoxPH", "Rayleigh", "Uniform"):
+        assert hasattr(surpyval, name)

--- a/surpyval/tests/utils/test_score.py
+++ b/surpyval/tests/utils/test_score.py
@@ -53,12 +53,16 @@ def test_censored_after_event_still_comparable():
 
 
 def test_tied_time_event_vs_censored():
-    # At a tied time the censored sample outlived the event, so the
-    # event having the higher mortality scores 1, otherwise 0.5.
+    # At a tied time the censored sample outlived the event, so the pair
+    # is fully comparable (Harrell): the event having the higher
+    # mortality scores 1, a genuine score tie 0.5, and the event having
+    # the *lower* mortality is discordant and scores 0 (it used to be
+    # credited 0.5, biasing tie-heavy data toward 0.5, #276).
     x = [5.0, 5.0]
     c = [0, 1]
     assert score(x, c, [2.0, 1.0]) == 1.0
-    assert score(x, c, [1.0, 2.0]) == 0.5
+    assert score(x, c, [1.5, 1.5]) == 0.5
+    assert score(x, c, [1.0, 2.0]) == 0.0
 
 
 def test_tied_time_both_events():

--- a/surpyval/univariate/competing_risks/nonparametric/competing_risks.py
+++ b/surpyval/univariate/competing_risks/nonparametric/competing_risks.py
@@ -237,8 +237,13 @@ class CompetingRisks:
         # Aalen-Johansen increment: the cause-specific hazard at t_i acts on
         # the population still alive just *before* t_i, so the incidence
         # weight is S(t_i-) — the survival after the previous event time —
-        # not S(t_i) (#253).
-        S_prev = np.concatenate([[1.0], S[:-1]])
+        # not S(t_i) (#253). The weight must be the *product-limit* (KM)
+        # survival regardless of the estimator reported as sf: only KM
+        # satisfies the telescoping identity sum_j S(t-)·d_j/r = 1 - S(t),
+        # so pairing the discrete hazard increment with exp(-H) inflates
+        # the CIF and can push the total incidence past 1 (#278).
+        S_km = S if method == "Kaplan-Meier" else km(r, d)
+        S_prev = np.concatenate([[1.0], S_km[:-1]])
         model.IIF = S_prev * model.h0_e
         model.CIF = model.IIF.cumsum(axis=1)
         return model

--- a/surpyval/univariate/nonparametric/nonparametric.py
+++ b/surpyval/univariate/nonparametric/nonparametric.py
@@ -187,6 +187,24 @@ class NonParametric(NonParametricDistribution):
         idx = np.argsort(x)
         rev = np.argsort(idx)
         x = x[idx]
+        if x.size == 1:
+            # The pairwise-difference construction below yields a single
+            # zero for scalar input (nothing to backfill from), so hf()
+            # and df() always returned NaN for scalars (#282). Use the
+            # model's own step ladder instead: the discrete hazard
+            # increment of the step containing x (forward-filled over
+            # zero-increment censoring steps), matching what the array
+            # path returns for the same point inside a grid.
+            xs = np.atleast_1d(self.x)
+            H_steps = np.atleast_1d(self.Hf(xs, interp=interp))
+            dH = np.diff(np.hstack([[0.0], H_steps]))
+            pos = np.searchsorted(xs, x[0], side="right") - 1
+            if pos < 0:
+                return np.array([np.nan])[rev]
+            sub = dH[: pos + 1]
+            nz = sub[sub > 0]
+            out = nz[-1] if nz.size else np.nan
+            return np.array([out])[rev]
         hf = np.diff(
             np.hstack(
                 [self.Hf(x[0], interp=interp), self.Hf(x, interp=interp)]
@@ -449,15 +467,22 @@ class NonParametric(NonParametricDistribution):
             R_out = self.R + np.sqrt(self.greenwood * self.R**2) * stat
 
         # Allows for confidence bound to be estimated up to the last value.
-        # only used in event that there is no right censoring.
+        # only used in event that there is no right censoring. When *no*
+        # point on the curve has a finite bound (e.g. a single
+        # observation), fall back to the point estimate rather than
+        # propagating an all-NaN nanmin (#282).
+        def _fill_upper(row):
+            finite = np.isfinite(row)
+            if finite.any():
+                return np.where(finite, row, row[finite].min())
+            return np.asarray(self.R, dtype=float).copy()
+
         if bound == "upper":
-            R_out = np.where(np.isfinite(R_out), R_out, np.nanmin(R_out))
+            R_out = _fill_upper(R_out)
         elif bound == "lower":
             R_out = np.where(np.isfinite(R_out), R_out, 0)
         else:
-            R_out[0, :] = np.where(
-                np.isfinite(R_out[0, :]), R_out[0, :], np.nanmin(R_out[0, :])
-            )
+            R_out[0, :] = _fill_upper(R_out[0, :])
             R_out[1, :] = np.where(np.isfinite(R_out[1, :]), R_out[1, :], 0)
 
         if interp == "step":

--- a/surpyval/univariate/nonparametric/turnbull.py
+++ b/surpyval/univariate/nonparametric/turnbull.py
@@ -29,24 +29,6 @@ def turnbull(
     if max_iter < 1:
         raise ValueError(f"max_iter must be at least 1; got {max_iter}")
     any_truncated = np.isfinite(t).any()
-    # Exact + right-censored (possibly weighted) untruncated data is the
-    # regime where Turnbull reduces exactly to Kaplan-Meier; keep the raw
-    # inputs so the variance can use the *observed* count ladder rather
-    # than the EM's expected-count ladder, which redistributes censored
-    # mass as fractional later events and silently understates the
-    # variance (#260).
-    km_reducible = (
-        (not any_truncated)
-        and np.asarray(x).ndim == 1
-        and not np.isin(c, (-1, 2)).any()
-    )
-    if km_reducible:
-        x_raw, c_raw, n_raw, t_raw = (
-            np.asarray(x).copy(),
-            np.asarray(c).copy(),
-            np.asarray(n).copy(),
-            np.asarray(t).copy(),
-        )
     # Find all unique bounding points
     bounds = np.unique(np.concatenate([np.unique(x), np.unique(t)]))
     # Add the times at which there was an observation again since
@@ -84,9 +66,12 @@ def turnbull(
     # - a right-censored event may sit on any bound strictly after the
     #   censoring time;
     # - an interval-censored event (including left censored, whose interval
-    #   is (-inf, xr)) may sit on any bound in [xl, xr), *except* the
-    #   zero-width exact interval at xl when xl is also an exactly observed
-    #   time -- the event is known to be after xl.
+    #   is (-inf, xr]) may sit on any bound in (xl, xr]: the zero-width
+    #   exact interval at xl is excluded when xl is also an exactly
+    #   observed time (the event is known to be after xl), and the one at
+    #   xr is *included* -- the standard (l, r] convention (Turnbull 1976),
+    #   under which an interval whose right endpoint coincides with an
+    #   exact event time may have failed at that time (#272).
     exact = xl == xr
     right = ~exact & np.isinf(xr)
     interval = ~exact & ~right
@@ -100,23 +85,56 @@ def turnbull(
     lo[interval] = np.searchsorted(
         bounds, xl[interval], side="left"
     ) + np.isin(xl[interval], exact_times)
-    hi[interval] = np.searchsorted(bounds, xr[interval], side="left") - 1
+    hi[interval] = (
+        np.searchsorted(bounds, xr[interval], side="left")
+        - 1
+        + np.isin(xr[interval], exact_times)
+    )
+
+    # Exact + right-censored (possibly weighted) untruncated data -- in
+    # either 1-D or degenerate-interval form -- is the regime where
+    # Turnbull reduces exactly to Kaplan-Meier; keep equivalent 1-D
+    # inputs so the variance can use the *observed* count ladder rather
+    # than the EM's expected-count ladder, which redistributes censored
+    # mass as fractional later events and silently understates the
+    # variance (#260, #273).
+    km_reducible = (not any_truncated) and not interval.any()
+    if km_reducible:
+        x_raw = xl.copy()
+        c_raw = np.where(exact, 0, 1)
+        n_raw = np.asarray(n).copy()
+        t_raw = np.asarray(t).copy()
 
     # Each observation's truncation window is likewise a contiguous index
     # range [w_lo, w_hi]: the bound points at which an event was observable
     # -- strictly after its left truncation time and at or before its right
     # truncation time.
     if any_truncated:
-        w_lo = np.where(
+        w_lo_all = np.where(
             np.isfinite(tl), np.searchsorted(bounds, tl, side="right"), 0
         )
-        w_hi = np.where(
+        w_hi_all = np.where(
             np.isfinite(tr),
             np.searchsorted(bounds, tr, side="right") - 1,
             M - 1,
         )
+        # An observation's event provably lies inside its own truncation
+        # window (it was observed), so its support is the *intersection*
+        # of its censoring support with the window. Without this, mass
+        # from left-censored or entry-spanning interval observations is
+        # redistributed below the entry time -- where the event cannot
+        # be -- and the EM can wander to the degenerate all-zero fixed
+        # point on perfectly valid data (#273).
+        lo = np.maximum(lo, w_lo_all)
+        hi = np.minimum(hi, w_hi_all)
+        if (lo > hi).any():
+            raise ValueError(
+                "An observation's censoring interval does not intersect "
+                "its own truncation window, so it has zero probability of "
+                "being observed as recorded; check the x, c and t inputs."
+            )
         truncated = np.isfinite(tl) | np.isfinite(tr)
-        w_lo, w_hi = w_lo[truncated], w_hi[truncated]
+        w_lo, w_hi = w_lo_all[truncated], w_hi_all[truncated]
         n_truncated = n[truncated]
 
     # The identifiable support: a bound may carry probability mass only if it
@@ -266,60 +284,67 @@ def turnbull(
         )
 
     if any_truncated:
-        # Variance ladder from *observed* information only. The estimation
+        # Variance ladder from *observed* counts only. The estimation
         # ladder above includes the ghost events -- they are what make the
         # estimate correct under truncation -- but ghosts are not data, and
-        # a risk set inflated by them understates the variance. Instead,
-        # each observed item contributes its conditional probability of
-        # still being event-free at each bound, and only while that bound
-        # lies inside its observation window (so delayed entry removes it
-        # from the early risk sets, exactly as in the Kaplan-Meier
-        # delayed-entry risk set, to which this reduces for exactly
-        # observed left-truncated data):
-        #
-        #   r_var[j] = sum_i n_i * 1[w_lo_i <= j <= w_hi_i] * P_i(T >= j)
-        #
-        # with P_i(T >= j) equal to 1 before the item's support, the
-        # conditional tail (cum[hi+1] - cum[j]) / P(support) inside it, and
-        # 0 after it. Piece one and the constant part of piece two are
-        # range-adds; the j-dependent part is cum[j] times a range-added
-        # weight -- all still O(N + M). For untruncated data this ladder
-        # equals the estimation ladder, so it is only computed (and only
-        # used for the variance) when truncation is present.
+        # a risk set inflated by them understates the variance. Exactly
+        # observed items count one event at their atom and leave the risk
+        # set there; right-censored items count no event anywhere and
+        # leave the risk set at their censoring time (the previous ladder
+        # redistributed their mass as fractional later events and kept
+        # them at risk via a conditional tail probability -- the same
+        # anti-conservative mechanism #260 removed for untruncated data,
+        # and at the last event the near-equal r and d floats produced
+        # huge *negative* Greenwood increments, #273). Only genuinely
+        # interval/left-censored items, whose event position is unknown,
+        # keep the probabilistic redistribution over their support. Every
+        # item is at risk only while the bound lies inside its own
+        # observation window, so delayed entry removes it from the early
+        # risk sets exactly as in the Kaplan-Meier delayed-entry risk
+        # set -- to which this ladder reduces for exact + right-censored
+        # left-truncated data.
         cumulative = np.concatenate([[0.0], np.cumsum(p)])
         support_p = cumulative[hi + 1] - cumulative[lo]
-        weight = np.where(support_p > 0, n / support_p, 0.0)
-        delta = np.zeros(M + 1)
-        np.add.at(delta, lo, weight)
-        np.add.at(delta, hi + 1, -weight)
-        d_var = p * np.cumsum(delta[:M])
 
-        w_lo_all = np.where(
-            np.isfinite(tl), np.searchsorted(bounds, tl, side="right"), 0
-        )
-        w_hi_all = np.where(
-            np.isfinite(tr),
-            np.searchsorted(bounds, tr, side="right") - 1,
-            M - 1,
-        )
+        # Events: hard counts at exact atoms; interval rows redistribute.
+        d_var = np.zeros(M)
+        np.add.at(d_var, lo[exact], n[exact])
+        weight_int = np.where(interval & (support_p > 0), n / support_p, 0.0)
+        delta = np.zeros(M + 1)
+        np.add.at(delta, lo, weight_int)
+        np.add.at(delta, hi + 1, -weight_int)
+        d_var += p * np.cumsum(delta[:M])
 
         const = np.zeros(M + 1)
         coeff = np.zeros(M + 1)
-        # Before the support (probability 1), within the window.
+        # Exact rows: at risk through their event atom, within the window.
         a1 = w_lo_all
         b1 = np.minimum(lo, w_hi_all)
-        ok = a1 <= b1
+        ok = exact & (a1 <= b1)
         np.add.at(const, a1[ok], n[ok])
         np.add.at(const, b1[ok] + 1, -n[ok])
-        # Within the support (conditional tail), within the window.
+        # Right-censored rows: at risk through their censoring time (the
+        # last bound before their support starts), within the window.
+        b1r = np.minimum(lo - 1, w_hi_all)
+        ok = right & (a1 <= b1r)
+        np.add.at(const, a1[ok], n[ok])
+        np.add.at(const, b1r[ok] + 1, -n[ok])
+        # Interval rows: probability 1 before the support, conditional
+        # tail (cum[hi+1] - cum[j]) / P(support) inside it, 0 after --
+        # all within the window. The j-dependent part is cum[j] times a
+        # range-added weight, keeping the ladder O(N + M).
+        ok = interval & (a1 <= b1)
+        np.add.at(const, a1[ok], n[ok])
+        np.add.at(const, b1[ok] + 1, -n[ok])
         a2 = np.maximum(lo + 1, w_lo_all)
         b2 = np.minimum(hi, w_hi_all)
-        ok = (a2 <= b2) & (support_p > 0)
+        ok = interval & (a2 <= b2) & (support_p > 0)
         tail_const = np.where(
             support_p > 0, n * cumulative[hi + 1] / support_p, 0.0
         )
         np.add.at(const, a2[ok], tail_const[ok])
         np.add.at(const, b2[ok] + 1, -tail_const[ok])
+        weight = np.where(support_p > 0, n / support_p, 0.0)
         np.add.at(coeff, a2[ok], weight[ok])
         np.add.at(coeff, b2[ok] + 1, -weight[ok])
 

--- a/surpyval/univariate/parametric/distributions/beta.py
+++ b/surpyval/univariate/parametric/distributions/beta.py
@@ -404,6 +404,7 @@ class Beta_(ParametricFitter):
         x,
         c=None,
         n=None,
+        t=None,
         heuristic="Nelson-Aalen",
         rr="y",
         on_d_is_0=False,

--- a/surpyval/univariate/parametric/distributions/beta4.py
+++ b/surpyval/univariate/parametric/distributions/beta4.py
@@ -226,9 +226,16 @@ class Beta4_(ParametricFitter):
         >>> Beta4.df(x, 3, 4, 2, 3)
         array([0.4374, 1.2288, 1.8522, 2.0736, 1.875 ])
         """
-        num = (x - a) ** (alpha - 1) * (b - x) ** (beta - 1)
+        # The density is zero outside [a, b]; evaluating the power terms
+        # there returned arbitrary nonzero, negative, or NaN values
+        # (fractional powers of negative bases), so hf inherited garbage
+        # on any grid extending past the fitted support (#280).
+        x = np.asarray(x, dtype=float)
+        inside = (x >= a) & (x <= b)
+        xc = np.where(inside, x, 0.5 * (a + b))
+        num = (xc - a) ** (alpha - 1) * (b - xc) ** (beta - 1)
         den = abeta(alpha, beta) * (b - a) ** (alpha + beta - 1)
-        return num / den
+        return np.where(inside, num / den, 0.0)
 
     def hf(self, x, alpha, beta, a, b):
         r"""

--- a/surpyval/univariate/parametric/distributions/exponential.py
+++ b/surpyval/univariate/parametric/distributions/exponential.py
@@ -401,13 +401,17 @@ class Exponential_(ParametricFitter):
         x,
         c=None,
         n=None,
+        t=None,
         heuristic="Nelson-Aalen",
         rr="y",
         on_d_is_0=False,
         offset=False,
     ):
         assert rr in ["x", "y"]
-        x_pp, r, d, F = plotting_positions(x, c=c, n=n, heuristic=heuristic)
+        # Forward the truncation windows (previously dropped, #280).
+        x_pp, r, d, F = plotting_positions(
+            x, c=c, n=n, t=t, heuristic=heuristic
+        )
 
         if not on_d_is_0:
             x_pp = x_pp[d > 0]

--- a/surpyval/univariate/parametric/distributions/gamma.py
+++ b/surpyval/univariate/parametric/distributions/gamma.py
@@ -466,12 +466,16 @@ class Gamma_(ParametricFitter):
         x,
         c=None,
         n=None,
+        t=None,
         heuristic="Nelson-Aalen",
         rr="y",
         on_d_is_0=False,
         offset=False,
     ):
-        x_pp, r, d, F = plotting_positions(x, c=c, n=n, heuristic=heuristic)
+        # Forward the truncation windows (previously dropped, #280).
+        x_pp, r, d, F = plotting_positions(
+            x, c=c, n=n, t=t, heuristic=heuristic
+        )
 
         results = {}
 

--- a/surpyval/univariate/parametric/distributions/loglogistic.py
+++ b/surpyval/univariate/parametric/distributions/loglogistic.py
@@ -59,8 +59,10 @@ class LogLogistic_(ParametricFitter):
         >>> LogLogistic.sf(x, 3, 4)
         array([0.62245933, 0.5621765 , 0.5       , 0.4378235 , 0.37754067])
         """
-        exp_term = (x / alpha) ** -beta
-        return exp_term / (1 + exp_term)
+        # 1 / (1 + (x/alpha)^beta): algebraically identical to the
+        # (x/alpha)^-beta form but defined at x = 0 (sf(0) = 1) instead
+        # of raising/NaN-ing on the negative power (#280).
+        return 1.0 / (1.0 + (x / alpha) ** beta)
 
     def cs(self, x, X, alpha, beta):
         r"""
@@ -131,7 +133,10 @@ class LogLogistic_(ParametricFitter):
         >>> LogLogistic.ff(x, 3, 4)
         array([0.01219512, 0.16494845, 0.5       , 0.75964392, 0.88526912])
         """
-        return 1.0 / (1 + (x / alpha) ** -beta)
+        # z^beta / (1 + z^beta) rather than 1 / (1 + z^-beta): the
+        # negative power raised/NaN-ed at x = 0, where ff(0) = 0 (#280).
+        z = (x / alpha) ** beta
+        return z / (1.0 + z)
 
     def df(self, x, alpha, beta):
         r"""
@@ -314,10 +319,17 @@ class LogLogistic_(ParametricFitter):
         )
 
     def log_sf(self, x, alpha, beta):
-        return beta * np.log(alpha) - np.log(alpha**beta + x**beta)
+        # logaddexp form: log(alpha^beta + x^beta) overflows for
+        # beta*log(alpha) or beta*log(x) beyond ~709 even when the log
+        # probability itself is modest (#280).
+        la = beta * np.log(alpha)
+        lx = beta * np.log(x)
+        return la - np.logaddexp(la, lx)
 
     def log_ff(self, x, alpha, beta):
-        return beta * np.log(x) - np.log(alpha**beta + x**beta)
+        la = beta * np.log(alpha)
+        lx = beta * np.log(x)
+        return lx - np.logaddexp(la, lx)
 
     def mpp_x_transform(self, x, gamma=0):
         return np.log(x - gamma)

--- a/surpyval/univariate/parametric/distributions/rayleigh.py
+++ b/surpyval/univariate/parametric/distributions/rayleigh.py
@@ -347,17 +347,29 @@ class Rayleigh_(ParametricFitter):
         x,
         c=None,
         n=None,
+        t=None,
         heuristic="Nelson-Aalen",
         rr="y",
         on_d_is_0=False,
         offset=False,
     ):
         assert rr in ["x", "y"]
-        x_pp, r, d, F = plotting_positions(x, c=c, n=n, heuristic=heuristic)
+        # Forward the truncation windows: the custom Rayleigh path used to
+        # drop them silently, making fits with and without tl/tr
+        # bit-identical (#280).
+        x_pp, r, d, F = plotting_positions(
+            x, c=c, n=n, t=t, heuristic=heuristic
+        )
 
         if not on_d_is_0:
             x_pp = x_pp[d > 0]
             F = F[d > 0]
+
+        # Plotting positions of exactly 0 or 1 have no finite transform
+        # (sqrt(-log 0) = inf poisoned e.g. the ECDF heuristic, #280).
+        valid = (F != 0) & (F != 1)
+        x_pp = x_pp[valid]
+        F = F[valid]
 
         # Linearise
         y_pp = self.mpp_y_transform(F)

--- a/surpyval/univariate/parametric/distributions/uniform.py
+++ b/surpyval/univariate/parametric/distributions/uniform.py
@@ -367,6 +367,16 @@ class Uniform_(ParametricFitter):
         return np.log(b - a)
 
     def mle(self, data):
+        if np.asarray(data.x).ndim == 2 or (data.c == 2).any():
+            # The closed-form min/max estimator is not the MLE with
+            # interval-censored rows (an interval term favours shrinking
+            # the range), and the masks below assume 1-D x -- interval
+            # input used to die with a cryptic IndexError (#280).
+            raise ValueError(
+                "Uniform distribution MLE does not support "
+                "interval-censored observations."
+            )
+
         if (data.c[data.x == data.x.max()] == 1).all():
             raise ValueError(
                 "Uniform distribution cannot be estimated using MLE when"

--- a/surpyval/univariate/parametric/fitters/mle.py
+++ b/surpyval/univariate/parametric/fitters/mle.py
@@ -230,6 +230,15 @@ def mle(model):
             else:
                 u_var = u_full[var_idx]
                 hess_u = hessian(transformed_fun)(u_var)
+                # A corrupted autograd Hessian (e.g. a primitive whose
+                # VJP silently drops second-order terms) shows up as
+                # asymmetry; recompute numerically rather than invert
+                # garbage (#270).
+                asym = np.max(np.abs(hess_u - hess_u.T)) > 1e-4 * max(
+                    np.max(np.abs(hess_u)), 1.0
+                )
+                if np.isnan(hess_u).any() or asym:
+                    hess_u = Hessian(transformed_fun)(u_var)
                 cov_u = inv(hess_u)
                 if np.isnan(cov_u).any():
                     cov_u = inv(Hessian(transformed_fun)(u_var))

--- a/surpyval/univariate/parametric/fitters/mom.py
+++ b/surpyval/univariate/parametric/fitters/mom.py
@@ -1,3 +1,5 @@
+import warnings
+
 from scipy.optimize import minimize
 
 from surpyval import np
@@ -41,12 +43,31 @@ def mom(model):
     for i in range(0, model.k):
         moments[i] = (x_ ** (i + 1)).mean()
 
+    # A loose tolerance here silently returned parameters far from the
+    # moment-matching solution for offset/fixed fits (#275): use a tight
+    # tolerance, polish with Nelder-Mead if needed, and warn when the
+    # relative moment mismatch remains large.
     res = minimize(
         mom_fun,
         np.array(init),
-        tol=1e-1,
         args=(dist, inv_trans, const, offset, moments),
     )
+    if not res.success or res.fun > 1e-8:
+        res_nm = minimize(
+            mom_fun,
+            res.x if np.all(np.isfinite(res.x)) else np.array(init),
+            method="Nelder-Mead",
+            options={"maxiter": 10000, "xatol": 1e-12, "fatol": 1e-12},
+            args=(dist, inv_trans, const, offset, moments),
+        )
+        if np.isfinite(res_nm.fun) and res_nm.fun < res.fun:
+            res = res_nm
+    if res.fun > 1e-4:
+        warnings.warn(
+            "MOM optimisation did not match the sample moments (relative "
+            f"squared mismatch {res.fun:.3g}); the returned parameters may "
+            "be unreliable. Consider how='MLE'."
+        )
 
     params = inv_trans(const(res.x))
 

--- a/surpyval/univariate/parametric/fitters/mpp.py
+++ b/surpyval/univariate/parametric/fitters/mpp.py
@@ -57,6 +57,7 @@ def mpp(model):
             x,
             c,
             n,
+            t=t,
             heuristic=heuristic,
             rr=rr,
             on_d_is_0=on_d_is_0,

--- a/surpyval/univariate/parametric/fitters/mps.py
+++ b/surpyval/univariate/parametric/fitters/mps.py
@@ -9,7 +9,26 @@ from . import fallback_minimize
 
 def mps_fun(params, dist, x, inv_trans, const, c, n, tl, tr, offset):
     if offset:
-        x_new = x - inv_trans(const(params))[0]
+        gamma = inv_trans(const(params))[0]
+        x_new = x - gamma
+        # The truncation bounds live on the same (observed) timescale as
+        # x, so they must be shifted with it; leaving them unshifted
+        # evaluated F(tl) on the unshifted distribution and made the
+        # objective infinite at the true parameters (#268). Infinite
+        # bounds are unaffected by the shift. A shifted left bound at or
+        # below the base distribution's support carries F = 0 exactly --
+        # evaluate it as -inf rather than feeding a negative time to the
+        # base CDF (NaN for e.g. Weibull, which fails the whole fit).
+        s0 = dist.support[0]
+        tl = tl - gamma
+        tr = tr - gamma
+        if np.isfinite(tl) and tl <= s0:
+            tl = -np.inf
+        if np.isfinite(tr) and tr <= s0:
+            # The whole window sits below the support: F(tr) = 0 makes
+            # the spacings denominator collapse, which neg_mean_D
+            # reports as an infinite objective.
+            tr = s0
         params = inv_trans(const(params))[1:]
     else:
         params = inv_trans(const(params))

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -198,11 +198,20 @@ class ParametricFitter:
         *params, gamma, f0, p = params
         xr = xr - gamma
         xl = xl - gamma
-        right = np.where(np.isfinite(xr), self.ff(xr, *params), 1)
-        left = np.where(np.isfinite(xl), self.ff(xl, *params), 0)
-        return np.sum(
-            n * np.log(np.maximum(right - left, 0.0))
-        ) + n.sum() * np.log(p - f0)
+        # Probabilities must come from the mixture CDF
+        # F_mix(t) = f0 + (p - f0) * F0(t), not (p - f0) * F0(t): with no
+        # right bound (tr = inf) the window probability is the mixture
+        # survival 1 - F_mix(tl), which includes the never-failing mass
+        # (1 - p). The old (p - f0) * (1 - F0(tl)) form made the LFP +
+        # left-truncation likelihood unbounded (#269). For finite-bound
+        # intervals the f0 terms cancel, so plain fits are unchanged.
+        right = np.where(
+            np.isfinite(xr), f0 + (p - f0) * self.ff(xr, *params), 1.0
+        )
+        left = np.where(
+            np.isfinite(xl), f0 + (p - f0) * self.ff(xl, *params), 0.0
+        )
+        return np.sum(n * np.log(np.maximum(right - left, 0.0)))
 
     def parameter_transform(self, x_min, params):
         *params, gamma, f0, p = params

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -262,26 +262,31 @@ class ParametricFitter:
         D_0_1_normed = (all_F - F_tl) / denom
         D = np.diff(D_0_1_normed)
 
-        # Censoring
-        Dr = self.sf(x[c == 1], *params)
-        Dl = self.ff(x[c == -1], *params)
+        # Censored contributions, conditioned on the truncation window:
+        # under truncation the sample comes from the conditional
+        # distribution, so survivor/CDF terms are renormalised exactly
+        # like the spacings (previously they were left unconditioned,
+        # biasing every truncated + censored fit, #268).
+        Dr = (F_tr - self.ff(x[c == 1], *params)) / denom
+        Dl = (self.ff(x[c == -1], *params) - F_tl) / denom
 
+        # Cheng-Amin sum form: one log-spacing per distinct observed
+        # value (plus the two boundary spacings), (n - 1) conditional
+        # density terms for ties, and one conditional survivor/CDF term
+        # per censored unit -- all in a single sum. The previous form
+        # divided the spacings block and the censored/ties block by
+        # different counts, which made the estimator inconsistent for
+        # censored or tied data (#268); dividing the single sum by the
+        # total count only scales the objective.
+        obj = np.sum(np.log(D))
         if (n_obs > 1).any():
-            n_ties = (n_obs - 1).sum()
-            Df = self.df(x_obs, *params)
-            LL = np.concatenate([Dl, Df, Dr])
-            ll_n = np.concatenate([n[c == -1], (n_obs - 1), n[c == 1]])
-        else:
-            Df = []
-            n_ties = n_obs.sum()
-            LL = np.concatenate([Dl, Dr])
-            ll_n = np.concatenate([n[c == -1], n[c == 1]])
-
-        M = np.log(D)
-        M = -np.sum(M) / (M.shape[0])
-
-        LL = -(np.log(LL) * ll_n).sum() / (n.sum() - n_obs.sum() + n_ties)
-        return M + LL
+            Df = self.df(x_obs, *params) / denom
+            obj = obj + np.sum((n_obs - 1) * np.log(Df))
+        if (c == 1).any():
+            obj = obj + np.sum(n[c == 1] * np.log(Dr))
+        if (c == -1).any():
+            obj = obj + np.sum(n[c == -1] * np.log(Dl))
+        return -obj / n.sum()
 
     def _moment(self, n, *params, offset=False):
         if offset:
@@ -465,6 +470,16 @@ class ParametricFitter:
                         lower=self.support[0], upper=self.support[1]
                     )
                     raise ValueError(detail)
+
+        if how == "MPS" and (surv_data.c == 2).any():
+            # neg_mean_D has no interval-censored term; without this
+            # guard 2-D input dies deep in np.hstack with a cryptic
+            # dimensions error (#268).
+            raise ValueError(
+                "MPS does not support interval-censored observations; "
+                "use MLE (or MPP with the Turnbull heuristic) for "
+                "interval data."
+            )
 
         if (surv_data.tl[0] != surv_data.tl).any() and how == "MPS":
             raise ValueError("Left truncated value can only be single number \

--- a/surpyval/univariate/parametric/royston_parmar.py
+++ b/surpyval/univariate/parametric/royston_parmar.py
@@ -462,9 +462,25 @@ class RoystonParmar_:
 
         if knots is None:
             n_internal = max(int(df) - 1, 0)
+            n_distinct = np.unique(event_times).size
+            if n_distinct < n_internal + 2:
+                raise ValueError(
+                    f"Royston-Parmar with df={df} needs at least "
+                    f"{n_internal + 2} distinct event times to place "
+                    f"{n_internal + 2} knots; the data have {n_distinct}. "
+                    "Reduce df (df=1 fits a two-parameter model with no "
+                    "internal knots) or pass explicit knots."
+                )
             knots = _place_knots(event_times, n_internal)
         else:
             knots = np.asarray(knots, dtype=float)
+        if np.unique(knots).size != len(knots):
+            raise ValueError(
+                "Royston-Parmar knots must be distinct; quantile placement "
+                "over tied event times produced coincident knots "
+                f"({np.exp(knots).tolist()} in time units). Reduce df or "
+                "pass explicit knots."
+            )
         n_params = len(knots)  # [1, x] + (len(knots) - 2) internal terms
 
         lx_o = np.log(x_o) if x_o.size else x_o
@@ -508,7 +524,18 @@ class RoystonParmar_:
                 method="Nelder-Mead",
                 options={"maxiter": 20000, "xatol": 1e-9, "fatol": 1e-9},
             )
-            res = minimize(neg_ll, res.x, method="BFGS")
+            # The BFGS polish can diverge (e.g. from a boundary point on
+            # doubly-truncated data); keep it only if it produced a finite
+            # improvement over the Nelder-Mead result (#274).
+            res_polish = minimize(neg_ll, res.x, method="BFGS")
+            if np.isfinite(res_polish.fun) and res_polish.fun <= res.fun:
+                res = res_polish
+        if not np.isfinite(res.fun):
+            raise ValueError(
+                "Royston-Parmar optimisation failed to find a finite "
+                "likelihood; the model may be unidentifiable for these data "
+                "(check truncation bounds and df)."
+            )
         gamma = res.x
 
         covariance = None

--- a/surpyval/univariate/regression/additive_hazards/additive_hazards.py
+++ b/surpyval/univariate/regression/additive_hazards/additive_hazards.py
@@ -222,14 +222,43 @@ class AdditiveHazardsModel:
         idx = np.searchsorted(self.x, x, side="right") - 1
         return idx
 
-    def hf(
-        self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"
+    def _h0_rate(
+        self, x: npt.NDArray, bandwidth: "float | None" = None
     ) -> npt.NDArray:
+        # Kernel-smoothed (Ramlau-Hansen) baseline hazard *rate* from the
+        # increments of the corrected baseline cumulative hazard H0 (the
+        # raw self.h0 = d/S0 jumps include the covariate-mean drift and
+        # are dimensionless besides -- adding such a jump to the rate
+        # beta'Z was dimensionally incoherent and asymptotically dropped
+        # the baseline from hf/df entirely, #277).
+        if bandwidth is None:
+            spread = float(np.std(self.x)) if self.x.size > 1 else 1.0
+            bandwidth = max(
+                1.06 * spread * max(self.x.size, 2) ** (-1 / 5), 1e-12
+            )
+        dH0 = np.diff(np.concatenate([[0.0], self.H0]))
+        u = (x[:, None] - self.x[None, :]) / bandwidth
+        kern = np.where(np.abs(u) <= 1.0, 0.75 * (1.0 - u**2), 0.0)
+        return (kern * dH0[None, :]).sum(axis=1) / bandwidth
+
+    def hf(
+        self,
+        x: npt.ArrayLike,
+        Z: "npt.ArrayLike | pd.DataFrame",
+        bandwidth: "float | None" = None,
+    ) -> npt.NDArray:
+        """
+        Hazard rate ``h0(t) + beta'Z`` with a kernel-smoothed baseline.
+
+        The semiparametric baseline is a step cumulative hazard, so the
+        rate requires smoothing (Epanechnikov kernel over the increments;
+        ``bandwidth`` defaults to a normal-reference rule on the event
+        times). Estimates near the boundaries of the observed time range
+        are attenuated by kernel truncation.
+        """
         Z = self._prepare_Z(Z)
         x = np.atleast_1d(np.asarray(x, dtype=float))
-        idx = self._h0_at(x)
-        h0 = np.where(idx < 0, 0.0, self.h0[np.clip(idx, 0, self.x.size - 1)])
-        return h0 + (Z @ self.beta)
+        return self._h0_rate(x, bandwidth) + (Z @ self.beta)
 
     def Hf(
         self, x: npt.ArrayLike, Z: "npt.ArrayLike | pd.DataFrame"

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -405,6 +405,15 @@ class ParametricRegressionModel:
 
     def phi(self, Z: "npt.ArrayLike | pd.DataFrame") -> npt.NDArray:
         Z = self._prepare_Z(Z)
+        if not hasattr(self.reg_model, "phi"):
+            # Additive-hazards reg models have no multiplier: the
+            # covariate effect enters as beta'Z added to the hazard, so
+            # phi() is undefined rather than an AttributeError (#277).
+            raise NotImplementedError(
+                "phi() is not defined for additive-hazards models: the "
+                "covariate effect is additive (beta'Z on the hazard), "
+                "not a multiplier."
+            )
         return self.reg_model.phi(Z, *self.phi_params)
 
     def sf(

--- a/surpyval/univariate/regression/proportional_hazards/diagnostics.py
+++ b/surpyval/univariate/regression/proportional_hazards/diagnostics.py
@@ -54,24 +54,30 @@ def _require_cox(model: "SemiParametricRegressionModel") -> dict:
     return model._fit_data
 
 
-def _H0_at(
-    model: "SemiParametricRegressionModel", t: np.ndarray
-) -> np.ndarray:
-    """Breslow cumulative baseline hazard ``H0(t)`` as a right-continuous
-    step function: the sum of the baseline hazard increments at event times
-    ``<= t`` (0 below the first event time)."""
-    idx = np.searchsorted(model.x, t, side="right")
-    H0_padded = np.concatenate([[0.0], model.H0])
-    return H0_padded[idx]
+def _risk_set_means(data: dict, beta: np.ndarray, tie_method: str = "breslow"):
+    """Per distinct event time: risk-set covariate means and baseline-hazard
+    step aggregates, weighted by ``n * exp(beta'Z)`` and respecting delayed
+    entry.
 
+    Under Efron ties the ``m`` tied deaths at a time are spread over ``m``
+    pseudo-risk-sets ``S0 - (l/m) * S0_D`` (Therneau & Grambsch ch. 3), and
+    every returned quantity is the corresponding step aggregate; with
+    Breslow (or no ties) each event time is a single step and the classic
+    forms are recovered. Using Breslow forms for an Efron fit made the
+    residuals, ``check_ph`` and the robust covariance disagree with R /
+    lifelines under heavy ties (#279).
 
-def _risk_set_means(data: dict, beta: np.ndarray):
-    """For every distinct event time, the covariate mean over the risk set,
-    weighted by ``n * exp(beta'Z)`` and respecting delayed entry.
+    Returns ``(event_times, Zbar, S0, d, A, B, A_own, B_own)`` where per
+    event time ``k``:
 
-    Returns ``(event_times, Zbar, S0, d)`` where ``Zbar[k]`` is the risk-set
-    covariate mean at ``event_times[k]``, ``S0[k]`` the summed risk weight and
-    ``d[k]`` the ``n``-weighted number of events there.
+    - ``Zbar[k]``: tie-averaged risk-set covariate mean ``mean_l(E_l)``
+      (the Schoenfeld expectation),
+    - ``S0[k]``: full risk weight, ``d[k]``: n-weighted deaths,
+    - ``A[k] = sum_l 1 / S0_l``: the baseline-hazard increment seen by a
+      subject at risk through the whole tie group,
+    - ``B[k] = sum_l E_l / S0_l`` (p-vector),
+    - ``A_own[k] = sum_l (1 - l/m) / S0_l``: the partial increment a tied
+      death itself accrues, and ``B_own[k]`` its E-weighted analogue.
     """
     x, c, n, Z, tl = (
         data["x"],
@@ -81,20 +87,48 @@ def _risk_set_means(data: dict, beta: np.ndarray):
         data["tl"],
     )
     w = n * np.exp(Z @ beta)  # risk weight per observation
+    efron = str(tie_method).lower() == "efron"
 
     event_times = np.unique(x[c == 0])
     p = Z.shape[1]
-    Zbar = np.empty((event_times.size, p))
-    S0 = np.empty(event_times.size)
-    d = np.empty(event_times.size)
+    K = event_times.size
+    Zbar = np.empty((K, p))
+    S0 = np.empty(K)
+    d = np.empty(K)
+    A = np.empty(K)
+    B = np.empty((K, p))
+    A_own = np.empty(K)
+    B_own = np.empty((K, p))
     for k, tau in enumerate(event_times):
         at_risk = (tl < tau) & (x >= tau)
         s0 = w[at_risk].sum()
-        S0[k] = s0
-        Zbar[k] = (w[at_risk, None] * Z[at_risk]).sum(axis=0) / s0
+        s1 = (w[at_risk, None] * Z[at_risk]).sum(axis=0)
         is_event = (x == tau) & (c == 0)
-        d[k] = n[is_event].sum()
-    return event_times, Zbar, S0, d
+        d_k = float(n[is_event].sum())
+        S0[k] = s0
+        d[k] = d_k
+        m = int(round(d_k))
+        if efron and m > 1:
+            s0D = w[is_event].sum()
+            s1D = (w[is_event, None] * Z[is_event]).sum(axis=0)
+            fracs = np.arange(m) / m  # l/m for l = 0..m-1
+            s0_l = s0 - fracs * s0D
+            e_l = (s1[None, :] - fracs[:, None] * s1D[None, :]) / s0_l[:, None]
+            inv_l = 1.0 / s0_l
+            own_coef = 1.0 - fracs  # (m - l)/m
+            Zbar[k] = e_l.mean(axis=0)
+            A[k] = inv_l.sum()
+            B[k] = (inv_l[:, None] * e_l).sum(axis=0)
+            A_own[k] = (own_coef * inv_l).sum()
+            B_own[k] = ((own_coef * inv_l)[:, None] * e_l).sum(axis=0)
+        else:
+            zbar = s1 / s0
+            Zbar[k] = zbar
+            A[k] = d_k / s0
+            B[k] = zbar * (d_k / s0)
+            A_own[k] = A[k]
+            B_own[k] = B[k]
+    return event_times, Zbar, S0, d, A, B, A_own, B_own
 
 
 def _information(model: "SemiParametricRegressionModel") -> np.ndarray:
@@ -153,10 +187,28 @@ def compute_residuals(
         data["Z"],
         data["tl"],
     )
+    tie_method = getattr(model, "tie_method", "breslow")
+
+    event_times, Zbar, S0, d, A, B, A_own, B_own = _risk_set_means(
+        data, beta, tie_method
+    )
 
     if kind in ("martingale", "deviance"):
+        # Expected events from the tie-method-consistent baseline
+        # increments (A); a tied death accrues only its own partial step
+        # (A_own) at its event time under Efron (#279). With Breslow (or
+        # no ties) A_own == A and this equals H0(x) - H0(tl).
         delta = (c == 0).astype(float)
-        cum_haz = np.exp(Z @ beta) * (_H0_at(model, x) - _H0_at(model, tl))
+        Lam = np.concatenate([[0.0], np.cumsum(A)])
+
+        def _Lam_at(t):
+            return Lam[np.searchsorted(event_times, t, side="right")]
+
+        cum_haz = _Lam_at(x) - _Lam_at(tl)
+        event_rows = np.flatnonzero(c == 0)
+        own_idx = np.searchsorted(event_times, x[event_rows])
+        cum_haz[event_rows] += A_own[own_idx] - A[own_idx]
+        cum_haz = np.exp(Z @ beta) * cum_haz
         martingale = delta - cum_haz
         if kind == "martingale":
             return martingale
@@ -169,11 +221,9 @@ def compute_residuals(
         dev = np.where(delta == 0, -np.sqrt(2.0 * cum_haz), dev)
         return dev
 
-    event_times, Zbar, S0, d = _risk_set_means(data, beta)
-
     if kind in ("schoenfeld", "scaled_schoenfeld"):
-        # One residual per event observation: covariate minus the risk-set
-        # mean at its event time.
+        # One residual per event observation: covariate minus the
+        # (tie-averaged) risk-set mean at its event time.
         event_rows = np.flatnonzero(c == 0)
         zbar_idx = np.searchsorted(event_times, x[event_rows])
         sch = Z[event_rows] - Zbar[zbar_idx]
@@ -187,24 +237,31 @@ def compute_residuals(
         return beta + n_events * (sch @ V)
 
     # Score / dfbeta residuals. The score residual for observation i is
-    #   delta_i (Z_i - Zbar(x_i)) - exp(beta'Z_i) * sum_k in-window
-    #       (Z_i - Zbar_k) (d_k / S0_k)
-    # summing over event times k in the observation's at-risk window.
+    #   delta_i (Z_i - Zbar(x_i))
+    #     - exp(beta'Z_i) * sum_{k in window} (Z_i * A_k - B_k)
+    # where A_k / B_k are the per-event step aggregates from
+    # _risk_set_means, and a tied death's own event time contributes its
+    # partial (A_own, B_own) instead (#279). Breslow reduces to the
+    # classic (Z_i - Zbar_k) d_k / S0_k form.
     w = np.exp(Z @ beta)
-    delta = (c == 0).astype(float)
-    increments = d / S0  # baseline-hazard increment per event time
     score = np.zeros_like(Z, dtype=float)
     # First term (only for events).
     event_rows = np.flatnonzero(c == 0)
     zbar_idx = np.searchsorted(event_times, x[event_rows])
     score[event_rows] += Z[event_rows] - Zbar[zbar_idx]
     # Second term: subtract the expected score accrued while at risk.
+    is_event_row = c == 0
     for i in range(Z.shape[0]):
         in_window = (event_times > tl[i]) & (event_times <= x[i])
         if not in_window.any():
             continue
-        contrib = (Z[i] - Zbar[in_window]) * increments[in_window, None]
-        score[i] -= w[i] * contrib.sum(axis=0)
+        A_sum = A[in_window].sum()
+        B_sum = B[in_window].sum(axis=0)
+        if is_event_row[i]:
+            k_own = np.searchsorted(event_times, x[i])
+            A_sum += A_own[k_own] - A[k_own]
+            B_sum += B_own[k_own] - B[k_own]
+        score[i] -= w[i] * (Z[i] * A_sum - B_sum)
     score = score * n[:, None]
     if kind == "score":
         return score
@@ -321,7 +378,13 @@ def _transform_times(
     if transform == "log":
         return np.log(t)
     if transform == "rank":
-        return np.argsort(np.argsort(t)).astype(float)
+        # Average ranks for tied event times (scipy.stats.rankdata), as
+        # in R / lifelines; ordinal argsort ranks split ties arbitrarily
+        # and changed the statistic on tied data (#279). The constant
+        # offset relative to 0-based ranks cancels in the centring.
+        from scipy.stats import rankdata
+
+        return rankdata(t).astype(float)
     if transform == "km":
         # Scale-free transform (Grambsch-Therneau default): 1 - KM(t) with
         # the Kaplan-Meier estimate fit on the *full* data, so censoring
@@ -379,7 +442,10 @@ def check_ph(
     -----
     Both the global and per-covariate statistics follow the
     Grambsch-Therneau forms used by R's ``cox.zph`` and lifelines, so the
-    results are directly comparable across packages (#262).
+    results are directly comparable across packages (#262), including
+    under tied event times for Efron fits (#279). The ``"rank"``
+    transform uses average ranks for ties (R's convention); lifelines'
+    ``"rank"`` is a cumulative event count and differs on tied data.
     """
     _require_cox(model)
     if transform not in _TRANSFORMS:

--- a/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
+++ b/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
@@ -111,10 +111,17 @@ class ProportionalHazardsFitter(TVCFitMixin, DataFrameRegressionMixin):
     def random(self, size, Z, *params):
         dist_params = np.array(params[0 : self.k_dist])
         phi_params = np.array(params[self.k_dist :])
-        U = np.random.uniform(0, 1, size)
-        x = self.dist.qf(U ** (self.phi(Z, *phi_params)), *dist_params)
-        Z_out = np.ones_like(x) * Z
-        return x.flatten(), Z_out.flatten()
+        Z_arr = np.atleast_2d(np.asarray(Z, dtype=float))
+        x = []
+        Z_out = []
+        for row in Z_arr:
+            phi = self.phi(row, *phi_params)
+            U = np.random.uniform(0, 1, size)
+            # S(x|Z) = S0(x)^phi, so inverting S(x|Z) = U gives
+            # x = qf(1 - U^(1/phi)); U^phi inverts the wrong quantity.
+            x.append(self.dist.qf(1 - U ** (1.0 / phi), *dist_params))
+            Z_out.append(np.tile(row, (size, 1)))
+        return np.concatenate(x), np.vstack(Z_out)
 
     def neg_ll(self, data, *params):
         return regression_neg_ll(self, data, *params)

--- a/surpyval/utils/__init__.py
+++ b/surpyval/utils/__init__.py
@@ -797,14 +797,15 @@ def xcnt_to_xrd(x, c=None, n=None, t=None, **kwargs):
     array([5, 4, 3, 2, 1])
     >>> d
     array([1, 0, 0, 1, 1])
-    >>> # Using left truncated data
+    >>> # Using left truncated data: under the (entry, exit] convention a
+    >>> # subject entering exactly at an event time is not at risk for it.
     >>> x = np.array([1, 2, 3, 4, 5])
     >>> tl = np.array([0, 1, 2, 3, 4])
     >>> x, r, d = xcnt_to_xrd(x, tl=tl)
     >>> x
     array([1., 2., 3., 4., 5.])
     >>> r
-    array([2, 2, 2, 2, 1])
+    array([1, 1, 1, 1, 1])
     >>> d
     array([1, 1, 1, 1, 1])
     """
@@ -813,11 +814,11 @@ def xcnt_to_xrd(x, c=None, n=None, t=None, **kwargs):
     if np.isfinite(t[:, 1]).any():
         raise ValueError("xrd format can't be used right truncated data")
 
-    if (t[:, 0] == t[0, 0]).all() and np.isfinite(t[0, 0]):
-        warnings.warn(
-            "Ignoring left truncated values as all observations truncated at"
-            + " same value"
-        )
+    # No warning for a shared entry time: validation guarantees tl < x for
+    # every observation, so a common entry time never alters the (entry,
+    # exit] risk sets -- the old "Ignoring left truncated values" warning
+    # fired on perfectly ordinary inputs like tl=0 everywhere, e.g. from
+    # check_ph on a model fit with a constant entry column (#282).
 
     if ((c != 1) & (c != 0)).any():
         raise ValueError(
@@ -902,6 +903,19 @@ def xrd_to_xcnt(x, r, d):
     mask = n_f != 0
     n_f = n_f[mask]
     x_f = x_f[mask]
+
+    # A risk set that grows (after accounting for that step's events) means
+    # late entry / left truncation, which the xcnt output cannot represent;
+    # the old np.abs() silently converted such data into a different study
+    # instead of raising (#281).
+    r_arr = np.asarray(r)
+    d_arr = np.asarray(d)
+    if (np.diff(r_arr) + d_arr[:-1] > 0).any():
+        raise ValueError(
+            "The risk set increases between observation times (late entry /"
+            " left truncation); truncation cannot be represented in xcnt"
+            " output, so this data cannot be converted with xrd_to_xcnt."
+        )
 
     delta = np.abs(np.diff(np.hstack([r, [0]])))
 

--- a/surpyval/utils/autograd_gamma_compat.py
+++ b/surpyval/utils/autograd_gamma_compat.py
@@ -8,12 +8,18 @@ Replaces the abandoned autograd-gamma package. VJP approach:
     computes Hessians by tracing through the backward pass) are handled
     correctly, giving correct second-order derivatives for the x (rate) param.
 
-  shape-parameter derivatives (numerical central difference):
-    Use getval() to strip ArrayBox before all scipy calls. The returned value
-    is plain numpy (via getval(g) + ndarray.sum()), so the Hessian
-    contribution from shape-parameter paths is zero — an acceptable
-    approximation that matches the original autograd-gamma behaviour.
-    This also avoids autograd 1.8's np.sum VJP bug with the `out` kwarg.
+  shape-parameter derivatives (numerical central difference, traced):
+    Each shape derivative is itself a ``primitive`` whose VJPs return
+    numerical second derivatives (pure in a, mixed in the other shape
+    parameter and in x). The first-order VJP therefore stays inside the
+    autograd trace — both the cotangent ``g`` and the derivative factor are
+    boxed — so Hessians through shape-parameter paths are correct. The
+    previous implementation stripped the trace with ``getval`` on both
+    factors, silently zeroing every second-derivative contribution through
+    a shape parameter: censored/truncated Gamma and Beta fits got a
+    corrupted (even asymmetric) covariance while their point estimates
+    were fine (#270). Third- and higher-order derivatives are cut (the
+    inner VJPs are plain numpy), which nothing in surpyval needs.
 """
 
 import autograd.numpy as anp
@@ -36,37 +42,121 @@ def _step(v):
     return (v + h) - v
 
 
+def _cdiff(f, v):
+    """5th-order central difference of a one-argument callable at v."""
+    h = _step(v)
+    return (-f(v + 2 * h) + 8 * f(v + h) - 8 * f(v - h) + f(v - 2 * h)) / (
+        12 * h
+    )
+
+
+def _cdiff_second(f, v):
+    """5-point second-derivative stencil of a one-argument callable at v."""
+    h = _step(v)
+    return (
+        -f(v + 2 * h)
+        + 16 * f(v + h)
+        - 30 * f(v)
+        + 16 * f(v - h)
+        - f(v - 2 * h)
+    ) / (12 * h * h)
+
+
 def _cdiff1(f, a, x):
     """5th-order central diff of f(a, x) w.r.t. a.
 
     Both a and x must be plain numpy values — call with getval().
     """
-    h = _step(a)
-    return (
-        -f(a + 2 * h, x) + 8 * f(a + h, x) - 8 * f(a - h, x) + f(a - 2 * h, x)
-    ) / (12 * h)
+    return _cdiff(lambda aa: f(aa, x), a)
 
 
 def _cdiff2_a(f, a, b, x):
     """5th-order central diff of f(a, b, x) w.r.t. a — all args plain numpy."""
-    h = _step(a)
-    return (
-        -f(a + 2 * h, b, x)
-        + 8 * f(a + h, b, x)
-        - 8 * f(a - h, b, x)
-        + f(a - 2 * h, b, x)
-    ) / (12 * h)
+    return _cdiff(lambda aa: f(aa, b, x), a)
 
 
 def _cdiff2_b(f, a, b, x):
     """5th-order central diff of f(a, b, x) w.r.t. b — all args plain numpy."""
-    h = _step(b)
-    return (
-        -f(a, b + 2 * h, x)
-        + 8 * f(a, b + h, x)
-        - 8 * f(a, b - h, x)
-        + f(a, b - 2 * h, x)
-    ) / (12 * h)
+    return _cdiff(lambda bb: f(a, bb, x), b)
+
+
+def _make_da_primitive(f):
+    """Traced first derivative w.r.t. the shape parameter of f(a, x).
+
+    Returns a primitive ``f_da(a, x) = df/da`` whose own VJPs are the
+    numerical second derivatives d2f/da2 and d2f/dadx, so a Hessian pass
+    through ``f_da`` picks up the correct curvature (further orders cut).
+    """
+
+    @primitive
+    def f_da(a, x):
+        return _cdiff1(f, a, x)
+
+    def vjp_a(ans, a, x):
+        av, xv = getval(a), getval(x)
+        d2 = _cdiff_second(lambda aa: f(aa, xv), av)
+        return lambda g: (getval(g) * d2).sum()
+
+    def vjp_x(ans, a, x):
+        av, xv = getval(a), getval(x)
+        mixed = _cdiff(lambda xx: _cdiff1(f, av, xx), xv)
+        return lambda g: getval(g) * mixed
+
+    defvjp(f_da, vjp_a, vjp_x)
+    return f_da
+
+
+def _make_dab_primitives(f):
+    """Traced first derivatives w.r.t. both shape parameters of f(a, b, x).
+
+    Returns primitives ``(f_da, f_db)`` whose VJPs are the numerical pure,
+    cross and mixed-with-x second derivatives.
+    """
+
+    @primitive
+    def f_da(a, b, x):
+        return _cdiff2_a(f, a, b, x)
+
+    @primitive
+    def f_db(a, b, x):
+        return _cdiff2_b(f, a, b, x)
+
+    def _vals(a, b, x):
+        return getval(a), getval(b), getval(x)
+
+    def da_vjp_a(ans, a, b, x):
+        av, bv, xv = _vals(a, b, x)
+        d2 = _cdiff_second(lambda aa: f(aa, bv, xv), av)
+        return lambda g: (getval(g) * d2).sum()
+
+    def da_vjp_b(ans, a, b, x):
+        av, bv, xv = _vals(a, b, x)
+        d2 = _cdiff(lambda bb: _cdiff2_a(f, av, bb, xv), bv)
+        return lambda g: (getval(g) * d2).sum()
+
+    def da_vjp_x(ans, a, b, x):
+        av, bv, xv = _vals(a, b, x)
+        mixed = _cdiff(lambda xx: _cdiff2_a(f, av, bv, xx), xv)
+        return lambda g: getval(g) * mixed
+
+    def db_vjp_a(ans, a, b, x):
+        av, bv, xv = _vals(a, b, x)
+        d2 = _cdiff(lambda aa: _cdiff2_b(f, aa, bv, xv), av)
+        return lambda g: (getval(g) * d2).sum()
+
+    def db_vjp_b(ans, a, b, x):
+        av, bv, xv = _vals(a, b, x)
+        d2 = _cdiff_second(lambda bb: f(av, bb, xv), bv)
+        return lambda g: (getval(g) * d2).sum()
+
+    def db_vjp_x(ans, a, b, x):
+        av, bv, xv = _vals(a, b, x)
+        mixed = _cdiff(lambda xx: _cdiff2_b(f, av, bv, xx), xv)
+        return lambda g: getval(g) * mixed
+
+    defvjp(f_da, da_vjp_a, da_vjp_b, da_vjp_x)
+    defvjp(f_db, db_vjp_a, db_vjp_b, db_vjp_x)
+    return f_da, f_db
 
 
 # ---------------------------------------------------------------------------
@@ -79,12 +169,13 @@ def gammainc(a, x):
     return _sc_gammainc(a, x)
 
 
+_gammainc_da = _make_da_primitive(_sc_gammainc)
+
 defvjp(
     gammainc,
-    # d/da: numerical; getval(g) + .sum() avoids autograd 1.8 np.sum bug
-    lambda ans, a, x: lambda g: (
-        getval(g) * _cdiff1(_sc_gammainc, getval(a), getval(x))
-    ).sum(),
+    # d/da: numerical but traced — the product keeps both g and the
+    # derivative factor boxed so Hessians through a are correct (#270)
+    lambda ans, a, x: lambda g: anp.sum(g * _gammainc_da(a, x)),
     # d/dx: analytical; anp.log handles ArrayBox x for correct Hessian
     lambda ans, a, x: lambda g: g
     * anp.exp(-x + anp.log(x) * (a - 1) - _ag_gammaln(a)),
@@ -104,11 +195,11 @@ def gammaincln(a, x):
     return _gammaincln_raw(a, x)
 
 
+_gammaincln_da = _make_da_primitive(_gammaincln_raw)
+
 defvjp(
     gammaincln,
-    lambda ans, a, x: lambda g: (
-        getval(g) * _cdiff1(_gammaincln_raw, getval(a), getval(x))
-    ).sum(),
+    lambda ans, a, x: lambda g: anp.sum(g * _gammaincln_da(a, x)),
     # d/dx of log P = (dP/dx)/P; ans = log P avoids recomputing P
     lambda ans, a, x: lambda g: g
     * anp.exp(-x + anp.log(x) * (a - 1) - _ag_gammaln(a) - ans),
@@ -128,11 +219,11 @@ def gammainccln(a, x):
     return _gammainccln_raw(a, x)
 
 
+_gammainccln_da = _make_da_primitive(_gammainccln_raw)
+
 defvjp(
     gammainccln,
-    lambda ans, a, x: lambda g: (
-        getval(g) * _cdiff1(_gammainccln_raw, getval(a), getval(x))
-    ).sum(),
+    lambda ans, a, x: lambda g: anp.sum(g * _gammainccln_da(a, x)),
     # d/dx of log Q = -(dP/dx)/Q; negated, ans = log Q
     lambda ans, a, x: lambda g: g
     * -anp.exp(-x + anp.log(x) * (a - 1) - _ag_gammaln(a) - ans),
@@ -148,14 +239,12 @@ def betainc(a, b, x):
     return _sc_betainc(a, b, x)
 
 
+_betainc_da, _betainc_db = _make_dab_primitives(_sc_betainc)
+
 defvjp(
     betainc,
-    lambda ans, a, b, x: lambda g: (
-        getval(g) * _cdiff2_a(_sc_betainc, getval(a), getval(b), getval(x))
-    ).sum(),
-    lambda ans, a, b, x: lambda g: (
-        getval(g) * _cdiff2_b(_sc_betainc, getval(a), getval(b), getval(x))
-    ).sum(),
+    lambda ans, a, b, x: lambda g: anp.sum(g * _betainc_da(a, b, x)),
+    lambda ans, a, b, x: lambda g: anp.sum(g * _betainc_db(a, b, x)),
     # d/dx: x^(a-1)*(1-x)^(b-1)/B(a,b); anp handles ArrayBox x
     lambda ans, a, b, x: lambda g: g
     * anp.exp(
@@ -177,14 +266,12 @@ def betaincln(a, b, x):
     return _betaincln_raw(a, b, x)
 
 
+_betaincln_da, _betaincln_db = _make_dab_primitives(_betaincln_raw)
+
 defvjp(
     betaincln,
-    lambda ans, a, b, x: lambda g: (
-        getval(g) * _cdiff2_a(_betaincln_raw, getval(a), getval(b), getval(x))
-    ).sum(),
-    lambda ans, a, b, x: lambda g: (
-        getval(g) * _cdiff2_b(_betaincln_raw, getval(a), getval(b), getval(x))
-    ).sum(),
+    lambda ans, a, b, x: lambda g: anp.sum(g * _betaincln_da(a, b, x)),
+    lambda ans, a, b, x: lambda g: anp.sum(g * _betaincln_db(a, b, x)),
     # d/dx of log B = (dB/dx)/B; ans = log B
     lambda ans, a, b, x: lambda g: g
     * anp.exp(

--- a/surpyval/utils/score.py
+++ b/surpyval/utils/score.py
@@ -28,9 +28,12 @@ def score(
     # 6. If x_1 == x_2 and both are deaths,
     #    if x_hat_1 == x_hat_2 => concordance += 1
     #    else concordance += 0.5
-    # 7. If x_1 == x_2 and only one of them is a death (say x_1),
+    # 7. If x_1 == x_2 and only one of them is a death (say x_1), the
+    #    censored observation demonstrably outlived the death, so the
+    #    pair is fully comparable (Harrell):
     #    if x_hat_1 > x_hat_2 => concordance += 1
-    #    otherwise => concordance += 0.5
+    #    if x_hat_1 == x_hat_2 => concordance += 0.5
+    #    if x_hat_1 < x_hat_2 => concordance += 0 (discordant, #276)
     # c-index = concordance / n_permissible_pairs
 
     # Correct input
@@ -80,11 +83,17 @@ def score(
                 else:
                     concordance += 0.5
             else:
-                if c_1 == 0 and x_hat_1 > x_hat_2:
-                    concordance += 1
-                elif c_2 == 0 and x_hat_2 > x_hat_1:
-                    concordance += 1
+                # Exactly one of the tied pair is a death; the censored
+                # subject outlived it, so the pair is fully comparable:
+                # 0.5 only on a genuine score tie, 0 when the death has
+                # the lower risk score (previously credited 0.5, #276).
+                if c_1 == 0:
+                    death_score, other_score = x_hat_1, x_hat_2
                 else:
+                    death_score, other_score = x_hat_2, x_hat_1
+                if isclose(death_score, other_score, abs_tol=tie_tol):
                     concordance += 0.5
+                elif death_score > other_score:
+                    concordance += 1
 
     return concordance / n_permissible_pairs

--- a/surpyval/utils/surpyval_data.py
+++ b/surpyval/utils/surpyval_data.py
@@ -184,7 +184,12 @@ class SurpyvalData:
             tuple
                 The xrd data.
         """
-        if not hasattr(self, "xrd"):
+        # Cache per estimator: the first call used to be returned for
+        # every later call regardless of a different ``estimator``
+        # argument (#282).
+        if not hasattr(self, "_xrd_cache"):
+            self._xrd_cache: dict = {}
+        if estimator not in self._xrd_cache:
             if (
                 np.isfinite(self.t[:, 1]).any()
                 or (2 in self.c)
@@ -198,8 +203,8 @@ class SurpyvalData:
                 xrd = surpyval.utils.xcnt_to_xrd(
                     self.x, self.c, self.n, self.t
                 )
-            self.xrd = xrd
-        return self.xrd
+            self._xrd_cache[estimator] = xrd
+        return self._xrd_cache[estimator]
 
     def _split_by_mask(
         self, mask: np.ndarray
@@ -208,13 +213,31 @@ class SurpyvalData:
         return x, self.n[mask]
 
     def __getitem__(self, index):
-        return SurpyvalData(
-            np.atleast_1d(self.x[index]),
+        # A scalar index on interval-censored (2-D) data used to flatten
+        # one [xl, xr] row into two 1-D observations and crash the type
+        # split; keep the row structure instead (#282).
+        if self.x.ndim == 2:
+            x_idx = np.atleast_2d(self.x[index])
+        else:
+            x_idx = np.atleast_1d(self.x[index])
+        out = SurpyvalData(
+            x_idx,
             np.atleast_1d(self.c[index]),
             np.atleast_1d(self.n[index]),
             np.atleast_2d(self.t[index]),
             handle=False,
         )
+        # Carry the covariates through (slicing used to silently return
+        # Z=None, losing alignment, #282).
+        if getattr(self, "Z", None) is not None:
+            Z_arr = np.asarray(self.Z)
+            Z_idx = Z_arr[index]
+            if Z_arr.ndim == 2:
+                Z_idx = np.atleast_2d(Z_idx)
+            else:
+                Z_idx = np.atleast_1d(Z_idx)
+            out.add_covariates(Z_idx)
+        return out
 
     def __len__(self) -> int:
         return len(self.x)


### PR DESCRIPTION
## Summary

Fixes all 15 issues from the second deep-dive review of the univariate module (#268–#282), in five batches:

**High severity**
- **#269** — the LFP + left-truncation likelihood was unbounded (normaliser dropped the never-failing mass); fits returned α~1e-42 with optimiser success. Now uses the mixture survival; recovery verified (α=10.03, β=2.01, p=0.599 vs truth 10/2/0.6).
- **#271** — parametric PH `random()` sampled the wrong distribution (`qf(U**φ)` vs `qf(1−U**(1/φ))`) and crashed for ≥2 covariates.
- **#274** — Royston-Parmar kept a diverged BFGS polish (silent NaN models on doubly-truncated data) and placed coincident knots on tied/scarce event times; now guarded and validated.
- **#270** — censored/truncated Gamma and Beta Wald covariance was corrupted (the incomplete-gamma/beta shims stripped the trace in shape-parameter VJPs; stored Var(α) 12.5× the truth and 29% asymmetric). Shape derivatives are now traced primitives with numerical second-derivative VJPs; verified against numdifftools to ~1e-4, plus a symmetry-validation fallback in `mle`.
- **#268** — MPS rewritten to the Cheng-Amin sum form: consistent block weighting (ties/censoring), truncation-conditioned censored terms, offset-shifted bounds, clear interval-data rejection. All four failure scenarios now track MLE to ~2%.
- **#272/#273** — Turnbull: (l, r] endpoint atoms included (sf 0.83 vs the old 0.45, matching the NPMLE); truncated variance ladder rebuilt from observed counts (no more −1.5e15 Greenwood increments; reduces exactly to delayed-entry KM); supports intersected with truncation windows (the original #203 reproduction now converges to a healthy estimate); degenerate-interval inputs get the KM-reducible variance.

**Medium/low**
- **#279** — Efron tie corrections throughout the Cox diagnostics: Schoenfeld and `check_ph` (km/identity/log) match lifelines to 6+ figures under heavy ties; martingale/score sums vanish at the MLE for both tie methods; dfbeta correlates 0.999 with exact leave-one-out influence. Rank transform uses R's average-rank convention.
- **#275** — MOM numeric path optimises to convergence (was `tol=1e-1`, unchecked).
- **#276** — concordance index scores discordant tied event/censored pairs 0 per Harrell.
- **#277** — Lin-Ying `hf`/`df` use a kernel-smoothed baseline rate (was ≈β′Z); `phi()` raises `NotImplementedError` on additive models.
- **#278** — Aalen-Johansen CIFs use product-limit weights; total incidence can no longer exceed 1.
- **#280** — LogLogistic at 0 / log-space overflow; Beta4 density outside support; truncation forwarding in Rayleigh/Gamma/Exponential MPP; Rayleigh F=1 masking; Uniform interval rejection.
- **#281** — `xrd_to_xcnt` raises on late-entry data instead of silently corrupting it.
- **#282** — `SurpyvalData` container fixes, scalar `hf`/`df`, single-observation bounds, spurious warning, stale docs.

## Verification

Every fix is covered by new regression tests (60+ added across five test modules), each pinning the original failure scenario. Full local suite green (1782 → 1854 tests); mypy/flake8/black clean.

Closes #268. Closes #269. Closes #270. Closes #271. Closes #272. Closes #273. Closes #274. Closes #275. Closes #276. Closes #277. Closes #278. Closes #279. Closes #280. Closes #281. Closes #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_