### PR TITLE
Bring the estimation documentation up to date with the fitters

### DIFF
--- a/docs/Parametric Estimation.rst
+++ b/docs/Parametric Estimation.rst
@@ -50,6 +50,18 @@ Because there is only one parameter of the exponential distribution, we need to 
 
 This is to say that the method of moments solution for the parameter of the exponential is simply the inverse of the average. This is an easy result. When we extend to other distributions with more than one parameter, such simple analytical solutions are not available, so numeric optimisation is needed. SurPyval uses numeric optimisation to compute the parameters for these distributions.
 
+That optimisation matches *central* moments — the variance, and the skew- and
+kurtosis-like higher moments about the mean — rather than the raw moments
+:math:`E[X^{k}]`, and scales each by the corresponding power of the standard
+deviation before comparing. The two are equivalent in exact arithmetic, since
+one set is a binomial transform of the other, but they are not equally easy to
+optimise. Raw moments of offset data are dominated by the offset: for data
+sitting near :math:`\gamma`, every :math:`E[X^{k}]` is close to
+:math:`\gamma^{k}`, so the moments grow like powers of the offset while the
+differences that actually identify the shape parameters are swamped. Centring
+removes that common term and the scaling puts each residual on a comparable
+footing, which leaves the estimator far better conditioned on shifted data.
+
 The method of moments, although interesting, can produce incorrect results, and it can only be used with observed data, so it cannot account for truncation or censoring. But it is good to understand as it is one of the oldest methods used to estimate the parameters of a distribution.
 
 Method of Probability Plotting (MPP)
@@ -252,6 +264,38 @@ renormalised by the probability of landing in that window:
 This inflates the contribution of observations from a narrow window, correcting
 for the units that could never have been seen — exactly the delayed-entry
 (left-truncation) and right-truncation adjustments.
+
+The two combine. An observation can be *both* censored and truncated: a unit
+that entered a study late and was still running when it ended, or the
+right-truncated failure of an instrument that can only record events below some
+threshold. Such a point must be conditioned on its own window, so a
+right-censored observation inside :math:`(t_{l}, t_{r}]` contributes
+
+.. math::
+
+    \frac{F(t_{r} \mid \theta) - F(x \mid \theta)}
+         {F(t_{r} \mid \theta) - F(t_{l} \mid \theta)},
+
+and a left-censored one contributes the mirror image with
+:math:`F(x) - F(t_{l})` on top. The numerator matters: it must be capped by the
+truncation bound rather than run out to infinity as :math:`R(x)` does. A ratio
+of :math:`R(x)` to the window probability is not a probability at all — it grows
+without bound as the fitted distribution puts less and less mass inside the
+window, so an optimiser can drive the likelihood arbitrarily high and return a
+meaningless answer while reporting success.
+
+SurPyval sidesteps this by *rewriting* the observation rather than special-casing
+the likelihood. A right-censored point with a finite :math:`t_{r}` is recast as
+the interval :math:`(x, t_{r}]`, and a left-censored point with a finite
+:math:`t_{l}` as :math:`(t_{l}, x]`, before the likelihood is ever evaluated.
+The expressions above are then just the ordinary interval-censored contribution,
+already conditioned by the truncation denominator. Where the relevant bound is
+infinite there is nothing to cap, and the point stays a plain censored
+observation so that the numerically stable ``log_sf`` is used.
+
+This rewriting happens inside surpyval's internal representation of the data.
+The ``x``, ``c``, ``n`` and ``t`` arrays you passed to ``fit`` are unchanged, and
+the model reports the data back to you exactly as you supplied it.
 
 Maximum Product of Spacings (MPS)
 ---------------------------------

