### PR TITLE
Stop two fitters doing per-event and nested-optimiser work

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,22 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **ExpoWeibull no longer runs a nested optimiser ladder to build its
+  initial guess.** It seeds itself from a Gumbel fit to ``log(x)``, and
+  that inner fit was a full maximum likelihood run -- an optimiser
+  ladder, to produce a *starting point* for another optimiser. It cost
+  15-30% of the fit (20 ms at n=200, 41 ms at n=5000) and the
+  probability plot alone turned out to be just as good a seed: across 54
+  parameter combinations, plus right-censored, left-censored and heavily
+  tied data, every fit reached the same optimum to the optimiser's own
+  tolerance. Ordinary fits are about 20% faster.
+
+  The offset path keeps the refinement. There the seed reads ``log(x)``
+  of the *unshifted* data, so a large shift compresses the logs into a
+  narrow band and the probability plot is a poor starting point --
+  dropping it moved one fit in twelve to a worse optimum (861.898 to
+  861.962) and made that fit seven times slower.
+
 - **The ARI likelihood is evaluated for the whole sample at once, making
   imperfect-repair fits 30-160x faster.** It used to walk every event in
   Python, calling the baseline ``cif`` and ``iif`` and rebuilding the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,43 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **The ARI likelihood is evaluated for the whole sample at once, making
+  imperfect-repair fits 30-160x faster.** It used to walk every event in
+  Python, calling the baseline ``cif`` and ``iif`` and rebuilding the
+  intensity reduction from the failure history at each step -- around
+  ten milliseconds per event, repeated for every one of the optimiser's
+  several hundred objective evaluations. Fitting 250 items took 19
+  seconds and 1000 items was impractical.
+
+  The apparent obstacle is that the reduction depends on the failure
+  history, which looks inherently sequential. It is not: summing over
+  the reduction's *window offset* rather than over the failures turns it
+  into a handful of whole-array passes, and the offset only ever runs to
+  ``min(m, longest item)`` -- exactly one pass for ARI1. Each failure's
+  ordinal within its own item bounds the window, which is what stops one
+  item's history leaking into the next.
+
+  =========================  ==========  ==========
+  fit                        before      after
+  =========================  ==========  ==========
+  35 items x 6 events        2.11 s      0.07 s
+  250 items x 8 events       19.02 s     0.12 s
+  Cramer-von Mises, 10 boot  24.16 s     1.71 s
+  1000 items x 10 events     ~80 s       0.53 s
+  =========================  ==========  ==========
+
+  Results are unchanged to floating point: over 312 captured values --
+  the reduction helper across memory regimes, the objective on a fixed
+  parameter grid, fitted parameters and the rescaled-increment
+  residuals -- the largest relative difference is 1.1e-14, from
+  summation order. The original per-event implementation is kept in the
+  test suite as an oracle so the two cannot drift.
+
+  One behavioural nicety: a non-positive reduced intensity is outside
+  the model's support, and the scalar loop returned ``inf`` early on
+  reaching one. The vectorised form tests the whole array before taking
+  logs, so it returns ``inf`` rather than warning its way to a ``nan``.
+
 - **Method of moments now matches central moments rather than raw
   ones.** The two describe the same estimator -- the binomial transform
   between them is exact and bijective, so matching the first ``k``

--- a/surpyval/recurrent/renewal/ari.py
+++ b/surpyval/recurrent/renewal/ari.py
@@ -37,6 +37,76 @@ def ari_reduction(failure_intensities, rho, m):
     return rho * np.sum(weights * recent)
 
 
