### PR TITLE
Match central moments rather than raw ones in MOM

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,37 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **Method of moments now matches central moments rather than raw
+  ones.** The two describe the same estimator -- the binomial transform
+  between them is exact and bijective, so matching the first ``k``
+  central moments is matching the first ``k`` raw moments -- but raw
+  moments hide the answer from the optimiser once a distribution is
+  offset. ``E[X^k]`` is then dominated by ``gamma^k`` and the shape
+  contributes only a fractional correction: 0.5% of ``E[X^3]`` for a
+  Gamma(3, 4) shifted by 10. Fitting three parameters off the third
+  decimal place of a large number degenerates, and offset fits settled
+  on parameters that matched the sample moments *better than the true
+  parameters did* while being nowhere near them -- a shape of 17.7
+  against a true 3.0, unchanged at any sample size.
+
+  Central moments remove the offset by construction, so the shape is
+  the whole of the third moment rather than a rounding error in it. An
+  offset Gamma at n=5000 goes from ``gamma=49.01, alpha=15.74,
+  beta=9.07`` to ``gamma=50.01, alpha=2.74, beta=3.75`` against a true
+  ``(50, 3, 4)``, and the fit drops from up to 25 s to under a second.
+  Unshifted fits are unaffected -- Weibull, Gamma, Normal, LogNormal,
+  Logistic, Gumbel and Exponential all agree with the previous results
+  to at least four decimal places, because there the conditioning was
+  never the problem.
+
+  The terms are scaled by the sample's own ``sigma^k``, so each is
+  dimensionless: the mean in units of sigma, the relative variance
+  error, then the skewness difference. The mismatch warning's threshold
+  moves from 1e-4 to 1e-2 to suit those units. Healthy fits land near
+  1e-12 when the moment equations have an exact solution and near 1e-3
+  when sampling noise means none exists and the optimiser returns the
+  closest match; a fit that has actually failed sits near 0.5.
+
 - **Offset Gamma fits no longer start from a corrupted initial guess.**
   Every offset-capable distribution returns the shift first in its
   parameter vector, because ``_initial_guess`` overwrites that slot

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -487,3 +487,47 @@ def test_mse(dist, random_parameters):
             break
     else:
         raise AssertionError("MPS fit not very good in %s\n" % dist.name)
+
+
+def test_raw_to_central_moment_transform():
+    # mu_k = sum_j C(k, j) (-1)^(k-j) E[X^j] mean^(k-j), with the mean
+    # kept in the leading slot. Checked against a shifted Gamma, whose
+    # central moments are known exactly: a/b^2 and 2a/b^3.
+    from math import comb
+
+    from surpyval.univariate.parametric.fitters.mom import raw_to_central
+
+    g, a, b = 10.0, 3.0, 4.0
+    raw = []
+    for k in (1, 2, 3):
+        total = 0.0
+        for j in range(k + 1):
+            rising = 1.0
+            for i in range(j):
+                rising *= a + i
+            total += comb(k, j) * g ** (k - j) * rising / b**j
+        raw.append(total)
+
+    mean, var, mu3 = raw_to_central(np.array(raw))
+    assert mean == pytest.approx(g + a / b)
+    assert var == pytest.approx(a / b**2)
+    assert mu3 == pytest.approx(2 * a / b**3)
+
+
+def test_offset_gamma_mom_recovers_the_shape():
+    # MOM compares central moments, not raw ones. On an offset fit
+    # E[X^k] is dominated by gamma^k -- the shape is a 0.5% correction
+    # to E[X^3] -- so the raw-moment objective was nearly blind to it
+    # and settled on a shape of 17.7 against a true 3.0, matching the
+    # sample moments *better than the true parameters did*. MOM is not
+    # in the offset parametrisation above, so nothing caught this.
+    np.random.seed(11)
+    x = Gamma.random(10_000, 3.0, 4.0) + 10.0
+
+    model = Gamma.fit(x, offset=True, how="MOM")
+    assert model.gamma == pytest.approx(10.0, abs=0.5)
+    # Generous on the shape: the three-parameter moment estimator is
+    # biased upward at finite n because alpha goes like 1 / skewness^2.
+    # The point is that it is near 3 rather than near 17.
+    assert model.params[0] == pytest.approx(3.0, rel=0.35)
+    assert model.params[1] == pytest.approx(4.0, rel=0.35)

