### PR TITLE
Separate discrete distributions; make degenerate distributions first-class

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,24 @@ Changelog
 v0.17.0 (unreleased)
 --------------------
 
+- **Discrete distributions are now structurally separated from the
+  continuous catalogue.** A new ``DiscreteParametricFitter`` base class
+  (Geometric, Poisson, DiscreteWeibull, NegativeBinomial, Binomial,
+  Bernoulli/FixedEventProbability, BetaGeometric, and ``Discretize``
+  wrappers) is the single home for what discreteness means when fitting:
+  the ``discrete`` trait, the central ``supports_mpp = False`` (each
+  class previously set its own flag), and a new clear rejection of
+  ``how="MPS"`` — spacings are increments of a continuous CDF and
+  repeated integers make them degenerate, so this now raises instead of
+  fitting nonsense. MLE, MSE and MOM behaviour is unchanged.
+- **``InstantlyOccurs`` and ``NeverOccurs`` are now first-class
+  degenerate distributions** in
+  ``univariate/parametric/distributions/degenerate.py`` (previously
+  partial-API classes tucked into ``parametric/__init__.py``). They gain
+  the missing ``df``/``hf``/``qf``/``mean`` methods and serialisation:
+  ``to_dict`` stamps the schema and ``surpyval.from_dict`` restores the
+  class itself (identity preserved, as the survival-tree leaves
+  require). Historical import paths keep working.
 - **Simplification: one shared ``fit()`` skeleton for the parametric
   regression families** (#295). PH, AFT, PO and parametric AH carried
   five copy-pasted versions of the same fit pipeline — data prep, the

--- a/surpyval/serialisation.py
+++ b/surpyval/serialisation.py
@@ -78,6 +78,12 @@ _TAGGED_MODELS: dict[str, str] = {
     "DestructiveDegradationModel": "surpyval.degradation.destructive",
     "SurvivalTree": "surpyval.beta.ml.forest.tree",
     "RandomSurvivalForest": "surpyval.beta.ml.forest.forest",
+    # The degenerate distributions are stateless: the class is the model,
+    # so they serialise by name alone.
+    "NeverOccurs": ("surpyval.univariate.parametric.distributions.degenerate"),
+    "InstantlyOccurs": (
+        "surpyval.univariate.parametric.distributions.degenerate"
+    ),
 }
 
 # ``"parameterization"`` value -> (defining module, class name), for

--- a/surpyval/tests/univariate/parametric/test_degenerate.py
+++ b/surpyval/tests/univariate/parametric/test_degenerate.py
@@ -1,0 +1,63 @@
+"""The degenerate distributions: InstantlyOccurs (point mass at 0) and
+NeverOccurs (point mass at +inf).
+
+Previously these lived in ``parametric/__init__.py`` with a partial API
+(no df/hf/qf/mean) and no serialisation; they are now first-class
+members of the distributions package.
+"""
+
+import numpy as np
+
+import surpyval
+from surpyval import InstantlyOccurs, NeverOccurs
+
+X = np.array([0.0, 1.0, 5.0, 100.0])
+
+
+def test_never_occurs_api():
+    assert (NeverOccurs.sf(X) == 1.0).all()
+    assert (NeverOccurs.ff(X) == 0.0).all()
+    assert (NeverOccurs.df(X) == 0.0).all()
+    assert (NeverOccurs.hf(X) == 0.0).all()
+    assert (NeverOccurs.Hf(X) == 0.0).all()
+    assert (NeverOccurs.qf(np.array([0.1, 0.5, 0.99])) == np.inf).all()
+    assert NeverOccurs.mean() == np.inf
+    assert (NeverOccurs.random(5) == np.inf).all()
+
+
+def test_instantly_occurs_api():
+    assert (InstantlyOccurs.sf(X) == 0.0).all()
+    assert (InstantlyOccurs.ff(X) == 1.0).all()
+    assert (InstantlyOccurs.hf(X) == np.inf).all()
+    assert (InstantlyOccurs.Hf(X) == np.inf).all()
+    df = InstantlyOccurs.df(X)
+    assert df[0] == np.inf and (df[1:] == 0.0).all()
+    assert (InstantlyOccurs.qf(np.array([0.1, 0.9])) == 0.0).all()
+    assert InstantlyOccurs.mean() == 0.0
+    assert (InstantlyOccurs.random(5) == 0.0).all()
+
+
+def test_degenerate_serialisation_round_trip():
+    # Stateless: the class is the model, so from_dict returns the class
+    # itself and identity is preserved (the survival-tree leaves rely on
+    # ``model is NeverOccurs``).
+    for cls in (NeverOccurs, InstantlyOccurs):
+        d = cls.to_dict()
+        assert d["model"] == cls.name
+        assert d["schema"] == 1
+        assert surpyval.from_dict(d) is cls
+
+
+def test_import_paths_preserved():
+    # The historical import locations must keep working, and must resolve
+    # to the same class objects.
+    from surpyval.univariate.parametric import (
+        InstantlyOccurs as from_parametric_i,
+    )
+    from surpyval.univariate.parametric import NeverOccurs as from_parametric_n
+    from surpyval.univariate.parametric.distributions.degenerate import (
+        NeverOccurs as from_module_n,
+    )
+
+    assert from_parametric_n is NeverOccurs is from_module_n
+    assert from_parametric_i is InstantlyOccurs

--- a/surpyval/tests/univariate/parametric/test_discrete.py
+++ b/surpyval/tests/univariate/parametric/test_discrete.py
@@ -218,6 +218,45 @@ def test_supports_mpp_is_false():
         Geometric.fit(Geometric.random(200, 0.3), how="MPP")
 
 
+def test_discrete_distributions_are_discrete_fitters():
+    # The discrete/continuous distinction is structural: every integer-
+    # support distribution is a DiscreteParametricFitter with the
+    # ``discrete`` trait, and the continuous catalogue is not.
+    from surpyval import Bernoulli, Binomial, FixedEventProbability
+    from surpyval.univariate.parametric import DiscreteParametricFitter
+
+    for dist in (
+        Geometric,
+        Poisson,
+        DiscreteWeibull,
+        NegativeBinomial,
+        Binomial,
+        Bernoulli,
+        FixedEventProbability,
+        BetaGeometric,
+        DiscretizedWeibull,
+    ):
+        assert isinstance(dist, DiscreteParametricFitter), dist.name
+        assert dist.discrete is True
+        assert dist.supports_mpp is False
+    for dist in (Weibull, Gamma, LogNormal, Normal):
+        assert not isinstance(dist, DiscreteParametricFitter)
+        assert dist.discrete is False
+
+
+def test_mps_rejected_for_discrete():
+    # Maximum product of spacings is defined by increments of a continuous
+    # CDF; repeated integers make the spacings degenerate, so it must be
+    # rejected with a clear error rather than fit nonsense.
+    x = Geometric.random(200, 0.3)
+    with pytest.raises(ValueError, match="MPS"):
+        Geometric.fit(x, how="MPS")
+    with pytest.raises(ValueError, match="MPS"):
+        Poisson.fit(Poisson.random(200, 3.0), how="MPS")
+    # MLE remains the standard path.
+    assert 0.0 < Geometric.fit(x).params[0] < 1.0
+
+
 # --- Tier 2: Poisson, Beta-Geometric, and the Discretize wrapper ----------
 
 

--- a/surpyval/univariate/parametric/__init__.py
+++ b/surpyval/univariate/parametric/__init__.py
@@ -11,10 +11,7 @@ Parametric Analysis
 
 """
 
-import numpy as np
-
-from surpyval.distribution import Distribution
-
+from .discrete_fitter import DiscreteParametricFitter
 from .distributions import (
     Bernoulli,
     Beta,
@@ -35,10 +32,12 @@ from .distributions import (
     Geometric,
     Gumbel,
     GumbelLEV,
+    InstantlyOccurs,
     Logistic,
     LogLogistic,
     LogNormal,
     NegativeBinomial,
+    NeverOccurs,
     Normal,
     Poisson,
     Rayleigh,
@@ -49,39 +48,3 @@ from .mixture_model import MixtureModel
 from .parametric import Parametric
 from .parametric_fitter import ParametricFitter
 from .royston_parmar import RoystonParmar, RoystonParmarModel
-
-
-class NeverOccurs(Distribution):
-    @classmethod
-    def sf(cls, x):
-        return np.ones_like(x).astype(float)
-
-    @classmethod
-    def ff(cls, x):
-        return np.zeros_like(x).astype(float)
-
-    @classmethod
-    def Hf(cls, x):
-        return np.zeros_like(x).astype(float)
-
-    @classmethod
-    def random(cls, size):
-        return np.ones(size) * np.inf
-
-
-class InstantlyOccurs(Distribution):
-    @classmethod
-    def sf(cls, x):
-        return np.zeros_like(x).astype(float)
-
-    @classmethod
-    def ff(cls, x):
-        return np.ones_like(x).astype(float)
-
-    @classmethod
-    def Hf(cls, x):
-        return np.full_like(x, np.inf, dtype=float)
-
-    @classmethod
-    def random(cls, size):
-        return np.zeros(size)

--- a/surpyval/univariate/parametric/discrete_fitter.py
+++ b/surpyval/univariate/parametric/discrete_fitter.py
@@ -1,0 +1,42 @@
+"""Base class for the discrete lifetime distributions.
+
+The discrete/continuous distinction used to live in scattered per-class
+conventions: each discrete distribution individually set
+``supports_mpp = False``, and nothing structurally stopped a
+continuous-only estimation method from being asked of a discrete model.
+This class is now the single home for that distinction.
+
+A discrete distribution here is one whose mass sits on integers: ``df``
+is the probability mass function ``P(T = k)`` (not a density), ``hf`` is
+the discrete hazard ``P(T = k) / R(k - 1)``, and the survival ``sf(k)``
+is ``P(T > k)``.
+"""
+
+from .parametric_fitter import ParametricFitter
+
+
+class DiscreteParametricFitter(ParametricFitter):
+    """A :class:`ParametricFitter` for distributions on the integers.
+
+    Centralises what discreteness means for fitting:
+
+    - ``discrete`` is ``True`` (``ParametricFitter`` declares ``False``),
+      so callers can branch on the trait instead of keeping a list.
+    - Probability plotting (``how="MPP"``) is rejected: it assumes a
+      continuous, invertible CDF.
+    - Maximum product of spacings (``how="MPS"``) is rejected: spacings
+      are increments of a continuous CDF, and repeated integer
+      observations make them degenerate.
+
+    MLE, MSE (least squares against the nonparametric estimate, which is
+    a step function anyway) and MOM (via each distribution's ``moment``)
+    remain available.
+    """
+
+    discrete = True
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Kept as an instance attribute (not only the class trait) because
+        # the shared ``_validate_fit_inputs`` reads it for every fitter.
+        self.supports_mpp = False

--- a/surpyval/univariate/parametric/distributions/__init__.py
+++ b/surpyval/univariate/parametric/distributions/__init__.py
@@ -4,6 +4,7 @@ from .beta4 import Beta4
 from .beta_geometric import BetaGeometric
 from .binomial import Binomial
 from .custom_distribution import CustomDistribution
+from .degenerate import InstantlyOccurs, NeverOccurs
 from .discrete_weibull import DiscreteWeibull
 from .discretize import Discretize, DiscretizedFitter
 from .exact_event_time import ExactEventTime

--- a/surpyval/univariate/parametric/distributions/bernoulli.py
+++ b/surpyval/univariate/parametric/distributions/bernoulli.py
@@ -1,12 +1,14 @@
 from scipy.stats import uniform
 
 from surpyval import np
-from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
+from surpyval.univariate.parametric.discrete_fitter import (
+    DiscreteParametricFitter,
+)
 
 from ..parametric import Parametric
 
 
-class Bernoulli_(ParametricFitter):
+class Bernoulli_(DiscreteParametricFitter):
     def __init__(self, name):
         super().__init__(
             name=name,

--- a/surpyval/univariate/parametric/distributions/beta_geometric.py
+++ b/surpyval/univariate/parametric/distributions/beta_geometric.py
@@ -3,10 +3,12 @@ from scipy.stats import beta as beta_rv
 from scipy.stats import geom
 
 from surpyval import np
-from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
+from surpyval.univariate.parametric.discrete_fitter import (
+    DiscreteParametricFitter,
+)
 
 
-class BetaGeometric_(ParametricFitter):
+class BetaGeometric_(DiscreteParametricFitter):
     r"""
 
     The (shifted) Beta-Geometric distribution: a discrete-time frailty model
@@ -43,7 +45,6 @@ class BetaGeometric_(ParametricFitter):
             param_map={"a": 0, "b": 1},
             plot_x_scale="linear",
         )
-        self.supports_mpp = False
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         # A neutral, proper starting point; the Beta(1, 1) mixing is the

--- a/surpyval/univariate/parametric/distributions/binomial.py
+++ b/surpyval/univariate/parametric/distributions/binomial.py
@@ -1,12 +1,14 @@
 from scipy.stats import binom
 
 from surpyval import np
-from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
+from surpyval.univariate.parametric.discrete_fitter import (
+    DiscreteParametricFitter,
+)
 
 from ..parametric import Parametric
 
 
-class Binomial_(ParametricFitter):
+class Binomial_(DiscreteParametricFitter):
     r"""
     The Binomial distribution: the number of events (failures) ``k`` in a
     fixed number ``n`` of independent pass/fail trials, each with event
@@ -33,10 +35,6 @@ class Binomial_(ParametricFitter):
             param_map={"n": 0, "p": 1},
             plot_x_scale="linear",
         )
-        # A binomial is a discrete count distribution with a fixed number
-        # of trials; probability plotting (which assumes a continuous,
-        # invertible CDF) does not apply.
-        self.supports_mpp = False
 
     def df(self, x, n, p):
         r"""

--- a/surpyval/univariate/parametric/distributions/degenerate.py
+++ b/surpyval/univariate/parametric/distributions/degenerate.py
@@ -1,0 +1,114 @@
+"""The two degenerate lifetime distributions.
+
+``InstantlyOccurs`` is the point mass at zero (every unit has already
+failed) and ``NeverOccurs`` the point mass at infinity (no unit ever
+fails). They are the limits of distributions in the ordinary catalogue —
+``FixedEventProbability`` at ``p = 1`` / ``p = 0``, or ``ExactEventTime``
+at ``T = 0`` / ``T = inf`` — kept as their own named models because they
+arise as boundary cases in composed models: the survival-tree leaves use
+``NeverOccurs`` for a node with no events, and mixtures or renewal
+compositions can degenerate the same way.
+
+They are stateless (no parameters, nothing to fit), so the *class* is
+the model: every method is a classmethod and the classes serialise by
+name alone.
+"""
+
+import numpy as np
+
+from surpyval.distribution import Distribution
+from surpyval.serialisation import stamp_schema
+
+
+class NeverOccurs(Distribution):
+    """The event never occurs: ``R(x) = 1`` everywhere (mass at +inf)."""
+
+    name = "NeverOccurs"
+
+    @classmethod
+    def sf(cls, x):
+        return np.ones_like(x).astype(float)
+
+    @classmethod
+    def ff(cls, x):
+        return np.zeros_like(x).astype(float)
+
+    @classmethod
+    def df(cls, x):
+        return np.zeros_like(x).astype(float)
+
+    @classmethod
+    def hf(cls, x):
+        return np.zeros_like(x).astype(float)
+
+    @classmethod
+    def Hf(cls, x):
+        return np.zeros_like(x).astype(float)
+
+    @classmethod
+    def qf(cls, u):
+        return np.full_like(np.asarray(u, dtype=float), np.inf)
+
+    @classmethod
+    def mean(cls):
+        return np.inf
+
+    @classmethod
+    def random(cls, size):
+        return np.ones(size) * np.inf
+
+    @classmethod
+    def to_dict(cls):
+        return stamp_schema({"model": cls.name})
+
+    @classmethod
+    def from_dict(cls, model_dict):
+        return cls
+
+
+class InstantlyOccurs(Distribution):
+    """The event has already occurred: ``F(x) = 1`` everywhere (mass at 0)."""
+
+    name = "InstantlyOccurs"
+
+    @classmethod
+    def sf(cls, x):
+        return np.zeros_like(x).astype(float)
+
+    @classmethod
+    def ff(cls, x):
+        return np.ones_like(x).astype(float)
+
+    @classmethod
+    def df(cls, x):
+        # Point mass at zero: the "density" is the degenerate spike there.
+        x = np.asarray(x, dtype=float)
+        return np.where(x == 0, np.inf, 0.0)
+
+    @classmethod
+    def hf(cls, x):
+        return np.full_like(np.asarray(x, dtype=float), np.inf)
+
+    @classmethod
+    def Hf(cls, x):
+        return np.full_like(x, np.inf, dtype=float)
+
+    @classmethod
+    def qf(cls, u):
+        return np.zeros_like(np.asarray(u, dtype=float))
+
+    @classmethod
+    def mean(cls):
+        return 0.0
+
+    @classmethod
+    def random(cls, size):
+        return np.zeros(size)
+
+    @classmethod
+    def to_dict(cls):
+        return stamp_schema({"model": cls.name})
+
+    @classmethod
+    def from_dict(cls, model_dict):
+        return cls

--- a/surpyval/univariate/parametric/distributions/discrete_weibull.py
+++ b/surpyval/univariate/parametric/distributions/discrete_weibull.py
@@ -1,10 +1,12 @@
 from scipy.stats import uniform
 
 from surpyval import np
-from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
+from surpyval.univariate.parametric.discrete_fitter import (
+    DiscreteParametricFitter,
+)
 
 
-class DiscreteWeibull_(ParametricFitter):
+class DiscreteWeibull_(DiscreteParametricFitter):
     r"""
 
     The (Type I) discrete Weibull distribution of Nakagawa & Osaki (1975):
@@ -45,7 +47,6 @@ class DiscreteWeibull_(ParametricFitter):
             param_map={"q": 0, "beta": 1},
             plot_x_scale="linear",
         )
-        self.supports_mpp = False
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         # q ~ P(survive the first cycle) from the empirical fraction above 1;

--- a/surpyval/univariate/parametric/distributions/discretize.py
+++ b/surpyval/univariate/parametric/distributions/discretize.py
@@ -1,8 +1,10 @@
 from surpyval import np
-from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
+from surpyval.univariate.parametric.discrete_fitter import (
+    DiscreteParametricFitter,
+)
 
 
-class DiscretizedFitter(ParametricFitter):
+class DiscretizedFitter(DiscreteParametricFitter):
     r"""
 
     A continuous lifetime distribution discretized to the positive integers
@@ -44,7 +46,6 @@ class DiscretizedFitter(ParametricFitter):
             param_map=dict(distribution.param_map),
             plot_x_scale=distribution.plot_x_scale,
         )
