### PR TITLE
MSE and MPS: faster optimiser order, and information criteria for every fit method

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,36 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **``aic``, ``bic``, ``aic_c`` and ``neg_ll`` now work for every fit
+  method.** They were available only after a maximum-likelihood or
+  closed-form fit, because only those compute a log-likelihood on the
+  way to the answer. A model fitted with ``how='MPS'``, ``'MSE'``,
+  ``'MOM'`` or ``'MPP'`` raised ``AttributeError`` from all four --
+  which meant the usual way of choosing between distributions was
+  unavailable for four of the five methods, and failed with a message
+  that did not say why.
+
+  The log-likelihood is a property of the parameters and the data, not
+  of the search that found them, so it is now evaluated after any fit.
+  Methods that already reported one keep it exactly: maximum
+  likelihood's is the optimiser's own final objective, which on its
+  fallback path is deliberately taken at the initial guess rather than
+  at the failed result (#261).
+
+  A worked consequence, on 500 Weibull(10, 2) points -- the maximum
+  likelihood estimator attaining the maximum likelihood, which was not
+  checkable before:
+
+  ===========  ==========
+  method       ``neg_ll``
+  ===========  ==========
+  MLE          1466.3254
+  MPS          1466.3865
+  MOM          1466.3979
+  MSE          1466.6759
+  MPP          1470.7119
+  ===========  ==========
+
 - **MSE and MPS fits try BFGS before Newton-CG, and are several times
   faster for it.** Both go through a shared fallback that reached for
   Newton-CG first, which needs a hessian. Building one is

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,32 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **MSE and MPS fits try BFGS before Newton-CG, and are several times
+  faster for it.** Both go through a shared fallback that reached for
+  Newton-CG first, which needs a hessian. Building one is
+  disproportionately expensive for the distributions whose derivatives
+  autograd cannot take analytically -- the incomplete gamma is
+  central-differenced, so every second-order entry costs a difference of
+  differences. An offset Gamma MSE fit at n=5000 spent 8.2 of its 8.3
+  seconds there, and BFGS reached a marginally *better* optimum in half
+  a second.
+
+  Reversing the order was checked over 132 fits: MSE and MPS, nine
+  distributions, at two sample sizes, on plain, right-censored,
+  left-censored and offset data. 129 objectives came back identical,
+  three improved, none got worse, for 3.9x less time overall. Newton-CG
+  is still there, escalated to when BFGS fails, and Nelder-Mead behind
+  it; the zero-hessian guard is kept, since a hessian of zeros makes
+  Newton-CG stop at the initial guess while reporting success, so there
+  is nothing to escalate to and Nelder-Mead should take over.
+
+  ``scipy.optimize.least_squares`` was tried first, on the reasoning
+  that the MSE objective is a sum of squares and Gauss-Newton should
+  exploit it. It is far worse: it needs the full residual jacobian, so
+  n=5000 means 5000 rows each paying that central-differenced
+  derivative, and the same fit took 239 seconds against the scalar
+  gradient's three numbers.
+
 - **ExpoWeibull no longer runs a nested optimiser ladder to build its
   initial guess.** It seeds itself from a Gumbel fit to ``log(x)``, and
   that inner fit was a full maximum likelihood run -- an optimiser

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -549,3 +549,47 @@ def test_expoweibull_offset_keeps_the_refined_seed():
     x = ExpoWeibull.random(300, 10.0, 2.0, 1.5) + 25.0
     model = ExpoWeibull.fit(x, offset=True)
     assert model.neg_ll() < 861.93
+
+
+# -- information criteria for every fit method --------------------------
+#
+# Only MLE and the closed forms used to report a log-likelihood, because
+# only they compute one on the way to the answer. neg_ll, aic, bic and
+# aic_c therefore raised AttributeError for MPS, MSE, MOM and MPP -- the
+# usual way of choosing between distributions was unavailable for four
+# of the five methods. The log-likelihood belongs to the parameters and
+# the data, not to the search that found them.
+
+ALL_HOWS = ["MLE", "MPS", "MSE", "MOM", "MPP"]
+
+
+@pytest.mark.parametrize("how", ALL_HOWS)
+def test_information_criteria_available_for_every_method(how):
+    np.random.seed(1)
+    x = Weibull.random(500, 10.0, 2.0)
+    model = Weibull.fit(x, how=how)
+    for name in ("neg_ll", "aic", "bic", "aic_c"):
+        assert np.isfinite(getattr(model, name)()), f"{how}.{name}()"
+
+
+@pytest.mark.parametrize("how", ALL_HOWS)
+def test_reported_log_likelihood_is_the_one_at_the_fitted_parameters(how):
+    # Computed independently of the fitter, so a method that reported
+    # its own objective by mistake -- MPS's mean log-spacing, say, or
+    # MSE's sum of squares -- would be caught.
+    np.random.seed(1)
+    x = Weibull.random(500, 10.0, 2.0)
+    model = Weibull.fit(x, how=how)
+    direct = -np.sum(np.log(Weibull.from_params(list(model.params)).df(x)))
+    assert model.neg_ll() == pytest.approx(direct, rel=1e-10)
+
+
+def test_maximum_likelihood_attains_the_largest_likelihood():
+    # The defining property, and only checkable now that the other
+    # methods report one: no other estimator on the same data can beat
+    # MLE's log-likelihood.
+    np.random.seed(1)
+    x = Weibull.random(500, 10.0, 2.0)
+    best = Weibull.fit(x, how="MLE").neg_ll()
+    for how in ("MPS", "MSE", "MOM", "MPP"):
+        assert Weibull.fit(x, how=how).neg_ll() >= best - 1e-9, how

--- a/surpyval/univariate/parametric/fitters/__init__.py
+++ b/surpyval/univariate/parametric/fitters/__init__.py
@@ -5,18 +5,40 @@ from surpyval import np
 
 def fallback_minimize(fun, init, args, jac, hess, newton_tol=None):
     """
-    Minimise ``fun`` trying Newton-CG with the supplied jacobian and
-    hessian first, then falling back to BFGS, then Nelder-Mead, whenever
-    a method fails or returns nan parameters.
+    Minimise ``fun`` with BFGS and the supplied jacobian, escalating to
+    Newton-CG with the hessian and then to Nelder-Mead whenever a method
+    fails or returns nan parameters.
 
-    Some distributions have all-shape parameters whose autograd second
-    derivatives are zero (see autograd_gamma_compat); a zero hessian
-    makes Newton-CG terminate at the initial guess while reporting
-    success, so skip straight to BFGS in that case.
+    Newton-CG used to go first. It reaches the same answers, but it
+    needs the hessian, and building one is disproportionately expensive
+    for the distributions whose derivatives autograd cannot take
+    analytically: the incomplete gamma is central-differenced (see
+    ``autograd_gamma_compat``), so every second-order entry costs a
+    difference of differences. An offset Gamma MSE fit at n=5000 spent
+    8.2 of its 8.3 seconds there, and BFGS reached a marginally better
+    optimum in half a second.
+
+    Measured over 132 fits -- MSE and MPS, nine distributions, plain,
+    right censored, left censored and offset -- reversing the order left
+    129 objectives identical and improved three, none worse, for 3.9x
+    less time.
+
+    The hessian is still consulted before escalating. Some distributions
+    have all-shape parameters whose autograd second derivatives are
+    zero, and a zero hessian makes Newton-CG stop at the initial guess
+    while reporting success, so there is nothing to escalate to and
+    Nelder-Mead should take over instead.
     """
     with np.errstate(all="ignore"):
-        if np.any(hess(np.array(init, dtype=float), *args)):
-            res = minimize(
+        res = minimize(fun, init, method="BFGS", jac=jac, args=args)
+
+        failed = (
+            (res.success is False)
+            or np.isnan(res.x).any()
+            or (not np.isfinite(res.fun))
+        )
+        if failed and np.any(hess(np.array(init, dtype=float), *args)):
+            newton = minimize(
                 fun,
                 init,
                 method="Newton-CG",
@@ -25,11 +47,8 @@ def fallback_minimize(fun, init, args, jac, hess, newton_tol=None):
                 tol=newton_tol,
                 args=args,
             )
-        else:
-            res = None
-
-        if (res is None) or (res.success is False) or (np.isnan(res.x).any()):
-            res = minimize(fun, init, method="BFGS", jac=jac, args=args)
+            if newton.success and np.isfinite(newton.fun):
+                res = newton
 
         if (res.success is False) or (np.isnan(res.x).any()):
             res = minimize(fun, init, args=args)

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -1084,6 +1084,32 @@ class ParametricFitter:
         for k, v in results.items():
             setattr(model, k, v)
 
+        # Only maximum likelihood and the closed forms report a
+        # log-likelihood, because only they compute one on the way to
+        # the answer. That left ``neg_ll``, ``aic``, ``bic`` and
+        # ``aic_c`` raising AttributeError for every MPS, MSE, MOM and
+        # MPP fit -- so the usual way of choosing between distributions
+        # was unavailable for four of the five methods.
+        #
+        # The log-likelihood is a property of the parameters and the
+        # data, not of the search that found them, so evaluate it here.
+        # Guarded by ``hasattr`` so the methods that already report one
+        # keep theirs untouched: maximum likelihood's is the optimiser's
+        # own final objective, which on its fallback path is deliberately
+        # taken at the initial guess rather than at the failed result
+        # (#261), and recomputing would quietly undo that.
+        if not hasattr(model, "_neg_ll"):
+            with np.errstate(all="ignore"):
+                model._neg_ll = float(
+                    self._neg_ll_func(
+                        surv_data,
+                        *model.params,
+                        model.gamma,
+                        model.f0,
+                        model.p,
+                    )
+                )
+
         # Expose each fitted parameter by name (e.g. ``model.alpha``), but
         # never overwrite the reserved offset / limited-failure /
         # zero-inflation attributes, which the survival functions rely on.


### PR DESCRIPTION
Two findings from a deep dive into MSE and MPS, mirroring the earlier one into MLE. One is a 3.9x speedup from reordering two optimisers; the other is a bug that made `aic` and `bic` unavailable for most of the package's fit methods.

---

# 1. BFGS before Newton-CG

MSE and MPS share `fallback_minimize`, which reached for Newton-CG first. Profiling an offset Gamma MSE fit at n=5000:

```
autograd_gamma_compat.py:45(_cdiff)   5.288s of 9.859s
autograd_gamma_compat.py:65(_cdiff1)  5.271s
```

`_cdiff` is a **central difference**. Autograd has no analytic derivative for the incomplete gamma with respect to its shape, so surpyval finite-differences it — and asking for a *hessian* differentiates that difference again, so every second-order entry costs a difference of differences. Tracing the real fit shows where it goes:

```
n=500   Newton-CG 1.69s  success=True  fun=0.0299948
n=1000  Newton-CG 2.15s  success=True  fun=0.0765509
n=5000  Newton-CG 8.22s  success=True  fun=0.0342359      <- 8.22 of the fit's 8.26s
```

Newton-CG converges perfectly well. It is paying for a hessian it does not need.

BFGS with the jacobian now goes first, Newton-CG is escalated to when BFGS fails, Nelder-Mead stays behind that. Verified over **132 fits** — MSE and MPS, nine distributions, two sample sizes, plain, right-censored, left-censored and offset:

```
identical objective  129
better                 3
worse                  0
total time          11.1s -> 2.8s   (3.9x)
```

| distribution | n | before | after |
|---|---|---|---|
| Gamma (offset) | 5000 | 8.42 s | **0.52 s** |
| Gamma (offset) | 2000 | 3.04 s | **0.22 s** |
| LogLogistic (offset) | 5000 | 0.84 s | **0.05 s** |
| Weibull (offset) | 5000 | 0.47 s | **0.07 s** |

Test-suite effect, on two entries from the original slow list:

```
test_offset_fit_recovers_gamma[Gamma-MSE]   13.11s -> 0.64s
test_fixed                                  14.46s -> 1.26s
```

The zero-hessian guard is preserved but moves into the escalation path: a hessian of zeros makes Newton-CG stop at the initial guess while reporting success, so there is nothing to escalate to and Nelder-Mead should take over.

## Two things that were wrong along the way

**`scipy.optimize.least_squares` is much worse, not better.** The MSE objective is a sum of squares, so Gauss-Newton looks obvious — but it needs the full `(n_residuals x n_params)` jacobian, so n=5000 means 5000 rows each paying that central-differenced derivative, where the scalar gradient is three numbers. The same fit took **239 seconds** against 7.9. Recorded so nobody repeats it.

**An intermediate measurement suggested Newton-CG converged to points 60x worse than BFGS.** That was an artefact of a hand-built harness that reconstructed the objective and transform outside the fitter and got the transform wrong. Tracing the real path showed Newton-CG converging correctly at every size. This is a pure cost win, not a correctness fix.

---

# 2. `neg_ll`, `aic`, `bic` and `aic_c` for every fit method

```
how=MLE   neg_ll=1466  aic=2937  bic=2945  aic_c=2937
how=MPS   neg_ll=AttributeError  aic=AttributeError  bic=AttributeError  aic_c=AttributeError
how=MSE   neg_ll=AttributeError  ...
how=MOM   neg_ll=AttributeError  ...
how=MPP   neg_ll=AttributeError  ...
```

`_neg_ll` is set in exactly three places — `mle.py:256`, `closed_form.py:110`, and Royston-Parmar's own path — because only those compute a log-likelihood on the way to the answer. Everything else left the attribute unset, so all four accessors raised. Information criteria are the standard way to choose between candidate distributions, and they were unavailable for four of the five methods, failing with a message that gives no hint why.

The log-likelihood belongs to the parameters and the data, not to the search that found them, so it is now evaluated centrally once the fit is assembled. Guarded on `hasattr`, so methods that already report one keep theirs exactly — maximum likelihood's is the optimiser's own final objective, and on its fallback path that is deliberately taken at the initial guess rather than at the failed result (#261); recomputing would quietly undo that.

`lfp` and `zi` are rejected upstream for the non-MLE methods, so `p` and `f0` are always 1 and 0 there and the call is unambiguous.

The fix makes a property checkable that was not before — the maximum likelihood estimator attaining the maximum likelihood, on 500 Weibull(10, 2) points:

| method | `neg_ll` |
|---|---|
| **MLE** | **1466.3254** |
| MPS | 1466.3865 |
| MOM | 1466.3979 |
| MSE | 1466.6759 |
| MPP | 1470.7119 |

Three tests: every method exposes finite criteria; the reported value matches an independently computed `-sum log f(x)` to 1e-10, so a method returning its *own* objective by mistake (MPS's mean log-spacing, MSE's sum of squares) would be caught; and MLE attains the largest likelihood of the five.

---

## Also checked, no action needed

- **Non-offset MSE was never slow** — 0.01 to 0.23 s across nine distributions, error shrinking with n as it should.
- **MPS is fast and accurate** — 0.00 to 0.04 s, and it matches or beats MLE on every distribution tested, which is what the theory predicts.
- **MPS tie handling is sound.** The docstring warns that "some complication comes in when using repeated data", so it was probed down to 14 unique values from 2000 observations; MPS tracked MLE closely throughout. The #268 rewrite did its job.
- **ExpoWeibull MSE is inaccurate** (110% error on one sample at n=1000), but MLE is off on the same data too (`[8.893, 1.798, 1.887]` against a true `[10, 2, 1.5]`). A hard three-parameter model, not an MSE defect.

## Verification

Full suite 2045 passed, 1 skipped, 5 xfailed. `black`, `flake8`, `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts