### PR TITLE
Return the offset first from the Gamma initialiser

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,36 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **Offset Gamma fits no longer start from a corrupted initial guess.**
+  Every offset-capable distribution returns the shift first in its
+  parameter vector, because ``_initial_guess`` overwrites that slot
+  with its own estimate of the shift. ``Gamma`` returned it *last*, so
+  the overwrite landed on the shape parameter and destroyed it, while
+  the initialiser's own copy of the shift stayed behind in the scale
+  slot: the seed came back as ``(offset, shape-ish, offset)``.
+
+  Compounding it, the shape approximation was computed on the raw
+  ``x``. On offset data the constant squashes
+  ``s = log(mean x) - mean(log x)`` towards zero, and since the shape
+  grows like ``1 / 12s`` the estimate exploded -- 649 for a true shape
+  of 3. The moments are now taken after the shift is removed.
+
+  The consequences were silent wrong answers, not just slow ones. A
+  600-point sample from ``Gamma(3, 4)`` shifted up by 10 fitted by MSE
+  returned a *negative* shift of -1.35 with a shape of 63.8; another
+  sample stopped after 0.03 s at the seed itself, reporting a scale
+  equal to the offset. Both now recover the shift, and the fit is also
+  4x faster (6.2 s to 1.6 s) because the optimiser no longer has to
+  travel back from a nonsense starting point. MLE was unaffected -- it
+  found its way regardless -- and non-offset fits are untouched.
+
+  Method of moments still disagrees on offset Gamma, but that is not a
+  defect: its solution matches the sample moments *better than the true
+  parameters do* (first three moments 10.76 / 116 / 1253 against the
+  truth's 10.75 / 115.7 / 1248). The three-parameter moment system with
+  a threshold is close to non-identifiable, which is why ``MOM`` is not
+  among the offset methods exercised in the test suite.
+
 - **Fitted parameters change for censored *and* truncated data: the
   likelihood was unbounded there (#310).** A censored observation is
   only ever known to lie inside its own truncation window -- it could

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -343,6 +343,61 @@ OFFSET_CASES = [
 ]
 
 
+@pytest.mark.parametrize(
+    "dist,dist_params", OFFSET_CASES, ids=[d.name for d, _ in OFFSET_CASES]
+)
+def test_offset_initialiser_puts_the_offset_first(dist, dist_params):
+    # `_initial_guess` overwrites slot 0 with the offset seed, so every
+    # offset initialiser must return gamma first. Gamma returned it last,
+    # which meant the overwrite landed on the shape and destroyed it --
+    # the seed came back as (offset, shape-estimate, offset) and MSE fits
+    # converged to nonsense.
+    shift = 10.0
+    x = dist.random(2000, *dist_params) + shift
+    c = np.zeros(x.size, dtype=int)
+    n = np.ones(x.size, dtype=np.int64)
+
+    init = np.asarray(
+        dist._initial_guess(x, c, n, True, False, False, "Nelson-Aalen"),
+        dtype=float,
+    )
+    assert len(init) == len(dist_params) + 1
+
+    # Slot 0 is the offset: just below the smallest observation.
+    assert init[0] == pytest.approx(x.min() - 1.0)
+    assert np.isfinite(init[1:]).all()
+    assert (init[1:] > 0).all()
+
+    # The tell-tale of an initialiser that returns the offset in the
+    # wrong position: `_initial_guess` writes the offset into slot 0
+    # while the initialiser's own copy of it is still sitting in a
+    # parameter slot, so the value appears twice and one real parameter
+    # estimate has been thrown away. Gamma returned
+    # ``(alpha, 1/beta, offset)`` and seeded (9.07, 14.88, 9.07) where
+    # the parameters are (3.0, 2.0).
+    assert not np.isclose(init[1:], init[0]).any(), (
+        f"{dist.name} seeded {init}: the offset {init[0]:.4g} also "
+        f"appears in a parameter slot, so its initialiser is returning "
+        f"the offset somewhere other than first"
+    )
+
+
+def test_offset_gamma_mse_recovers_the_shift():
+    # The user-visible consequence of the seeding bug above. With the
+    # offset written over the shape estimate, MSE returned a *negative*
+    # shift for data shifted up by 10, with a shape of 63 against a true
+    # 3 -- and on other samples it stopped after 0.03s at the seed
+    # itself, reporting beta equal to the offset. Neither raised.
+    np.random.seed(3)
+    shift = 10.0
+    x = Gamma.random(600, 3.0, 4.0) + shift
+
+    model = Gamma.fit(x, offset=True, how="MSE")
+    assert model.gamma == pytest.approx(shift, abs=0.5)
+    assert model.params[0] == pytest.approx(3.0, rel=0.4)
+    assert model.params[1] == pytest.approx(4.0, rel=0.4)
+
+
 @pytest.mark.parametrize("how", ["MLE", "MPS", "MSE", "MPP"])
 @pytest.mark.parametrize(
     "dist,dist_params", OFFSET_CASES, ids=[d.name for d, _ in OFFSET_CASES]

--- a/surpyval/univariate/parametric/distributions/gamma.py
+++ b/surpyval/univariate/parametric/distributions/gamma.py
@@ -36,18 +36,38 @@ class Gamma_(ParametricFitter):
             plot_x_scale="linear",
         )
 
+    @staticmethod
+    def _moment_estimate(x):
+        """Closed-form approximation to the Gamma MLE.
+
+        The shape solves ``log(alpha) - digamma(alpha) = s`` with
+        ``s = log(mean x) - mean(log x)``; this is the standard
+        approximation to that root (Minka 2002, after Thom 1958), good
+        to about 1.5% and used only as a starting point.
+        """
+        s = np.log(x.sum() / len(x)) - np.log(x).sum() / len(x)
+        alpha = (3 - s + np.sqrt((s - 3) ** 2 + 24 * s)) / (12 * s)
+        beta = x.sum() / (len(x) * alpha)
+        return alpha, 1.0 / beta
+
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
-        # These equations are truly magical
         if offset:
-            s = np.log(x.sum() / len(x)) - np.log(x).sum() / len(x)
-            alpha = (3 - s + np.sqrt((s - 3) ** 2 + 24 * s)) / (12 * s)
-            beta = x.sum() / (len(x) * alpha)
-            return alpha, 1.0 / beta, np.min(x) - 1
-        else:
-            s = np.log(x.sum() / len(x)) - np.log(x).sum() / len(x)
-            alpha = (3 - s + np.sqrt((s - 3) ** 2 + 24 * s)) / (12 * s)
-            beta = x.sum() / (len(x) * alpha)
-            return alpha, 1.0 / beta
+            # ``gamma`` leads the vector, as it does for every other
+            # offset-capable distribution. Returning it last put the
+            # shape in slot 0, where ``_initial_guess`` overwrites that
+            # slot with the offset seed -- so the shape estimate was
+            # destroyed and the offset written into the scale as well.
+            #
+            # The moments must also be taken *after* the shift. On
+            # offset data ``s = log(mean x) - mean(log x)`` is squashed
+            # towards zero by the constant, and since alpha grows like
+            # ``1 / 12s`` the estimate explodes: 649 for a true shape of
+            # 3. Together these made MSE and MOM offset fits return
+            # silent nonsense.
+            gamma_init = np.min(x) - 1.0
+            alpha, beta = self._moment_estimate(x - gamma_init)
+            return gamma_init, alpha, beta
+        return self._moment_estimate(x)
 
     def sf(self, x, alpha, beta):
         r"""


### PR DESCRIPTION
Offset `Gamma` fits started from a corrupted initial guess and returned silent wrong answers.

## The convention

`_initial_guess` overwrites slot 0 of the seed with its own estimate of the shift:

```python
if offset:
    init[0] = x_nonzero.min() - 1.0
```

That is only correct if slot 0 *is* the offset, and every offset-capable distribution returns it first:

```python
weibull      return (mpp_model.gamma, *mpp_model.params)
lognormal    return gamma_init, mu, sigma
loglogistic  return gamma_init, ..., 2.0
rayleigh     return gamma_init, sigma_init
exponential  return np.min(x) - ..., rate
```

`Gamma` returned it last:

```python
return alpha, 1.0 / beta, np.min(x) - 1
```

So the overwrite landed on the shape and destroyed it, while the initialiser's own copy of the shift stayed behind in the scale slot — the offset appearing twice and one real estimate thrown away:

```
initialiser returns  [649.47, 60.44, 9.02]
after the overwrite  [  9.02, 60.44, 9.02]
true                 [ 10.0,   3.0,  4.0]
```

## A second, compounding bug

That `649.47` is the shape approximation applied to the raw `x`. On offset data the constant squashes `s = log(mean x) - mean(log x)` towards zero, and since the shape grows like `1 / 12s` the estimate explodes. The moments are now taken after the shift is removed.

## Consequences — wrong answers, not just slow fits

600 points from `Gamma(3, 4)` shifted up by 10, fitted by MSE:

| | result | time |
|---|---|---|
| before | `gamma=-1.35, alpha=63.81, beta=13.33` | 6.21s |
| after | `gamma=9.92, alpha=3.93, beta=4.85` | **1.55s** |

A *negative* shift on data shifted up by 10. On another sample it was worse in a different way — it stopped after 0.03s at the seed itself, returning `beta == gamma == 9.01`, the duplicated offset surviving into the reported answer.

At `n=10,000` with `Gamma(3, 4) + 10`:

| method | before | after |
|---|---|---|
| MSE | `gamma=7.77, alpha=56.45, beta=19.23` | `gamma=9.99, alpha=3.12, beta=4.13` |
| MPS | correct, 7.51s | correct, **3.15s** |
| MPP | — | `gamma=9.99, alpha=3.14, beta=4.15` |
| MLE | correct | correct, unchanged |

MLE was unaffected throughout: it found its way from the bad seed regardless, which is why this went unnoticed. Non-offset fits are untouched.

## Tests

Both fail without the fix.

`test_offset_initialiser_puts_the_offset_first` runs over all six offset distributions and asserts the offset does not also appear in a parameter slot — the exact signature of an initialiser returning it in the wrong position. A magnitude bound was tried first (`seeded < 50 * true`) and passed with the bug present, so it was replaced.

`test_offset_gamma_mse_recovers_the_shift` pins the user-visible behaviour on the 600-point case above.

Worth noting the existing `test_offset_fit_recovers_gamma[Gamma-MSE]` **passed** with this bug: its parameters happened to let the optimiser recover from the bad seed, just slowly. The failure is data-dependent, which is why it needed a case chosen to expose it.

## Not changed: method of moments

`MOM` still disagrees on offset Gamma, but it is not wrongly implemented — its solution matches the sample moments *better than the true parameters do*:

```
sample moments:            10.76   116    1253
true      (10, 3, 4)       10.75   115.7  1248
MOM fit (8.93, 17.7, 9.66) 10.76   116    1253
```

The three-parameter moment system with a threshold parameter is close to non-identifiable. That is a property of the estimator, not a defect, and presumably why `MOM` is absent from the offset methods exercised in `test_offset_fit_recovers_gamma`.

## Verification

Full suite 2023 passed, 1 skipped, 5 xfailed. `black`, `flake8`, `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_