--- a/docs/Parametric SurPyval Modelling.rst
+++ b/docs/Parametric SurPyval Modelling.rst
@@ -380,9 +380,9 @@ Offsets only make sense for distributions supported on the half real line ``[0, 
 A caution: offset parameters can be unidentifiable
 --------------------------------------------------
 
-The offset ``gamma`` is a *threshold* parameter, and threshold parameters are statistically awkward. ``gamma`` trades off against the shape and scale parameters, so two very different parameter tuples can describe almost the same distribution. This means a fit can report parameters that are badly wrong while the distribution it implies is still an excellent fit to your data. It is important to understand this so you are not alarmed by - or misled by - the printed parameters.
+The offset ``gamma`` is a *threshold* parameter, and threshold parameters are statistically awkward. ``gamma`` trades off against the shape and scale parameters, so two very different parameter tuples can describe almost the same distribution. A high-shape Gamma sitting near the origin is, by the central limit theorem, nearly the same bell-shaped curve as a moderate Gamma shifted out to 10. The likelihood surface is correspondingly flat along that trade-off, which makes a threshold fit far more sensitive to its starting point than an ordinary two-parameter fit.
 
-The clearest way to see this is to fit the same offset data with different estimation methods. Below we generate Gamma data shifted by ``gamma = 10`` and fit it both with the probability-plotting method (``MPP``) and maximum likelihood (``MLE``):
+In practice that sensitivity is the estimator's problem to solve, not yours. Shifted Gamma data is recovered by every fit method:
 
 .. jupyter-execute::
 
@@ -392,26 +392,20 @@ The clearest way to see this is to fit the same offset data with different estim
     np.random.seed(0)
     x = surv.Gamma.random(10_000, 3.0, 2.0) + 10.0
 
-    mpp = surv.Gamma.fit(x, offset=True, how='MPP')
-    mle = surv.Gamma.fit(x, offset=True, how='MLE')
-
     print('Truth : gamma=10.000, alpha=3.000, beta=2.000')
-    print('MPP   : gamma={:.3f}, alpha={:.3f}, beta={:.3f}'.format(mpp.gamma, *mpp.params))
-    print('MLE   : gamma={:.3f}, alpha={:.3f}, beta={:.3f}'.format(mle.gamma, *mle.params))
+    for how in ['MPP', 'MOM', 'MSE', 'MPS', 'MLE']:
+        m = surv.Gamma.fit(x, offset=True, how=how)
+        print('{:6s}: gamma={:.3f}, alpha={:.3f}, beta={:.3f}'.format(
+            how, m.gamma, *m.params))
 
-The ``MPP`` parameters look like nonsense: a negative ``gamma`` and a shape parameter inflated by two orders of magnitude. But a high-shape Gamma sitting near the origin is, by the central limit theorem, almost the same bell-shaped curve as a moderate Gamma shifted out to 10. If we compare what the models actually *predict*, the two fits are nearly indistinguishable - and both are close to the truth:
+This was not always so. Earlier versions could land on an absurd tuple - a negative ``gamma`` with a shape parameter inflated by two orders of magnitude - which was nonetheless an acceptable *distribution*, precisely because of the flat trade-off described above. Two separate causes were at work, and both are now fixed. The probability-plotting search was stranded at a poor local optimum by a single starting shape, so it now tries several and keeps the best correlation. The moment-based initialisers took their moments from the *unshifted* data, where the offset dominates every moment and the shape estimate explodes - 649 for a true shape of 3 - so they now estimate the threshold first and read the remaining parameters off ``x - gamma``.
 
-.. jupyter-execute::
+The underlying caution still stands, though, and it is worth keeping in mind for your own data:
 
-    truth = surv.Gamma.from_params([3.0, 2.0], gamma=10.0)
+- **Judge an offset fit by what it predicts, not only by the printed parameters.** Plot it against the non-parametric estimate, or compare the survival function, quantiles, mean and variance. Two parameter tuples that look very different can imply nearly the same distribution.
+- **If you need ``gamma`` itself to be meaningful** - you are interpreting it as a guaranteed minimum life, say - prefer ``MLE``, which remains the most accurate on the parameters, and treat a single point estimate of a threshold with care regardless of method.
 
-    for name, m in [('Truth', truth), ('MPP', mpp), ('MLE', mle)]:
-        print('{:5s} mean={:.3f}  median={:.3f}  90th percentile={:.3f}'.format(
-            name, float(m.mean()), float(m.qf(0.5)), float(m.qf(0.9))))
-
-Despite the ``MPP`` parameters being off by thousands of percent, its mean, median and upper percentile all agree with the truth to better than 2%. The lesson is that when you use an offset, **judge the fit by what it predicts, not by the printed parameters**. Plot it against the non-parametric estimate, or compare the survival function, quantiles, mean and variance, rather than reading meaning into ``gamma`` and the shape parameters individually.
-
-This unidentifiability is also why the estimation method matters more than usual for offset fits. ``MLE`` is the most reliable for recovering the parameters themselves; the method-of-moments (``MOM``) and probability-plotting (``MPP``) initialisers can be badly biased on the parameters even when the resulting distribution is acceptable. If you need the threshold ``gamma`` to be meaningful - for example you are interpreting it as a guaranteed minimum life - prefer ``MLE`` and treat any single parameter estimate with care. The library's test suite pins this behaviour down with measured KL and Wasserstein distances in ``test_offset_divergence.py``.
+``test_offset_divergence.py`` in the test suite pins this down with measured KL and Wasserstein distances alongside parameter tolerances: ``MLE`` is held to 5% on every parameter, ``MOM`` to 10% and ``MPP`` to 20%, with the implied distributions essentially identical in all three cases.
 
 Fixing parameters
 -----------------

--- a/docs/Parametric SurPyval Modelling.rst
+++ b/docs/Parametric SurPyval Modelling.rst
@@ -529,6 +529,29 @@ Our estimation has worked! Even though we used the MPS estimate for the paramete
 
 This shows the power of the flexible API that surpyval offers, because if your modelling fails using one estimation method, you can use another. In this case, the MPS method is quite good at handling offset distributions. It is therefore a good approach to use when using offset distributions.
 
+That extends to the information criteria. A log-likelihood is a property of the
+parameters and the data, not of the search that found them, so ``neg_ll()``,
+``aic()``, ``bic()`` and ``aic_c()`` are available after *any* fit — not only
+after MLE:
+
+.. jupyter-execute::
+
+    np.random.seed(1)
+    x = surv.Weibull.random(500, 10., 2.)
+
+    print(f"{'how':<6}{'neg_ll':>12}{'AIC':>12}{'BIC':>12}")
+    for how in ["MLE", "MPS", "MSE", "MOM", "MPP"]:
+        m = surv.Weibull.fit(x, how=how)
+        print(f"{how:<6}{m.neg_ll():12.3f}{m.aic():12.3f}{m.bic():12.3f}")
+
+Two things are worth noticing. The first is that you can compare distributions
+by AIC or BIC regardless of how you fitted them, which is the usual way of
+choosing between candidate models. The second is a sanity check on the
+estimators themselves: MLE attains the lowest negative log-likelihood, because
+that is precisely the quantity it minimises. The others land close behind, each
+optimising something else — MPS the spacings, MSE the distance to the plotting
+positions, MOM the moments.
+
 As stated in the Non-Parametric section, there is a risk that using the Turnbull estimator when all
 values are trunctated by the same values. We will now show what happens. First, some example data:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,25 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **Documentation caught up with the estimator changes above.** The
+  maximum likelihood notes in :doc:`Parametric Estimation` now cover the
+  observation that is *both* censored and truncated -- the contribution
+  it makes, why the numerator has to be capped by the truncation bound,
+  and the fact that surpyval recasts such a point as interval censored
+  in its internal representation rather than special-casing the
+  likelihood. The user's own ``x``, ``c``, ``n`` and ``t`` are untouched,
+  which is now said explicitly.
+
+  The method of moments section explains that the optimisation matches
+  scaled *central* moments rather than raw ones, and why that matters for
+  offset data, where every raw moment is dominated by the offset.
+
+  :doc:`Parametric SurPyval Modelling` gains a worked comparison of
+  ``neg_ll``, ``aic`` and ``bic`` across all five fit methods, showing
+  both that the criteria are available whatever the method and that MLE
+  attains the lowest negative log-likelihood -- a check that could not be
+  run before.
+
 - **An offset ``ExpoWeibull`` fit now seeds itself from the shifted
   data.** ``ExpoWeibull`` starts from a Gumbel fit to ``log(x)``, since
   a Weibull's logs are Gumbel distributed. With ``offset=True`` it took


### PR DESCRIPTION
Documentation only — no source changes. The recent estimator work left several
pages describing behaviour the library no longer has.

## The offset unidentifiability section was wrong, not just stale

`Parametric SurPyval Modelling` demonstrated the hazard of threshold parameters
by fitting `Gamma(3, 2) + 10` and reporting that `MPP` returned "a negative
`gamma` and a shape parameter inflated by two orders of magnitude", parameters
"off by thousands of percent", concluding that offset fits must be judged by
predictions rather than parameters.

That is no longer what happens:

```
Truth : gamma=10.000, alpha=3.000, beta=2.000
MPP   : gamma=10.000, alpha= 2.949, beta=1.980
MOM   : gamma=10.039, alpha= 2.804, beta=1.931
MSE   : gamma= 9.994, alpha= 2.981, beta=1.992
MPS   : gamma= 9.986, alpha= 3.013, beta=2.003
MLE   : gamma= 9.990, alpha= 2.996, beta=1.997
```

Checked at offsets of 10, 100 and 1000, at n=200 and n=10 000 — the pathology is
gone throughout.

The page had also drifted from the test file it cites. `test_offset_divergence.py`
was tightened by #257 and #275 to assert *parameter recovery* — `MLE` to 5%,
`MOM` to 10%, `MPP` to 20% — so it has been pinning the opposite of the prose
for some time.

The theory is kept, since it is exactly what made a bad seed so damaging:
`gamma` trades off against shape and scale, a high-shape Gamma near the origin
is nearly a moderate Gamma shifted out, and the likelihood is flat along that
ridge. It is now framed as a caution for the reader's own data rather than a
demonstration of broken output.

Both causes of the old behaviour are named, because they were separate defects:
the probability-plotting search was stranded by a single starting shape and now
tries several (#257), while the moment-based initialisers took moments from the
*unshifted* data and now estimate the threshold first (#313). `MPP` calls
`_parameter_initialiser` without `offset=True`, so it never used the
shifted-moment path at all — worth stating, since the obvious summary of "the
initialisers now shift first" is wrong for the very method the section is about.

## Three gaps in the estimation notes

**Censored *and* truncated observations.** `Parametric Estimation` covered
censoring and truncation separately but never their combination — the case that
changed. It now gives the contribution
`(F(t_r) − F(x)) / (F(t_r) − F(t_l))`, explains why the numerator must be capped
by the truncation bound (an `R(x)` numerator is not a probability and grows
without bound, so an optimiser can drive the likelihood arbitrarily high and
report success), and records that surpyval recasts such a point as interval
censored internally — leaving the user's `x`, `c`, `n` and `t` unchanged.

**Method of moments.** The section said only that numeric optimisation is used.
It now says what is matched: scaled *central* moments rather than raw ones, and
why that matters for offset data, where every raw moment is dominated by the
offset.

**Information criteria.** The modelling notes already made the point that a
model is fully featured whatever fitted it. That now extends to `neg_ll`,
`aic`, `bic` and `aic_c`, so there is a worked comparison across all five
methods. It doubles as a check on the estimators — MLE attains the lowest
negative log-likelihood, which is only verifiable now that the criteria are
available after any fit.

## Verification

Full docs build succeeds. Every new code cell was run before being added, and
the new content confirmed in the rendered HTML. The build's warnings are
unchanged: the `ProportionalIntensityNHPP` autodoc failures, the duplicate
labels in `changelog.rst`, and the `gamma.py:534` `ConstantInputWarning` from
the MPP multi-start search are all pre-existing, and the last of these was
triggered identically by the cell this PR replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_