+def _reduction_sequence(failure_intensities, position, rho, m):
+    """``R_n`` after every failure at once, for failures from many items.
+
+    ``failure_intensities`` holds ``lambda_0`` at each *observed* failure
+    with the items laid end to end, and ``position`` gives each failure's
+    index within its own item, which is what keeps one item's history
+    from leaking into the next.
+
+    This is ``ari_reduction`` evaluated at every prefix, but summed over
+    the *window offset* rather than over the failures. The offset only
+    ever runs to ``min(m, longest item)``, so the loop is a handful of
+    whole-array passes -- for ARI1 exactly one -- in place of one Python
+    step per failure. The offset ``i`` contributes only where the item
+    actually has ``i`` earlier failures, which is the ``position >= i``
+    mask and reproduces ``upper = min(m, n)`` above.
+    """
+    lam = np.asarray(failure_intensities, dtype=float)
+    if lam.size == 0:
+        return lam
+    pos = np.asarray(position)
+    longest = int(pos.max()) + 1
+    span = longest if np.isinf(m) else min(int(m), longest)
+
+    q = 1.0 - rho
+    total = np.array(lam, copy=True)
+    for i in range(1, span):
+        shifted = np.concatenate([np.zeros(i), lam[:-i]])
+        total += (q**i) * np.where(pos >= i, shifted, 0.0)
+    return rho * total
+
+
+def _event_layout(data):
+    """Per-row bookkeeping shared by the likelihood and the residuals.
+
+    ``prev`` is the previous event time, restarting at 0 for each item.
+    ``observed`` marks the failures. ``failure_pos`` gives each failure's
+    ordinal within its own item, which bounds the reduction window.
+    ``in_force`` indexes the reduction sequence at the reduction acting
+    over each row's interval, or ``-1`` where the item has not failed
+    yet and the intensity is still the unreduced baseline.
+
+    Rows are assumed grouped by item, as ``handle_xicn`` leaves them.
+    """
+    x = np.asarray(data.x, dtype=float)
+    item = np.asarray(data.i)
+    observed = np.asarray(data.c) == 0
+
+    starts = np.empty(x.size, dtype=bool)
+    starts[0] = True
+    starts[1:] = item[1:] != item[:-1]
+
+    prev = np.empty_like(x)
+    prev[0] = 0.0
+    prev[1:] = x[:-1]
+    prev[starts] = 0.0
+
+    # Failures strictly before each row, globally then per item.
+    before = np.cumsum(observed) - observed
+    first_rows = np.flatnonzero(starts)
+    lengths = np.diff(np.append(first_rows, x.size))
+    before_item = before - np.repeat(before[first_rows], lengths)
+
+    # Within an item the most recent earlier failure is also the most
+    # recent one globally, so the global running count indexes it -- the
+    # per-item count only decides whether one exists at all.
+    in_force = np.where(before_item > 0, before - 1, -1)
+    failure_pos = before_item[observed]
+    return prev, observed, failure_pos, in_force
+
+
 @singleton_fitter
 class ARI(RenewalFitMixin):
     """
@@ -132,23 +202,15 @@ class ARI(RenewalFitMixin):
         """
         rho, m = model.rho, model.m
         dist = model.model
-        _, idx = np.unique(data.i, return_index=True)
-        x_by_item = np.split(data.x, idx)[1:]
-        c_by_item = np.split(data.c, idx)[1:]
+        x = np.asarray(data.x, dtype=float)
+        prev, observed, failure_pos, in_force = _event_layout(data)
 
