### PR TITLE
Seed an offset ExpoWeibull fit from the shifted data

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,36 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **An offset ``ExpoWeibull`` fit now seeds itself from the shifted
+  data.** ``ExpoWeibull`` starts from a Gumbel fit to ``log(x)``, since
+  a Weibull's logs are Gumbel distributed. With ``offset=True`` it took
+  those logs *before* removing the shift, so it read ``log(x)`` where
+  the model wants ``log(x - gamma)``. A large offset compresses those
+  logs into a narrow band, the Gumbel ``sigma`` collapses, and
+  ``beta = 1 / sigma`` explodes: on 500 points from ``ExpoWeibull(10,
+  2, 1) + 100`` the seed came back as ``alpha = 111, beta = 23.5``
+  against a true 10 and 2. The maximum likelihood fit then failed
+  outright, returning ``nan`` and warning its way back to the MPP
+  estimate.
+
+  This was not an edge case. Over 120 offset fits -- four offsets, five
+  parameter sets, six replicates each -- **54 returned nan**, which is
+  every configuration at an offset of 100 or 1000. All 54 now converge,
+  none of the 66 that already worked changed for the worse, and the
+  whole sweep takes 25.5 seconds against 188.3, since a hopeless
+  starting point is expensive to fail from.
+
+  The offset is now estimated first and the shape parameters read off
+  ``x - gamma``. It is estimated as ``min(x) - 1``, which is what the
+  fitter installs regardless of what the initialiser returns -- seeding
+  against a different shift than the one being optimised under defeats
+  the point.
+
+  The nested Gumbel MLE that refines the offset seed is kept. Removing
+  it was tried, on the reasoning that shifting the data correctly makes
+  the probability plot alone good enough; it is not, and five of 48
+  offset fits landed on a worse optimum without it.
+
 - **``aic``, ``bic``, ``aic_c`` and ``neg_ll`` now work for every fit
   method.** They were available only after a maximum-likelihood or
   closed-form fit, because only those compute a log-likelihood on the

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -540,15 +540,45 @@ def test_expoweibull_offset_keeps_the_refined_seed():
     # same optimum -- so the nested optimiser ladder there was 15-30% of
     # the fit for nothing.
     #
-    # With an offset it is not enough. The seed reads log(x) of the
-    # *unshifted* data, so a large shift compresses the logs into a
-    # narrow band and the plot is a poor starting point. This dataset is
-    # the one in twelve where dropping the refinement moved the fit to a
-    # worse optimum (861.898 -> 861.962) and made it seven times slower.
+    # With an offset it is not enough: five of 48 offset fits seeded from
+    # the plot alone landed on a worse optimum, one of them at 685.85
+    # against 622.26. So the offset path still refines -- on the shifted
+    # data, see test_expoweibull_offset_seeds_from_shifted_data.
     np.random.seed(8)
     x = ExpoWeibull.random(300, 10.0, 2.0, 1.5) + 25.0
     model = ExpoWeibull.fit(x, offset=True)
     assert model.neg_ll() < 861.93
+
+
+def test_expoweibull_offset_seeds_from_shifted_data():
+    # The offset initialiser used to take log(x) before removing the
+    # shift. A large offset compresses those logs into a narrow band, so
+    # the Gumbel sigma collapses and beta = 1 / sigma explodes: with a
+    # true beta of 2 the seed came back at 23.5, and the MLE then failed
+    # outright, returning nan and silently falling back to MPP.
+    #
+    # 54 of 120 offset fits returned nan that way -- every configuration
+    # at an offset of 100 or 1000. The offset is now estimated first and
+    # the seed read off x - gamma.
+    np.random.seed(11)
+    x = 100.0 + ExpoWeibull.random(500, 10.0, 2.0, 1.0)
+
+    gamma, alpha, beta, mu = ExpoWeibull._parameter_initialiser(x, offset=True)
+    # Seeded from x - gamma these sit near the truth; seeded from x they
+    # came back as alpha = 111, beta = 23.5.
+    assert beta == pytest.approx(2.0, rel=0.5)
+    assert alpha == pytest.approx(10.0, rel=0.5)
+
+    # ...and the fit that seed feeds now converges rather than returning
+    # nan and warning its way back to MPP.
+    model = ExpoWeibull.fit(x, offset=True)
+    assert np.isfinite(model.neg_ll())
+    assert model.gamma == pytest.approx(100.0, abs=1.0)
+
+    # The offset the fitter will actually install, so that the seed is
+    # taken against the same shift it will be optimised under.
+    assert gamma < x.min()
+    assert gamma == pytest.approx(x.min() - 1.0)
 
 
 # -- information criteria for every fit method --------------------------

--- a/surpyval/univariate/parametric/distributions/expo_weibull.py
+++ b/surpyval/univariate/parametric/distributions/expo_weibull.py
@@ -23,26 +23,27 @@ class ExpoWeibull_(ParametricFitter):
         )
         self.supports_mpp = False
 
-    def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
+    def _gumbel_seed(self, x, c, n, refine):
+        """
+        Seed alpha and beta from a Gumbel fit to log(x).
+
+        The ExpoWeibull with mu = 1 is a Weibull, and a Weibull's logs
+        are Gumbel distributed with mu = log(alpha) and sigma = 1 / beta,
+        so a fit of log(x) gives both shape parameters at once.
+
+        ``refine`` runs the Gumbel MLE rather than reading the
+        probability plot alone. Without an offset the plot is already
+        good enough: refining cost 15-30% of the fit and changed nothing
+        over 54 parameter combinations plus right, left and heavily tied
+        data, every fit reaching the same optimum to the optimiser's own
+        tolerance. With an offset the plot alone is measurably worse --
+        five of 48 offset fits landed on a worse optimum, one of them at
+        685.85 against 622.26 -- so the offset path refines.
+        """
         log_x = np.log(x)
         log_x[np.isnan(log_x)] = 0