--- a/surpyval/univariate/parametric/fitters/mom.py
+++ b/surpyval/univariate/parametric/fitters/mom.py
@@ -1,15 +1,71 @@
 import warnings
+from math import comb
 
 from scipy.optimize import minimize
 
 from surpyval import np
 
 
+def raw_to_central(moments):
+    """``(mean, var, mu3, ...)`` from raw moments ``E[X], E[X^2], ...``.
+
+    ``mu_k = sum_j C(k, j) (-1)^(k-j) E[X^j] mean^(k-j)``, with the mean
+    kept in the leading slot because the first central moment is zero by
+    construction and carries no information.
+
+    The transform is exact and bijective, so matching the first ``k``
+    central moments is the same estimator as matching the first ``k``
+    raw ones -- it is only better conditioned. See ``mom_fun``.
+    """
+    mean = moments[0]
+    central = [mean]
+    for k in range(2, len(moments) + 1):
+        acc = (-1) ** k * mean**k  # the j = 0 term, where E[X^0] = 1
+        for j in range(1, k + 1):
+            acc = acc + comb(k, j) * (-1) ** (k - j) * moments[j - 1] * (
+                mean ** (k - j)
+            )
+        central.append(acc)
+    return np.array(central)
+
+
 def mom_fun(params, dist, inv_trans, const, offset, moments):
+    """Squared mismatch between the sample and model moments.
+
+    Compared as *central* moments scaled by the sample's own standard
+    deviation, so every term is dimensionless and of comparable size:
+    the mean in units of sigma, then the relative variance error, then
+    the skewness difference, and so on.
+
+    Raw moments describe the same estimator but hide it. Once a
+    distribution is offset, ``E[X^k]`` is dominated by ``gamma^k`` and
+    the shape contributes only a fractional correction -- 0.5% of
+    ``E[X^3]`` for a Gamma(3, 4) shifted by 10. The optimiser is then
+    reading three parameters off the third decimal place of a large
+    number, and offset fits converged to parameter sets that matched the
+    sample moments *better than the true parameters did* while being
+    nowhere near them: a shape of 17.7 against a true 3.
+
+    Central moments remove the offset by construction, so the shape
+    information is the whole of ``mu_3`` rather than a rounding error in
+    it. For unshifted fits the two agree to several decimal places,
+    because there the conditioning was never the problem.
+    """
     dist_moments = dist.mom_moment_gen(
         *inv_trans(const(params)), offset=offset
     )
-    return ((moments - dist_moments) ** 2 / moments).sum()
+    sample = raw_to_central(moments)
+    model = raw_to_central(dist_moments)
+
+    # sigma^k puts every term on a common footing. Taken from the sample
+    # alone so the scale is a constant of the problem, not something the
+    # optimiser can shrink to flatter itself.
+    sigma = np.sqrt(np.abs(sample[1])) if len(sample) > 1 else 1.0
+    if not np.isfinite(sigma) or sigma <= 0:
+        sigma = 1.0
+    scale = np.array([sigma ** (k + 1) for k in range(len(sample))])
+
+    return (((sample - model) / scale) ** 2).sum()
 
 
 def mom(model):
@@ -62,11 +118,22 @@ def mom(model):
         )
         if np.isfinite(res_nm.fun) and res_nm.fun < res.fun:
             res = res_nm
-    if res.fun > 1e-4:
+    # The objective is a sum of squared standardised-moment differences
+    # (see ``mom_fun``), so this threshold is in those units. Healthy
+    # fits land in one of two places: ~1e-12 when the moment equations
+    # have an exact solution, or ~1e-3 when sampling noise means no
+    # parameter vector reproduces the sample moments exactly and the
+    # optimiser returns the closest one -- a third central moment is
+    # noisy enough at n=5000 for that to be routine. A fit that has
+    # actually failed sits near 0.5. 1e-2 separates them with roughly an
+    # order of magnitude of clearance on either side; the previous 1e-4
+    # was calibrated against the old raw-moment objective and fires on
+    # ordinary sampling noise under this one.
+    if res.fun > 1e-2:
         warnings.warn(
-            "MOM optimisation did not match the sample moments (relative "
-            f"squared mismatch {res.fun:.3g}); the returned parameters may "
-            "be unreliable. Consider how='MLE'."
+            "MOM optimisation did not match the sample moments (squared "
+            f"standardised-moment mismatch {res.fun:.3g}); the returned "
+            "parameters may be unreliable. Consider how='MLE'."
         )
 
     params = inv_trans(const(res.x))


