### PR TITLE
Cut v0.18.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,11 +1,30 @@
 Changelog
 =========
 
-v0.17.1 (unreleased)
---------------------
+v0.18.0 (2 August 2026)
+-----------------------
 
-- **Documentation caught up with the estimator changes above.** The
-  maximum likelihood notes in :doc:`Parametric Estimation` now cover the
+- **Documentation caught up with the estimator changes below.** The
+  most consequential correction is in :doc:`Parametric SurPyval
+  Modelling`, whose section on offset unidentifiability demonstrated the
+  hazard of threshold parameters by fitting ``Gamma(3, 2) + 10`` and
+  reporting that ``MPP`` returned a negative ``gamma`` with a shape
+  parameter inflated by two orders of magnitude. That has not been true
+  since #257 and #313: every fit method now recovers the offset to three
+  decimal places, at offsets from 10 to 1000 and at both small and large
+  samples. The page had also drifted from the test file it cites --
+  ``test_offset_divergence.py`` was tightened by #257 and #275 to assert
+  parameter *recovery*, the opposite of what the prose claimed.
+
+  The underlying theory is kept, since it is exactly what made a poor
+  starting point so damaging: ``gamma`` trades off against the shape and
+  scale, and the likelihood is flat along that ridge. It now reads as a
+  caution for your own data rather than a demonstration of broken
+  output, and names both causes of the old behaviour separately -- the
+  probability-plotting search stranded by a single starting shape, and
+  the moment-based initialisers taking their moments before the shift.
+
+  The maximum likelihood notes in :doc:`Parametric Estimation` now cover the
   observation that is *both* censored and truncated -- the contribution
   it makes, why the numerator has to be capped by the truncation bound,
   and the fact that surpyval recasts such a point as interval censored

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "surpyval"
-version = "0.17.0"
+version = "0.18.0"
 description = "A python package for survival analysis"
 readme = "README.md"
 license = {text = "MIT"}

--- a/surpyval/__init__.py
+++ b/surpyval/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.17.0"
+__version__ = "0.18.0"
 
 from autograd import numpy as np
 


### PR DESCRIPTION
Bumps the version in `pyproject.toml` and `surpyval/__init__.py`, and dates the
changelog heading — the same three-file shape as the v0.17.0 cut (`6453bc1`).

## Why minor rather than patch

Two reasons, either sufficient on its own:

- **Fitted results move.** The truncated-likelihood fix changes parameters for
  any dataset carrying observations that are both censored and truncated. That
  is a behavioural change for existing users, not a bug fix they can ignore.
- **New API surface.** `neg_ll`, `aic`, `bic` and `aic_c` previously raised
  `AttributeError` on four of the five fit methods and now return values.

## Contents

Sixteen entries covering #309 through #318. The substantive ones:

- Fitted parameters change for censored *and* truncated data — the likelihood
  was unbounded and could return garbage with `success=True`
- Information criteria after any fit method, not just MLE and closed forms
- Offset `ExpoWeibull` seeded from shifted data (54 of 120 offset fits were
  returning `nan`)
- Offset `Gamma` no longer starts from a corrupted initial guess
- Method of moments matches central rather than raw moments
- MSE and MPS try BFGS before Newton-CG
- ARI likelihood evaluated for the whole sample at once
- `group_xcnt` no longer walks every observation in Python
- Documentation brought back in line with the fitters

One changelog edit beyond the version bump: the documentation entry opened with
"the estimator changes **above**" while sitting at the top of the section, and
predated the offset-unidentifiability correction. It now reads "below" and
leads with that correction, which is the most consequential of the doc changes —
the page had been telling readers to distrust parameters the library recovers
to three decimal places.

## Verification

`surpyval.__version__` reports `0.18.0`. Full suite: **2046 passed, 1 skipped,
5 xfailed**. Lint clean. The only remaining `0.17.0` strings in the tree are
historical references in `alpha/__init__.py` and `experimental/__init__.py`
("removed entirely in v0.17.0"), correctly left alone.

No tag is created here, matching v0.17.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_