-        increments = []
-        for x_item, c_item in zip(x_by_item, c_by_item):
-            prev = 0.0
-            reduction = 0.0
-            history_iif = []
-            for t, censor in zip(x_item, c_item):
-                delta_cif = float(dist.cif(t) - dist.cif(prev))
-                increments.append(delta_cif - reduction * (t - prev))
-                if censor == 0:
-                    history_iif.append(float(dist.iif(t)))
-                    reduction = ari_reduction(history_iif, rho, m)
-                prev = t
-        return np.asarray(increments, dtype=float)
+        lam = np.asarray(dist.iif(x[observed]), dtype=float)
+        reductions = _reduction_sequence(lam, failure_pos, rho, m)
+        active = np.where(in_force >= 0, reductions[in_force], 0.0)
+
+        delta_cif = np.asarray(dist.cif(x) - dist.cif(prev), dtype=float)
+        return delta_cif - active * (x - prev)
 
     def _refit(self, model, data):
         """Refit this model family on ``data`` with the same baseline
@@ -158,35 +220,35 @@ class ARI(RenewalFitMixin):
         )
 
     def create_negll_func(self, data, dist, m):
-        _, idx = np.unique(data.i, return_index=True)
-        x_by_item = np.split(data.x, idx)[1:]
-        c_by_item = np.split(data.c, idx)[1:]
+        x = np.asarray(data.x, dtype=float)
+        prev, observed, failure_pos, in_force = _event_layout(data)
+        gap = x - prev
+        x_failures = x[observed]
 
         def negll_func(params):
             rho = params[0]
             dist_params = params[1:]
 
-            ll = 0.0
-            for x_item, c_item in zip(x_by_item, c_by_item):
-                prev = 0.0
-                reduction = 0.0
-                history_iif = []
-                for t, censor in zip(x_item, c_item):
-                    # Integral of the (reduced) intensity over (prev, t]; the
-                    # reduction is constant across the interval.
-                    delta_cif = dist.cif(t, *dist_params) - dist.cif(
-                        prev, *dist_params
-                    )
-                    ll -= delta_cif - reduction * (t - prev)
+            # lambda_0 at the failures drives the reductions; every row
+            # then picks up whichever reduction was in force over its own
+            # interval (`in_force` is -1 before the item's first failure,
+            # where the baseline is unreduced).
+            lam = dist.iif(x_failures, *dist_params)
+            reductions = _reduction_sequence(lam, failure_pos, rho, m)
+            active = np.where(in_force >= 0, reductions[in_force], 0.0)
 
-                    if censor == 0:
-                        intensity = dist.iif(t, *dist_params) - reduction
-                        if intensity <= 0:
-                            return np.inf
-                        ll += np.log(intensity)
-                        history_iif.append(dist.iif(t, *dist_params))
-                        reduction = ari_reduction(history_iif, rho, m)
-                    prev = t
+            # A non-positive intensity is outside the model's support.
+            # Checked before the log so it returns inf rather than
+            # warning its way to a nan, as the scalar loop did by
+            # returning early.
+            intensity = lam - active[observed]
+            if not np.all(intensity > 0):
+                return np.inf
+
+            delta_cif = dist.cif(x, *dist_params) - dist.cif(
+                prev, *dist_params
+            )
+            ll = -np.sum(delta_cif - active * gap) + np.sum(np.log(intensity))
             return -ll
 
         return negll_func

--- a/surpyval/tests/recurrent/test_ari.py
+++ b/surpyval/tests/recurrent/test_ari.py
@@ -79,3 +79,120 @@ def test_ari_inference_requires_fit_from_data():
     model = ARI.fit_from_parameters([60.0, 2.0], rho=0.3, m=1, dist=CrowAMSAA)
     with pytest.raises(ValueError, match="fitted from data"):
         model.aic
+
+
+# -- the vectorised likelihood against the scalar original -------------
+#
+# The likelihood used to walk every event in Python, calling the
+# baseline cif/iif and rebuilding the reduction from the failure history
+# each step. That was ~10ms per event and made a 250-item fit take 19
+# seconds. The replacement evaluates the whole sample at once, summing
+# over the reduction *window offset* instead of over the events. The
+# original is kept here as the oracle so the two cannot drift apart.
+
+
+def _scalar_negll(data, dist, m, params):
+    """The original per-event implementation, verbatim."""
+    _, idx = np.unique(data.i, return_index=True)
+    x_by_item = np.split(data.x, idx)[1:]
+    c_by_item = np.split(data.c, idx)[1:]
+
+    rho = params[0]
+    dist_params = params[1:]
+
+    ll = 0.0
+    for x_item, c_item in zip(x_by_item, c_by_item):
+        prev = 0.0
+        reduction = 0.0
+        history_iif = []
+        for t, censor in zip(x_item, c_item):
+            delta_cif = dist.cif(t, *dist_params) - dist.cif(
+                prev, *dist_params
+            )
+            ll -= delta_cif - reduction * (t - prev)
+            if censor == 0:
+                intensity = dist.iif(t, *dist_params) - reduction
+                if intensity <= 0:
+                    return np.inf
+                ll += np.log(intensity)
+                history_iif.append(dist.iif(t, *dist_params))
+                reduction = ari_reduction(history_iif, rho, m)
+            prev = t
+    return -ll
+
+
+PARAM_GRID = [
+    [0.0, 20.0, 1.5],
+    [0.1, 20.0, 1.5],
+    [0.5, 20.0, 1.5],
+    [0.9, 20.0, 1.5],
+    [0.999, 20.0, 1.5],
+    [0.5, 5.0, 0.7],
+    [0.3, 50.0, 2.5],
+]
+
+
+@pytest.mark.parametrize("m", [1, 2, 3, np.inf])
+def test_vectorised_negll_matches_the_scalar_original(m):
+    truth = ARI.fit_from_parameters([20.0, 1.5], 0.5, m=m, dist=CrowAMSAA)
+    data = truth.count_terminated_simulation_data(6, items=12, seed=1)
+    negll = ARI.create_negll_func(data, CrowAMSAA, m)
+    for params in PARAM_GRID:
+        want = _scalar_negll(data, CrowAMSAA, m, np.array(params))
+        got = negll(np.array(params))
+        if np.isinf(want):
+            assert np.isinf(got) and np.sign(want) == np.sign(got)
+        else:
+            assert got == pytest.approx(want, rel=1e-12)
+
+
+def test_vectorised_negll_matches_with_censoring_and_uneven_items():
+    # Items of different lengths, some ending in a suspension, is where
+    # the per-item bookkeeping has to be right: a reduction must not leak
+    # from one item into the next, and a suspension consumes an interval
+    # without updating the reduction.
+    x = np.array([3, 9, 20, 35, 4, 11, 7, 15, 22, 40], dtype=float)
+    i = np.array([1, 1, 1, 1, 2, 2, 3, 3, 3, 3])
+    c = np.array([0, 0, 0, 1, 0, 0, 0, 0, 0, 1])
+    data = handle_xicn(x, i, c)
+    for m in (1, 2, np.inf):
+        negll = ARI.create_negll_func(data, CrowAMSAA, m)
+        for params in PARAM_GRID:
+            want = _scalar_negll(data, CrowAMSAA, m, np.array(params))
+            got = negll(np.array(params))
+            if np.isinf(want):
+                assert np.isinf(got)
+            else:
+                assert got == pytest.approx(want, rel=1e-12)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        [0.9, 20.0, 0.7],  # decreasing baseline: the reduction overtakes it
+        [1.0, 20.0, 1.0],  # flat baseline, full reduction: intensity is 0
+    ],
+    ids=["overtaken", "exactly zero"],
+)
+def test_negll_is_infinite_when_the_intensity_is_not_positive(params):
+    # A non-positive reduced intensity is outside the model's support.
+    # The scalar loop returned early on it; the vectorised form has to
+    # test before taking logs rather than warning its way to a nan. Note
+    # a rising baseline (beta > 1) stays positive even at rho = 1, so
+    # the case has to be built from a flat or falling one.
+    truth = ARI.fit_from_parameters([20.0, 1.5], 0.5, m=1, dist=CrowAMSAA)
+    data = truth.count_terminated_simulation_data(6, items=10, seed=2)
+    negll = ARI.create_negll_func(data, CrowAMSAA, 1)
+    got = negll(np.array(params))
+    assert np.isinf(got) and got > 0
+    # ... and the original agrees it is out of support.
+    assert np.isinf(_scalar_negll(data, CrowAMSAA, 1, np.array(params)))
+
+
+def test_fit_scales_to_many_items():
+    # 250 items took 19 seconds under the per-event loop.
+    truth = ARI.fit_from_parameters([20.0, 1.5], 0.5, m=1, dist=CrowAMSAA)
+    data = truth.count_terminated_simulation_data(8, items=250, seed=5)
+    model = ARI.fit_from_recurrent_data(data, dist=CrowAMSAA, m=1)
+    assert 0.0 <= model.rho <= 1.0
+    assert np.isfinite(model.model.params).all()

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -531,3 +531,21 @@ def test_offset_gamma_mom_recovers_the_shape():
     # The point is that it is near 3 rather than near 17.
     assert model.params[0] == pytest.approx(3.0, rel=0.35)
     assert model.params[1] == pytest.approx(4.0, rel=0.35)
+
+
+def test_expoweibull_offset_keeps_the_refined_seed():
+    # ExpoWeibull seeds itself from a Gumbel fit to log(x). Without an
+    # offset the probability plot alone is enough -- 54 parameter
+    # combinations, plus right, left and heavily tied data, all reach the
+    # same optimum -- so the nested optimiser ladder there was 15-30% of
+    # the fit for nothing.
+    #
+    # With an offset it is not enough. The seed reads log(x) of the
+    # *unshifted* data, so a large shift compresses the logs into a
+    # narrow band and the plot is a poor starting point. This dataset is
+    # the one in twelve where dropping the refinement moved the fit to a
+    # worse optimum (861.898 -> 861.962) and made it seven times slower.
+    np.random.seed(8)
+    x = ExpoWeibull.random(300, 10.0, 2.0, 1.5) + 25.0
+    model = ExpoWeibull.fit(x, offset=True)
+    assert model.neg_ll() < 861.93

--- a/surpyval/univariate/parametric/distributions/expo_weibull.py
+++ b/surpyval/univariate/parametric/distributions/expo_weibull.py
@@ -26,8 +26,23 @@ class ExpoWeibull_(ParametricFitter):
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         log_x = np.log(x)
         log_x[np.isnan(log_x)] = 0
-        gumb = para.Gumbel.fit(log_x, c, n, how="MLE")
-        if not gumb.res.success:
+        if offset:
+            # The offset path keeps the nested MLE. It reads log(x) of the
+            # *unshifted* data, so a large shift compresses the logs into a
+            # narrow band and the probability plot alone is a poor seed --
+            # the extra refinement earns its keep there. Dropping it moved
+            # one fit in twelve to a worse optimum (861.898 -> 861.962) and
+            # made that fit seven times slower.
+            gumb = para.Gumbel.fit(log_x, c, n, how="MLE")
+            if not gumb.res.success:
+                gumb = para.Gumbel.fit(log_x, c, n, how="MPP")
+        else:
+            # Without an offset the probability plot is already a good
+            # enough seed: running a whole optimiser ladder to refine a
+            # starting point cost 15-30% of the fit and changed nothing.
+            # Checked over 54 parameter combinations plus right, left and
+            # heavily tied data -- every fit reached the same optimum, to
+            # the optimiser's own tolerance.
             gumb = para.Gumbel.fit(log_x, c, n, how="MPP")
         mu, sigma = gumb.params
         alpha, beta = np.exp(mu), 1.0 / sigma


### PR DESCRIPTION
Two independent speedups, both found by profiling the test suite's slowest tests, both verified against captured references before merging.

---

# 1. The ARI likelihood is evaluated for the whole sample at once

`create_negll_func` walked every event in Python:

```python
for x_item, c_item in zip(x_by_item, c_by_item):
    for t, censor in zip(x_item, c_item):
        delta_cif = dist.cif(t, ...) - dist.cif(prev, ...)
        ...
        history_iif.append(dist.iif(t, ...))
        reduction = ari_reduction(history_iif, rho, m)
```

Two `cif` calls, two `iif` calls and an `ari_reduction` per event — about 10 ms each, repeated for every one of the optimiser's several hundred objective evaluations. Profiling a single 35-item fit:

```
negll_func       670 calls (optimiser evaluations)   3.051s cumulative
ari_reduction    164,150 calls                       1.760s
crow_amsaa.iif   328,300 calls
crow_amsaa.cif   329,002 calls
```

Essentially 100% of the fit.

## The fix

The reduction depends on the failure history, which looks inherently sequential:

```
R_n = rho * sum_{j=0}^{min(m,n)-1} (1 - rho)^j lambda_0(T_{n-j})
```

Summing over the **window offset** `j` rather than over the failures `n` makes it a few whole-array passes. The offset only runs to `min(m, longest item)` — exactly one pass for ARI1, and still only a few for ARI-infinity, since the bound is the longest item and not the sample size. Each failure's ordinal within its own item bounds the window, which stops one item's history leaking into the next and reproduces the original's `upper = min(m, n)`.

| fit | before | after |
|---|---|---|
| 35 items x 6 events | 2.11 s | **0.07 s** |
| 250 items x 8 events | 19.02 s | **0.12 s** |
| Cramer-von Mises, 10 bootstraps | 24.16 s | **1.71 s** |
| 1000 items x 10 events | ~80 s (est.) | **0.53 s** |

The scaling changes character: 250 items now costs barely more than 35, because the cost is the fixed optimiser iteration count rather than per-event Python.

## Verification

References captured before the change and compared after: the reduction helper across `m` in {1, 2, 3, inf} and `rho` in {0, 0.25, 0.5, 0.99, 1}, the objective on a fixed 8-point parameter grid over 8 datasets, the fitted parameters, and the rescaled-increment residuals.

**312 values, 0 mismatches, largest relative difference 1.1e-14.**

Not bit-identical, and it cannot be — the terms are summed in a different order. The original per-event implementation is kept in `test_ari.py` as the oracle, across all four memory regimes, items of uneven length, and suspensions.

A non-positive reduced intensity is outside the model's support: the scalar loop returned `inf` on reaching one, and the vectorised form tests before taking logs so it still returns `inf` rather than warning its way to a `nan`. Two tests pin that, including the boundary where a flat baseline and full reduction make the intensity exactly zero — worth stating because a *rising* baseline stays positive even at `rho = 1`.

---

# 2. ExpoWeibull is seeded from the probability plot, not a nested MLE

ExpoWeibull seeds itself from a Gumbel fit to `log(x)`, and that inner fit ran a **full optimiser ladder** — an optimiser, to produce a starting point for another optimiser:

```
n=200    nested Gumbel MLE  20.8ms   MPP  0.7ms   init share 30%
n=1000   nested Gumbel MLE  21.1ms   MPP  1.1ms   init share 15%
n=5000   nested Gumbel MLE  41.3ms   MPP  3.5ms   init share 22%
```

The probability plot alone is just as good a seed. Across 54 parameter combinations (`alpha` in {0.5, 10, 500}, `beta` in {0.8, 2, 4}, `mu` in {0.6, 1.5, 3}, two sample sizes), plus right-censored, left-censored and heavily tied data, **every fit reached the same optimum** — largest log-likelihood difference 5e-9, the optimiser's own tolerance. Ordinary fits are about 20% faster.

## The offset path keeps the refinement

This is the point of the change rather than a footnote. With an offset the seed reads `log(x)` of the **unshifted** data, so a large shift compresses the logs into a narrow band and the probability plot is a poor start. Dropping it there moved one dataset in twelve to a worse optimum and made that fit seven times slower:

```
seed 8:  neg_ll 861.898 -> 861.962     0.30s -> 2.10s
```

A test pins that dataset so the branch is not later simplified away as redundant.

Fixing the offset seed properly means taking the logs *after* removing the shift — the same defect just corrected in the Gamma initialiser — but that is a larger change and is left alone here.

---

## Verification

Full suite 2034 passed, 1 skipped, 5 xfailed. `black`, `flake8`, `mypy` clean.

## Follow-up

The two remaining slow recurrent tests (`test_simulated_data_round_trips_through_fit` 13.0 s, `test_cramer_von_mises_multi_item_and_cox_lewis` 11.1 s) are on a different path — no sibling renewal model has the per-event loop, so they are slow for other reasons and would need their own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts