### PR TITLE
Cut v0.17.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-v0.17.0 (unreleased)
---------------------
+v0.17.0 (1 August 2026)
+-----------------------
 
 - **Discrete distributions are now structurally separated from the
   continuous catalogue.** A new ``DiscreteParametricFitter`` base class

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "surpyval"
-version = "0.16.0"
+version = "0.17.0"
 description = "A python package for survival analysis"
 readme = "README.md"
 license = {text = "MIT"}

--- a/surpyval/__init__.py
+++ b/surpyval/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.16.0"
+__version__ = "0.17.0"
 
 from autograd import numpy as np
 


### PR DESCRIPTION
Version bump to 0.17.0 (`pyproject.toml` + `surpyval/__init__.py`) and changelog dated 1 August 2026. No code changes.

Once this is in, develop → master follows as the release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_