-        self.supports_mpp = False
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         return self.dist._parameter_initialiser(x, c=c, n=n, t=t)

--- a/surpyval/univariate/parametric/distributions/geometric.py
+++ b/surpyval/univariate/parametric/distributions/geometric.py
@@ -1,10 +1,12 @@
 from scipy.stats import uniform
 
 from surpyval import np
-from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
+from surpyval.univariate.parametric.discrete_fitter import (
+    DiscreteParametricFitter,
+)
 
 
-class Geometric_(ParametricFitter):
+class Geometric_(DiscreteParametricFitter):
     r"""
 
     The Geometric distribution: the discrete analogue of the Exponential.
@@ -36,9 +38,6 @@ class Geometric_(ParametricFitter):
             param_map={"p": 0},
             plot_x_scale="linear",
         )
-        # Probability plotting assumes a continuous inverse CDF; a discrete
-        # lifetime is fit by maximum likelihood.
-        self.supports_mpp = False
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         # Method-of-moments seed: the mean of a geometric on {1, 2, ...} is

--- a/surpyval/univariate/parametric/distributions/negative_binomial.py
+++ b/surpyval/univariate/parametric/distributions/negative_binomial.py
@@ -2,11 +2,13 @@ from autograd.scipy.special import gammaln
 from scipy.stats import nbinom
 
 from surpyval import np
-from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
+from surpyval.univariate.parametric.discrete_fitter import (
+    DiscreteParametricFitter,
+)
 from surpyval.utils.autograd_gamma_compat import betainc, betaincln
 
 
-class NegativeBinomial_(ParametricFitter):
+class NegativeBinomial_(DiscreteParametricFitter):
     r"""
 
     The Negative Binomial distribution as a discrete lifetime on the