### PR DESCRIPTION
Offset MOM fits converged to parameters nowhere near the truth. This fixes it with no new API, because there is nothing for a user to choose between.

## Same estimator, different conditioning

The binomial transform between raw and central moments is exact and bijective, so matching the first `k` central moments **is** matching the first `k` raw moments. It is not a different estimator, and there is no data for which the raw form is preferable — which is why this is not exposed as an option.

What differs is whether the optimiser can see the answer. Once a distribution is offset, `E[X^k]` is dominated by `gamma^k`:

```
E[X^3] = 1248 for Gamma(3, 4) shifted by 10
         of which the shape contributes ~6  --  a 0.5% correction
```

Fitting three parameters off the third decimal place of a large number degenerates. Offset fits settled on parameter sets that matched the sample moments *better than the true parameters did*, while being nowhere near them:

```
sample moments:            10.76   116    1253
true      (10, 3, 4)       10.75   115.7  1248
old MOM fit (8.93, 17.7, 9.66) 10.76   116    1253
```

That is not a convergence failure — the optimiser was doing exactly what it was asked. The raw-moment parametrisation simply cannot distinguish those two, and no amount of extra moments helps: the discriminating signal saturates at 0.66% while the sampling noise in the k-th moment grows past it at k=6.

Central moments remove the offset by construction, so the shape is the whole of `mu_3` rather than a rounding error in it. The information was always there — the two candidates differ by 2.4x in skewness and 5.9x in excess kurtosis, which sample skewness at n=2000 resolves at 6.5 standard errors.

## Results

Offset Gamma, n=5000, true `(50, 3, 4)`:

| | gamma | alpha | beta | time |
|---|---|---|---|---|
| before | 49.01 | **15.74** | 9.07 | up to 25s |
| after | 50.01 | **2.74** | 3.75 | <1s |

Unshifted fits are unaffected. Weibull, Gamma, Normal, LogNormal, Logistic, Gumbel and Exponential all agree with the previous results to at least four decimal places — there the conditioning was never the problem, so there is nothing to change.

Offset Weibull is a wash: the new fit matches the moments 8x better (`res.fun` 6.9e-4 vs 5.6e-3) and lands marginally further from truth (`9.85, 1.94` vs `10.07, 2.01`, true `10, 2`). That is MOM being more faithful to its own objective under sampling noise, not a regression, and the existing #275 regression test passes unchanged.

## Scaling

Terms are scaled by the sample's own `sigma^k`, so each is dimensionless: the mean in units of sigma, then the relative variance error, then the skewness difference. Dividing by the central moments themselves would be unstable — `mu_1` is near zero for a Normal centred at zero, and `mu_3` vanishes for any symmetric distribution. The scale comes from the sample alone so it is a constant of the problem rather than something the optimiser can shrink to flatter itself.

## Warning threshold

Moves from 1e-4 to 1e-2, since the objective is now in different units. Measured, not guessed:

- healthy fit, exact solution exists: **~1e-12**
- healthy fit, sampling noise means none exists and the optimiser returns the closest match: **~7e-4** (routine at n=5000 — a third central moment is noisy)
- fit that has actually failed: **~0.5 to 580**

The old threshold sat inside the healthy range and fired on ordinary sampling noise in the offset Weibull test. 1e-2 keeps roughly an order of magnitude of clearance either side. Verified both directions: the healthy offset Weibull no longer warns, and an impossible `fixed={"beta": 8.0}` still does.

## Tests

`test_raw_to_central_moment_transform` checks the transform against a shifted Gamma's exact central moments (`a/b^2`, `2a/b^3`).

`test_offset_gamma_mom_recovers_the_shape` pins the behaviour. Note `MOM` is absent from the offset parametrisation in `test_offset_fit_recovers_gamma`, which is why this was never caught.

Full suite 2025 passed, 1 skipped, 5 xfailed. `black`, `flake8`, `mypy` clean.

## Follow-up, not included

For a shifted Gamma the central moments invert in closed form, since skewness is location- and scale-invariant and so depends on the shape alone:

```
alpha = 4 / g1^2,    beta = 2 / (g1 * s),    gamma = xbar - 2s / g1
```

That reaches the same answer this PR now converges to, in about a millisecond rather than up to a second. It is a speed optimisation on top of a correctness fix, wants guards for non-positive sample skewness, and is biased upward in the shape at small n (32% at n=100, 0.1% at n=10000), so it belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_