### PR TITLE
Medium simplifications: shared fit skeleton, hazard/IC mixins, numerical dedup batch (#295–#299)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,55 @@ Changelog
 v0.17.0 (unreleased)
 --------------------
 
+- **Simplification: one shared ``fit()`` skeleton for the parametric
+  regression families** (#295). PH, AFT, PO and parametric AH carried
+  five copy-pasted versions of the same fit pipeline — data prep, the
+  #251 param-map offset merge, ``bounds_convert``, optimisation, model
+  assembly — which had already drifted (different optimiser ladders;
+  only some families setting ``dist_params``/``phi_params``). The
+  skeleton now lives once in ``_fit_skeleton.py`` (each family supplies
+  its optimiser strategy and covariate-link object), along with a single
+  ``LogLinearPhi`` for the ``exp(beta'Z)`` link previously defined
+  inline in seven places. Fitted values are bit-identical; each
+  family's historical optimiser ladder and serialisation name tags are
+  preserved exactly.
+- **Simplification: shared hazard identities and information criteria**
+  (#297, #298). The six ``sf``/``ff``/``df``/``log_*`` identities
+  derived from ``Hf``/``hf`` were repeated in four regression fitters;
+  they now live in one ``HazardIdentitiesMixin``. PH and parametric AH
+  ``ff`` now use ``-expm1(-H)`` (matching AFT/AL), which is more
+  accurate in the deep left tail where ``H`` is tiny; all other values
+  are bit-identical. ``neg_ll``/``aic``/``bic``/``aic_c`` were
+  duplicated between ``Parametric`` and ``ParametricRegressionModel``;
+  one ``InformationCriteriaMixin`` now serves both, preserving each
+  class's historical ``aic_c`` parameter-count convention exactly.
+- **Simplification: NHPP likelihood data split hoisted** (#296). The
+  five-way censoring/interval split of recurrent-event data (the code
+  that drifted into #288) was duplicated between the NHPP fitter and
+  the proportional-intensity NHPP fitter; it now lives once as
+  ``RecurrentEventData.split_for_nhpp_likelihood``. Fitted values are
+  bit-identical.
+- **Simplification: numerical dedup batch** (#299). The Aalen-Johansen
+  ``S(t-)`` incidence weighting (the pattern behind #253/#278) was
+  implemented three times — nonparametric ``CompetingRisks``, the
+  competing-risks PH ``cif`` and Gray's pooled CIF — and now lives once
+  in ``aalen_johansen_iif`` (Gray's pooled CIF is vectorised in the
+  process). The Cox at-risk rule (entry-strict ``tl < tau``,
+  exit-inclusive ``x >= tau``) is now documented in one
+  ``cox_at_risk_mask`` helper used by the exact-tie preparation and the
+  Schoenfeld risk-set means, and ``CoxPH.baseline`` replaces its
+  O(K·N) Python loop with the same suffix-sum subtraction the Efron
+  generator uses (values agree to ~1e-15 relative; pinned by the
+  R/lifelines comparison tests). The degradation ``bootstrap_cb`` and
+  ``bootstrap_cb_accelerated`` merged into one function (``Z=None``
+  selects the plain path; the plain path now also drops non-finite
+  refit curves instead of letting them poison the quantiles).
+  ``CopulaModel`` serialisation is now round-trippable: ``to_dict``
+  stamps the schema version and a new ``from_dict`` (registered with
+  ``surpyval.from_dict`` under the ``"copula"`` parameterization)
+  rebuilds the model, where previously the dictionary was written in a
+  form nothing could read. The CB transform sharing and Cox TVC
+  wrapper collapse from #299 are deferred.
 - **Simplification: low-risk cleanup batch from the code-simplification
   review** (#295-#299 track the medium-risk remainder). Dead code removed:
   the unused ``surv_sksurv_transformations`` module, ``init_from_bounds``,

--- a/surpyval/degradation/_bounds.py
+++ b/surpyval/degradation/_bounds.py
@@ -225,67 +225,20 @@ def analytic_cb(model, x, on, alpha_ci, bound):
     return (1.0 - sf_b) if on in ("ff", "F") else -np.log(sf_b)
 
 
-def bootstrap_cb(model, x, on, alpha_ci, bound, n_boot, seed):
-    import warnings
-
-    from .degradation_analysis import DegradationAnalysis
-
-    x = np.atleast_1d(np.asarray(x, dtype=float))
-    rng = np.random.default_rng(seed)
-    curves = []
-    # Each resampled fit may emit the usual small-sample path-covariance
-    # warnings; silence them here so a single bootstrap call does not surface
-    # hundreds of duplicates.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        for _ in range(n_boot):
-            picks = rng.choice(len(model.units), size=len(model.units))
-            xs, ys, ids = [], [], []
-            for new_id, idx in enumerate(picks):
-                mask = model.i == model.units[idx]
-                xs.append(model.x[mask])
-                ys.append(model.y[mask])
-                ids.append(np.full(int(mask.sum()), new_id))
-            try:
-                m = DegradationAnalysis.fit(
-                    np.concatenate(xs),
-                    np.concatenate(ys),
-                    np.concatenate(ids),
-                    threshold=model.threshold,
-                    path=model.path_model,
-                    distribution=model._distribution,
-                    how=model._how,
-                )
-                curves.append(np.asarray(getattr(m, _on_method(on))(x)))
-            except Exception:
-                continue
-    if len(curves) < 2:
-        raise RuntimeError(
-            "The degradation bootstrap produced too few successful refits to "
-            "form a confidence bound."
-        )
-    curves = np.asarray(curves)
-    alpha, _ = _bound_signs(alpha_ci, bound)
-    if bound == "two-sided":
-        lo = np.quantile(curves, alpha_ci / 2.0, axis=0)
-        hi = np.quantile(curves, 1.0 - alpha_ci / 2.0, axis=0)
-        return np.stack([lo, hi], axis=-1)
-    q = alpha_ci if bound == "lower" else 1.0 - alpha_ci
-    return np.quantile(curves, q, axis=0)
-
-
-def bootstrap_cb_accelerated(model, x, Z, on, alpha_ci, bound, n_boot, seed):
+def bootstrap_cb(model, x, on, alpha_ci, bound, n_boot, seed, Z=None):
     """
-    Two-stage bootstrap confidence bounds for an *accelerated* (covariate)
-    degradation model, evaluated at the stress ``Z``.
+    Two-stage bootstrap confidence bounds: resample units with
+    replacement and rerun the whole pipeline (per-unit path fit ->
+    pseudo failure time -> life fit) on each resample, so the
+    first-stage path/extrapolation uncertainty is folded in.
 
-    Units are resampled with replacement -- each carrying its stress row --
-    and the whole accelerated pipeline (per-unit path fit -> pseudo failure
-    time -> covariate life fit) is rerun on each resample, so the first-stage
-    path/extrapolation uncertainty is folded into the reliability at ``Z``
-    just as it is for the plain model. The selected path model is held fixed
-    across resamples (matching ``path="best"``'s chosen model), so the bound
-    reflects life-fit and extrapolation variability, not path re-selection.
+    For an *accelerated* (covariate) model pass the stress ``Z`` to
+    evaluate at: each resampled unit carries its stress row and the
+    covariate life fit is rerun per resample. The selected path model is
+    held fixed across resamples (matching ``path="best"``'s chosen
+    model), so the bound reflects life-fit and extrapolation
+    variability, not path re-selection. Refits whose curve is not
+    finite everywhere are dropped rather than poisoning the quantiles.
     """
     import warnings
 
@@ -296,6 +249,9 @@ def bootstrap_cb_accelerated(model, x, Z, on, alpha_ci, bound, n_boot, seed):
     method_name = _on_method(on)
     n_units = len(model.units)
     curves = []
+    # Each resampled fit may emit the usual small-sample path-covariance
+    # warnings; silence them here so a single bootstrap call does not surface
+    # hundreds of duplicates.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         for _ in range(n_boot):
@@ -307,7 +263,8 @@ def bootstrap_cb_accelerated(model, x, Z, on, alpha_ci, bound, n_boot, seed):
                 xs.append(model.x[mask])
                 ys.append(model.y[mask])
                 ids.append(np.full(n_meas, new_id))
-                Zs.append(np.tile(model.Z[idx], (n_meas, 1)))
+                if Z is not None:
+                    Zs.append(np.tile(model.Z[idx], (n_meas, 1)))
             try:
                 m = DegradationAnalysis.fit(
                     np.concatenate(xs),
@@ -317,18 +274,26 @@ def bootstrap_cb_accelerated(model, x, Z, on, alpha_ci, bound, n_boot, seed):
                     path=model.path_model,
                     distribution=model._distribution,
                     how=model._how,
-                    Z=np.concatenate(Zs),
+                    Z=None if Z is None else np.concatenate(Zs),
                 )
-                curve = np.asarray(getattr(m, method_name)(x, Z), dtype=float)
+                curve_fn = getattr(m, method_name)
+                curve = np.asarray(
+                    curve_fn(x) if Z is None else curve_fn(x, Z), dtype=float
+                )
                 if np.isfinite(curve).all():
                     curves.append(curve)
             except Exception:
                 continue
     if len(curves) < 2:
+        detail = (
+            " (a resample may not span enough stress levels to identify "
+            "the covariate fit)"
+            if Z is not None
+            else ""
+        )
         raise RuntimeError(
-            "The accelerated degradation bootstrap produced too few "
-            "successful refits to form a confidence bound (a resample may not "
-            "span enough stress levels to identify the covariate fit)."
+            "The degradation bootstrap produced too few successful refits "
+            "to form a confidence bound" + detail + "."
         )
     curves = np.asarray(curves)
     if bound == "two-sided":

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -31,7 +31,6 @@ from surpyval.univariate.regression.parametric_regression_model import (
 from ._bounds import (
     analytic_cb,
     bootstrap_cb,
-    bootstrap_cb_accelerated,
     life_parameter_covariance,
 )
 from .path_models import PATH_MODELS, PathModel, get_path_model
@@ -1069,8 +1068,8 @@ class DegradationModel(SerialisableMixin):
                     "regression bounds."
                 )
             if method == "bootstrap":
-                return bootstrap_cb_accelerated(
-                    self, x, Z, on, alpha_ci, bound, n_boot, seed
+                return bootstrap_cb(
+                    self, x, on, alpha_ci, bound, n_boot, seed, Z=Z
                 )
             raise ValueError("`method` must be 'analytic' or 'bootstrap'")
         if method == "analytic":

--- a/surpyval/multivariate/parametric/copula/copula_model.py
+++ b/surpyval/multivariate/parametric/copula/copula_model.py
@@ -3,11 +3,12 @@
 import numpy as onp
 
 from surpyval.distribution import MultivariateDistribution
+from surpyval.serialisation import SerialisableMixin, stamp_schema
 
 _EPS = 1e-10
 
 
-class CopulaModel(MultivariateDistribution):
+class CopulaModel(SerialisableMixin, MultivariateDistribution):
     """A fitted bivariate copula glued to two univariate margins.
 
     Attributes
@@ -90,13 +91,47 @@ class CopulaModel(MultivariateDistribution):
         margins = []
         for m in self.margins:
             margins.append(m.to_dict() if hasattr(m, "to_dict") else None)
-        return {
-            "parameterization": "copula",
-            "copula": self.copula.name,
-            "params": self.params.tolist(),
-            "how": self.method,
-            "margins": margins,
+        return stamp_schema(
+            {
+                "parameterization": "copula",
+                "copula": self.copula.name,
+                "params": self.params.tolist(),
+                "how": self.method,
+                "margins": margins,
+            }
+        )
+
+    @classmethod
+    def from_dict(cls, model_dict):
+        import surpyval
+        from .archimedean import Clayton, Frank, Gumbel, Independence
+        from .elliptical import Gaussian
+
+        families = {
+            c.name: c for c in (Independence, Clayton, Gumbel, Frank, Gaussian)
         }
+        copula_name = model_dict["copula"]
+        if copula_name not in families:
+            raise ValueError(
+                f"Unknown copula family {copula_name!r}; expected one of "
+                f"{sorted(families)}. A custom copula cannot be rebuilt "
+                "from its name alone."
+            )
+        margins = []
+        for i, m in enumerate(model_dict["margins"]):
+            if m is None:
+                raise ValueError(
+                    f"Margin {i} was not serialisable (it has no `to_dict`), "
+                    "so this copula model cannot be rebuilt."
+                )
+            margins.append(surpyval.from_dict(m))
+        return cls(
+            families[copula_name],
+            model_dict["params"],
+            margins,
+            data=None,
+            how=model_dict.get("how", "given"),
+        )
 
     def __repr__(self):
         param_str = ", ".join(

--- a/surpyval/recurrent/parametric/nhpp_fitter.py
+++ b/surpyval/recurrent/parametric/nhpp_fitter.py
@@ -11,50 +11,12 @@ from surpyval.utils.recurrent_utils import handle_xicn
 
 class NHPPFitter(IntensityModel):
     def create_negll_func(self, data):
-        x, c, n = data.x, data.c, data.n
-        x_prev = data.get_previous_x()
-
-        has_interval_censoring = True if 2 in c else False
-        has_observed = True if 0 in c else False
-        has_left_censoring = True if -1 in c else False
-        has_right_censoring = True if 1 in c else False
-
-        x_l = x if x.ndim == 1 else x[:, 0]
-        x_r = x[:, 1] if x.ndim == 2 else None
-
-        x_prev_l = (
-            x_prev if x_prev.ndim == 1 else x_prev[:, 0]
-        )  # not x[:, 0] (#288)
-        x_prev_r = x_prev[:, 1] if x_prev.ndim == 2 else None
-
-        x_o = x_l[c == 0] if has_observed else np.array([])
-        if has_interval_censoring:
-            x_o_prev = x_prev_r[c == 0] if has_observed else np.array([])
-        else:
-            x_o_prev = x_prev_l[c == 0] if has_observed else np.array([])
-
-        x_right = x_l[c == 1] if has_right_censoring else np.array([])
-        if has_interval_censoring:
-            x_right_prev = (
-                x_prev_r[c == 1] if has_right_censoring else np.array([])
-            )
-        else:
-            x_right_prev = (
-                x_prev_l[c == 1] if has_right_censoring else np.array([])
-            )
-
-        x_left = x_l[c == -1] if has_left_censoring else np.array([])
-        n_left = n[c == -1] if has_left_censoring else np.array([])
-
-        x_i_l = x_l[c == 2] if has_interval_censoring else np.array([])
-        x_i_r = x_r[c == 2] if has_interval_censoring else np.array([])
-        n_i = n[c == 2] if has_interval_censoring else np.array([])
-
-        # Right window-close: for items with a finite right-truncation time
-        # ``tr`` the intensity is integrated out to ``tr`` rather than
-        # merely to the last observed event / censoring row. These arrays are
-        # empty for untruncated data, so the term adds nothing in that case.
-        x_close_last, x_close_tr, _ = data.get_right_truncation_close()
+        s = data.split_for_nhpp_likelihood()
+        x_o, x_o_prev = s["x_o"], s["x_o_prev"]
+        x_right, x_right_prev = s["x_right"], s["x_right_prev"]
+        x_left, n_left = s["x_left"], s["n_left"]
+        x_i_l, x_i_r, n_i = s["x_i_l"], s["x_i_r"], s["n_i"]
+        x_close_last, x_close_tr = s["x_close_last"], s["x_close_tr"]
 
         # Using the empty arrays avoids the need for if statements in the
         # likelihood function. It also means that the likelihood function

--- a/surpyval/recurrent/regression/nhpp_proportional_intensity.py
+++ b/surpyval/recurrent/regression/nhpp_proportional_intensity.py
@@ -64,66 +64,30 @@ class ProportionalIntensityNHPP:
     """
 
     def create_negll_func(self, data, dist):
-        x, c, n = data.x, data.c, data.n
         Z = data.Z
-        # Covariates
-        x_prev = data.get_previous_x()
+        s = data.split_for_nhpp_likelihood()
+        x_o, x_o_prev = s["x_o"], s["x_o_prev"]
+        x_right, x_right_prev = s["x_right"], s["x_right_prev"]
+        x_left, n_left = s["x_left"], s["n_left"]
+        x_i_l, x_i_r, n_i = s["x_i_l"], s["x_i_r"], s["n_i"]
+        x_close_last, x_close_tr = s["x_close_last"], s["x_close_tr"]
 
-        has_interval_censoring = True if 2 in c else False
-        has_observed = True if 0 in c else False
-        has_left_censoring = True if -1 in c else False
-        has_right_censoring = True if 1 in c else False
-
-        x_l = x if x.ndim == 1 else x[:, 0]
-        x_r = x[:, 1] if x.ndim == 2 else None
-
-        x_prev_l = (
-            x_prev if x_prev.ndim == 1 else x_prev[:, 0]
-        )  # not x[:, 0] (#288)
-        x_prev_r = x_prev[:, 1] if x_prev.ndim == 2 else None
-
-        # Untangle the observed data
-        x_o = x_l[c == 0] if has_observed else np.array([])
-        if has_interval_censoring:
-            x_o_prev = x_prev_r[c == 0] if has_observed else np.array([])
-        else:
-            x_o_prev = x_prev_l[c == 0] if has_observed else np.array([])
-        Z_o = Z[c == 0] if has_observed else np.zeros((1, Z.shape[1]))
-
-        # Untangle the right censored data
-        x_right = x_l[c == 1] if has_right_censoring else np.array([])
-        if has_interval_censoring:
-            x_right_prev = (
-                x_prev_r[c == 1] if has_right_censoring else np.array([])
-            )
-        else:
-            x_right_prev = (
-                x_prev_l[c == 1] if has_right_censoring else np.array([])
-            )
+        # Covariate rows gathered with the same masks; the zeros((1, p))
+        # placeholders keep the dot products defined when a censoring
+        # type is absent (the matching x arrays are empty, so the terms
+        # vanish in the sums).
+        p_cov = Z.shape[1]
+        Z_o = Z[s["mask_o"]] if s["mask_o"].any() else np.zeros((1, p_cov))
         Z_right = (
-            Z[c == 1] if has_right_censoring else np.zeros((1, Z.shape[1]))
+            Z[s["mask_right"]]
+            if s["mask_right"].any()
+            else np.zeros((1, p_cov))
         )
-
-        # Untangle the left censored data
-        x_left = x_l[c == -1] if has_left_censoring else np.array([])
-        n_left = n[c == -1] if has_left_censoring else np.array([])
         Z_left = (
-            Z[c == -1] if has_left_censoring else np.zeros((1, Z.shape[1]))
+            Z[s["mask_left"]] if s["mask_left"].any() else np.zeros((1, p_cov))
         )
-
-        # Untangle the interval censored data
-        x_i_l = x_l[c == 2] if has_interval_censoring else np.array([])
-        x_i_r = x_r[c == 2] if has_interval_censoring else np.array([])
-        n_i = n[c == 2] if has_interval_censoring else np.array([])
-        Z_i = (
-            Z[c == 2] if has_interval_censoring else np.zeros((1, Z.shape[1]))
-        )
-
-        # Right window-close: for items with a finite right-truncation time
-        # ``tr`` the baseline intensity is integrated out to ``tr`` (scaled by
-        # the item's proportional factor). Empty for untruncated data.
-        x_close_last, x_close_tr, close_idx = data.get_right_truncation_close()
-        Z_close = Z[close_idx]
+        Z_i = Z[s["mask_i"]] if s["mask_i"].any() else np.zeros((1, p_cov))
+        Z_close = Z[s["close_idx"]]
 
         # Using the empty arrays avoids the need for if statements in the
         # likelihood function. It also means that the likelihood function

--- a/surpyval/serialisation.py
+++ b/surpyval/serialisation.py
@@ -97,6 +97,10 @@ _PARAMETERIZATIONS: dict[str, tuple[str, str]] = {
         "surpyval.univariate.regression.parametric_regression_model",
         "ParametricRegressionModel",
     ),
+    "copula": (
+        "surpyval.multivariate.parametric.copula.copula_model",
+        "CopulaModel",
+    ),
 }
 
 

--- a/surpyval/tests/multivariate/test_copula_serialisation.py
+++ b/surpyval/tests/multivariate/test_copula_serialisation.py
@@ -1,0 +1,62 @@
+"""CopulaModel to_dict/from_dict round-trip (#299).
+
+CopulaModel.to_dict used to be the only serialiser without a schema
+stamp or a reader — it wrote dictionaries nothing could load.
+"""
+
+import numpy as np
+import pytest
+
+import surpyval
+from surpyval import Weibull
+from surpyval.multivariate import Clayton, CopulaModel, Gaussian
+
+PTS = np.array([[3.0, 2.0], [8.0, 4.0], [1.0, 6.0]])
+
+
+def _model(copula, theta):
+    return copula.from_params(
+        theta,
+        margins=[Weibull.from_params([10, 2]), Weibull.from_params([5, 1.5])],
+    )
+
+
+@pytest.mark.parametrize("copula,theta", [(Clayton, 2.0), (Gaussian, 0.6)])
+def test_round_trip_preserves_predictions(copula, theta):
+    m = _model(copula, theta)
+    d = m.to_dict()
+    assert d["schema"] == 1
+    assert d["parameterization"] == "copula"
+    r = surpyval.from_dict(d)
+    assert isinstance(r, CopulaModel)
+    np.testing.assert_allclose(r.sf(PTS), m.sf(PTS), rtol=0, atol=0)
+    np.testing.assert_allclose(r.cdf(PTS), m.cdf(PTS), rtol=0, atol=0)
+    np.testing.assert_allclose(r.pdf(PTS), m.pdf(PTS), rtol=0, atol=0)
+    assert r.method == m.method
+
+
+def test_json_file_round_trip(tmp_path):
+    m = _model(Clayton, 2.0)
+    fp = tmp_path / "copula.json"
+    m.to_json(str(fp))
+    r = CopulaModel.from_json(str(fp))
+    np.testing.assert_allclose(r.sf(PTS), m.sf(PTS), rtol=0, atol=0)
+
+
+def test_fitted_model_round_trips():
+    m0 = _model(Clayton, 2.0)
+    x = m0.random(150, random_state=3)
+    m = Clayton.fit(x, margins=[Weibull, Weibull])
+    r = surpyval.from_dict(m.to_dict())
+    np.testing.assert_allclose(r.sf(PTS), m.sf(PTS), rtol=0, atol=0)
+    np.testing.assert_allclose(
+        np.atleast_1d(r.params), np.atleast_1d(m.params), rtol=0, atol=0
+    )
+
+
+def test_unknown_family_rejected():
+    m = _model(Clayton, 2.0)
+    d = m.to_dict()
+    d["copula"] = "NotACopula"
+    with pytest.raises(ValueError, match="Unknown copula family"):
+        surpyval.from_dict(d)

--- a/surpyval/univariate/competing_risks/aalen_johansen.py
+++ b/surpyval/univariate/competing_risks/aalen_johansen.py
@@ -1,0 +1,24 @@
+"""Shared Aalen-Johansen incidence increment (#299).
+
+The S(t-) weighting that turns cause-specific hazard increments into
+cumulative-incidence increments was implemented three times (the
+nonparametric CIF, the CR-PH ``cif`` and Gray's pooled CIF), and one of
+those copies went wrong (#278). It now lives here once.
+"""
+
+import numpy as np
+
+
+def aalen_johansen_iif(S, hazard_increments):
+    """Instantaneous incidence increments.
+
+    The cause-specific hazard increment at ``t_i`` acts on the
+    population still alive just *before* ``t_i``, so each increment is
+    weighted by ``S(t_i-)`` — the survival after the previous event
+    time — not ``S(t_i)`` (#253). ``S`` and the last axis of
+    ``hazard_increments`` must be aligned on the same event-time grid;
+    the cumulative incidence is the cumulative sum of the result.
+    """
+    S = np.asarray(S, dtype=float)
+    S_prev = np.concatenate([[1.0], S[:-1]])
+    return np.asarray(hazard_increments) * S_prev

--- a/surpyval/univariate/competing_risks/nonparametric/competing_risks.py
+++ b/surpyval/univariate/competing_risks/nonparametric/competing_risks.py
@@ -12,6 +12,9 @@ import textwrap
 import numpy as np
 
 import surpyval as surv
+from surpyval.univariate.competing_risks.aalen_johansen import (
+    aalen_johansen_iif,
+)
 from surpyval.univariate.nonparametric.kaplan_meier import kaplan_meier as km
 from surpyval.univariate.nonparametric.nelson_aalen import nelson_aalen as na
 from surpyval.utils import (
@@ -222,16 +225,12 @@ class CompetingRisks(SerialisableMixin):
         model.d_e = d_e
         model.h0_e = d_e / r
         model.H0_e = model.h0_e.cumsum(axis=1)
-        # Aalen-Johansen increment: the cause-specific hazard at t_i acts on
-        # the population still alive just *before* t_i, so the incidence
-        # weight is S(t_i-) — the survival after the previous event time —
-        # not S(t_i) (#253). The weight must be the *product-limit* (KM)
-        # survival regardless of the estimator reported as sf: only KM
-        # satisfies the telescoping identity sum_j S(t-)·d_j/r = 1 - S(t),
-        # so pairing the discrete hazard increment with exp(-H) inflates
+        # The incidence weight must be the *product-limit* (KM) survival
+        # regardless of the estimator reported as sf: only KM satisfies
+        # the telescoping identity sum_j S(t-)·d_j/r = 1 - S(t), so
+        # pairing the discrete hazard increment with exp(-H) inflates
         # the CIF and can push the total incidence past 1 (#278).
         S_km = S if method == "Kaplan-Meier" else km(r, d)
-        S_prev = np.concatenate([[1.0], S_km[:-1]])
-        model.IIF = S_prev * model.h0_e
+        model.IIF = aalen_johansen_iif(S_km, model.h0_e)
         model.CIF = model.IIF.cumsum(axis=1)
         return model

--- a/surpyval/univariate/competing_risks/nonparametric/gray_test.py
+++ b/surpyval/univariate/competing_risks/nonparametric/gray_test.py
@@ -20,6 +20,10 @@ from typing import Any, NamedTuple
 import numpy as np
 from scipy.stats import chi2
 
+from surpyval.univariate.competing_risks.aalen_johansen import (
+    aalen_johansen_iif,
+)
+
 
 class GrayTestResult(NamedTuple):
     statistic: float
@@ -190,15 +194,17 @@ def _pooled_cif(x, all_event, is_cause, n, cause_times) -> np.ndarray:
     """Aalen-Johansen cumulative incidence of the cause on the pooled sample,
     evaluated at ``cause_times``."""
     times = np.unique(x)
-    surv = 1.0
-    cif = 0.0
-    out = {}
-    for t in times:
-        at_risk = n[x >= t].sum()
-        d_all = n[all_event & (x == t)].sum()
-        d_k = n[is_cause & (x == t)].sum()
-        if at_risk > 0:
-            cif += surv * d_k / at_risk
-            surv *= 1.0 - d_all / at_risk
-        out[t] = cif
-    return np.array([out[t] for t in cause_times])
+    t_idx = np.searchsorted(times, x)
+    counts = np.zeros(times.shape)
+    np.add.at(counts, t_idx, n)
+    # Everyone with x >= t is at risk at t.
+    r = counts[::-1].cumsum()[::-1]
+    d_all = np.zeros(times.shape)
+    np.add.at(d_all, t_idx[all_event], n[all_event])
+    d_k = np.zeros(times.shape)
+    np.add.at(d_k, t_idx[is_cause], n[is_cause])
+    h_all = np.where(r > 0, d_all / np.where(r > 0, r, 1.0), 0.0)
+    h_k = np.where(r > 0, d_k / np.where(r > 0, r, 1.0), 0.0)
+    S_km = np.cumprod(1.0 - h_all)
+    cif = aalen_johansen_iif(S_km, h_k).cumsum()
+    return cif[np.searchsorted(times, cause_times)]

--- a/surpyval/univariate/competing_risks/regression/competing_risks_proportional_hazard.py
+++ b/surpyval/univariate/competing_risks/regression/competing_risks_proportional_hazard.py
@@ -9,6 +9,9 @@ Copyright 2022 Cartiga LLC
 
 import numpy as np
 
+from surpyval.univariate.competing_risks.aalen_johansen import (
+    aalen_johansen_iif,
+)
 from surpyval.univariate.regression import CoxPH
 from surpyval.utils import (
     _get_idx,
@@ -111,13 +114,7 @@ class CompetingRisksProportionalHazards:
 
         lambda_e = self.hf(self.x, Z, event)
         S = self.sf(self.x, Z)
-        # Aalen-Johansen increment: the hazard at t_i acts on the population
-        # alive just *before* t_i, so weight by S(t_i-) — the survival after
-        # the previous event time — not S(t_i) (#253).
-        S_prev = np.concatenate([[1.0], S[:-1]])
-        # iif = instantaneous incidence function
-        iif = lambda_e * S_prev
-        cif = iif.cumsum()
+        cif = aalen_johansen_iif(S, lambda_e).cumsum()
 
         # Times before the first event would wrap to the last value (#253).
         return np.where(idx[rev] < 0, 0.0, cif[idx][rev])

--- a/surpyval/univariate/information_criteria.py
+++ b/surpyval/univariate/information_criteria.py
@@ -1,0 +1,162 @@
+"""Shared information-criterion methods (#298).
+
+``Parametric`` and ``ParametricRegressionModel`` carried near-identical
+``neg_ll``/``aic``/``bic``/``aic_c`` implementations. They differed only
+in how the fitted data is stored (an xcnt dict versus a ``SurpyvalData``
+object) and in one deliberate convention difference: the small-sample
+AIC correction term uses ``self.k`` for univariate models but
+``len(self.params)`` for regression models. Both are preserved exactly
+through the ``_ic_counts``/``_ic_k_aic_c`` hooks so fitted values do not
+change.
+"""
+
+import numpy as np
+
+
+class InformationCriteriaMixin:
+    """Log-likelihood based model-selection criteria.
+
+    Requires the host class to set ``self.k`` (penalised parameter
+    count), ``self._neg_ll`` and ``self.data`` when fitted, and to
+    implement ``_ic_counts`` returning ``(n_observed, n_total)`` — the
+    weighted count of exactly-observed events and of all observations.
+    """
+
+    # Set by the host class when fitted; annotated (not assigned) so the
+    # hasattr-based caching below still works.
+    k: int
+    _neg_ll: float
+    _bic: float
+    _aic: float
+    _aic_c: float
+
+    def _ic_counts(self):
+        raise NotImplementedError
+
+    def _ic_k_aic_c(self):
+        # The parameter count used in the aic_c correction term.
+        return self.k
+
+    def neg_ll(self) -> float:
+        r"""
+
+        The negative log-likelihood for the model, if it was fit with the
+        ``fit()`` method. Not available if fit with the ``from_params()``
+        method.
+
+        Returns
+        -------
+
+        neg_ll : float
+            The negative log-likelihood of the model
+
+        Examples
+        --------
+
+        >>> from surpyval import Weibull
+        >>> import numpy as np
+        >>> np.random.seed(1)
+        >>> x = Weibull.random(100, 10, 3)
+        >>> model = Weibull.fit(x)
+        >>> model.neg_ll()
+        262.52685642385734
+        """
+        if getattr(self, "data", None) is None:
+            raise ValueError("Must have been fit with data")
+
+        return self._neg_ll
+
+    def bic(self) -> float:
+        r"""
+
+        The Bayesian Information Criterion (BIC) for the model, if it
+        was fit with the ``fit()`` method. Not available if fit with the
+        ``from_params()`` method.
+
+        Returns
+        -------
+
+        bic : float
+            The BIC of the model
+
+        Examples
+        --------
+
+        >>> from surpyval import Weibull
+        >>> import numpy as np
+        >>> np.random.seed(1)
+        >>> x = Weibull.random(100, 10, 3)
+        >>> model = Weibull.fit(x)
+        >>> model.bic()
+        534.2640532196908
+
+        References
+        ----------
+
+        `Bayesian Information Criterion for Censored Survival Models
+        <https://www.jstor.org/stable/2677130>`_.
+
+        """
+        if hasattr(self, "_bic"):
+            return self._bic
+        n_observed, _ = self._ic_counts()
+        self._bic = self.k * np.log(n_observed) + 2 * self.neg_ll()
+        return self._bic
+
+    def aic(self) -> float:
+        r"""
+        The Aikake Information Criterion (AIC) for the model, if it was
+        fit with the ``fit()`` method. Not available if fit with the
+        ``from_params()`` method.
+
+        Returns
+        -------
+
+        aic : float
+            The AIC of the model
+
+        Examples
+        --------
+
+        >>> from surpyval import Weibull
+        >>> import numpy as np
+        >>> np.random.seed(1)
+        >>> x = Weibull.random(100, 10, 3)
+        >>> model = Weibull.fit(x)
+        >>> model.aic()
+        529.0537128477147
+        """
+        if hasattr(self, "_aic"):
+            return self._aic
+        self._aic = 2 * self.k + 2 * self.neg_ll()
+        return self._aic
+
+    def aic_c(self) -> float:
+        r"""
+        The Corrected Aikake Information Criterion (AIC) for the model,
+        if it was fit with the ``fit()`` method. Not available if fit with
+        the ``from_params()`` method.
+
+        Returns
+        -------
+
+        aic_c : float
+            The Corrected AIC of the model
+
+        Examples
+        --------
+
+        >>> from surpyval import Weibull
+        >>> import numpy as np
+        >>> np.random.seed(1)
+        >>> x = Weibull.random(100, 10, 3)
+        >>> model = Weibull.fit(x)
+        >>> model.aic_c()
+        529.1774241879209
+        """
+        if hasattr(self, "_aic_c"):
+            return self._aic_c
+        k = self._ic_k_aic_c()
+        _, n = self._ic_counts()
+        self._aic_c = self.aic() + (2 * k**2 + 2 * k) / (n - k - 1)
+        return self._aic_c

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from surpyval.utils.surpyval_data import SurpyvalData
 
 from surpyval.serialisation import SerialisableMixin, stamp_schema, to_native
+from surpyval.univariate.information_criteria import InformationCriteriaMixin
 
 from .probability_plotting import (
     adjust_heuristic,
@@ -35,7 +36,9 @@ from .probability_plotting import (
 _CBContext = namedtuple("_CBContext", ["phi_hat", "cov", "n_core"])
 
 
-class Parametric(SerialisableMixin, ParametricDistribution):
+class Parametric(
+    InformationCriteriaMixin, SerialisableMixin, ParametricDistribution
+):
     """
     Result of ``.fit()`` or ``.from_params()`` method for every parametric
     surpyval distribution.
@@ -1450,136 +1453,12 @@ class Parametric(SerialisableMixin, ParametricDistribution):
             cb = cb.T
         return cb
 
-    def neg_ll(self) -> float:
-        r"""
-
-        The negative log-likelihood for the model, if it was fit with the
-        ``fit()`` method. Not available if fit with the ``from_params()``
-        method.
-
-        Returns
-        -------
-
-        neg_ll : float
-            The negative log-likelihood of the model
-
-        Examples
-        --------
-
-        >>> from surpyval import Weibull
-        >>> import numpy as np
-        >>> np.random.seed(1)
-        >>> x = Weibull.random(100, 10, 3)
-        >>> model = Weibull.fit(x)
-        >>> model.neg_ll()
-        262.52685642385734
-        """
-        if self.data is None:
-            raise ValueError("Must have been fit with data")
-
-        return self._neg_ll
-
-    def bic(self) -> float:
-        r"""
-
-        The Bayesian Information Criterion (BIC) for the model, if it
-        was fit with the ``fit()`` method. Not available if fit with the
-        ``from_params()`` method.
-
-        Returns
-        -------
-
-        bic : float
-            The BIC of the model
-
-        Examples
-        --------
-
-        >>> from surpyval import Weibull
-        >>> import numpy as np
-        >>> np.random.seed(1)
-        >>> x = Weibull.random(100, 10, 3)
-        >>> model = Weibull.fit(x)
-        >>> model.bic()
-        534.2640532196908
-
-        References
-        ----------
-
-        `Bayesian Information Criterion for Censored Survival Models
-        <https://www.jstor.org/stable/2677130>`_.
-
-        """
-        if hasattr(self, "_bic"):
-            return self._bic
-        else:
-            self._bic = (
-                self.k * np.log(self.data["n"][self.data["c"] == 0].sum())
-                + 2 * self.neg_ll()
-            )
-            return self._bic
-
-    def aic(self) -> float:
-        r"""
-        The Aikake Information Criterion (AIC) for the model, if it was
-        fit with the ``fit()`` method. Not available if fit with the
-        ``from_params()`` method.
-
-        Returns
-        -------
-
-        aic : float
-            The AIC of the model
-
-        Examples
-        --------
-
-        >>> from surpyval import Weibull
-        >>> import numpy as np
-        >>> np.random.seed(1)
-        >>> x = Weibull.random(100, 10, 3)
-        >>> model = Weibull.fit(x)
-        >>> model.aic()
-        529.0537128477147
-        """
-        if hasattr(self, "_aic"):
-            return self._aic
-        else:
-            self._aic = 2 * self.k + 2 * self.neg_ll()
-            return self._aic
-
-    def aic_c(self) -> float:
-        r"""
-        The Corrected Aikake Information Criterion (AIC) for the model,
-        if it was fit with the ``fit()`` method. Not available if fit with
-        the ``from_params()`` method.
-
-        Returns
-        -------
-
-        aic_c : float
-            The Corrected AIC of the model
-
-        Examples
-        --------
-
-        >>> from surpyval import Weibull
-        >>> import numpy as np
-        >>> np.random.seed(1)
-        >>> x = Weibull.random(100, 10, 3)
-        >>> model = Weibull.fit(x)
-        >>> model.aic()
-        529.1774241879209
-        """
-        if hasattr(self, "_aic_c"):
-            return self._aic_c
-        else:
-            # Same parameter count as the aic() penalty it corrects —
-            # including gamma / p / f0 when fitted (#256).
-            k = self.k
-            n = self.data["n"].sum()
-            self._aic_c = self.aic() + (2 * k**2 + 2 * k) / (n - k - 1)
-            return self._aic_c
+    # neg_ll/aic/bic/aic_c come from InformationCriteriaMixin. The aic_c
+    # correction uses the same parameter count as the aic() penalty it
+    # corrects — including gamma / p / f0 when fitted (#256).
+    def _ic_counts(self):
+        n, c = self.data["n"], self.data["c"]
+        return n[c == 0].sum(), n.sum()
 
     def get_plot_data(
         self, heuristic: str = "Nelson-Aalen", alpha_ci: float = 0.05

--- a/surpyval/univariate/regression/_fit_skeleton.py
+++ b/surpyval/univariate/regression/_fit_skeleton.py
@@ -1,0 +1,186 @@
+"""Shared ``fit()`` plumbing for the parametric regression families.
+
+PH, AFT, PO and (parametric) AH used to carry five copy-pasted versions
+of the same skeleton — data prep, the #251 param-map offset merge,
+``bounds_convert``, optimisation, and model assembly — which had already
+drifted (different optimiser ladders, only some families setting
+``dist_params``/``phi_params``). The skeleton now lives here once; each
+family supplies only its optimiser strategy and covariate-link object
+(#295). The Accelerated Life parameter-substitution fitter remains
+separate: its life-model parameter juggling does not fit this shape.
+"""
+
+from typing import Any, Callable
+
+import autograd.numpy as np
+from scipy.optimize import minimize
+
+from surpyval.univariate.parametric.fitters import bounds_convert
+from surpyval.utils.surpyval_data import SurpyvalData
+
+from .parametric_regression_model import ParametricRegressionModel
+
+
+class LogLinearPhi:
+    """The ``exp(beta'Z)`` covariate link shared by PH, AFT and PO —
+    previously defined inline in at least seven places (#295).
+
+    ``name`` must match the family's serialisation tag exactly (PH
+    historically uses ``e^`` where AFT/PO use ``exp``), so it is a
+    constructor argument.
+    """
+
+    def __init__(self, name: str, phi_param_map: dict):
+        self.name = name
+        self.phi_param_map = phi_param_map
+
+    @staticmethod
+    def phi(Z, *params):
+        return np.exp(np.dot(Z, np.array(params)))
+
+    @staticmethod
+    def phi_bounds(Z):
+        return ((None, None),) * Z.shape[1]
+
+    @staticmethod
+    def make_param_map(Z):
+        return {"beta_" + str(i): i for i in range(Z.shape[1])}
+
+
+class HazardIdentitiesMixin:
+    """The standard survival identities in terms of ``Hf``/``hf``.
+
+    Any fitter defining ``Hf(x, Z, *params)`` and ``hf(x, Z, *params)``
+    gets ``sf``/``ff``/``df`` and their logs from here instead of
+    carrying its own copy (#297). ``ff`` uses ``-expm1(-H)``, which
+    stays accurate when ``H`` is tiny (the deep left tail), and
+    ``log_df = log(h) - H`` avoids exponentiating and re-logging. For
+    additive-hazard models the hazard can be driven non-positive, in
+    which case ``log_df`` is nan and the MLE machinery rejects the
+    point — the fit fails rather than returning an invalid model.
+    """
+
+    def sf(self, x, Z, *params):
+        return np.exp(-self.Hf(x, Z, *params))
+
+    def ff(self, x, Z, *params):
+        return -np.expm1(-self.Hf(x, Z, *params))
+
+    def df(self, x, Z, *params):
+        return self.hf(x, Z, *params) * np.exp(-self.Hf(x, Z, *params))
+
+    def log_sf(self, x, Z, *params):
+        return -self.Hf(x, Z, *params)
+
+    def log_ff(self, x, Z, *params):
+        return np.log(self.ff(x, Z, *params))
+
+    def log_df(self, x, Z, *params):
+        return np.log(self.hf(x, Z, *params)) - self.Hf(x, Z, *params)
+
+
+def prepare_regression_fit(
+    fitter: Any,
+    x,
+    Z,
+    c,
+    n,
+    t,
+    init,
+    fixed,
+    phi_bounds,
+    phi_param_map,
+    phi_init=None,
+):
+    """Common head of every parametric-regression ``fit``.
+
+    Returns ``(data, fun_builder_inputs)`` where the second element is the
+    tuple ``(init_t, bounds, pmap, transform, inv_trans, const, not_fixed,
+    fixed)`` — everything the family's optimiser step and the final
+    assembly need. ``phi_bounds``/``phi_param_map``/``phi_init`` may be
+    callables of the covariate array or static values.
+    """
+    data = SurpyvalData(x, c, n, t, group_and_sort=False)
+    data.add_covariates(Z)
+
+    fixed = {} if fixed is None else fixed
+    Z_data = np.asarray(data.Z)
+
+    if init is None or len(np.atleast_1d(init)) == 0:
+        ps = fitter.dist.fit_from_surpyval_data(data).params
+        if callable(phi_init):
+            init_phi = phi_init(Z_data)
+        else:
+            init_phi = np.zeros(Z_data.shape[1])
+        init = np.array([*ps, *init_phi])
+    else:
+        init = np.array(init)
+
+    bounds = (
+        *fitter.bounds,
+        *(phi_bounds(Z_data) if callable(phi_bounds) else phi_bounds),
+    )
+    pmap = phi_param_map(Z_data) if callable(phi_param_map) else phi_param_map
+    # The covariate coefficients sit after the distribution parameters in
+    # the packed parameter vector, so their map indices must be offset by
+    # the number of distribution parameters — otherwise
+    # ``fixed={"beta_0": v}`` silently pins the first *distribution*
+    # parameter instead (#251).
+    param_map = {
+        **fitter.param_map,
+        **{k: v + len(fitter.param_map) for k, v in pmap.items()},
+    }
+
+    transform, inv_trans, const, fixed_idx, not_fixed = bounds_convert(
+        data.x, bounds, fixed, param_map
+    )
+    init_t = transform(init)[not_fixed]
+    return data, (init_t, bounds, pmap, transform, inv_trans, const, fixed)
+
+
+def assemble_regression_model(
+    fitter: Any,
+    kind: str,
+    reg_model: Any,
+    data: SurpyvalData,
+    res: Any,
+    params,
+    bounds,
+    pmap: dict,
+    fixed: dict,
+    neg_ll: "float | None" = None,
+) -> ParametricRegressionModel:
+    """Common tail of every parametric-regression ``fit``."""
+    model = ParametricRegressionModel()
+    model.distribution_param_map = fitter.param_map
+    model.phi_param_map = pmap
+    model.model = fitter
+    model.reg_model = reg_model
+    model.kind = kind
+    model.distribution = fitter.dist
+    model.params = np.array(params)
+    model.dist_params = np.array(params[: fitter.k_dist])
+    model.phi_params = np.array(params[fitter.k_dist :])
+    model.res = res
+    model._neg_ll = float(res.fun) if neg_ll is None else neg_ll
+    model.fixed = fixed
+    model.k_dist = fitter.k_dist
+    model.k = len(bounds)
+    model.data = data
+    return model
+
+
+def optimise_ph(fun: Callable, init_t):
+    """PH's historical ladder: default method, then TNC unconditionally."""
+    res = minimize(fun, init_t)
+    return minimize(fun, res.x, method="TNC")
+
+
+def optimise_nm_tnc(fun: Callable, init_t):
+    """AFT/PO's historical ladder: Nelder-Mead, then TNC kept only on
+    success."""
+    res = minimize(
+        fun, init_t, method="Nelder-Mead", options={"maxiter": 1000}
+    )
+    res2 = minimize(fun, res.x, method="TNC")
+    return res2 if res2.success else res

--- a/surpyval/univariate/regression/accelerated_failure_time/aft_fitter.py
+++ b/surpyval/univariate/regression/accelerated_failure_time/aft_fitter.py
@@ -1,11 +1,15 @@
 import autograd.numpy as np
 import numpy.typing as npt
-from scipy.optimize import minimize
 
-from surpyval.univariate.parametric.fitters import bounds_convert
-from surpyval.utils.surpyval_data import SurpyvalData
 
 from .._likelihood import regression_neg_ll
+from .._fit_skeleton import (
+    HazardIdentitiesMixin,
+    LogLinearPhi,
+    assemble_regression_model,
+    optimise_nm_tnc,
+    prepare_regression_fit,
+)
 from ..parametric_regression_model import ParametricRegressionModel
 from ..regression_data import DataFrameRegressionMixin
 from .aft_tvc_fit import AFTTVCFitMixin
@@ -26,7 +30,9 @@ class _LogLinearPhiModel:
         return {"beta_" + str(i): i for i in range(Z.shape[1])}
 
 
-class AFTFitter(AFTTVCFitMixin, DataFrameRegressionMixin):
+class AFTFitter(
+    HazardIdentitiesMixin, AFTTVCFitMixin, DataFrameRegressionMixin
+):
     """
     Accelerated Failure Time fitter using exp(beta'Z) as the acceleration
     factor.
@@ -69,24 +75,6 @@ class AFTFitter(AFTTVCFitMixin, DataFrameRegressionMixin):
         phi_val = self._phi(Z, *phi_params)
         return phi_val * self.hf_dist(phi_val * x, *dist_params)
 
-    def sf(self, x, Z, *params):
-        return np.exp(-self.Hf(x, Z, *params))
-
-    def ff(self, x, Z, *params):
-        return -np.expm1(-self.Hf(x, Z, *params))
-
-    def df(self, x, Z, *params):
-        return self.hf(x, Z, *params) * self.sf(x, Z, *params)
-
-    def log_sf(self, x, Z, *params):
-        return -self.Hf(x, Z, *params)
-
-    def log_ff(self, x, Z, *params):
-        return np.log(self.ff(x, Z, *params))
-
-    def log_df(self, x, Z, *params):
-        return np.log(self.hf(x, Z, *params)) - self.Hf(x, Z, *params)
-
     def neg_ll(self, data, *params):
         return regression_neg_ll(self, data, *params)
 
@@ -100,73 +88,41 @@ class AFTFitter(AFTTVCFitMixin, DataFrameRegressionMixin):
         init: npt.ArrayLike | None = None,
         fixed: dict[str, float] | None = None,
     ) -> ParametricRegressionModel:
-        data = SurpyvalData(x, c, n, t, group_and_sort=False)
-        data.add_covariates(Z)
-
-        if fixed is None:
-            fixed = {}
-
-        if init is None:
-            ps = self.dist.fit_from_surpyval_data(data).params
-            assert data.Z is not None
-            phi_init = np.zeros(data.Z.shape[1])
-            init = np.array([*ps, *phi_init])
-        else:
-            init = np.array(init)
-
-        phi_bounds = self._phi_model.phi_bounds(data.Z)
-        phi_param_map = self._phi_model.phi_param_map(data.Z)
-        bounds = (*self.bounds, *phi_bounds)
-
-        param_map = {
-            **self.param_map,
-            **{k: v + len(self.param_map) for k, v in phi_param_map.items()},
-        }
-
-        transform, inv_trans, const, fixed_idx, not_fixed = bounds_convert(
-            data.x, bounds, fixed, param_map
+        data, prep = prepare_regression_fit(
+            self,
+            x,
+            Z,
+            c,
+            n,
+            t,
+            init,
+            fixed,
+            self._phi_model.phi_bounds,
+            self._phi_model.phi_param_map,
         )
-        init = transform(init)[not_fixed]
+        init_t, bounds, pmap, transform, inv_trans, const, fixed = prep
 
         with np.errstate(all="ignore"):
 
             def fun(params):
                 return self.neg_ll(data, *inv_trans(const(params)))
 
-            res = minimize(
-                fun, init, method="Nelder-Mead", options={"maxiter": 1000}
-            )
-            res2 = minimize(fun, res.x, method="TNC")
-            res = res2 if res2.success else res
+            res = optimise_nm_tnc(fun, init_t)
 
         params = inv_trans(const(res.x))
+        reg_model = LogLinearPhi(_LogLinearPhiModel.name, pmap)
 
-        # Build a lightweight phi model object for ParametricRegressionModel
-        _pm = phi_param_map
-
-        class _PhiModel:
-            name = _LogLinearPhiModel.name
-            phi_param_map = _pm
-
-            def phi(self, Z, *p):
-                return np.exp(np.dot(Z, np.array(p)))
-
-        model = ParametricRegressionModel()
-        model.model = self
-        model.reg_model = _PhiModel()
-        model.kind = "Accelerated Failure Time"
-        model.distribution = self.dist
-        model.params = np.array(params)
-        model.dist_params = np.array(params[: self.k_dist])
-        model.phi_params = np.array(params[self.k_dist :])
-        model.res = res
-        model._neg_ll = res.fun
-        model.fixed = fixed
-        model.k_dist = self.k_dist
-        model.k = len(bounds)
-        model.data = data
-
-        return model
+        return assemble_regression_model(
+            self,
+            "Accelerated Failure Time",
+            reg_model,
+            data,
+            res,
+            params,
+            bounds,
+            pmap,
+            fixed,
+        )
 
 
 def AFT(distribution):

--- a/surpyval/univariate/regression/accelerated_life/parameter_substitution.py
+++ b/surpyval/univariate/regression/accelerated_life/parameter_substitution.py
@@ -8,12 +8,15 @@ from scipy.optimize import minimize
 from surpyval.univariate.parametric.fitters import bounds_convert
 from surpyval.utils.surpyval_data import SurpyvalData
 
+from .._fit_skeleton import HazardIdentitiesMixin
 from .._likelihood import regression_neg_ll
 from ..parametric_regression_model import ParametricRegressionModel
 from ..regression_data import DataFrameRegressionMixin
 
 
-class ParameterSubstitutionFitter(DataFrameRegressionMixin):
+class ParameterSubstitutionFitter(
+    HazardIdentitiesMixin, DataFrameRegressionMixin
+):
     def __init__(
         self,
         kind,
@@ -119,41 +122,9 @@ class ParameterSubstitutionFitter(DataFrameRegressionMixin):
 
         return hf
 
-    def df(self, x, Z, *params):
-        x = np.array(x)
-        if np.isscalar(Z):
-            Z = np.ones_like(x) * Z
-        else:
-            Z = np.array(Z)
-        if Z.ndim == 1:
-            # A 1-D stress vector (one stress variable) becomes a single
-            # column so the per-stress masking below works (#261).
-            Z = Z.reshape(-1, 1)
-        return self.hf(x, Z, *params) * np.exp(-self.Hf(x, Z, *params))
-
-    def sf(self, x, Z, *params):
-        x = np.array(x)
-        if np.isscalar(Z):
-            Z = np.ones_like(x) * Z
-        else:
-            Z = np.array(Z)
-        if Z.ndim == 1:
-            # A 1-D stress vector (one stress variable) becomes a single
-            # column so the per-stress masking below works (#261).
-            Z = Z.reshape(-1, 1)
-        return np.exp(-self.Hf(x, Z, *params))
-
-    def ff(self, x, Z, *params):
-        x = np.array(x)
-        if np.isscalar(Z):
-            Z = np.ones_like(x) * Z
-        else:
-            Z = np.array(Z)
-        if Z.ndim == 1:
-            # A 1-D stress vector (one stress variable) becomes a single
-            # column so the per-stress masking below works (#261).
-            Z = Z.reshape(-1, 1)
-        return -np.expm1(-self.Hf(x, Z, *params))
+    # sf/ff/df and the log identities come from HazardIdentitiesMixin;
+    # Hf and hf above already do the scalar/1-D stress coercion (#261),
+    # so the identities need no preamble of their own.
 
     def _parameter_initialiser_dist(self, x, c=None, n=None, t=None):
         out = []
@@ -177,15 +148,6 @@ class ParameterSubstitutionFitter(DataFrameRegressionMixin):
 
     def mpp_x_transform(self, x, gamma=0):
         return x - gamma
-
-    def log_df(self, x, Z, *params):
-        return np.log(self.hf(x, Z, *params)) - self.Hf(x, Z, *params)
-
-    def log_sf(self, x, Z, *params):
-        return -self.Hf(x, Z, *params)
-
-    def log_ff(self, x, Z, *params):
-        return np.log(self.ff(x, Z, *params))
 
     def random(self, size, Z, *params):
         dist_params = np.array(params[0 : self.k_dist])

--- a/surpyval/univariate/regression/additive_hazards/additive_hazards_fitter.py
+++ b/surpyval/univariate/regression/additive_hazards/additive_hazards_fitter.py
@@ -34,10 +34,14 @@ import autograd.numpy as np
 import numpy.typing as npt
 from scipy.optimize import minimize
 
-from surpyval.univariate.parametric.fitters import bounds_convert
-from surpyval.utils.surpyval_data import SurpyvalData
 
 from .._likelihood import regression_neg_ll
+from .._fit_skeleton import (
+    HazardIdentitiesMixin,
+    LogLinearPhi,
+    assemble_regression_model,
+    prepare_regression_fit,
+)
 from ..parametric_regression_model import ParametricRegressionModel
 from ..regression_data import DataFrameRegressionMixin
 from ..tvc_fit import TVCFitMixin
@@ -50,7 +54,9 @@ class _AdditiveReg:
     phi_param_map: object
 
 
-class AdditiveHazardsFitter(TVCFitMixin, DataFrameRegressionMixin):
+class AdditiveHazardsFitter(
+    HazardIdentitiesMixin, TVCFitMixin, DataFrameRegressionMixin
+):
     def __init__(self, name, dist):
         self.name = name
         self.dist = dist
@@ -78,26 +84,9 @@ class AdditiveHazardsFitter(TVCFitMixin, DataFrameRegressionMixin):
         beta = params[self.k_dist :]
         return self.Hf_dist(x, *dist_params) + x * self._beta_Z(Z, beta)
 
-    def sf(self, x, Z, *params):
-        return np.exp(-self.Hf(x, Z, *params))
-
-    def ff(self, x, Z, *params):
-        return 1 - np.exp(-self.Hf(x, Z, *params))
-
-    def df(self, x, Z, *params):
-        return self.hf(x, Z, *params) * np.exp(-self.Hf(x, Z, *params))
-
-    def log_df(self, x, Z, *params):
-        # log h - H. When the additive hazard is driven non-positive the log
-        # is nan; the optimiser then rejects that point (the fit fails rather
-        # than returning an invalid model).
-        return np.log(self.hf(x, Z, *params)) - self.Hf(x, Z, *params)
-
-    def log_sf(self, x, Z, *params):
-        return -self.Hf(x, Z, *params)
-
-    def log_ff(self, x, Z, *params):
-        return np.log(self.ff(x, Z, *params))
+    # sf/ff/df and the log identities come from HazardIdentitiesMixin;
+    # when the additive hazard is driven non-positive its log_df is nan
+    # and the optimiser rejects that point (see the module docstring).
 
     # mpp transforms are the identity (probability plotting is not used for
     # these models, but the interface is kept consistent with the other
@@ -214,30 +203,19 @@ class AdditiveHazardsFitter(TVCFitMixin, DataFrameRegressionMixin):
         >>> from surpyval import WeibullAH
         >>> model = WeibullAH.fit(x=x, Z=Z, c=c)
         """
-        data = SurpyvalData(x, c, n, t, group_and_sort=False)
-        data.add_covariates(Z)
-
-        if fixed is None:
-            fixed = {}
-
-        assert data.Z is not None  # set by add_covariates above
-        n_cov = data.Z.shape[1]
-        beta_param_map = {
-            "beta_" + str(i): self.k_dist + i for i in range(n_cov)
-        }
-        param_map = {**self.param_map, **beta_param_map}
-        bounds = (*self.bounds, *(((None, None),) * n_cov))
-
-        if init is None or len(init) == 0:  # type: ignore[arg-type]
-            ps = self.dist.fit_from_surpyval_data(data).params
-            init = np.array([*ps, *np.zeros(n_cov)])
-        else:
-            init = np.array(init)
-
-        transform, inv_trans, const, fixed_idx, not_fixed = bounds_convert(
-            x, bounds, fixed, param_map
+        data, prep = prepare_regression_fit(
+            self,
+            x,
+            Z,
+            c,
+            n,
+            t,
+            init,
+            fixed,
+            LogLinearPhi.phi_bounds,
+            LogLinearPhi.make_param_map,
         )
-        init = transform(init)[not_fixed]
+        init, bounds, pmap, transform, inv_trans, const, fixed = prep
 
         with np.errstate(all="ignore"):
 
@@ -275,21 +253,17 @@ class AdditiveHazardsFitter(TVCFitMixin, DataFrameRegressionMixin):
 
         reg_model = _AdditiveReg()
         reg_model.name = "Additive [beta'Z]"
-        reg_model.phi_param_map = beta_param_map
+        reg_model.phi_param_map = pmap
 
-        model = ParametricRegressionModel()
-        model.distribution_param_map = self.param_map
-        model.phi_param_map = beta_param_map
-        model.model = self
-        model.reg_model = reg_model
-        model.kind = "Additive Hazard"
-        model.distribution = self.dist
-        model.params = np.array(params)
-        model.res = res
-        model._neg_ll = final_neg_ll
-        model.fixed = fixed
-        model.k_dist = self.k_dist
-        model.k = len(bounds)
-        model.data = data
-
-        return model
+        return assemble_regression_model(
+            self,
+            "Additive Hazard",
+            reg_model,
+            data,
+            res,
+            params,
+            bounds,
+            pmap,
+            fixed,
+            neg_ll=final_neg_ll,
+        )

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -7,6 +7,7 @@ from matplotlib import pyplot as plt
 from scipy.stats import norm
 
 from surpyval.serialisation import SerialisableMixin, stamp_schema
+from surpyval.univariate.information_criteria import InformationCriteriaMixin
 
 from ._bounds import (
     bound_signs,
@@ -49,7 +50,7 @@ _SERIALISABLE_REG_NAMES = {
 }
 
 
-class ParametricRegressionModel(SerialisableMixin):
+class ParametricRegressionModel(InformationCriteriaMixin, SerialisableMixin):
     """
     Result of ``.fit()`` or ``.from_params()`` method for parametric
     regression modelling.
@@ -846,156 +847,16 @@ class ParametricRegressionModel(SerialisableMixin):
             f"random() is not implemented for {self.kind} models."
         )
 
-    def neg_ll(self) -> float:
-        r"""
+    # neg_ll/aic/bic/aic_c come from InformationCriteriaMixin.
+    def _ic_counts(self):
+        n, c = self.data.n, self.data.c
+        return n[c == 0].sum(), n.sum()
 
-        The the negative log-likelihood for the model, if it was fit with the
-        ``fit()`` method. Not available if fit with the ``from_params()``
-        method.
-
-        Parameters
-        ----------
-
-        None
-
-        Returns
-        -------
-
-        neg_ll : float
-            The negative log-likelihood of the model
-
-        Examples
-        --------
-
-        >>> from surpyval import Weibull
-        >>> import numpy as np
-        >>> np.random.seed(1)
-        >>> x = Weibull.random(100, 10, 3)
-        >>> model = Weibull.fit(x)
-        >>> model.neg_ll()
-        262.52685642385734
-        """
-        if not hasattr(self, "data"):
-            raise ValueError("Must have been fit with data")
-
-        return self._neg_ll
-
-    def bic(self) -> float:
-        r"""
-
-        The the Bayesian Information Criterion (BIC) for the model, if it was
-        fit with the ``fit()`` method. Not available if fit with the
-        ``from_params()`` method.
-
-        Parameters
-        ----------
-
-        None
-
-        Returns
-        -------
-
-        bic : float
-            The BIC of the model
-
-        Examples
-        --------
-
-        >>> from surpyval import Weibull
-        >>> import numpy as np
-        >>> np.random.seed(1)
-        >>> x = Weibull.random(100, 10, 3)
-        >>> model = Weibull.fit(x)
-        >>> model.bic()
-        534.2640532196908
-
-        References:
-        -----------
-
-        `Bayesian Information Criterion for Censored Survival Models
-        <https://www.jstor.org/stable/2677130>`_.
-
-        """
-        if hasattr(self, "_bic"):
-            return self._bic
-        else:
-            self._bic = (
-                self.k * np.log(self.data.n[self.data.c == 0].sum())
-                + 2 * self.neg_ll()
-            )
-            return self._bic
-
-    def aic(self) -> float:
-        r"""
-
-        The the Aikake Information Criterion (AIC) for the model, if it was
-        fit with the ``fit()`` method. Not available if fit with the
-        ``from_params()`` method.
-
-        Parameters
-        ----------
-
-        None
-
-        Returns
-        -------
-
-        aic : float
-            The AIC of the model
-
-        Examples
-        --------
-
-        >>> from surpyval import Weibull
-        >>> import numpy as np
-        >>> np.random.seed(1)
-        >>> x = Weibull.random(100, 10, 3)
-        >>> model = Weibull.fit(x)
-        >>> model.aic()
-        529.0537128477147
-        """
-        if hasattr(self, "_aic"):
-            return self._aic
-        else:
-            self._aic = 2 * self.k + 2 * self.neg_ll()
-            return self._aic
-
-    def aic_c(self) -> float:
-        r"""
-
-        The the Corrected Aikake Information Criterion (AIC) for the model, if
-        it was fit with the ``fit()`` method. Not available if fit with the
-        ``from_params()`` method.
-
-        Parameters
-        ----------
-
-        None
-
-        Returns
-        -------
-
-        aic_c : float
-            The Corrected AIC of the model
-
-        Examples
-        --------
-
-        >>> from surpyval import Weibull
-        >>> import numpy as np
-        >>> np.random.seed(1)
-        >>> x = Weibull.random(100, 10, 3)
-        >>> model = Weibull.fit(x)
-        >>> model.aic()
-        529.1774241879209
-        """
-        if hasattr(self, "_aic_c"):
-            return self._aic_c
-        else:
-            k = len(self.params)
-            n = self.data.n.sum()
-            self._aic_c = self.aic() + (2 * k**2 + 2 * k) / (n - k - 1)
-            return self._aic_c
+    def _ic_k_aic_c(self):
+        # Regression models have historically used the full parameter-
+        # vector length here (which can differ from ``self.k`` when
+        # parameters are fixed); preserved as-is (#298).
+        return len(self.params)
 
     # -- confidence bounds -------------------------------------------------
 

--- a/surpyval/univariate/regression/proportional_hazards/cox_ph.py
+++ b/surpyval/univariate/regression/proportional_hazards/cox_ph.py
@@ -294,6 +294,15 @@ def _combine_generators(gens):
     return neg_ll, jac_hess
 
 
+def cox_at_risk_mask(x, tl, tau):
+    """The Cox risk-set convention, in one place (#299): a row is at risk
+    at event time ``tau`` once it has entered (``tl < tau`` — strict, so a
+    start-stop row is not at risk at its own entry time) and until it
+    exits (``x >= tau`` — inclusive, so a row is at risk at its own event
+    or censoring time)."""
+    return (tl < tau) & (x >= tau)
+
+
 class CoxPH_:
     # Best reference I can find that covers all the
     # possibilities for estimating betas
@@ -303,28 +312,39 @@ class CoxPH_:
         self, beta, x, c, n, Z, tl=None
     ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
         # Breslow baseline hazard. The risk set at each event time ``tau_i``
-        # is every observation that has entered (``tl < tau_i``; delayed
-        # entry / start-stop) and has not yet exited (``x >= tau_i``), each
-        # weighted by its count ``n`` and hazard multiplier ``exp(Z'beta)``.
-        # Respecting ``tl`` is what makes the baseline correct for
-        # left-truncated and time-varying-covariate (start-stop) data.
+        # follows ``cox_at_risk_mask`` (entered ``tl < tau_i``, not yet
+        # exited ``x >= tau_i``), each row weighted by its count ``n`` and
+        # hazard multiplier ``exp(Z'beta)``. Respecting ``tl`` is what makes
+        # the baseline correct for left-truncated and time-varying-covariate
+        # (start-stop) data. Computed by suffix sums — the risk set is
+        # everyone with ``x >= tau_i`` minus the not-yet-entered
+        # ``tl >= tau_i`` (valid because ``tl < x`` on every row) — the same
+        # subtraction the Efron generator uses, replacing the previous
+        # O(K·N) Python loop (#299).
 
         unique_x = np.unique(x)
         if tl is None:
             tl = np.full(x.shape[0], -np.inf)
 
+        w = n * np.exp(Z @ beta)
+
+        event = c == 0
         d = np.zeros_like(unique_x)
-        r = np.zeros_like(unique_x)
-        e_beta_z = np.exp(Z @ beta)
+        np.add.at(d, np.searchsorted(unique_x, x[event]), n[event])
 
-        for i, tau_i in enumerate(unique_x):
-            mask_d_i = (x == tau_i) & (c == 0)
-            d[i] = n[mask_d_i].sum()
+        r_exit = np.zeros_like(unique_x)
+        np.add.at(r_exit, np.searchsorted(unique_x, x), w)
+        r_exit = r_exit[::-1].cumsum()[::-1]
 
-            mask_at_risk_i = (tl < tau_i) & (x >= tau_i)
-            r[i] = (n[mask_at_risk_i] * e_beta_z[mask_at_risk_i]).sum()
+        # Bucket each row at the largest event time <= its entry time; the
+        # suffix sum then gives, at each tau_i, the weight not yet entered.
+        k = np.searchsorted(unique_x, tl, side="right") - 1
+        entered_late = k >= 0
+        r_pre = np.zeros_like(unique_x)
+        np.add.at(r_pre, k[entered_late], w[entered_late])
+        r_pre = r_pre[::-1].cumsum()[::-1]
 
-        return unique_x, r, d
+        return unique_x, r_exit - r_pre, d
 
     def create_efron_ll_jac_hess(self, x, Z, c, n, tl):
         # The reference used to compute the jacobian and hessian
@@ -547,9 +567,7 @@ class CoxPH_:
         death_Z_sum = []
         for tau in event_times:
             d_mask = (xe == tau) & (ce == 0)
-            # Delayed entry: a row is at risk at tau only once it has entered
-            # (tl < tau) and before it exits (x >= tau).
-            r_mask = (tle < tau) & (xe >= tau)
+            r_mask = cox_at_risk_mask(xe, tle, tau)
             death_idx.append(np.where(d_mask)[0])
             risk_idx.append(np.where(r_mask)[0])
             death_Z_sum.append(Ze[d_mask].sum(axis=0))

--- a/surpyval/univariate/regression/proportional_hazards/diagnostics.py
+++ b/surpyval/univariate/regression/proportional_hazards/diagnostics.py
@@ -19,6 +19,8 @@ import numpy as np
 from numpy.linalg import inv, pinv
 from scipy.stats import chi2
 
+from .cox_ph import cox_at_risk_mask
+
 if TYPE_CHECKING:  # pragma: no cover
     from ..semi_parametric_regression_model import (
         SemiParametricRegressionModel,
@@ -100,7 +102,7 @@ def _risk_set_means(data: dict, beta: np.ndarray, tie_method: str = "breslow"):
     A_own = np.empty(K)
     B_own = np.empty((K, p))
     for k, tau in enumerate(event_times):
-        at_risk = (tl < tau) & (x >= tau)
+        at_risk = cox_at_risk_mask(x, tl, tau)
         s0 = w[at_risk].sum()
         s1 = (w[at_risk, None] * Z[at_risk]).sum(axis=0)
         is_event = (x == tau) & (c == 0)

--- a/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
+++ b/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
@@ -3,11 +3,12 @@ from typing import Any
 
 import autograd.numpy as np
 import numpy.typing as npt
-from scipy.optimize import minimize
-
-from surpyval.univariate.parametric.fitters import bounds_convert
-from surpyval.utils.surpyval_data import SurpyvalData
-
+from .._fit_skeleton import (
+    HazardIdentitiesMixin,
+    assemble_regression_model,
+    optimise_ph,
+    prepare_regression_fit,
+)
 from .._likelihood import regression_neg_ll
 from ..parametric_regression_model import ParametricRegressionModel
 from ..regression_data import DataFrameRegressionMixin
@@ -21,7 +22,9 @@ class Phi:
     name: str
 
 
-class ProportionalHazardsFitter(TVCFitMixin, DataFrameRegressionMixin):
+class ProportionalHazardsFitter(
+    HazardIdentitiesMixin, TVCFitMixin, DataFrameRegressionMixin
+):
     def __init__(
         self,
         name,
@@ -67,15 +70,6 @@ class ProportionalHazardsFitter(TVCFitMixin, DataFrameRegressionMixin):
         hf_raw = self.hf_dist(x, *dist_params)
         return self.phi(Z, *phi_params) * hf_raw
 
-    def df(self, x, Z, *params):
-        return self.hf(x, Z, *params) * np.exp(-self.Hf(x, Z, *params))
-
-    def sf(self, x, Z, *params):
-        return np.exp(-self.Hf(x, Z, *params))
-
-    def ff(self, x, Z, *params):
-        return 1 - np.exp(-self.Hf(x, Z, *params))
-
     def _parameter_initialiser_dist(self, x, c=None, n=None, t=None):
         out = []
         for low, high in self.bounds:
@@ -98,15 +92,6 @@ class ProportionalHazardsFitter(TVCFitMixin, DataFrameRegressionMixin):
 
     def mpp_x_transform(self, x, gamma=0):
         return x - gamma
-
-    def log_df(self, x, Z, *params):
-        return np.log(self.hf(x, Z, *params)) - self.Hf(x, Z, *params)
-
-    def log_sf(self, x, Z, *params):
-        return -self.Hf(x, Z, *params)
-
-    def log_ff(self, x, Z, *params):
-        return np.log(self.ff(x, Z, *params))
 
     def random(self, size, Z, *params):
         dist_params = np.array(params[0 : self.k_dist])
@@ -247,92 +232,45 @@ class ProportionalHazardsFitter(TVCFitMixin, DataFrameRegressionMixin):
             beta_2: -25.952407717383302
             beta_3: 17.270173771235655
         """
-        data = SurpyvalData(x, c, n, t, group_and_sort=False)
-        data.add_covariates(Z)
-
-        if fixed is None:
-            fixed = {}
-
-        if init is None or len(init) == 0:  # type: ignore[arg-type]
-            ps = self.dist.fit_from_surpyval_data(data).params
-            # Use the validated covariate array — the raw ``Z`` argument may
-            # be a plain list without a ``.shape`` (#261) — and fall back to
-            # zeros when no phi initialiser is configured (previously an
-            # unbound-name error).
-            Z_data = np.asarray(data.Z)
-            if callable(self.phi_init):
-                init_phi = self.phi_init(Z_data)
-            else:
-                init_phi = np.zeros(Z_data.shape[1])
-
-            init = np.array([*ps, *init_phi])
-        else:
-            init = np.array(init)
-
-        # Dynamic or static bounds determination for models where the
-        # number of covariates is not fixed in advance.
-        if callable(self.phi_bounds):
-            bounds = (*self.bounds, *self.phi_bounds(data.Z))
-        else:
-            bounds = (*self.bounds, *self.phi_bounds)
-
-        # Dynamic or static parameter mapping for models where the
-        # number of covariates is not fixed in advance.
-        if callable(self.phi_param_map):
-            phi_param_map = self.phi_param_map(data.Z)
-        else:
-            phi_param_map = self.phi_param_map
-
-        # The covariate coefficients sit after the distribution parameters
-        # in the packed parameter vector, so their map indices must be
-        # offset by the number of distribution parameters — otherwise
-        # ``fixed={"beta_0": v}`` silently pins the first *distribution*
-        # parameter instead (#251).
-        param_map = {
-            **self.param_map,
-            **{k: v + len(self.param_map) for k, v in phi_param_map.items()},
-        }
-
-        # Create functions to make parameters unbounded for optimisation
-        # Also create function to insert fixed values.
-        transform, inv_trans, const, fixed_idx, not_fixed = bounds_convert(
-            x, bounds, fixed, param_map
+        data, prep = prepare_regression_fit(
+            self,
+            x,
+            Z,
+            c,
+            n,
+            t,
+            init,
+            fixed,
+            self.phi_bounds,
+            self.phi_param_map,
+            self.phi_init,
         )
-
-        init = transform(init)[not_fixed]
+        init_t, bounds, pmap, transform, inv_trans, const, fixed = prep
 
         with np.errstate(all="ignore"):
 
             def fun(params):
                 return self.neg_ll(data, *inv_trans(const(params)))
 
-            res = minimize(fun, init)
-            res = minimize(fun, res.x, method="TNC")
+            res = optimise_ph(fun, init_t)
 
-        # Unpack parameters found from optimisation to actual values.
         params = inv_trans(const(res.x))
 
-        # Create "Phi" model
+        # Keep this fitter's possibly-custom phi (and its historical
+        # serialisation name) rather than assuming log-linear.
         reg_model = Phi()
         reg_model.phi = self.phi
-        reg_model.phi_param_map = phi_param_map
+        reg_model.phi_param_map = pmap
         reg_model.name = self.phi_name
 
-        # Create regression model.
-        model = ParametricRegressionModel()
-        model.distribution_param_map = self.param_map
-        model.phi_param_map = phi_param_map
-        model.model = self
-        model.reg_model = reg_model
-        model.kind = "Proportional Hazard"
-        model.distribution = self.dist
-        model.params = np.array(params)
-        model.res = res
-        model._neg_ll = res["fun"]
-        model.fixed = fixed
-        model.k_dist = self.k_dist
-        model.k = len(bounds)
-        model.phi_param_map = phi_param_map
-        model.data = data
-
-        return model
+        return assemble_regression_model(
+            self,
+            "Proportional Hazard",
+            reg_model,
+            data,
+            res,
+            params,
+            bounds,
+            pmap,
+            fixed,
+        )

--- a/surpyval/univariate/regression/proportional_odds/proportional_odds_fitter.py
+++ b/surpyval/univariate/regression/proportional_odds/proportional_odds_fitter.py
@@ -1,11 +1,14 @@
 import autograd.numpy as np
 import numpy.typing as npt
-from scipy.optimize import minimize
 
-from surpyval.univariate.parametric.fitters import bounds_convert
-from surpyval.utils.surpyval_data import SurpyvalData
 
 from .._likelihood import regression_neg_ll
+from .._fit_skeleton import (
+    LogLinearPhi,
+    assemble_regression_model,
+    optimise_nm_tnc,
+    prepare_regression_fit,
+)
 from ..parametric_regression_model import ParametricRegressionModel
 from ..regression_data import DataFrameRegressionMixin
 
@@ -140,72 +143,41 @@ class ProportionalOddsFitter(DataFrameRegressionMixin):
         init: npt.ArrayLike | None = None,
         fixed: dict[str, float] | None = None,
     ) -> ParametricRegressionModel:
-        data = SurpyvalData(x, c, n, t, group_and_sort=False)
-        data.add_covariates(Z)
-
-        if fixed is None:
-            fixed = {}
-
-        if init is None:
-            ps = self.dist.fit_from_surpyval_data(data).params
-            assert data.Z is not None
-            phi_init = np.zeros(data.Z.shape[1])
-            init = np.array([*ps, *phi_init])
-        else:
-            init = np.array(init)
-
-        phi_bounds = self._phi_bounds(data.Z)
-        phi_param_map = self._phi_param_map(data.Z)
-        bounds = (*self.bounds, *phi_bounds)
-
-        param_map = {
-            **self.param_map,
-            **{k: v + len(self.param_map) for k, v in phi_param_map.items()},
-        }
-
-        transform, inv_trans, const, fixed_idx, not_fixed = bounds_convert(
-            data.x, bounds, fixed, param_map
+        data, prep = prepare_regression_fit(
+            self,
+            x,
+            Z,
+            c,
+            n,
+            t,
+            init,
+            fixed,
+            self._phi_bounds,
+            self._phi_param_map,
         )
-        init = transform(init)[not_fixed]
+        init_t, bounds, pmap, transform, inv_trans, const, fixed = prep
 
         with np.errstate(all="ignore"):
 
             def fun(params):
                 return self.neg_ll(data, *inv_trans(const(params)))
 
-            res = minimize(
-                fun, init, method="Nelder-Mead", options={"maxiter": 1000}
-            )
-            res2 = minimize(fun, res.x, method="TNC")
-            res = res2 if res2.success else res
+            res = optimise_nm_tnc(fun, init_t)
 
         params = inv_trans(const(res.x))
+        reg_model = LogLinearPhi("Log Linear [exp(beta'Z)]", pmap)
 
-        _pm = phi_param_map
-
-        class _PhiModel:
-            name = "Log Linear [exp(beta'Z)]"
-            phi_param_map = _pm
-
-            def phi(self, Z, *p):
-                return np.exp(np.dot(Z, np.array(p)))
-
-        model = ParametricRegressionModel()
-        model.model = self
-        model.reg_model = _PhiModel()
-        model.kind = "Proportional Odds"
-        model.distribution = self.dist
-        model.params = np.array(params)
-        model.dist_params = np.array(params[: self.k_dist])
-        model.phi_params = np.array(params[self.k_dist :])
-        model.res = res
-        model._neg_ll = res.fun
-        model.fixed = fixed
-        model.k_dist = self.k_dist
-        model.k = len(bounds)
-        model.data = data
-
-        return model
+        return assemble_regression_model(
+            self,
+            "Proportional Odds",
+            reg_model,
+            data,
+            res,
+            params,
+            bounds,
+            pmap,
+            fixed,
+        )
 
 
 def PO(distribution):

--- a/surpyval/utils/recurrent_event_data.py
+++ b/surpyval/utils/recurrent_event_data.py
@@ -259,6 +259,59 @@ class RecurrentEventData:
 
         return np.concatenate(x_previous)
 
+    def split_for_nhpp_likelihood(self):
+        """Split the data into the pieces every NHPP-style likelihood
+        needs: per-censoring-type event and previous-event times, the
+        right-truncation window close, and the row masks (so regression
+        variants can gather covariates the same way). This preamble used
+        to be copy-pasted between the plain and proportional-intensity
+        NHPP fitters and drifted (#288); it now lives here once (#296).
+        """
+        x, c, n = self.x, self.c, self.n
+        x_prev = self.get_previous_x()
+
+        has_interval = 2 in c
+        x_l = x if x.ndim == 1 else x[:, 0]
+        x_r = x[:, 1] if x.ndim == 2 else None
+
+        x_prev_l = (
+            x_prev if x_prev.ndim == 1 else x_prev[:, 0]
+        )  # not x[:, 0] (#288)
+        x_prev_r = x_prev[:, 1] if x_prev.ndim == 2 else None
+        prev = x_prev_r if has_interval else x_prev_l
+
+        mask_o = c == 0
+        mask_right = c == 1
+        mask_left = c == -1
+        mask_i = c == 2
+
+        empty = np.array([])
+        out = {
+            "x_o": x_l[mask_o] if mask_o.any() else empty,
+            "x_o_prev": prev[mask_o] if mask_o.any() else empty,
+            "x_right": x_l[mask_right] if mask_right.any() else empty,
+            "x_right_prev": prev[mask_right] if mask_right.any() else empty,
+            "x_left": x_l[mask_left] if mask_left.any() else empty,
+            "n_left": n[mask_left] if mask_left.any() else empty,
+            "x_i_l": x_l[mask_i] if mask_i.any() else empty,
+            "x_i_r": x_r[mask_i] if mask_i.any() else empty,
+            "n_i": n[mask_i] if mask_i.any() else empty,
+            "mask_o": mask_o,
+            "mask_right": mask_right,
+            "mask_left": mask_left,
+            "mask_i": mask_i,
+        }
+        # Right window-close: for items with a finite right-truncation
+        # time ``tr`` the intensity is integrated out to ``tr`` rather
+        # than merely to the last observed event / censoring row. Empty
+        # for untruncated data.
+        (
+            out["x_close_last"],
+            out["x_close_tr"],
+            out["close_idx"],
+        ) = self.get_right_truncation_close()
+        return out
+
     def get_right_truncation_close(self):
         """
         Per-item integration bounds for the NHPP likelihood's right


### PR DESCRIPTION
Implements the medium-risk simplifications from the code-simplification review: #295, #296, #297, #298, and #299 (items 1–3 and 6).

Every refactor was verified against reference outputs captured before any change (fitted params, sf curves, neg_ll/AIC/BIC/AICc, CIFs, Cox baseline, NHPP/PI fits, degradation bootstrap values, all compared with `rtol=0, atol=0`). Everything is **bit-identical** except two documented reconciliations noted below.

### #295 — one shared `fit()` skeleton for the parametric regression families
PH, AFT, PO and parametric AH carried five copy-pasted fit pipelines (data prep, the #251 param-map offset merge, `bounds_convert`, optimisation, assembly) that had already drifted. The skeleton now lives once in `_fit_skeleton.py`; each family supplies only its optimiser ladder (`optimise_ph` / `optimise_nm_tnc`; AH keeps its penalty loop in place) and covariate-link object. A single `LogLinearPhi` replaces seven inline `exp(beta'Z)` definitions. Serialisation name tags (PH's `e^` vs AFT/PO's `exp`) preserved exactly. Bit-identical.

### #296 — NHPP likelihood split hoisted
The five-way censoring/interval split (the code that drifted into #288) was duplicated between `CrowAMSAA`-style NHPP fits and the PI-NHPP fitter; now lives once as `RecurrentEventData.split_for_nhpp_likelihood()`. Bit-identical.

### #297 — `HazardIdentitiesMixin`
The six `sf`/`ff`/`df`/`log_*` identities derived from `Hf`/`hf` were repeated in PH, AFT, parametric AH and the AL parameter-substitution fitter; one mixin now serves all four (PO is sf/ff-native and keeps its own forms). **Reconciliation:** PH and AH `ff` switch from `1 - exp(-H)` to `-expm1(-H)` (matching AFT/AL) — more accurate in the deep left tail; only affects left-censored/interval likelihood terms and `ff` queries at tiny `H`. All captured values bit-identical.

### #298 — `InformationCriteriaMixin`
`neg_ll`/`aic`/`bic`/`aic_c` were duplicated between `Parametric` and `ParametricRegressionModel`. One mixin now serves both, with `_ic_counts`/`_ic_k_aic_c` hooks preserving each class's historical conventions exactly (including regression's `len(params)` AICc count vs the univariate `k`). Bit-identical.

### #299 — numerical dedup batch (items 1–3, 6)
- **Aalen-Johansen increment** (item 1): the `S(t-)` weighting behind #253/#278 was implemented three times; now once in `aalen_johansen_iif`. Gray's pooled CIF is vectorised in the process. CIF refs bit-identical.
- **Cox risk-set convention** (item 2): the entry-strict/exit-inclusive rule now lives in one documented `cox_at_risk_mask` helper (used by the exact-tie prep and Schoenfeld risk-set means), and `CoxPH.baseline` replaces its O(K·N) Python loop with the same suffix-sum subtraction the Efron generator uses. **Reconciliation:** summation reordering shifts H0 by ≤1.7e-15 relative (beta and event times identical); correctness pinned by the R/lifelines comparison tests.
- **Degradation bootstrap merge** (item 3): `bootstrap_cb` and `bootstrap_cb_accelerated` merged into one function (`Z=None` selects the plain path). RNG stream unchanged — plain bootstrap refs bit-identical. The plain path now also drops non-finite refit curves instead of letting them poison the quantiles.
- **CopulaModel serialisation** (item 6): `to_dict` now stamps the schema version, a new `from_dict` rebuilds the model, and the `"copula"` parameterization is registered with `surpyval.from_dict` — previously the dictionary was written in a form nothing could read. New round-trip test file.

Items 4 (CB transform sharing) and 5 (Cox TVC wrapper collapse) are **deferred** — least net win for the churn; #299 stays open for them.

### Verification
- Reference harness: 13 model families captured pre-refactor, re-captured after each issue; all `rtol=0, atol=0` equal except the two documented reconciliations above.
- Full local suite: **1,848 passed, 1 skipped** (regression+CR 374, degradation+multivariate 200, remainder 1,274).
- `black`, `flake8`, `mypy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_