@@ -42,7 +44,6 @@ class NegativeBinomial_(ParametricFitter):
             param_map={"r": 0, "p": 1},
             plot_x_scale="linear",
         )
-        self.supports_mpp = False
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         # Method-of-moments seed from the shifted counts Y = T - 1: for the

--- a/surpyval/univariate/parametric/distributions/poisson.py
+++ b/surpyval/univariate/parametric/distributions/poisson.py
@@ -2,10 +2,12 @@ from autograd.scipy.special import gammainc, gammaincc, gammaln
 from scipy.stats import poisson
 
 from surpyval import np
-from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
+from surpyval.univariate.parametric.discrete_fitter import (
+    DiscreteParametricFitter,
+)
 
 
-class Poisson_(ParametricFitter):
+class Poisson_(DiscreteParametricFitter):
     r"""
 
     The Poisson distribution as a discrete count model on the non-negative
@@ -40,9 +42,6 @@ class Poisson_(ParametricFitter):
             param_map={"mu": 0},
             plot_x_scale="linear",
         )
-        # A discrete lifetime is fit by maximum likelihood, not probability
-        # plotting (which assumes a continuous inverse CDF).
-        self.supports_mpp = False
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         # The Poisson mean is mu, so the sample mean is the moment seed.

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -74,6 +74,11 @@ class ParametricFitter:
     gradients.
     """
 
