### PR TITLE
Run the test suite across all available cores

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -63,8 +63,20 @@ jobs:
         # The alpha-stage modules are not part of the release contract
         # and are excluded from the deployment test run. (Beta-stage
         # tests, e.g. the survival forest's, do run.)
+        #
+        # Run across all available cores: the suite is dominated by a
+        # handful of Monte Carlo and bootstrap tests, so it parallelises
+        # well -- 13m21 to 4m10 on four cores locally. Coverage comes
+        # from pytest-cov rather than `coverage run`, because the latter
+        # does not follow the xdist worker subprocesses; the totals are
+        # identical either way. The report and html steps below still
+        # read the .coverage file it writes.
+        # Invoked as ``python -m`` so the plugins resolve against the
+        # interpreter the dependencies were installed into, rather than
+        # whichever ``pytest`` happens to be first on PATH.
         run:
-          coverage run -m pytest --ignore=surpyval/tests/alpha
+          python -m pytest -n auto --cov=surpyval --cov-report=
+          --ignore=surpyval/tests/alpha
 
       - name: coverage
         run: |

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,4 +5,6 @@ flake8
 flake8-pyproject
 mypy
 coverage
+pytest-cov
+pytest-xdist
 pre-commit

--- a/surpyval/tests/utils/test_truncated_censoring.py
+++ b/surpyval/tests/utils/test_truncated_censoring.py
@@ -174,9 +174,12 @@ def test_right_censoring_under_right_truncation_recovers_the_truth():
     # so it happened at or before ``tr`` -- but cannot resolve where in
     # the remaining window it fell, so it is censored at ``x``. The
     # event is simply in ``(x, tr]``, and the fit must be consistent.
+    # 15,000 retained draws land inside 1% of the truth, which the 5%
+    # tolerance below covers comfortably; 50,000 took twice as long for
+    # no extra confidence.
     alpha, beta, tr_bound, cens_at = 10.0, 2.0, 14.0, 8.0
-    draws = Weibull.random(200_000, alpha, beta)
-    detected = draws[draws <= tr_bound][:50_000]  # right truncation
+    draws = Weibull.random(60_000, alpha, beta)
+    detected = draws[draws <= tr_bound][:15_000]  # right truncation
 
     c = (detected > cens_at).astype(int)
     x = np.where(c == 1, cens_at, detected)


### PR DESCRIPTION
CI's test step took 13m21 sequentially. This makes it 4-6 minutes without weakening a single test.

## Why parallelism rather than smaller tests

Profiling the whole suite by test showed the cost is extremely concentrated:

```
tests >= 10s:  14, totalling 302s (38%)
tests >=  5s:  31, totalling 419s (53%)
tests <   1s: 913, totalling  95s
```

913 tests cost 95 seconds between them, so there was nothing to win by optimising the many. And the expensive few are mostly Monte Carlo:

| kind | tests | sec |
|---|---|---|
| Monte Carlo / bootstrap replicates | 8 | ~202 |
| Forest tree counts | 2 | ~33 |
| Ill-conditioned optimiser paths (MSE/MOM + offset) | 3 | ~77 |

Cutting replicate counts would have been the obvious move, but it weakens exactly the tests whose replicate count *is* the assertion — `test_coverage_of_coefficient_interval` verifies a 95% interval covers ~95% of the time, and the renewal residual tests assert `e.var()` to within 0.15.

Parallelism gets more than those trims could have, and costs nothing in test strength.

## Measured

Identical command, identical test count:

| | wall | user |
|---|---|---|
| sequential | 801.38s (13m21) | 14m06 |
| `-n 4` | 250.12s (4m10) | 15m36 |

3.2x for 10% extra CPU. Confirmed stable over repeated runs (250.12s, 233.06s, both 2016 passed), and no ordering dependence surfaced — worth checking explicitly, since xdist varies execution order and this suite previously had a test drawing from the global RNG through an unseeded generator.

Full suite with coverage enabled, as CI runs it: **367.59s, 2016 passed, 94% coverage, html report written.**

## Coverage

`coverage run` does not follow xdist's worker subprocesses, so coverage moves to pytest-cov, which handles them natively. Totals are identical — on the same subset both mechanisms report 26051 statements, 18576 missed, 29%. With coverage enabled on both sides that subset goes 337s to 111s (3.0x). The existing `coverage report` and `coverage html` steps are unchanged and still read the `.coverage` file.

## Invocation

`python -m pytest` rather than bare `pytest`, so plugins resolve against the interpreter the dependencies were installed into rather than whichever `pytest` is first on PATH. This was not hypothetical — the bare binary in this environment is a separate tool install that rejects `-n` and `--cov` outright, which would have been a red CI run had the real command not been executed before pushing.

## Also

Trims the right-truncation consistency test from 50,000 retained draws to 15,000. It still lands within 1% of the true parameters, comfortably inside its 5% tolerance, in half the time — that test was mine from the previous PR and was larger than its assertion needed.

## Not addressed here

Profiling turned up that `Gamma.fit(..., offset=True, how="MSE")` on 10,000 points takes ~12s in a single optimisation (640 autograd backward passes through `gammainc`), with runtime non-monotonic in `n` — 6.8s at n=500, 1.1s at n=2000, 4.7s at n=10000 — and returns `params=[56.4, 19.2], gamma=7.77` against a true `[3.0, 4.0], gamma=10.0`. MOM returns `gamma=-4.889`. MLE gets it right in 0.31s. That looks like a conditioning problem in the MSE/MOM offset objectives rather than a test issue, and is worth its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_