-        if offset:
-            # The offset path keeps the nested MLE. It reads log(x) of the
-            # *unshifted* data, so a large shift compresses the logs into a
-            # narrow band and the probability plot alone is a poor seed --
-            # the extra refinement earns its keep there. Dropping it moved
-            # one fit in twelve to a worse optimum (861.898 -> 861.962) and
-            # made that fit seven times slower.
-            gumb = para.Gumbel.fit(log_x, c, n, how="MLE")
-            if not gumb.res.success:
-                gumb = para.Gumbel.fit(log_x, c, n, how="MPP")
-        else:
-            # Without an offset the probability plot is already a good
-            # enough seed: running a whole optimiser ladder to refine a
-            # starting point cost 15-30% of the fit and changed nothing.
-            # Checked over 54 parameter combinations plus right, left and
-            # heavily tied data -- every fit reached the same optimum, to
-            # the optimiser's own tolerance.
+        gumb = para.Gumbel.fit(log_x, c, n, how="MLE" if refine else "MPP")
+        if refine and not gumb.res.success:
             gumb = para.Gumbel.fit(log_x, c, n, how="MPP")
         mu, sigma = gumb.params
         alpha, beta = np.exp(mu), 1.0 / sigma
@@ -50,11 +51,26 @@ class ExpoWeibull_(ParametricFitter):
             alpha = np.median(x)
         if np.isinf(beta) | np.isnan(beta):
             beta = 1.0
+        return alpha, beta
+
+    def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         if offset:
-            gamma = np.min(x) - (np.max(x) - np.min(x)) / 10.0
+            # Estimate the offset first and seed alpha and beta from the
+            # shifted data. Taking logs before removing the shift reads
+            # log(x) instead of log(x - gamma), and a large shift
+            # compresses those logs into a narrow band: at gamma = 100
+            # with a true beta of 2 the seed came back at beta = 23 and
+            # the MLE then failed outright, falling back to MPP.
+            #
+            # min(x) - 1 rather than a fraction of the range because the
+            # fitter overwrites the returned offset with exactly that
+            # (see ParametricFitter.fit_from_surpyval_data); seeding
+            # alpha and beta against a different shift than the one
+            # actually installed defeats the point of shifting at all.
+            gamma = np.min(x) - 1.0
+            alpha, beta = self._gumbel_seed(x - gamma, c, n, refine=True)
             return gamma, alpha, beta, 1.0
-        else:
-            return alpha, beta, 1.0
+        return (*self._gumbel_seed(x, c, n, refine=False), 1.0)
 
     def sf(self, x, alpha, beta, mu):
         r"""


### PR DESCRIPTION
## The bug

`ExpoWeibull` seeds itself from a Gumbel fit to `log(x)`, since a Weibull's logs are Gumbel distributed with `mu = log(alpha)` and `sigma = 1 / beta`.

With `offset=True` it took those logs **before** removing the shift, so it read `log(x)` where the model wants `log(x - gamma)`. A large offset compresses those logs into a narrow band, the Gumbel `sigma` collapses, and `beta = 1 / sigma` explodes.

On 500 points from `ExpoWeibull(10, 2, 1) + 100`:

| | alpha | beta |
|---|---|---|
| true | 10 | 2 |
| seed, before | 111 | **23.5** |
| seed, after | 10.5 | 2.22 |

From that starting point the maximum likelihood fit failed outright — `nan`, and a warning back to the MPP estimate.

## How often

Not an edge case. Over **120 offset fits** — four offsets, five parameter sets, six replicates each:

| | before | after |
|---|---|---|
| returned `nan` | **54** | 0 |
| worse than before | — | 0 |
| unchanged | — | 66 |
| total time | 188.3s | 25.5s |

The 54 failures are *every* configuration at an offset of 100 or 1000. Nothing that already worked changed. The 7x speedup is incidental: a hopeless starting point is expensive to fail from.

## The fix

Estimate the offset first, then read the shape parameters off `x - gamma`.

The offset is taken as `min(x) - 1` rather than a fraction of the range, because `ParametricFitter.fit_from_surpyval_data` overwrites whatever the initialiser returns with exactly that. Seeding `alpha` and `beta` against a different shift than the one being optimised under defeats the point of shifting at all.

The nested Gumbel MLE that refines the offset seed is **kept**. Removing it was tried, on the reasoning that shifting the data correctly makes the probability plot alone good enough. It does not: five of 48 offset fits landed on a worse optimum without it, one at 685.85 against 622.26. The non-offset path still uses the plot alone, as before.

## On the measurement

Measured by monkeypatching the old initialiser back in as an oracle, not by comparing checkouts.

This package is installed editable, which registers a meta-path finder — so `import surpyval` resolves to the working tree regardless of cwd or `PYTHONPATH`. A second checkout silently runs the *same* code, and every A/B comes back "identical". Several intermediate sweeps here did exactly that before it was caught; the oracle harness was verified to reproduce the `nan` before its aggregate was trusted.

## Tests

`test_expoweibull_offset_seeds_from_shifted_data` asserts the seed lands near the truth, the fit is finite, the offset is recovered, and the offset convention matches the fitter's. Against the old code it fails with `beta = 23.5` against a true 2.0.

The existing `test_expoweibull_offset_keeps_the_refined_seed` is unchanged in behaviour; its comment was rewritten, since it justified the refinement by the compressed logs that this PR removes.

Full suite: **2046 passed, 1 skipped, 5 xfailed**. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_