+    # Whether the distribution's mass sits on integers rather than a
+    # continuum. ``DiscreteParametricFitter`` overrides this; fit-method
+    # validation and callers branch on the trait.
+    discrete = False
+
     def __init__(
         self,
         name: str,
@@ -360,6 +365,15 @@ class ParametricFitter:
                 f"{self.name} distribution does not work"
                 " with probability plot fitting; use how='MLE', 'MSE' or"
                 " 'MOM' instead"
+            )
+            raise ValueError(detail)
+
+        if how == "MPS" and self.discrete:
+            detail = (
+                f"{self.name} is a discrete distribution; maximum product"
+                " of spacings (MPS) is defined by increments of a"
+                " continuous CDF, and repeated integer observations make"
+                " the spacings degenerate. Use how='MLE' instead."
             )
             raise ValueError(detail)
 


### PR DESCRIPTION
Structural cleanup of the distribution catalogue, following on from the regression-fitter consolidation in #301.

### Discrete/continuous split
New `DiscreteParametricFitter(ParametricFitter)` base class (`discrete_fitter.py`) is now the single home of the discrete/continuous distinction:

- a `discrete` trait (`ParametricFitter` declares `False`) so callers can branch on it instead of keeping lists,
- the central `supports_mpp = False` — previously a hand-copied per-class flag on seven classes,
- a new, clear rejection of `how="MPS"` for discrete distributions: spacings are increments of a continuous CDF, and repeated integer observations make them degenerate, so this now raises a `ValueError` instead of fitting nonsense.

Geometric, Poisson, DiscreteWeibull, NegativeBinomial, Binomial, Bernoulli/FixedEventProbability, BetaGeometric and the `Discretize` wrapper now subclass it. MLE, MSE and MOM behaviour is unchanged (MSE fits the step-function nonparametric estimate, MOM uses each distribution's `moment` — both are well-defined for discrete models). The only behaviour change is the MPS rejection; no test exercised MPS on a discrete distribution.

### Degenerate distributions promoted
`InstantlyOccurs` (point mass at 0) and `NeverOccurs` (point mass at +inf) move from `parametric/__init__.py` — where they were partial-API classes with no `df`/`hf`/`qf`/`mean` and no serialisation — into `distributions/degenerate.py` as first-class degenerate distributions:

- full survival API (the missing `df`/`hf`/`qf`/`mean` added),
- schema-stamped `to_dict` and a `from_dict` registered with `surpyval.from_dict`; being stateless, the class *is* the model, so restore preserves identity (`surpyval.from_dict(NeverOccurs.to_dict()) is NeverOccurs`) — which the survival-tree leaves rely on (`model is NeverOccurs`),
- documented as the limits of `FixedEventProbability` (p = 1 / p = 0) and `ExactEventTime` (T = 0 / T = ∞),
- historical import paths (`surpyval.NeverOccurs`, `surpyval.univariate.parametric.NeverOccurs`) unchanged.

### Verification
- New tests: `test_degenerate.py` (full API values, serialisation identity round-trip, import-path preservation) and class-split/MPS-rejection tests in `test_discrete.py`.
- Full local suite: **1,854 passed, 1 skipped** (univariate 1,095; everything else 759, including the tree/forest suites that consume `NeverOccurs`).
- `black`, `flake8`, `mypy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_