### PR TITLE
Release v0.18.0

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -63,8 +63,20 @@ jobs:
         # The alpha-stage modules are not part of the release contract
         # and are excluded from the deployment test run. (Beta-stage
         # tests, e.g. the survival forest's, do run.)
+        #
+        # Run across all available cores: the suite is dominated by a
+        # handful of Monte Carlo and bootstrap tests, so it parallelises
+        # well -- 13m21 to 4m10 on four cores locally. Coverage comes
+        # from pytest-cov rather than `coverage run`, because the latter
+        # does not follow the xdist worker subprocesses; the totals are
+        # identical either way. The report and html steps below still
+        # read the .coverage file it writes.
+        # Invoked as ``python -m`` so the plugins resolve against the
+        # interpreter the dependencies were installed into, rather than
+        # whichever ``pytest`` happens to be first on PATH.
         run:
-          coverage run -m pytest --ignore=surpyval/tests/alpha
+          python -m pytest -n auto --cov=surpyval --cov-report=
+          --ignore=surpyval/tests/alpha
 
       - name: coverage
         run: |

--- a/docs/Parametric Estimation.rst
+++ b/docs/Parametric Estimation.rst
@@ -50,6 +50,18 @@ Because there is only one parameter of the exponential distribution, we need to 
 
 This is to say that the method of moments solution for the parameter of the exponential is simply the inverse of the average. This is an easy result. When we extend to other distributions with more than one parameter, such simple analytical solutions are not available, so numeric optimisation is needed. SurPyval uses numeric optimisation to compute the parameters for these distributions.
 
+That optimisation matches *central* moments — the variance, and the skew- and
+kurtosis-like higher moments about the mean — rather than the raw moments
+:math:`E[X^{k}]`, and scales each by the corresponding power of the standard
+deviation before comparing. The two are equivalent in exact arithmetic, since
+one set is a binomial transform of the other, but they are not equally easy to
+optimise. Raw moments of offset data are dominated by the offset: for data
+sitting near :math:`\gamma`, every :math:`E[X^{k}]` is close to
+:math:`\gamma^{k}`, so the moments grow like powers of the offset while the
+differences that actually identify the shape parameters are swamped. Centring
+removes that common term and the scaling puts each residual on a comparable
+footing, which leaves the estimator far better conditioned on shifted data.
+
 The method of moments, although interesting, can produce incorrect results, and it can only be used with observed data, so it cannot account for truncation or censoring. But it is good to understand as it is one of the oldest methods used to estimate the parameters of a distribution.
 
 Method of Probability Plotting (MPP)
@@ -252,6 +264,38 @@ renormalised by the probability of landing in that window:
 This inflates the contribution of observations from a narrow window, correcting
 for the units that could never have been seen — exactly the delayed-entry
 (left-truncation) and right-truncation adjustments.
+
+The two combine. An observation can be *both* censored and truncated: a unit
+that entered a study late and was still running when it ended, or the
+right-truncated failure of an instrument that can only record events below some
+threshold. Such a point must be conditioned on its own window, so a
+right-censored observation inside :math:`(t_{l}, t_{r}]` contributes
+
+.. math::
+
+    \frac{F(t_{r} \mid \theta) - F(x \mid \theta)}
+         {F(t_{r} \mid \theta) - F(t_{l} \mid \theta)},
+
+and a left-censored one contributes the mirror image with
+:math:`F(x) - F(t_{l})` on top. The numerator matters: it must be capped by the
+truncation bound rather than run out to infinity as :math:`R(x)` does. A ratio
+of :math:`R(x)` to the window probability is not a probability at all — it grows
+without bound as the fitted distribution puts less and less mass inside the
+window, so an optimiser can drive the likelihood arbitrarily high and return a
+meaningless answer while reporting success.
+
+SurPyval sidesteps this by *rewriting* the observation rather than special-casing
+the likelihood. A right-censored point with a finite :math:`t_{r}` is recast as
+the interval :math:`(x, t_{r}]`, and a left-censored point with a finite
+:math:`t_{l}` as :math:`(t_{l}, x]`, before the likelihood is ever evaluated.
+The expressions above are then just the ordinary interval-censored contribution,
+already conditioned by the truncation denominator. Where the relevant bound is
+infinite there is nothing to cap, and the point stays a plain censored
+observation so that the numerically stable ``log_sf`` is used.
+
+This rewriting happens inside surpyval's internal representation of the data.
+The ``x``, ``c``, ``n`` and ``t`` arrays you passed to ``fit`` are unchanged, and
+the model reports the data back to you exactly as you supplied it.
 
 Maximum Product of Spacings (MPS)
 ---------------------------------

--- a/docs/Parametric SurPyval Modelling.rst
+++ b/docs/Parametric SurPyval Modelling.rst
@@ -380,9 +380,9 @@ Offsets only make sense for distributions supported on the half real line ``[0, 
 A caution: offset parameters can be unidentifiable
 --------------------------------------------------
 
-The offset ``gamma`` is a *threshold* parameter, and threshold parameters are statistically awkward. ``gamma`` trades off against the shape and scale parameters, so two very different parameter tuples can describe almost the same distribution. This means a fit can report parameters that are badly wrong while the distribution it implies is still an excellent fit to your data. It is important to understand this so you are not alarmed by - or misled by - the printed parameters.
+The offset ``gamma`` is a *threshold* parameter, and threshold parameters are statistically awkward. ``gamma`` trades off against the shape and scale parameters, so two very different parameter tuples can describe almost the same distribution. A high-shape Gamma sitting near the origin is, by the central limit theorem, nearly the same bell-shaped curve as a moderate Gamma shifted out to 10. The likelihood surface is correspondingly flat along that trade-off, which makes a threshold fit far more sensitive to its starting point than an ordinary two-parameter fit.
 
-The clearest way to see this is to fit the same offset data with different estimation methods. Below we generate Gamma data shifted by ``gamma = 10`` and fit it both with the probability-plotting method (``MPP``) and maximum likelihood (``MLE``):
+In practice that sensitivity is the estimator's problem to solve, not yours. Shifted Gamma data is recovered by every fit method:
 
 .. jupyter-execute::
 
@@ -392,26 +392,20 @@ The clearest way to see this is to fit the same offset data with different estim
     np.random.seed(0)
     x = surv.Gamma.random(10_000, 3.0, 2.0) + 10.0
 
-    mpp = surv.Gamma.fit(x, offset=True, how='MPP')
-    mle = surv.Gamma.fit(x, offset=True, how='MLE')
-
     print('Truth : gamma=10.000, alpha=3.000, beta=2.000')
-    print('MPP   : gamma={:.3f}, alpha={:.3f}, beta={:.3f}'.format(mpp.gamma, *mpp.params))
-    print('MLE   : gamma={:.3f}, alpha={:.3f}, beta={:.3f}'.format(mle.gamma, *mle.params))
+    for how in ['MPP', 'MOM', 'MSE', 'MPS', 'MLE']:
+        m = surv.Gamma.fit(x, offset=True, how=how)
+        print('{:6s}: gamma={:.3f}, alpha={:.3f}, beta={:.3f}'.format(
+            how, m.gamma, *m.params))
 
-The ``MPP`` parameters look like nonsense: a negative ``gamma`` and a shape parameter inflated by two orders of magnitude. But a high-shape Gamma sitting near the origin is, by the central limit theorem, almost the same bell-shaped curve as a moderate Gamma shifted out to 10. If we compare what the models actually *predict*, the two fits are nearly indistinguishable - and both are close to the truth:
+This was not always so. Earlier versions could land on an absurd tuple - a negative ``gamma`` with a shape parameter inflated by two orders of magnitude - which was nonetheless an acceptable *distribution*, precisely because of the flat trade-off described above. Two separate causes were at work, and both are now fixed. The probability-plotting search was stranded at a poor local optimum by a single starting shape, so it now tries several and keeps the best correlation. The moment-based initialisers took their moments from the *unshifted* data, where the offset dominates every moment and the shape estimate explodes - 649 for a true shape of 3 - so they now estimate the threshold first and read the remaining parameters off ``x - gamma``.
 
-.. jupyter-execute::
+The underlying caution still stands, though, and it is worth keeping in mind for your own data:
 
-    truth = surv.Gamma.from_params([3.0, 2.0], gamma=10.0)
+- **Judge an offset fit by what it predicts, not only by the printed parameters.** Plot it against the non-parametric estimate, or compare the survival function, quantiles, mean and variance. Two parameter tuples that look very different can imply nearly the same distribution.
+- **If you need ``gamma`` itself to be meaningful** - you are interpreting it as a guaranteed minimum life, say - prefer ``MLE``, which remains the most accurate on the parameters, and treat a single point estimate of a threshold with care regardless of method.
 
-    for name, m in [('Truth', truth), ('MPP', mpp), ('MLE', mle)]:
-        print('{:5s} mean={:.3f}  median={:.3f}  90th percentile={:.3f}'.format(
-            name, float(m.mean()), float(m.qf(0.5)), float(m.qf(0.9))))
-
-Despite the ``MPP`` parameters being off by thousands of percent, its mean, median and upper percentile all agree with the truth to better than 2%. The lesson is that when you use an offset, **judge the fit by what it predicts, not by the printed parameters**. Plot it against the non-parametric estimate, or compare the survival function, quantiles, mean and variance, rather than reading meaning into ``gamma`` and the shape parameters individually.
-
-This unidentifiability is also why the estimation method matters more than usual for offset fits. ``MLE`` is the most reliable for recovering the parameters themselves; the method-of-moments (``MOM``) and probability-plotting (``MPP``) initialisers can be badly biased on the parameters even when the resulting distribution is acceptable. If you need the threshold ``gamma`` to be meaningful - for example you are interpreting it as a guaranteed minimum life - prefer ``MLE`` and treat any single parameter estimate with care. The library's test suite pins this behaviour down with measured KL and Wasserstein distances in ``test_offset_divergence.py``.
+``test_offset_divergence.py`` in the test suite pins this down with measured KL and Wasserstein distances alongside parameter tolerances: ``MLE`` is held to 5% on every parameter, ``MOM`` to 10% and ``MPP`` to 20%, with the implied distributions essentially identical in all three cases.
 
 Fixing parameters
 -----------------

--- a/docs/Parametric SurPyval Modelling.rst
+++ b/docs/Parametric SurPyval Modelling.rst
@@ -529,6 +529,29 @@ Our estimation has worked! Even though we used the MPS estimate for the paramete
 
 This shows the power of the flexible API that surpyval offers, because if your modelling fails using one estimation method, you can use another. In this case, the MPS method is quite good at handling offset distributions. It is therefore a good approach to use when using offset distributions.
 
+That extends to the information criteria. A log-likelihood is a property of the
+parameters and the data, not of the search that found them, so ``neg_ll()``,
+``aic()``, ``bic()`` and ``aic_c()`` are available after *any* fit — not only
+after MLE:
+
+.. jupyter-execute::
+
+    np.random.seed(1)
+    x = surv.Weibull.random(500, 10., 2.)
+
+    print(f"{'how':<6}{'neg_ll':>12}{'AIC':>12}{'BIC':>12}")
+    for how in ["MLE", "MPS", "MSE", "MOM", "MPP"]:
+        m = surv.Weibull.fit(x, how=how)
+        print(f"{how:<6}{m.neg_ll():12.3f}{m.aic():12.3f}{m.bic():12.3f}")
+
+Two things are worth noticing. The first is that you can compare distributions
+by AIC or BIC regardless of how you fitted them, which is the usual way of
+choosing between candidate models. The second is a sanity check on the
+estimators themselves: MLE attains the lowest negative log-likelihood, because
+that is precisely the quantity it minimises. The others land close behind, each
+optimising something else — MPS the spacings, MSE the distance to the plotting
+positions, MOM the moments.
+
 As stated in the Non-Parametric section, there is a risk that using the Turnbull estimator when all
 values are trunctated by the same values. We will now show what happens. First, some example data:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,22 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **ExpoWeibull no longer runs a nested optimiser ladder to build its
+  initial guess.** It seeds itself from a Gumbel fit to ``log(x)``, and
+  that inner fit was a full maximum likelihood run -- an optimiser
+  ladder, to produce a *starting point* for another optimiser. It cost
+  15-30% of the fit (20 ms at n=200, 41 ms at n=5000) and the
+  probability plot alone turned out to be just as good a seed: across 54
+  parameter combinations, plus right-censored, left-censored and heavily
+  tied data, every fit reached the same optimum to the optimiser's own
+  tolerance. Ordinary fits are about 20% faster.
+
+  The offset path keeps the refinement. There the seed reads ``log(x)``
+  of the *unshifted* data, so a large shift compresses the logs into a
+  narrow band and the probability plot is a poor starting point --
+  dropping it moved one fit in twelve to a worse optimum (861.898 to
+  861.962) and made that fit seven times slower.
+
 - **The ARI likelihood is evaluated for the whole sample at once, making
   imperfect-repair fits 30-160x faster.** It used to walk every event in
   Python, calling the baseline ``cif`` and ``iif`` and rebuilding the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,25 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **Documentation caught up with the estimator changes above.** The
+  maximum likelihood notes in :doc:`Parametric Estimation` now cover the
+  observation that is *both* censored and truncated -- the contribution
+  it makes, why the numerator has to be capped by the truncation bound,
+  and the fact that surpyval recasts such a point as interval censored
+  in its internal representation rather than special-casing the
+  likelihood. The user's own ``x``, ``c``, ``n`` and ``t`` are untouched,
+  which is now said explicitly.
+
+  The method of moments section explains that the optimisation matches
+  scaled *central* moments rather than raw ones, and why that matters for
+  offset data, where every raw moment is dominated by the offset.
+
+  :doc:`Parametric SurPyval Modelling` gains a worked comparison of
+  ``neg_ll``, ``aic`` and ``bic`` across all five fit methods, showing
+  both that the criteria are available whatever the method and that MLE
+  attains the lowest negative log-likelihood -- a check that could not be
+  run before.
+
 - **An offset ``ExpoWeibull`` fit now seeds itself from the shifted
   data.** ``ExpoWeibull`` starts from a Gumbel fit to ``log(x)``, since
   a Weibull's logs are Gumbel distributed. With ``offset=True`` it took

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,37 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **Method of moments now matches central moments rather than raw
+  ones.** The two describe the same estimator -- the binomial transform
+  between them is exact and bijective, so matching the first ``k``
+  central moments is matching the first ``k`` raw moments -- but raw
+  moments hide the answer from the optimiser once a distribution is
+  offset. ``E[X^k]`` is then dominated by ``gamma^k`` and the shape
+  contributes only a fractional correction: 0.5% of ``E[X^3]`` for a
+  Gamma(3, 4) shifted by 10. Fitting three parameters off the third
+  decimal place of a large number degenerates, and offset fits settled
+  on parameters that matched the sample moments *better than the true
+  parameters did* while being nowhere near them -- a shape of 17.7
+  against a true 3.0, unchanged at any sample size.
+
+  Central moments remove the offset by construction, so the shape is
+  the whole of the third moment rather than a rounding error in it. An
+  offset Gamma at n=5000 goes from ``gamma=49.01, alpha=15.74,
+  beta=9.07`` to ``gamma=50.01, alpha=2.74, beta=3.75`` against a true
+  ``(50, 3, 4)``, and the fit drops from up to 25 s to under a second.
+  Unshifted fits are unaffected -- Weibull, Gamma, Normal, LogNormal,
+  Logistic, Gumbel and Exponential all agree with the previous results
+  to at least four decimal places, because there the conditioning was
+  never the problem.
+
+  The terms are scaled by the sample's own ``sigma^k``, so each is
+  dimensionless: the mean in units of sigma, the relative variance
+  error, then the skewness difference. The mismatch warning's threshold
+  moves from 1e-4 to 1e-2 to suit those units. Healthy fits land near
+  1e-12 when the moment equations have an exact solution and near 1e-3
+  when sampling noise means none exists and the optimiser returns the
+  closest match; a fit that has actually failed sits near 0.5.
+
 - **Offset Gamma fits no longer start from a corrupted initial guess.**
   Every offset-capable distribution returns the shift first in its
   parameter vector, because ``_initial_guess`` overwrites that slot

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,36 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **``aic``, ``bic``, ``aic_c`` and ``neg_ll`` now work for every fit
+  method.** They were available only after a maximum-likelihood or
+  closed-form fit, because only those compute a log-likelihood on the
+  way to the answer. A model fitted with ``how='MPS'``, ``'MSE'``,
+  ``'MOM'`` or ``'MPP'`` raised ``AttributeError`` from all four --
+  which meant the usual way of choosing between distributions was
+  unavailable for four of the five methods, and failed with a message
+  that did not say why.
+
+  The log-likelihood is a property of the parameters and the data, not
+  of the search that found them, so it is now evaluated after any fit.
+  Methods that already reported one keep it exactly: maximum
+  likelihood's is the optimiser's own final objective, which on its
+  fallback path is deliberately taken at the initial guess rather than
+  at the failed result (#261).
+
+  A worked consequence, on 500 Weibull(10, 2) points -- the maximum
+  likelihood estimator attaining the maximum likelihood, which was not
+  checkable before:
+
+  ===========  ==========
+  method       ``neg_ll``
+  ===========  ==========
+  MLE          1466.3254
+  MPS          1466.3865
+  MOM          1466.3979
+  MSE          1466.6759
+  MPP          1470.7119
+  ===========  ==========
+
 - **MSE and MPS fits try BFGS before Newton-CG, and are several times
   faster for it.** Both go through a shared fallback that reached for
   Newton-CG first, which needs a hessian. Building one is

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,20 @@ v0.17.1 (unreleased)
   and small fits improve too -- Exponential at n=1000 from 5.9 ms to
   2.4 ms. Kaplan-Meier at n=100,000 now takes 140 ms.
 
+  On top of that, grouping is now skipped entirely when there is
+  nothing to group. Continuous measurements have distinct values, so
+  every row is already its own group in input order and the operation
+  is the identity -- but the data handler runs it several times per
+  fit regardless. Distinct values in the leading column of ``x`` are
+  enough to establish this (they make whole rows distinct whatever
+  ``c`` and ``t`` hold), which costs one sort of one column against
+  three sorts of the full key. Only tied data -- rounded, discrete, or
+  heavily weighted -- takes the grouping path now. Grouping 100,000
+  distinct points falls from 74 ms to 1.2 ms, taking the Normal fit
+  above to 64 ms, Weibull to 505 ms, and Kaplan-Meier to 63 ms. Repeated
+  ``nan`` values deliberately fail the check and fall through to
+  grouping, since ``nan != nan`` means they must stay separate.
+
 - **Exact closed-form maximum likelihood for the Exponential, Normal and
   LogNormal, where one exists.** These have analytic MLEs -- the
   Exponential's events-over-exposure ratio, the Normal's mean and

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,32 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **MSE and MPS fits try BFGS before Newton-CG, and are several times
+  faster for it.** Both go through a shared fallback that reached for
+  Newton-CG first, which needs a hessian. Building one is
+  disproportionately expensive for the distributions whose derivatives
+  autograd cannot take analytically -- the incomplete gamma is
+  central-differenced, so every second-order entry costs a difference of
+  differences. An offset Gamma MSE fit at n=5000 spent 8.2 of its 8.3
+  seconds there, and BFGS reached a marginally *better* optimum in half
+  a second.
+
+  Reversing the order was checked over 132 fits: MSE and MPS, nine
+  distributions, at two sample sizes, on plain, right-censored,
+  left-censored and offset data. 129 objectives came back identical,
+  three improved, none got worse, for 3.9x less time overall. Newton-CG
+  is still there, escalated to when BFGS fails, and Nelder-Mead behind
+  it; the zero-hessian guard is kept, since a hessian of zeros makes
+  Newton-CG stop at the initial guess while reporting success, so there
+  is nothing to escalate to and Nelder-Mead should take over.
+
+  ``scipy.optimize.least_squares`` was tried first, on the reasoning
+  that the MSE objective is a sum of squares and Gauss-Newton should
+  exploit it. It is far worse: it needs the full residual jacobian, so
+  n=5000 means 5000 rows each paying that central-differenced
+  derivative, and the same fit took 239 seconds against the scalar
+  gradient's three numbers.
+
 - **ExpoWeibull no longer runs a nested optimiser ladder to build its
   initial guess.** It seeds itself from a Gumbel fit to ``log(x)``, and
   that inner fit was a full maximum likelihood run -- an optimiser

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,27 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **Tests: a breadth sweep over Turnbull's supported inputs.** Every
+  combination of censoring type (observed, left, right, interval, and all
+  four mixed), truncation form (none, left, right, both) and hazard
+  estimator (Nelson-Aalen, Kaplan-Meier, Fleming-Harrington) is now fitted
+  and checked for a converged, valid, monotone survival curve with a
+  coherent risk-set ladder, complementing the existing tests that each pin
+  one regime. The sweep also pins that the estimator choice is honoured,
+  and that Fleming-Harrington coincides with Nelson-Aalen exactly when
+  event times are distinct (its tied-event correction being the only
+  difference). Building it surfaced #308.
+- **Known issue: left censoring combined with left truncation** (#308).
+  Turnbull either raises "censoring interval does not intersect its own
+  truncation window" on data where the intersection is plainly non-empty,
+  or fails to converge and returns a degenerate estimate. A left-censored
+  row lives on the ``(-inf, x]`` bound, and the support-window
+  intersection added for #273 drops that bound whenever an entry time
+  sits above its lower edge, even though the event interval ``(tl, x]``
+  is non-empty. Only fits with *both* left-censored observations and
+  left truncation are affected. The sweep marks this regime ``xfail``
+  (strict), so it will report as soon as it is fixed.
+
 - **Fixed: ``xcnt_to_xrd`` was quadratic in time and memory, and raised
   ``MemoryError`` past roughly 50,000 observations** (#306). The at-risk
   entry count was built as an ``N x K`` comparison matrix

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,43 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **The ARI likelihood is evaluated for the whole sample at once, making
+  imperfect-repair fits 30-160x faster.** It used to walk every event in
+  Python, calling the baseline ``cif`` and ``iif`` and rebuilding the
+  intensity reduction from the failure history at each step -- around
+  ten milliseconds per event, repeated for every one of the optimiser's
+  several hundred objective evaluations. Fitting 250 items took 19
+  seconds and 1000 items was impractical.
+
+  The apparent obstacle is that the reduction depends on the failure
+  history, which looks inherently sequential. It is not: summing over
+  the reduction's *window offset* rather than over the failures turns it
+  into a handful of whole-array passes, and the offset only ever runs to
+  ``min(m, longest item)`` -- exactly one pass for ARI1. Each failure's
+  ordinal within its own item bounds the window, which is what stops one
+  item's history leaking into the next.
+
+  =========================  ==========  ==========
+  fit                        before      after
+  =========================  ==========  ==========
+  35 items x 6 events        2.11 s      0.07 s
+  250 items x 8 events       19.02 s     0.12 s
+  Cramer-von Mises, 10 boot  24.16 s     1.71 s
+  1000 items x 10 events     ~80 s       0.53 s
+  =========================  ==========  ==========
+
+  Results are unchanged to floating point: over 312 captured values --
+  the reduction helper across memory regimes, the objective on a fixed
+  parameter grid, fitted parameters and the rescaled-increment
+  residuals -- the largest relative difference is 1.1e-14, from
+  summation order. The original per-event implementation is kept in the
+  test suite as an oracle so the two cannot drift.
+
+  One behavioural nicety: a non-positive reduced intensity is outside
+  the model's support, and the scalar loop returned ``inf`` early on
+  reaching one. The vectorised form tests the whole array before taking
+  logs, so it returns ``inf`` rather than warning its way to a ``nan``.
+
 - **Method of moments now matches central moments rather than raw
   ones.** The two describe the same estimator -- the binomial transform
   between them is exact and bijective, so matching the first ``k``

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,30 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **``group_xcnt`` no longer walks every observation in Python.** The
+  step that collapses duplicate ``(x, c, t)`` rows accumulated into a
+  triple-nested ``defaultdict``, one iteration per observation. That is
+  linear but with a very large constant -- around 13 microseconds an
+  observation -- which made it the single dominant cost of fitting once
+  samples grew: 94% of a 50,000-point Normal fit, and two seconds at
+  100,000 points. It is now a sort plus ``np.bincount``. Fitted values
+  are bit-identical.
+
+  Group *ordering* is preserved exactly, which matters more than it
+  appears: ``xcnt_sort`` runs immediately afterwards and is a *stable*
+  sort keyed on ``c``, ``t.min(axis=1)`` and ``x``, so any rows tying on
+  all three keep whatever order grouping produced. Rows sharing an ``x``
+  and ``c`` with different ``tr`` but equal ``t.min()`` are exactly such
+  a tie, and a plain sorted ``np.unique`` would silently reorder them,
+  so the original x-major nesting is reproduced instead. Integer counts
+  also stay integer (``np.bincount`` returns float64), and ``nan``
+  entries keep their own groups as they did under dictionary keying.
+
+  Measured end to end: a Normal fit at n=100,000 goes from 1137 ms to
+  125 ms (9.1x), Weibull at n=100,000 from 3890 ms to 926 ms (4.2x),
+  and small fits improve too -- Exponential at n=1000 from 5.9 ms to
+  2.4 ms. Kaplan-Meier at n=100,000 now takes 140 ms.
+
 - **Exact closed-form maximum likelihood for the Exponential, Normal and
   LogNormal, where one exists.** These have analytic MLEs -- the
   Exponential's events-over-exposure ratio, the Normal's mean and

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,44 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **Exact closed-form maximum likelihood for the Exponential, Normal and
+  LogNormal, where one exists.** These have analytic MLEs -- the
+  Exponential's events-over-exposure ratio, the Normal's mean and
+  standard deviation -- so the fit no longer builds an initial guess or
+  runs the five-optimiser ladder. Because the closed form is *exact*,
+  the result is not merely faster but at least as good: verified that
+  its log-likelihood is never worse than the optimiser's, and its
+  parameters agree to within the optimiser's own convergence tolerance
+  (~1e-8), as do its confidence bounds. At n=1000 a LogNormal fit goes
+  from 135 ms to 10 ms, a Normal from 42 ms to 5 ms, and an Exponential
+  from 11 ms to 5 ms; Weibull and the rest are untouched.
+
+  The applicability conditions are exact. The Exponential admits right
+  censoring and left truncation (which only moves each unit's exposure
+  from ``x`` to ``x - tl``), but falls back to the optimiser for left or
+  interval censoring and for right truncation, each of which makes the
+  score transcendental. The Normal and LogNormal need complete,
+  untruncated data: any censoring makes them the Tobit model and any
+  truncation introduces a normal-CDF normaliser.
+- **Fixed: closed-form fits silently ignored ``lfp``, ``zi``, ``offset``
+  and fixed parameters.** The hook that short-circuited to a
+  distribution's analytic MLE fired before any of these were checked, so
+  ``Uniform.fit(x, lfp=True)`` returned ``p = 1.0`` and
+  ``Uniform.fit(x, fixed={"a": 0.0})`` ignored the held value -- in both
+  cases without warning. Requests carrying that structure now go to the
+  optimiser, which estimates them.
+- **Fixed: ``Uniform`` fits had no usable log-likelihood.**
+  ``Uniform.fit(x).aic()`` raised ``AttributeError`` and ``cb()`` raised
+  for want of a covariance. The log density is now defined directly
+  rather than through the generic ``log(hf) - Hf`` identity, which is
+  ``nan`` at the upper support edge (where ``sf`` is 0) -- exactly where
+  the MLE puts ``b``. ``neg_ll``, ``aic``, ``bic`` and ``aic_c`` are now
+  correct. No parameter covariance is offered, deliberately: the Uniform
+  MLE is an order statistic sitting on the support edge rather than an
+  interior stationary point, so the observed information is not positive
+  definite and its inverse carries negative variances; ``cb`` refuses
+  rather than returning silent ``nan`` bounds.
+
 - **Tests: a breadth sweep over Turnbull's supported inputs.** Every
   combination of censoring type (observed, left, right, interval, and all
   four mixed), truncation form (none, left, right, both) and hazard

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,29 @@
 Changelog
 =========
 
+v0.17.1 (unreleased)
+--------------------
+
+- **Fixed: ``xcnt_to_xrd`` was quadratic in time and memory, and raised
+  ``MemoryError`` past roughly 50,000 observations** (#306). The at-risk
+  entry count was built as an ``N x K`` comparison matrix
+  (observations × distinct times): 20,000 observations needed a 3.2 GB
+  intermediate and ~15 s, and 50,000 attempted an 18.6 GiB allocation and
+  failed. Because this conversion feeds every nonparametric estimator —
+  and the MLE initial guess, which comes from probability plotting — the
+  ceiling applied to most of the package: ``Weibull.fit`` on 50,000
+  points raised ``MemoryError`` even though the likelihood itself was
+  fine. The entry count is now computed in two linear branches: a
+  constant when nothing is left truncated (the common case, where the
+  matrix was entirely ``True`` and merely recomputed ``n.sum()``), and a
+  sorted ``searchsorted`` lookup otherwise. ``side="left"`` counts
+  strictly-less-than exactly as the previous ``<`` did, so the
+  ``(entry, exit]`` convention from #260 is unchanged, and integer counts
+  make the cumulative sum exact — values are bit-identical. A
+  ``Weibull.fit`` at n=10,000 goes from 1,836 ms to 182 ms; 200,000
+  points now fit in 5.6 s and a 500,000-point Kaplan-Meier in 8.1 s,
+  where both previously failed.
+
 v0.17.0 (1 August 2026)
 -----------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,55 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **Fitted parameters change for censored *and* truncated data: the
+  likelihood was unbounded there (#310).** A censored observation is
+  only ever known to lie inside its own truncation window -- it could
+  not have been observed otherwise -- so its likelihood numerator has to
+  be the probability of that intersection. Every likelihood in the
+  package instead used the unconditional form, ``F(x)`` for left
+  censoring and ``S(x)`` for right, and divided by a separately
+  accumulated window probability. That counts territory the truncation
+  has already ruled out, so the contribution exceeds one, and the excess
+  grows without limit as the fitted distribution's mass slides out of
+  the window.
+
+  The consequence was a silent wrong answer. On 200 left-censored
+  LogNormal points with a true ``mu`` of 0 and mild left truncation, the
+  fit returned ``mu = -7.81`` with ``neg_ll`` of ``-inf`` and
+  ``res.success`` set to ``True``. Across eight distributions, 21 of 48
+  censoring/truncation combinations returned a non-finite likelihood,
+  reporting parameters such as a Weibull ``alpha`` of 1.3e81 or a Normal
+  ``mu`` of -1.77e4. Regression was affected too, and failed more
+  quietly: adding left truncation to a working ``WeibullAFT`` fit
+  returned an entirely plausible-looking parameter vector whose
+  covariate coefficient had collapsed from a true 0.5 to 0.0018.
+
+  Rather than teach each likelihood about truncation, such rows are now
+  handed over as *intervals*: a left-censored row truncated at ``tl``
+  becomes ``[tl, x]``, a right-censored row truncated at ``tr`` becomes
+  ``[x, tr]``. The interval term is already a difference of CDFs, so it
+  computes the correct numerator with no change to any likelihood
+  function -- which is also why interval-censored data never had the
+  bug. One change in ``SurpyvalData`` therefore fixes the parametric,
+  regression, Royston-Parmar and mixture likelihoods together.
+
+  Only rows with a *finite* bound on the relevant side are recast, which
+  is exactly where the defect lived. Untruncated fits are bit-identical:
+  verified over 292 cases spanning ten distributions, seven censoring
+  regimes, two sample sizes, weighted and unweighted, and three
+  regression fitters, compared as exact float bit patterns. The
+  restriction also keeps right censoring on the exact ``log_sf`` path,
+  since expressing it as ``1 - F(x)`` loses all precision once ``F(x)``
+  rounds to one -- a ``log_sf`` of -49 comes back as ``-inf``, and the
+  optimiser does evaluate the likelihood that far from the data.
+
+  The LogNormal case above now fits ``mu = -0.56``, matching the
+  maximum of the correctly conditioned likelihood, and all 48
+  combinations return finite results. Right censoring combined with
+  finite right truncation remains contradictory data and keeps its
+  existing warning; what changes is that it now yields the coherent
+  conditional ``P(x < X <= tr)`` rather than an unbounded direction.
+
 - **``group_xcnt`` no longer walks every observation in Python.** The
   step that collapses duplicate ``(x, c, t)`` rows accumulated into a
   triple-nested ``defaultdict``, one iteration per observation. That is

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,11 +1,30 @@
 Changelog
 =========
 
-v0.17.1 (unreleased)
---------------------
+v0.18.0 (2 August 2026)
+-----------------------
 
-- **Documentation caught up with the estimator changes above.** The
-  maximum likelihood notes in :doc:`Parametric Estimation` now cover the
+- **Documentation caught up with the estimator changes below.** The
+  most consequential correction is in :doc:`Parametric SurPyval
+  Modelling`, whose section on offset unidentifiability demonstrated the
+  hazard of threshold parameters by fitting ``Gamma(3, 2) + 10`` and
+  reporting that ``MPP`` returned a negative ``gamma`` with a shape
+  parameter inflated by two orders of magnitude. That has not been true
+  since #257 and #313: every fit method now recovers the offset to three
+  decimal places, at offsets from 10 to 1000 and at both small and large
+  samples. The page had also drifted from the test file it cites --
+  ``test_offset_divergence.py`` was tightened by #257 and #275 to assert
+  parameter *recovery*, the opposite of what the prose claimed.
+
+  The underlying theory is kept, since it is exactly what made a poor
+  starting point so damaging: ``gamma`` trades off against the shape and
+  scale, and the likelihood is flat along that ridge. It now reads as a
+  caution for your own data rather than a demonstration of broken
+  output, and names both causes of the old behaviour separately -- the
+  probability-plotting search stranded by a single starting shape, and
+  the moment-based initialisers taking their moments before the shift.
+
+  The maximum likelihood notes in :doc:`Parametric Estimation` now cover the
   observation that is *both* censored and truncated -- the contribution
   it makes, why the numerator has to be capped by the truncation bound,
   and the fact that surpyval recasts such a point as interval censored

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,36 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **Offset Gamma fits no longer start from a corrupted initial guess.**
+  Every offset-capable distribution returns the shift first in its
+  parameter vector, because ``_initial_guess`` overwrites that slot
+  with its own estimate of the shift. ``Gamma`` returned it *last*, so
+  the overwrite landed on the shape parameter and destroyed it, while
+  the initialiser's own copy of the shift stayed behind in the scale
+  slot: the seed came back as ``(offset, shape-ish, offset)``.
+
+  Compounding it, the shape approximation was computed on the raw
+  ``x``. On offset data the constant squashes
+  ``s = log(mean x) - mean(log x)`` towards zero, and since the shape
+  grows like ``1 / 12s`` the estimate exploded -- 649 for a true shape
+  of 3. The moments are now taken after the shift is removed.
+
+  The consequences were silent wrong answers, not just slow ones. A
+  600-point sample from ``Gamma(3, 4)`` shifted up by 10 fitted by MSE
+  returned a *negative* shift of -1.35 with a shape of 63.8; another
+  sample stopped after 0.03 s at the seed itself, reporting a scale
+  equal to the offset. Both now recover the shift, and the fit is also
+  4x faster (6.2 s to 1.6 s) because the optimiser no longer has to
+  travel back from a nonsense starting point. MLE was unaffected -- it
+  found its way regardless -- and non-offset fits are untouched.
+
+  Method of moments still disagrees on offset Gamma, but that is not a
+  defect: its solution matches the sample moments *better than the true
+  parameters do* (first three moments 10.76 / 116 / 1253 against the
+  truth's 10.75 / 115.7 / 1248). The three-parameter moment system with
+  a threshold is close to non-identifiable, which is why ``MOM`` is not
+  among the offset methods exercised in the test suite.
+
 - **Fitted parameters change for censored *and* truncated data: the
   likelihood was unbounded there (#310).** A censored observation is
   only ever known to lie inside its own truncation window -- it could

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,36 @@ Changelog
 v0.17.1 (unreleased)
 --------------------
 
+- **An offset ``ExpoWeibull`` fit now seeds itself from the shifted
+  data.** ``ExpoWeibull`` starts from a Gumbel fit to ``log(x)``, since
+  a Weibull's logs are Gumbel distributed. With ``offset=True`` it took
+  those logs *before* removing the shift, so it read ``log(x)`` where
+  the model wants ``log(x - gamma)``. A large offset compresses those
+  logs into a narrow band, the Gumbel ``sigma`` collapses, and
+  ``beta = 1 / sigma`` explodes: on 500 points from ``ExpoWeibull(10,
+  2, 1) + 100`` the seed came back as ``alpha = 111, beta = 23.5``
+  against a true 10 and 2. The maximum likelihood fit then failed
+  outright, returning ``nan`` and warning its way back to the MPP
+  estimate.
+
+  This was not an edge case. Over 120 offset fits -- four offsets, five
+  parameter sets, six replicates each -- **54 returned nan**, which is
+  every configuration at an offset of 100 or 1000. All 54 now converge,
+  none of the 66 that already worked changed for the worse, and the
+  whole sweep takes 25.5 seconds against 188.3, since a hopeless
+  starting point is expensive to fail from.
+
+  The offset is now estimated first and the shape parameters read off
+  ``x - gamma``. It is estimated as ``min(x) - 1``, which is what the
+  fitter installs regardless of what the initialiser returns -- seeding
+  against a different shift than the one being optimised under defeats
+  the point.
+
+  The nested Gumbel MLE that refines the offset seed is kept. Removing
+  it was tried, on the reasoning that shifting the data correctly makes
+  the probability plot alone good enough; it is not, and five of 48
+  offset fits landed on a worse optimum without it.
+
 - **``aic``, ``bic``, ``aic_c`` and ``neg_ll`` now work for every fit
   method.** They were available only after a maximum-likelihood or
   closed-form fit, because only those compute a log-likelihood on the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "surpyval"
-version = "0.17.0"
+version = "0.18.0"
 description = "A python package for survival analysis"
 readme = "README.md"
 license = {text = "MIT"}

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,4 +5,6 @@ flake8
 flake8-pyproject
 mypy
 coverage
+pytest-cov
+pytest-xdist
 pre-commit

--- a/surpyval/__init__.py
+++ b/surpyval/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.17.0"
+__version__ = "0.18.0"
 
 from autograd import numpy as np
 

--- a/surpyval/beta/ml/forest/deviance_split.py
+++ b/surpyval/beta/ml/forest/deviance_split.py
@@ -143,19 +143,31 @@ def _exp_theta0(data: SurpyvalData) -> "float | None":
     event-weight over exposure, or ``None`` when the data carries no
     event information.
     """
-    exposure = 0.0
-    events = 0.0
-    if data.x_o.size:
-        exposure += float(np.sum(data.n_o * data.x_o))
-        events += float(np.sum(data.n_o))
-    if data.x_r.size:
-        exposure += float(np.sum(data.n_r * data.x_r))
-    if data.x_l.size:
-        exposure += float(np.sum(data.n_l * data.x_l)) / 2.0
-        events += float(np.sum(data.n_l))
-    if data.x_il.size:
-        exposure += float(np.sum(data.n_i * (data.x_il + data.x_ir))) / 2.0
-        events += float(np.sum(data.n_i))
+    # Read the censoring codes directly rather than the likelihood
+    # buckets. Those buckets hand censored rows with a finite truncation
+    # bound to the likelihood as intervals (#310), which is right for a
+    # likelihood but wrong here: a right-censored row would arrive in
+    # the interval branch and be counted as an event.
+    c, x, n = data.c, data.x, data.n
+    lead = x if x.ndim == 1 else x[:, 0]
+    trail = x if x.ndim == 1 else x[:, -1]
+
+    observed = c == 0
+    right = c == 1
+    left = c == -1
+    interval = c == 2
+
+    exposure = (
+        float(np.sum(n[observed] * lead[observed]))
+        + float(np.sum(n[right] * lead[right]))
+        + float(np.sum(n[left] * lead[left])) / 2.0
+        + float(np.sum(n[interval] * (lead[interval] + trail[interval]))) / 2.0
+    )
+    events = (
+        float(np.sum(n[observed]))
+        + float(np.sum(n[left]))
+        + float(np.sum(n[interval]))
+    )
     if exposure <= 0 or events <= 0:
         return None
     return float(np.log(events / exposure))

--- a/surpyval/recurrent/renewal/ari.py
+++ b/surpyval/recurrent/renewal/ari.py
@@ -37,6 +37,76 @@ def ari_reduction(failure_intensities, rho, m):
     return rho * np.sum(weights * recent)
 
 
+def _reduction_sequence(failure_intensities, position, rho, m):
+    """``R_n`` after every failure at once, for failures from many items.
+
+    ``failure_intensities`` holds ``lambda_0`` at each *observed* failure
+    with the items laid end to end, and ``position`` gives each failure's
+    index within its own item, which is what keeps one item's history
+    from leaking into the next.
+
+    This is ``ari_reduction`` evaluated at every prefix, but summed over
+    the *window offset* rather than over the failures. The offset only
+    ever runs to ``min(m, longest item)``, so the loop is a handful of
+    whole-array passes -- for ARI1 exactly one -- in place of one Python
+    step per failure. The offset ``i`` contributes only where the item
+    actually has ``i`` earlier failures, which is the ``position >= i``
+    mask and reproduces ``upper = min(m, n)`` above.
+    """
+    lam = np.asarray(failure_intensities, dtype=float)
+    if lam.size == 0:
+        return lam
+    pos = np.asarray(position)
+    longest = int(pos.max()) + 1
+    span = longest if np.isinf(m) else min(int(m), longest)
+
+    q = 1.0 - rho
+    total = np.array(lam, copy=True)
+    for i in range(1, span):
+        shifted = np.concatenate([np.zeros(i), lam[:-i]])
+        total += (q**i) * np.where(pos >= i, shifted, 0.0)
+    return rho * total
+
+
+def _event_layout(data):
+    """Per-row bookkeeping shared by the likelihood and the residuals.
+
+    ``prev`` is the previous event time, restarting at 0 for each item.
+    ``observed`` marks the failures. ``failure_pos`` gives each failure's
+    ordinal within its own item, which bounds the reduction window.
+    ``in_force`` indexes the reduction sequence at the reduction acting
+    over each row's interval, or ``-1`` where the item has not failed
+    yet and the intensity is still the unreduced baseline.
+
+    Rows are assumed grouped by item, as ``handle_xicn`` leaves them.
+    """
+    x = np.asarray(data.x, dtype=float)
+    item = np.asarray(data.i)
+    observed = np.asarray(data.c) == 0
+
+    starts = np.empty(x.size, dtype=bool)
+    starts[0] = True
+    starts[1:] = item[1:] != item[:-1]
+
+    prev = np.empty_like(x)
+    prev[0] = 0.0
+    prev[1:] = x[:-1]
+    prev[starts] = 0.0
+
+    # Failures strictly before each row, globally then per item.
+    before = np.cumsum(observed) - observed
+    first_rows = np.flatnonzero(starts)
+    lengths = np.diff(np.append(first_rows, x.size))
+    before_item = before - np.repeat(before[first_rows], lengths)
+
+    # Within an item the most recent earlier failure is also the most
+    # recent one globally, so the global running count indexes it -- the
+    # per-item count only decides whether one exists at all.
+    in_force = np.where(before_item > 0, before - 1, -1)
+    failure_pos = before_item[observed]
+    return prev, observed, failure_pos, in_force
+
+
 @singleton_fitter
 class ARI(RenewalFitMixin):
     """
@@ -132,23 +202,15 @@ class ARI(RenewalFitMixin):
         """
         rho, m = model.rho, model.m
         dist = model.model
-        _, idx = np.unique(data.i, return_index=True)
-        x_by_item = np.split(data.x, idx)[1:]
-        c_by_item = np.split(data.c, idx)[1:]
+        x = np.asarray(data.x, dtype=float)
+        prev, observed, failure_pos, in_force = _event_layout(data)
 
-        increments = []
-        for x_item, c_item in zip(x_by_item, c_by_item):
-            prev = 0.0
-            reduction = 0.0
-            history_iif = []
-            for t, censor in zip(x_item, c_item):
-                delta_cif = float(dist.cif(t) - dist.cif(prev))
-                increments.append(delta_cif - reduction * (t - prev))
-                if censor == 0:
-                    history_iif.append(float(dist.iif(t)))
-                    reduction = ari_reduction(history_iif, rho, m)
-                prev = t
-        return np.asarray(increments, dtype=float)
+        lam = np.asarray(dist.iif(x[observed]), dtype=float)
+        reductions = _reduction_sequence(lam, failure_pos, rho, m)
+        active = np.where(in_force >= 0, reductions[in_force], 0.0)
+
+        delta_cif = np.asarray(dist.cif(x) - dist.cif(prev), dtype=float)
+        return delta_cif - active * (x - prev)
 
     def _refit(self, model, data):
         """Refit this model family on ``data`` with the same baseline
@@ -158,35 +220,35 @@ class ARI(RenewalFitMixin):
         )
 
     def create_negll_func(self, data, dist, m):
-        _, idx = np.unique(data.i, return_index=True)
-        x_by_item = np.split(data.x, idx)[1:]
-        c_by_item = np.split(data.c, idx)[1:]
+        x = np.asarray(data.x, dtype=float)
+        prev, observed, failure_pos, in_force = _event_layout(data)
+        gap = x - prev
+        x_failures = x[observed]
 
         def negll_func(params):
             rho = params[0]
             dist_params = params[1:]
 
-            ll = 0.0
-            for x_item, c_item in zip(x_by_item, c_by_item):
-                prev = 0.0
-                reduction = 0.0
-                history_iif = []
-                for t, censor in zip(x_item, c_item):
-                    # Integral of the (reduced) intensity over (prev, t]; the
-                    # reduction is constant across the interval.
-                    delta_cif = dist.cif(t, *dist_params) - dist.cif(
-                        prev, *dist_params
-                    )
-                    ll -= delta_cif - reduction * (t - prev)
+            # lambda_0 at the failures drives the reductions; every row
+            # then picks up whichever reduction was in force over its own
+            # interval (`in_force` is -1 before the item's first failure,
+            # where the baseline is unreduced).
+            lam = dist.iif(x_failures, *dist_params)
+            reductions = _reduction_sequence(lam, failure_pos, rho, m)
+            active = np.where(in_force >= 0, reductions[in_force], 0.0)
 
-                    if censor == 0:
-                        intensity = dist.iif(t, *dist_params) - reduction
-                        if intensity <= 0:
-                            return np.inf
-                        ll += np.log(intensity)
-                        history_iif.append(dist.iif(t, *dist_params))
-                        reduction = ari_reduction(history_iif, rho, m)
-                    prev = t
+            # A non-positive intensity is outside the model's support.
+            # Checked before the log so it returns inf rather than
+            # warning its way to a nan, as the scalar loop did by
+            # returning early.
+            intensity = lam - active[observed]
+            if not np.all(intensity > 0):
+                return np.inf
+
+            delta_cif = dist.cif(x, *dist_params) - dist.cif(
+                prev, *dist_params
+            )
+            ll = -np.sum(delta_cif - active * gap) + np.sum(np.log(intensity))
             return -ll
 
         return negll_func

--- a/surpyval/tests/recurrent/test_ari.py
+++ b/surpyval/tests/recurrent/test_ari.py
@@ -79,3 +79,120 @@ def test_ari_inference_requires_fit_from_data():
     model = ARI.fit_from_parameters([60.0, 2.0], rho=0.3, m=1, dist=CrowAMSAA)
     with pytest.raises(ValueError, match="fitted from data"):
         model.aic
+
+
+# -- the vectorised likelihood against the scalar original -------------
+#
+# The likelihood used to walk every event in Python, calling the
+# baseline cif/iif and rebuilding the reduction from the failure history
+# each step. That was ~10ms per event and made a 250-item fit take 19
+# seconds. The replacement evaluates the whole sample at once, summing
+# over the reduction *window offset* instead of over the events. The
+# original is kept here as the oracle so the two cannot drift apart.
+
+
+def _scalar_negll(data, dist, m, params):
+    """The original per-event implementation, verbatim."""
+    _, idx = np.unique(data.i, return_index=True)
+    x_by_item = np.split(data.x, idx)[1:]
+    c_by_item = np.split(data.c, idx)[1:]
+
+    rho = params[0]
+    dist_params = params[1:]
+
+    ll = 0.0
+    for x_item, c_item in zip(x_by_item, c_by_item):
+        prev = 0.0
+        reduction = 0.0
+        history_iif = []
+        for t, censor in zip(x_item, c_item):
+            delta_cif = dist.cif(t, *dist_params) - dist.cif(
+                prev, *dist_params
+            )
+            ll -= delta_cif - reduction * (t - prev)
+            if censor == 0:
+                intensity = dist.iif(t, *dist_params) - reduction
+                if intensity <= 0:
+                    return np.inf
+                ll += np.log(intensity)
+                history_iif.append(dist.iif(t, *dist_params))
+                reduction = ari_reduction(history_iif, rho, m)
+            prev = t
+    return -ll
+
+
+PARAM_GRID = [
+    [0.0, 20.0, 1.5],
+    [0.1, 20.0, 1.5],
+    [0.5, 20.0, 1.5],
+    [0.9, 20.0, 1.5],
+    [0.999, 20.0, 1.5],
+    [0.5, 5.0, 0.7],
+    [0.3, 50.0, 2.5],
+]
+
+
+@pytest.mark.parametrize("m", [1, 2, 3, np.inf])
+def test_vectorised_negll_matches_the_scalar_original(m):
+    truth = ARI.fit_from_parameters([20.0, 1.5], 0.5, m=m, dist=CrowAMSAA)
+    data = truth.count_terminated_simulation_data(6, items=12, seed=1)
+    negll = ARI.create_negll_func(data, CrowAMSAA, m)
+    for params in PARAM_GRID:
+        want = _scalar_negll(data, CrowAMSAA, m, np.array(params))
+        got = negll(np.array(params))
+        if np.isinf(want):
+            assert np.isinf(got) and np.sign(want) == np.sign(got)
+        else:
+            assert got == pytest.approx(want, rel=1e-12)
+
+
+def test_vectorised_negll_matches_with_censoring_and_uneven_items():
+    # Items of different lengths, some ending in a suspension, is where
+    # the per-item bookkeeping has to be right: a reduction must not leak
+    # from one item into the next, and a suspension consumes an interval
+    # without updating the reduction.
+    x = np.array([3, 9, 20, 35, 4, 11, 7, 15, 22, 40], dtype=float)
+    i = np.array([1, 1, 1, 1, 2, 2, 3, 3, 3, 3])
+    c = np.array([0, 0, 0, 1, 0, 0, 0, 0, 0, 1])
+    data = handle_xicn(x, i, c)
+    for m in (1, 2, np.inf):
+        negll = ARI.create_negll_func(data, CrowAMSAA, m)
+        for params in PARAM_GRID:
+            want = _scalar_negll(data, CrowAMSAA, m, np.array(params))
+            got = negll(np.array(params))
+            if np.isinf(want):
+                assert np.isinf(got)
+            else:
+                assert got == pytest.approx(want, rel=1e-12)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        [0.9, 20.0, 0.7],  # decreasing baseline: the reduction overtakes it
+        [1.0, 20.0, 1.0],  # flat baseline, full reduction: intensity is 0
+    ],
+    ids=["overtaken", "exactly zero"],
+)
+def test_negll_is_infinite_when_the_intensity_is_not_positive(params):
+    # A non-positive reduced intensity is outside the model's support.
+    # The scalar loop returned early on it; the vectorised form has to
+    # test before taking logs rather than warning its way to a nan. Note
+    # a rising baseline (beta > 1) stays positive even at rho = 1, so
+    # the case has to be built from a flat or falling one.
+    truth = ARI.fit_from_parameters([20.0, 1.5], 0.5, m=1, dist=CrowAMSAA)
+    data = truth.count_terminated_simulation_data(6, items=10, seed=2)
+    negll = ARI.create_negll_func(data, CrowAMSAA, 1)
+    got = negll(np.array(params))
+    assert np.isinf(got) and got > 0
+    # ... and the original agrees it is out of support.
+    assert np.isinf(_scalar_negll(data, CrowAMSAA, 1, np.array(params)))
+
+
+def test_fit_scales_to_many_items():
+    # 250 items took 19 seconds under the per-event loop.
+    truth = ARI.fit_from_parameters([20.0, 1.5], 0.5, m=1, dist=CrowAMSAA)
+    data = truth.count_terminated_simulation_data(8, items=250, seed=5)
+    model = ARI.fit_from_recurrent_data(data, dist=CrowAMSAA, m=1)
+    assert 0.0 <= model.rho <= 1.0
+    assert np.isfinite(model.model.params).all()

--- a/surpyval/tests/univariate/competing_risks/test_parametric_competing_risks.py
+++ b/surpyval/tests/univariate/competing_risks/test_parametric_competing_risks.py
@@ -23,7 +23,12 @@ from surpyval.univariate.competing_risks import (
 def _simulate(N, seed, cens=60.0):
     """Two-cause latent-minimum data: cause 1 ~ Weibull(30, 2.0), cause 2 ~
     Weibull(45, 1.2), with administrative right-censoring at ``cens``."""
-    rng = np.random.default_rng(seed)
+    # ``Weibull.random`` draws from numpy's *global* state, so seeding a
+    # local Generator left every one of these simulations unseeded and
+    # order-dependent -- the `seed` argument had no effect at all, and an
+    # unlucky draw could fail the tolerance-based assertions depending on
+    # which tests ran before.
+    np.random.seed(seed)
     t1 = Weibull.random(N, 30.0, 2.0)
     t2 = Weibull.random(N, 45.0, 1.2)
     t = np.minimum(t1, t2)
@@ -33,7 +38,6 @@ def _simulate(N, seed, cens=60.0):
     e = np.array(
         [None if ci == 1 else ei for ci, ei in zip(c, cause)], dtype=object
     )
-    del rng
     return x, e, c
 
 
@@ -155,7 +159,6 @@ def test_three_causes():
     idx = np.argmin(stack, axis=1)
     x = stack[np.arange(N), idx]
     e = np.array([idx_i + 1 for idx_i in idx], dtype=object)
-    del rng
     model = ParametricCompetingRisks.fit(
         x, e, dist={1: Weibull, 2: Weibull, 3: LogNormal}
     )

--- a/surpyval/tests/univariate/competing_risks/test_parametric_competing_risks.py
+++ b/surpyval/tests/univariate/competing_risks/test_parametric_competing_risks.py
@@ -150,7 +150,9 @@ def test_fit_from_df():
 
 
 def test_three_causes():
-    rng = np.random.default_rng(12)
+    # As in ``_simulate``: the draws come from numpy's global state, so
+    # that is what has to be seeded.
+    np.random.seed(12)
     N = 5000
     t1 = Weibull.random(N, 20.0, 1.5)
     t2 = Weibull.random(N, 30.0, 2.0)

--- a/surpyval/tests/univariate/nonparametric/test_turnbull_input_sweep.py
+++ b/surpyval/tests/univariate/nonparametric/test_turnbull_input_sweep.py
@@ -1,0 +1,213 @@
+"""Turnbull across the full matrix of supported inputs and estimators.
+
+The individual Turnbull tests each pin one regime (a truncation form, an
+endpoint convention, a variance identity). This file is the breadth
+counterpart: every combination of censoring type, truncation form and
+hazard estimator is fitted and checked to produce a valid survival curve.
+
+It exists so that a change anywhere upstream of Turnbull -- in the data
+handlers, the risk-set conversion, or the EM ladder -- cannot silently
+break one corner of the input space while the targeted tests keep
+passing.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval import Turnbull
+
+ESTIMATORS = ["Nelson-Aalen", "Kaplan-Meier", "Fleming-Harrington"]
+GRID = np.array([0.5, 2.0, 4.0, 6.0, 8.0, 11.0])
+N = 30
+# The Turnbull EM converges slowly on interval-censored data; the targeted
+# tests use the same allowance. A sweep should assert on converged fits,
+# not on whatever the default iteration cap happens to reach.
+MAX_ITER = 20_000
+
+
+def _case(kind):
+    """Build ``Turnbull.fit`` kwargs for one input regime.
+
+    Deterministic: every case is generated from a fixed seed so a failure
+    is reproducible.
+    """
+    rng = np.random.default_rng(24601)
+    base = np.sort(rng.uniform(1.0, 10.0, N))
+    right = (rng.random(N) < 0.35).astype(int)
+    upper = base + rng.uniform(0.5, 2.0, N)
+
+    if kind == "observed":
+        return dict(x=base, c=np.zeros(N, dtype=int))
+    if kind == "observed_right":
+        return dict(x=base, c=right)
+    if kind == "observed_left":
+        c = np.where(np.arange(N) % 4 == 1, -1, 0)
+        return dict(x=base, c=c)
+    if kind == "interval":
+        return dict(x=np.column_stack([base, upper]), c=np.full(N, 2))
+    if kind == "all_censoring_types":
+        c = rng.choice([0, 1, -1, 2], size=N)
+        c[0] = 0  # cannot be entirely censored
+        x = np.column_stack([base, np.where(c == 2, upper, base)])
+        return dict(x=x, c=c)
+    if kind == "left_truncated":
+        return dict(x=base, c=right, tl=rng.uniform(0.0, 0.9, N))
+    if kind == "right_truncated":
+        return dict(
+            x=base,
+            c=np.zeros(N, dtype=int),
+            tr=base + rng.uniform(1.0, 4.0, N),
+        )
+    if kind == "both_truncated":
+        # Observed events only: a right-censored row with a finite `tr` is
+        # a genuine data contradiction that the handler warns about, so it
+        # does not belong in a sweep of *valid* inputs.
+        return dict(
+            x=base,
+            c=np.zeros(N, dtype=int),
+            tl=rng.uniform(0.0, 0.9, N),
+            tr=base + rng.uniform(1.0, 4.0, N),
+        )
+    if kind == "interval_left_truncated":
+        return dict(
+            x=np.column_stack([base, upper]),
+            c=np.full(N, 2),
+            tl=rng.uniform(0.0, 0.9, N),
+        )
+    if kind == "all_censoring_types_truncated":
+        c = rng.choice([0, 1, -1, 2], size=N)
+        c[0] = 0
+        x = np.column_stack([base, np.where(c == 2, upper, base)])
+        return dict(x=x, c=c, tl=rng.uniform(0.0, 0.9, N))
+    raise ValueError(kind)
+
+
+KINDS = [
+    "observed",
+    "observed_right",
+    "observed_left",
+    "interval",
+    "all_censoring_types",
+    "left_truncated",
+    "right_truncated",
+    "both_truncated",
+    "interval_left_truncated",
+    # Left censoring together with left truncation is currently broken
+    # (#308): the support-window intersection drops the (-inf, x] bound a
+    # left-censored row lives on whenever an entry time sits above its
+    # lower edge, so the fit either raises or wanders to a degenerate
+    # estimate. Marked xfail rather than dropped so this sweep reports the
+    # day it starts working.
+    pytest.param(
+        "all_censoring_types_truncated",
+        marks=pytest.mark.xfail(
+            reason="left censoring + left truncation, see #308",
+            strict=True,
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("estimator", ESTIMATORS)
+@pytest.mark.parametrize("kind", KINDS)
+def test_fit_produces_a_valid_survival_curve(kind, estimator):
+    model = Turnbull.fit(
+        **_case(kind), turnbull_estimator=estimator, max_iter=MAX_ITER
+    )
+    assert model.converged, f"{kind}/{estimator} did not converge"
+    sf = np.ravel(model.sf(GRID)).astype(float)
+    finite = sf[np.isfinite(sf)]
+
+    assert finite.size, f"{kind}/{estimator} produced no finite survival"
+    assert (
+        (finite >= -1e-12) & (finite <= 1.0 + 1e-12)
+    ).all(), f"{kind}/{estimator} survival outside [0, 1]: {finite}"
+    assert (np.diff(finite) <= 1e-12).all(), (
+        f"{kind}/{estimator} survival is not monotone non-increasing: "
+        f"{finite}"
+    )
+    # The risk-set ladder must stay coherent: non-negative counts, no more
+    # events than units at risk.
+    r = np.asarray(model.r, dtype=float)
+    d = np.asarray(model.d, dtype=float)
+    assert (r >= -1e-9).all(), f"{kind}/{estimator} negative at-risk counts"
+    assert (d >= -1e-9).all(), f"{kind}/{estimator} negative event counts"
+    assert (d <= r + 1e-9).all(), f"{kind}/{estimator} more events than risk"
+
+
+@pytest.mark.parametrize("kind", KINDS)
+def test_estimator_choice_is_honoured(kind):
+    # The three hazard estimators must not collapse onto one another --
+    # a silently ignored `turnbull_estimator` would show up here.
+    kwargs = _case(kind)
+    curves = {}
+    for est in ESTIMATORS:
+        model = Turnbull.fit(
+            **kwargs, turnbull_estimator=est, max_iter=MAX_ITER
+        )
+        # Comparing estimators on a fit that never converged says nothing
+        # about the estimator switch, so require convergence first.
+        assert model.converged, f"{kind}/{est} did not converge"
+        curves[est] = np.ravel(model.sf(GRID)).astype(float)
+    na, km = curves["Nelson-Aalen"], curves["Kaplan-Meier"]
+    assert not np.array_equal(
+        na, km
+    ), f"{kind}: Nelson-Aalen and Kaplan-Meier gave identical curves"
+
+
+@pytest.mark.xfail(
+    reason="left censoring + left truncation, see #308", strict=True
+)
+def test_vacuous_left_truncation_does_not_change_a_left_censored_fit():
+    # Every entry time is 0 and every observation is above 0, so no unit is
+    # excluded and the truncated fit must equal the untruncated one. It
+    # currently raises instead: a left-censored row lives on the (-inf, x]
+    # bound, and the support-window intersection drops that bound as soon
+    # as an entry time sits above its lower edge, even though the event
+    # interval (0, x] is non-empty (#308).
+    x = np.array([2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+    c = np.array([-1, 0, 0, -1, 0, 0])
+    grid = [2.5, 4.5, 6.5]
+
+    untruncated = np.ravel(
+        Turnbull.fit(x=x, c=c, turnbull_estimator="Kaplan-Meier").sf(grid)
+    )
+    truncated = np.ravel(
+        Turnbull.fit(
+            x=x,
+            c=c,
+            tl=np.zeros(6),
+            turnbull_estimator="Kaplan-Meier",
+            max_iter=MAX_ITER,
+        ).sf(grid)
+    )
+    np.testing.assert_allclose(truncated, untruncated, rtol=1e-9, atol=1e-9)
+
+
+def test_fleming_harrington_matches_nelson_aalen_only_without_ties():
+    # Fleming-Harrington differs from Nelson-Aalen *only* in the tied-event
+    # correction, so the two must agree when every event time is distinct
+    # and separate once times are tied. Pinning both directions keeps the
+    # estimator switch honest.
+    def sf_for(x, estimator):
+        return np.ravel(
+            Turnbull.fit(
+                x=x, turnbull_estimator=estimator, max_iter=MAX_ITER
+            ).sf([2.0, 4.0, 6.0])
+        ).astype(float)
+
+    distinct = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+    tied = np.array([2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 5.0, 6.0, 7.0, 9.0])
+
+    np.testing.assert_allclose(
+        sf_for(distinct, "Fleming-Harrington"),
+        sf_for(distinct, "Nelson-Aalen"),
+        rtol=1e-9,
+        atol=1e-9,
+    )
+    assert not np.allclose(
+        sf_for(tied, "Fleming-Harrington"),
+        sf_for(tied, "Nelson-Aalen"),
+        rtol=1e-6,
+        atol=1e-6,
+    )

--- a/surpyval/tests/univariate/parametric/test_closed_form_mle.py
+++ b/surpyval/tests/univariate/parametric/test_closed_form_mle.py
@@ -1,0 +1,281 @@
+"""Closed-form maximum likelihood estimation.
+
+Where an exact analytic MLE exists it is used instead of the optimiser
+ladder. These tests pin three things: that it is taken exactly when it
+applies, that it agrees with the optimiser it replaces (and never fits
+worse, being exact), and that the resulting model is complete -- a fit
+without ``neg_ll`` or a covariance would silently lose ``aic``, ``bic``
+and ``cb``.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval import Exponential, LogNormal, Normal, Uniform, Weibull
+
+SEED = 20260801
+
+
+def _optimizer(model):
+    return getattr(model, "optimizer", None)
+
+
+def _is_closed_form(model):
+    return _optimizer(model) == "closed-form"
+
+
+# -- the closed form is taken when it applies --------------------------
+
+
+def test_exponential_uses_closed_form_and_matches_the_formula():
+    rng = np.random.default_rng(SEED)
+    x = rng.exponential(1 / 0.7, 300)
+    model = Exponential.fit(x)
+    assert _is_closed_form(model)
+    np.testing.assert_allclose(
+        model.params[0], len(x) / x.sum(), rtol=1e-12, atol=0
+    )
+
+
+def test_exponential_closed_form_with_right_censoring_and_weights():
+    rng = np.random.default_rng(SEED)
+    x = rng.exponential(1 / 0.7, 300)
+    c = (rng.random(300) < 0.3).astype(int)
+    n = rng.integers(1, 4, 300)
+    model = Exponential.fit(x, c=c, n=n)
+    assert _is_closed_form(model)
+    expected = (n * (c == 0)).sum() / (n * x).sum()
+    np.testing.assert_allclose(model.params[0], expected, rtol=1e-12, atol=0)
+
+
+def test_exponential_closed_form_with_left_truncation():
+    # Left truncation only moves each unit's exposure from x to x - tl,
+    # so the estimator stays events-over-exposure.
+    rng = np.random.default_rng(SEED)
+    x = rng.exponential(1 / 0.7, 400)
+    tl = rng.uniform(0, 0.4, 400)
+    keep = x > tl
+    x, tl = x[keep], tl[keep]
+    model = Exponential.fit(x, tl=tl)
+    assert _is_closed_form(model)
+    np.testing.assert_allclose(
+        model.params[0], len(x) / (x - tl).sum(), rtol=1e-12, atol=0
+    )
+
+
+@pytest.mark.parametrize(
+    "dist,transform", [(Normal, lambda v: v), (LogNormal, np.log)]
+)
+def test_normal_family_closed_form_matches_moments(dist, transform):
+    rng = np.random.default_rng(SEED)
+    x = (
+        rng.normal(10, 2, 300)
+        if dist is Normal
+        else rng.lognormal(2, 0.5, 300)
+    )
+    model = dist.fit(x)
+    assert _is_closed_form(model)
+    v = transform(x)
+    # The MLE divides by the total weight, not by total - 1.
+    np.testing.assert_allclose(model.params[0], v.mean(), rtol=1e-12, atol=0)
+    np.testing.assert_allclose(model.params[1], v.std(), rtol=1e-12, atol=0)
+
+
+def test_normal_closed_form_honours_weights():
+    rng = np.random.default_rng(SEED)
+    x = rng.normal(10, 2, 200)
+    n = rng.integers(1, 5, 200)
+    model = Normal.fit(x, n=n)
+    assert _is_closed_form(model)
+    mu = (n * x).sum() / n.sum()
+    sd = np.sqrt((n * (x - mu) ** 2).sum() / n.sum())
+    np.testing.assert_allclose(model.params, [mu, sd], rtol=1e-12, atol=0)
+
+
+# -- and skipped when it does not ---------------------------------------
+
+
+def _exp_data(rng, n=200):
+    return rng.exponential(1 / 0.7, n)
+
+
+@pytest.mark.parametrize(
+    "kind",
+    ["left_censored", "interval_censored", "right_truncated"],
+)
+def test_exponential_falls_back_on_unsupported_shapes(kind):
+    # Each of these introduces a log(1 - exp(-lambda t)) term, making the
+    # score transcendental.
+    rng = np.random.default_rng(SEED)
+    x = _exp_data(rng)
+    if kind == "left_censored":
+        c = np.where(rng.random(x.size) < 0.3, -1, 0)
+        model = Exponential.fit(x, c=c)
+    elif kind == "interval_censored":
+        xr = x + rng.uniform(0.1, 1.0, x.size)
+        model = Exponential.fit(
+            x=np.column_stack([x, xr]), c=np.full(x.size, 2)
+        )
+    else:
+        model = Exponential.fit(x, tr=x + rng.uniform(0.5, 3.0, x.size))
+    assert not _is_closed_form(model)
+
+
+@pytest.mark.parametrize("dist", [Normal, LogNormal])
+@pytest.mark.parametrize("kind", ["right_censored", "left_truncated"])
+def test_normal_family_falls_back_on_censoring_or_truncation(dist, kind):
+    # Censoring makes this the Tobit model; truncation introduces a Phi
+    # normaliser. Neither has an analytic solution.
+    rng = np.random.default_rng(SEED)
+    x = (
+        rng.normal(10, 2, 200)
+        if dist is Normal
+        else rng.lognormal(2, 0.5, 200)
+    )
+    if kind == "right_censored":
+        model = dist.fit(x, c=(rng.random(200) < 0.3).astype(int))
+    else:
+        tl = np.full(200, np.quantile(x, 0.1))
+        keep = x > tl
+        model = dist.fit(x[keep], tl=tl[keep])
+    assert not _is_closed_form(model)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"lfp": True},
+        {"zi": True},
+        {"offset": True},
+        {"fixed": {"failure_rate": 0.5}},
+    ],
+    ids=["lfp", "zi", "offset", "fixed"],
+)
+def test_structural_requests_skip_the_closed_form(kwargs):
+    # gamma / p / f0 and held parameters add structure the closed form
+    # does not solve for. Before the gate existed these were silently
+    # dropped and the closed-form answer returned regardless.
+    rng = np.random.default_rng(SEED)
+    x = rng.exponential(1 / 0.7, 200)
+    c = (rng.random(200) < 0.3).astype(int)
+    try:
+        model = Exponential.fit(x, c=c, **kwargs)
+    except ValueError:
+        # Some combinations are rejected outright by validation; that is
+        # also "not silently ignored".
+        return
+    assert not _is_closed_form(model)
+
+
+def test_limited_failure_population_is_actually_estimated():
+    # The sharp version of the above: with a genuinely cured fraction the
+    # fitted p must move away from 1, which the closed form could never
+    # report.
+    rng = np.random.default_rng(SEED)
+    n = 400
+    fails = rng.exponential(2.0, n)
+    cured = rng.random(n) < 0.35
+    x = np.where(cured, 12.0, np.minimum(fails, 12.0))
+    c = (cured | (fails > 12.0)).astype(int)
+    model = Exponential.fit(x, c=c, lfp=True)
+    assert not _is_closed_form(model)
+    assert 0.5 < model.p < 0.8
+
+
+def test_fixed_parameter_is_honoured():
+    rng = np.random.default_rng(SEED)
+    x = rng.uniform(2.0, 8.0, 200)
+    model = Uniform.fit(x, fixed={"a": 1.5})
+    assert np.isclose(model.params[0], 1.5)
+
+
+def test_weibull_is_untouched():
+    rng = np.random.default_rng(SEED)
+    model = Weibull.fit(rng.weibull(2.0, 200) * 10)
+    assert not _is_closed_form(model)
+
+
+# -- the closed-form result is complete ---------------------------------
+
+
+@pytest.mark.parametrize(
+    "dist,gen",
+    [
+        (Exponential, lambda r: r.exponential(1 / 0.7, 300)),
+        (Normal, lambda r: r.normal(10, 2, 300)),
+        (LogNormal, lambda r: r.lognormal(2, 0.5, 300)),
+    ],
+    ids=["Exponential", "Normal", "LogNormal"],
+)
+def test_closed_form_model_supports_the_usual_methods(dist, gen):
+    rng = np.random.default_rng(SEED)
+    model = dist.fit(gen(rng))
+    assert _is_closed_form(model)
+    for method in ("neg_ll", "aic", "bic", "aic_c"):
+        assert np.isfinite(getattr(model, method)())
+    grid = np.quantile(model.data["x"], [0.25, 0.5, 0.75])
+    bounds = np.asarray(model.cb(grid, alpha_ci=0.05), dtype=float)
+    assert np.isfinite(bounds).all()
+    assert model.cov_matrix is not None
+
+
+@pytest.mark.parametrize(
+    "dist,gen",
+    [
+        (Exponential, lambda r: r.exponential(1 / 0.7, 300)),
+        (Normal, lambda r: r.normal(10, 2, 300)),
+        (LogNormal, lambda r: r.lognormal(2, 0.5, 300)),
+    ],
+    ids=["Exponential", "Normal", "LogNormal"],
+)
+def test_closed_form_fits_no_worse_than_the_optimiser(dist, gen, monkeypatch):
+    # The strongest available check: the closed form is the exact
+    # maximiser, so its log-likelihood cannot be beaten by the optimiser
+    # ladder it replaced. Disabling the closed form sends the identical
+    # data down the identical path the optimiser used before.
+    rng = np.random.default_rng(SEED)
+    x = gen(rng)
+
+    closed = dist.fit(x)
+    assert _is_closed_form(closed)
+
+    monkeypatch.setattr(
+        type(dist), "_closed_form_mle", lambda self, data: None
+    )
+    optimised = dist.fit(x)
+    assert not _is_closed_form(optimised)
+
+    assert closed.neg_ll() <= optimised.neg_ll() + 1e-9
+    # ... and lands in the same place, to the optimiser's own tolerance.
+    np.testing.assert_allclose(
+        closed.params, optimised.params, rtol=1e-5, atol=0
+    )
+
+
+# -- Uniform: the pre-existing closed form -------------------------------
+
+
+def test_uniform_likelihood_is_finite():
+    # The generic log_df identity log(hf) - Hf is nan at the upper support
+    # edge, where sf is 0 -- and the MLE puts `b` exactly there, so the
+    # whole log-likelihood was nan and neg_ll/aic/bic raised.
+    rng = np.random.default_rng(SEED)
+    x = rng.uniform(2.0, 8.0, 300)
+    model = Uniform.fit(x)
+    assert _is_closed_form(model)
+    expected = len(x) * np.log(x.max() - x.min())
+    np.testing.assert_allclose(model.neg_ll(), expected, rtol=1e-12, atol=0)
+    for method in ("aic", "bic", "aic_c"):
+        assert np.isfinite(getattr(model, method)())
+
+
+def test_uniform_offers_no_covariance():
+    # The Uniform MLE is an order statistic sitting on the support edge,
+    # not an interior stationary point, so the observed information is not
+    # positive definite. Reporting its inverse would give negative
+    # variances and silent nan bounds.
+    rng = np.random.default_rng(SEED)
+    model = Uniform.fit(rng.uniform(2.0, 8.0, 300))
+    assert model.cov_matrix is None
+    with pytest.raises(ValueError, match="covariance"):
+        model.cb([3.0, 5.0])

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -540,15 +540,45 @@ def test_expoweibull_offset_keeps_the_refined_seed():
     # same optimum -- so the nested optimiser ladder there was 15-30% of
     # the fit for nothing.
     #
-    # With an offset it is not enough. The seed reads log(x) of the
-    # *unshifted* data, so a large shift compresses the logs into a
-    # narrow band and the plot is a poor starting point. This dataset is
-    # the one in twelve where dropping the refinement moved the fit to a
-    # worse optimum (861.898 -> 861.962) and made it seven times slower.
+    # With an offset it is not enough: five of 48 offset fits seeded from
+    # the plot alone landed on a worse optimum, one of them at 685.85
+    # against 622.26. So the offset path still refines -- on the shifted
+    # data, see test_expoweibull_offset_seeds_from_shifted_data.
     np.random.seed(8)
     x = ExpoWeibull.random(300, 10.0, 2.0, 1.5) + 25.0
     model = ExpoWeibull.fit(x, offset=True)
     assert model.neg_ll() < 861.93
+
+
+def test_expoweibull_offset_seeds_from_shifted_data():
+    # The offset initialiser used to take log(x) before removing the
+    # shift. A large offset compresses those logs into a narrow band, so
+    # the Gumbel sigma collapses and beta = 1 / sigma explodes: with a
+    # true beta of 2 the seed came back at 23.5, and the MLE then failed
+    # outright, returning nan and silently falling back to MPP.
+    #
+    # 54 of 120 offset fits returned nan that way -- every configuration
+    # at an offset of 100 or 1000. The offset is now estimated first and
+    # the seed read off x - gamma.
+    np.random.seed(11)
+    x = 100.0 + ExpoWeibull.random(500, 10.0, 2.0, 1.0)
+
+    gamma, alpha, beta, mu = ExpoWeibull._parameter_initialiser(x, offset=True)
+    # Seeded from x - gamma these sit near the truth; seeded from x they
+    # came back as alpha = 111, beta = 23.5.
+    assert beta == pytest.approx(2.0, rel=0.5)
+    assert alpha == pytest.approx(10.0, rel=0.5)
+
+    # ...and the fit that seed feeds now converges rather than returning
+    # nan and warning its way back to MPP.
+    model = ExpoWeibull.fit(x, offset=True)
+    assert np.isfinite(model.neg_ll())
+    assert model.gamma == pytest.approx(100.0, abs=1.0)
+
+    # The offset the fitter will actually install, so that the seed is
+    # taken against the same shift it will be optimised under.
+    assert gamma < x.min()
+    assert gamma == pytest.approx(x.min() - 1.0)
 
 
 # -- information criteria for every fit method --------------------------

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -487,3 +487,47 @@ def test_mse(dist, random_parameters):
             break
     else:
         raise AssertionError("MPS fit not very good in %s\n" % dist.name)
+
+
+def test_raw_to_central_moment_transform():
+    # mu_k = sum_j C(k, j) (-1)^(k-j) E[X^j] mean^(k-j), with the mean
+    # kept in the leading slot. Checked against a shifted Gamma, whose
+    # central moments are known exactly: a/b^2 and 2a/b^3.
+    from math import comb
+
+    from surpyval.univariate.parametric.fitters.mom import raw_to_central
+
+    g, a, b = 10.0, 3.0, 4.0
+    raw = []
+    for k in (1, 2, 3):
+        total = 0.0
+        for j in range(k + 1):
+            rising = 1.0
+            for i in range(j):
+                rising *= a + i
+            total += comb(k, j) * g ** (k - j) * rising / b**j
+        raw.append(total)
+
+    mean, var, mu3 = raw_to_central(np.array(raw))
+    assert mean == pytest.approx(g + a / b)
+    assert var == pytest.approx(a / b**2)
+    assert mu3 == pytest.approx(2 * a / b**3)
+
+
+def test_offset_gamma_mom_recovers_the_shape():
+    # MOM compares central moments, not raw ones. On an offset fit
+    # E[X^k] is dominated by gamma^k -- the shape is a 0.5% correction
+    # to E[X^3] -- so the raw-moment objective was nearly blind to it
+    # and settled on a shape of 17.7 against a true 3.0, matching the
+    # sample moments *better than the true parameters did*. MOM is not
+    # in the offset parametrisation above, so nothing caught this.
+    np.random.seed(11)
+    x = Gamma.random(10_000, 3.0, 4.0) + 10.0
+
+    model = Gamma.fit(x, offset=True, how="MOM")
+    assert model.gamma == pytest.approx(10.0, abs=0.5)
+    # Generous on the shape: the three-parameter moment estimator is
+    # biased upward at finite n because alpha goes like 1 / skewness^2.
+    # The point is that it is near 3 rather than near 17.
+    assert model.params[0] == pytest.approx(3.0, rel=0.35)
+    assert model.params[1] == pytest.approx(4.0, rel=0.35)

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -343,6 +343,61 @@ OFFSET_CASES = [
 ]
 
 
+@pytest.mark.parametrize(
+    "dist,dist_params", OFFSET_CASES, ids=[d.name for d, _ in OFFSET_CASES]
+)
+def test_offset_initialiser_puts_the_offset_first(dist, dist_params):
+    # `_initial_guess` overwrites slot 0 with the offset seed, so every
+    # offset initialiser must return gamma first. Gamma returned it last,
+    # which meant the overwrite landed on the shape and destroyed it --
+    # the seed came back as (offset, shape-estimate, offset) and MSE fits
+    # converged to nonsense.
+    shift = 10.0
+    x = dist.random(2000, *dist_params) + shift
+    c = np.zeros(x.size, dtype=int)
+    n = np.ones(x.size, dtype=np.int64)
+
+    init = np.asarray(
+        dist._initial_guess(x, c, n, True, False, False, "Nelson-Aalen"),
+        dtype=float,
+    )
+    assert len(init) == len(dist_params) + 1
+
+    # Slot 0 is the offset: just below the smallest observation.
+    assert init[0] == pytest.approx(x.min() - 1.0)
+    assert np.isfinite(init[1:]).all()
+    assert (init[1:] > 0).all()
+
+    # The tell-tale of an initialiser that returns the offset in the
+    # wrong position: `_initial_guess` writes the offset into slot 0
+    # while the initialiser's own copy of it is still sitting in a
+    # parameter slot, so the value appears twice and one real parameter
+    # estimate has been thrown away. Gamma returned
+    # ``(alpha, 1/beta, offset)`` and seeded (9.07, 14.88, 9.07) where
+    # the parameters are (3.0, 2.0).
+    assert not np.isclose(init[1:], init[0]).any(), (
+        f"{dist.name} seeded {init}: the offset {init[0]:.4g} also "
+        f"appears in a parameter slot, so its initialiser is returning "
+        f"the offset somewhere other than first"
+    )
+
+
+def test_offset_gamma_mse_recovers_the_shift():
+    # The user-visible consequence of the seeding bug above. With the
+    # offset written over the shape estimate, MSE returned a *negative*
+    # shift for data shifted up by 10, with a shape of 63 against a true
+    # 3 -- and on other samples it stopped after 0.03s at the seed
+    # itself, reporting beta equal to the offset. Neither raised.
+    np.random.seed(3)
+    shift = 10.0
+    x = Gamma.random(600, 3.0, 4.0) + shift
+
+    model = Gamma.fit(x, offset=True, how="MSE")
+    assert model.gamma == pytest.approx(shift, abs=0.5)
+    assert model.params[0] == pytest.approx(3.0, rel=0.4)
+    assert model.params[1] == pytest.approx(4.0, rel=0.4)
+
+
 @pytest.mark.parametrize("how", ["MLE", "MPS", "MSE", "MPP"])
 @pytest.mark.parametrize(
     "dist,dist_params", OFFSET_CASES, ids=[d.name for d, _ in OFFSET_CASES]

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -549,3 +549,47 @@ def test_expoweibull_offset_keeps_the_refined_seed():
     x = ExpoWeibull.random(300, 10.0, 2.0, 1.5) + 25.0
     model = ExpoWeibull.fit(x, offset=True)
     assert model.neg_ll() < 861.93
+
+
+# -- information criteria for every fit method --------------------------
+#
+# Only MLE and the closed forms used to report a log-likelihood, because
+# only they compute one on the way to the answer. neg_ll, aic, bic and
+# aic_c therefore raised AttributeError for MPS, MSE, MOM and MPP -- the
+# usual way of choosing between distributions was unavailable for four
+# of the five methods. The log-likelihood belongs to the parameters and
+# the data, not to the search that found them.
+
+ALL_HOWS = ["MLE", "MPS", "MSE", "MOM", "MPP"]
+
+
+@pytest.mark.parametrize("how", ALL_HOWS)
+def test_information_criteria_available_for_every_method(how):
+    np.random.seed(1)
+    x = Weibull.random(500, 10.0, 2.0)
+    model = Weibull.fit(x, how=how)
+    for name in ("neg_ll", "aic", "bic", "aic_c"):
+        assert np.isfinite(getattr(model, name)()), f"{how}.{name}()"
+
+
+@pytest.mark.parametrize("how", ALL_HOWS)
+def test_reported_log_likelihood_is_the_one_at_the_fitted_parameters(how):
+    # Computed independently of the fitter, so a method that reported
+    # its own objective by mistake -- MPS's mean log-spacing, say, or
+    # MSE's sum of squares -- would be caught.
+    np.random.seed(1)
+    x = Weibull.random(500, 10.0, 2.0)
+    model = Weibull.fit(x, how=how)
+    direct = -np.sum(np.log(Weibull.from_params(list(model.params)).df(x)))
+    assert model.neg_ll() == pytest.approx(direct, rel=1e-10)
+
+
+def test_maximum_likelihood_attains_the_largest_likelihood():
+    # The defining property, and only checkable now that the other
+    # methods report one: no other estimator on the same data can beat
+    # MLE's log-likelihood.
+    np.random.seed(1)
+    x = Weibull.random(500, 10.0, 2.0)
+    best = Weibull.fit(x, how="MLE").neg_ll()
+    for how in ("MPS", "MSE", "MOM", "MPP"):
+        assert Weibull.fit(x, how=how).neg_ll() >= best - 1e-9, how

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -531,3 +531,21 @@ def test_offset_gamma_mom_recovers_the_shape():
     # The point is that it is near 3 rather than near 17.
     assert model.params[0] == pytest.approx(3.0, rel=0.35)
     assert model.params[1] == pytest.approx(4.0, rel=0.35)
+
+
+def test_expoweibull_offset_keeps_the_refined_seed():
+    # ExpoWeibull seeds itself from a Gumbel fit to log(x). Without an
+    # offset the probability plot alone is enough -- 54 parameter
+    # combinations, plus right, left and heavily tied data, all reach the
+    # same optimum -- so the nested optimiser ladder there was 15-30% of
+    # the fit for nothing.
+    #
+    # With an offset it is not enough. The seed reads log(x) of the
+    # *unshifted* data, so a large shift compresses the logs into a
+    # narrow band and the plot is a poor starting point. This dataset is
+    # the one in twelve where dropping the refinement moved the fit to a
+    # worse optimum (861.898 -> 861.962) and made it seven times slower.
+    np.random.seed(8)
+    x = ExpoWeibull.random(300, 10.0, 2.0, 1.5) + 25.0
+    model = ExpoWeibull.fit(x, offset=True)
+    assert model.neg_ll() < 861.93

--- a/surpyval/tests/utils/test_group_xcnt.py
+++ b/surpyval/tests/utils/test_group_xcnt.py
@@ -1,0 +1,222 @@
+"""``group_xcnt`` -- collapsing duplicate ``(x, c, t)`` rows.
+
+This used to be a triple-nested ``defaultdict`` loop over every
+observation, which dominated fitting cost at scale. The vectorised
+replacement has to reproduce it *exactly*, including the group ordering:
+``xcnt_sort`` runs straight afterwards and is a stable sort, so any rows
+tying on its keys keep whatever order grouping produced. The original
+implementation is kept here as the oracle so the two cannot drift.
+"""
+
+from collections import defaultdict
+
+import numpy as np
+import pytest
+
+from surpyval.utils import group_xcnt, xcnt_sort
+
+INF = np.inf
+
+
+def dict_form(x, c, n, t):
+    """The original implementation, verbatim, as the reference."""
+    grouped = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+    if x.ndim == 2:
+        for vx, vc, vn, vt in zip(x, c, n, t):
+            grouped[tuple(vx)][vc][tuple(vt)] += vn
+    else:
+        for vx, vc, vn, vt in zip(x, c, n, t):
+            grouped[vx][vc][tuple(vt)] += vn
+
+    x_out, c_out, n_out, t_out = [], [], [], []
+    for xv, level2 in grouped.items():
+        for cv, level3 in level2.items():
+            for tv, nv in level3.items():
+                x_out.append(xv)
+                c_out.append(cv)
+                n_out.append(nv)
+                t_out.append(tv)
+    return np.array(x_out), np.array(c_out), np.array(n_out), np.array(t_out)
+
+
+def assert_matches_oracle(x, c, n, t):
+    expected = dict_form(x, c, n, t)
+    actual = group_xcnt(x, c, n, t)
+    for field, want, got in zip("xcnt", expected, actual):
+        np.testing.assert_array_equal(
+            got, want, err_msg=f"field {field!r} differs"
+        )
+    # The count dtype is load-bearing: integer counts must stay integer
+    # (np.bincount would hand back float64).
+    assert actual[2].dtype == expected[2].dtype
+
+
+def test_docstring_case():
+    x = np.array([1, 1, 3, 3])
+    c = np.zeros(4, dtype=int)
+    n = np.ones(4, dtype=int)
+    t = np.vstack([np.full(4, -INF), np.full(4, INF)]).T
+    x_g, c_g, n_g, _ = group_xcnt(x, c, n, t)
+    np.testing.assert_array_equal(x_g, [1, 3])
+    np.testing.assert_array_equal(c_g, [0, 0])
+    np.testing.assert_array_equal(n_g, [2, 2])
+
+
+def test_preserves_order_when_sort_keys_tie():
+    # The subtle one. These three rows share x and c, and all have
+    # t.min() == -inf, so they tie on every key `xcnt_sort` uses and it
+    # cannot reorder them. Their order is therefore whatever grouping
+    # produced -- a plain sorted np.unique would give 5, 7, 10.
+    x = np.array([1.0, 1.0, 1.0])
+    c = np.zeros(3, dtype=int)
+    n = np.ones(3, dtype=int)
+    t = np.column_stack([np.full(3, -INF), [10.0, 5.0, 7.0]])
+    assert_matches_oracle(x, c, n, t)
+    _, _, _, t_out = xcnt_sort(*group_xcnt(x, c, n, t))
+    np.testing.assert_array_equal(t_out[:, 1], [10.0, 5.0, 7.0])
+
+
+def test_preserves_nested_x_major_order():
+    # The dictionary iterated x-major, so (x=1, c=1) precedes (x=2, c=0)
+    # even though the latter appears first in the input.
+    x = np.array([1.0, 2.0, 1.0])
+    c = np.array([0, 0, 1])
+    n = np.ones(3, dtype=int)
+    t = np.column_stack([np.full(3, -INF), np.full(3, INF)])
+    assert_matches_oracle(x, c, n, t)
+    x_out, c_out, _, _ = group_xcnt(x, c, n, t)
+    assert list(zip(x_out, c_out)) == [(1.0, 0), (1.0, 1), (2.0, 0)]
+
+
+EDGE_CASES = {
+    "single row": (
+        [4.0],
+        [0],
+        [1],
+        [[-INF, INF]],
+    ),
+    "all identical": (
+        [2.0] * 5,
+        [0] * 5,
+        [1] * 5,
+        [[-INF, INF]] * 5,
+    ),
+    "no duplicates": (
+        [1.0, 2.0, 3.0],
+        [0, 0, 0],
+        [1, 1, 1],
+        [[-INF, INF]] * 3,
+    ),
+    "same x different c": (
+        [1.0, 1.0, 1.0],
+        [0, 1, -1],
+        [1, 1, 1],
+        [[-INF, INF]] * 3,
+    ),
+    "same x different tl": (
+        [3.0, 3.0],
+        [0, 0],
+        [1, 1],
+        [[0.0, INF], [1.0, INF]],
+    ),
+    "weights above one": (
+        [1.0, 1.0, 2.0],
+        [0, 0, 0],
+        [3, 4, 5],
+        [[-INF, INF]] * 3,
+    ),
+    # nan entry times are accepted upstream; nan != nan so each row stays
+    # its own group, and the replacement must agree.
+    "nan truncation": (
+        [1.0, 1.0, 3.0],
+        [0, 0, 0],
+        [1, 1, 1],
+        [[np.nan, INF]] * 3,
+    ),
+    "nan x": (
+        [np.nan, np.nan, 3.0],
+        [0, 0, 0],
+        [1, 1, 1],
+        [[-INF, INF]] * 3,
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "case", list(EDGE_CASES.values()), ids=list(EDGE_CASES)
+)
+def test_edge_cases_match_oracle(case):
+    x, c, n, t = case
+    assert_matches_oracle(
+        np.asarray(x, dtype=float),
+        np.asarray(c, dtype=int),
+        np.asarray(n, dtype=np.int64),
+        np.asarray(t, dtype=float),
+    )
+
+
+def test_interval_censored_two_dimensional_x():
+    xl = np.array([1.0, 1.0, 2.0, 2.0])
+    xr = np.array([3.0, 3.0, 4.0, 5.0])
+    x = np.column_stack([xl, xr])
+    c = np.full(4, 2)
+    n = np.ones(4, dtype=np.int64)
+    t = np.column_stack([np.full(4, -INF), np.full(4, INF)])
+    assert_matches_oracle(x, c, n, t)
+
+
+def test_float_counts_stay_float():
+    x = np.array([1.0, 1.0, 2.0])
+    c = np.zeros(3, dtype=int)
+    n = np.array([0.5, 1.5, 2.0])
+    t = np.column_stack([np.full(3, -INF), np.full(3, INF)])
+    _, _, n_out, _ = group_xcnt(x, c, n, t)
+    assert n_out.dtype == n.dtype
+    np.testing.assert_array_equal(n_out, [2.0, 2.0])
+
+
+def test_randomised_differential_sweep():
+    # Every shape of input the handler can produce, checked against the
+    # original implementation.
+    rng = np.random.default_rng(90210)
+    for _ in range(400):
+        n_obs = int(rng.integers(1, 40))
+        if rng.random() < 0.25:
+            lo = rng.choice(np.arange(1.0, 6.0), size=n_obs)
+            x = np.column_stack(
+                [lo, lo + rng.choice([0.5, 1.0, 2.0], size=n_obs)]
+            )
+            c = rng.choice([0, 1, -1, 2], size=n_obs)
+        else:
+            x = rng.choice(np.arange(1.0, 6.0), size=n_obs)
+            c = rng.choice([0, 1, -1], size=n_obs)
+        n = rng.integers(1, 4, size=n_obs).astype(np.int64)
+        t = np.column_stack(
+            [
+                rng.choice([-INF, 0.0, 0.5], size=n_obs),
+                rng.choice([INF, 5.0, 7.0, 10.0], size=n_obs),
+            ]
+        )
+        assert_matches_oracle(x, c, n, t)
+
+
+def test_totals_are_conserved():
+    rng = np.random.default_rng(11)
+    x = rng.choice(np.arange(1.0, 5.0), size=200)
+    c = rng.choice([0, 1], size=200)
+    n = rng.integers(1, 6, size=200).astype(np.int64)
+    t = np.column_stack([np.full(200, -INF), np.full(200, INF)])
+    _, _, n_out, _ = group_xcnt(x, c, n, t)
+    assert n_out.sum() == n.sum()
+
+
+def test_scales_to_large_samples():
+    # 200k distinct observations took ~4 s under the Python loop.
+    n_obs = 200_000
+    x = np.arange(1.0, n_obs + 1.0)
+    c = np.zeros(n_obs, dtype=int)
+    n = np.ones(n_obs, dtype=np.int64)
+    t = np.column_stack([np.full(n_obs, -INF), np.full(n_obs, INF)])
+    x_out, _, n_out, _ = group_xcnt(x, c, n, t)
+    assert x_out.shape == (n_obs,)
+    assert n_out.sum() == n_obs

--- a/surpyval/tests/utils/test_group_xcnt.py
+++ b/surpyval/tests/utils/test_group_xcnt.py
@@ -165,6 +165,82 @@ def test_interval_censored_two_dimensional_x():
     assert_matches_oracle(x, c, n, t)
 
 
+# -- the no-op fast path -----------------------------------------------
+#
+# Distinct leading values mean every row is already its own group, in
+# input order, so grouping is the identity and is skipped. `is` is the
+# observable: the fast path hands the inputs straight back.
+
+
+def _takes_fast_path(x, c, n, t):
+    got = group_xcnt(x, c, n, t)
+    return all(a is b for a, b in zip(got, (x, c, n, t)))
+
+
+def test_distinct_values_are_returned_untouched():
+    x = np.array([3.0, 1.0, 2.0])
+    c = np.array([1, 0, -1])
+    n = np.array([2, 5, 1], dtype=np.int64)
+    t = np.column_stack([[-INF, 0.0, 0.5], [INF, 7.0, INF]])
+    assert _takes_fast_path(x, c, n, t)
+    assert_matches_oracle(x, c, n, t)
+
+
+def test_distinct_leading_column_is_enough_for_two_dimensional_x():
+    # A distinct left endpoint makes whole rows distinct whatever the
+    # right endpoint, c or t hold, so the check need only look at it.
+    x = np.column_stack([[1.0, 2.0, 3.0], [4.0, 4.0, 4.0]])
+    c = np.full(3, 2)
+    n = np.ones(3, dtype=np.int64)
+    t = np.column_stack([np.full(3, -INF), np.full(3, INF)])
+    assert _takes_fast_path(x, c, n, t)
+    assert_matches_oracle(x, c, n, t)
+
+
+def test_tied_leading_column_still_groups():
+    x = np.column_stack([[1.0, 1.0, 2.0], [3.0, 9.0, 4.0]])
+    c = np.full(3, 2)
+    n = np.ones(3, dtype=np.int64)
+    t = np.column_stack([np.full(3, -INF), np.full(3, INF)])
+    assert not _takes_fast_path(x, c, n, t)
+    assert_matches_oracle(x, c, n, t)
+
+
+def test_repeated_x_takes_the_grouping_path():
+    x = np.array([1.0, 1.0, 2.0])
+    c = np.zeros(3, dtype=int)
+    n = np.ones(3, dtype=np.int64)
+    t = np.column_stack([np.full(3, -INF), np.full(3, INF)])
+    assert not _takes_fast_path(x, c, n, t)
+    assert_matches_oracle(x, c, n, t)
+
+
+def test_empty_input_is_returned_unchanged():
+    # Not compared against the oracle: the dictionary version built its
+    # outputs from empty lists, so `t` came back with shape (0,) rather
+    # than (0, 2). Handing the inputs back keeps the shapes right.
+    x = np.array([], dtype=float)
+    c = np.array([], dtype=int)
+    n = np.array([], dtype=np.int64)
+    t = np.empty((0, 2))
+    assert _takes_fast_path(x, c, n, t)
+
+
+@pytest.mark.parametrize("n_nan,fast", [(1, True), (2, False)])
+def test_nan_x_is_handled_conservatively(n_nan, fast):
+    # np.unique collapses repeated nans, so two of them fail the distinct
+    # count and drop to the grouping path -- which is what we want, since
+    # nan != nan means they must stay separate groups. One nan is
+    # genuinely distinct and can take the fast path.
+    x = np.array([np.nan] * n_nan + [3.0, 4.0])
+    size = x.size
+    c = np.zeros(size, dtype=int)
+    n = np.ones(size, dtype=np.int64)
+    t = np.column_stack([np.full(size, -INF), np.full(size, INF)])
+    assert _takes_fast_path(x, c, n, t) is fast
+    assert_matches_oracle(x, c, n, t)
+
+
 def test_float_counts_stay_float():
     x = np.array([1.0, 1.0, 2.0])
     c = np.zeros(3, dtype=int)

--- a/surpyval/tests/utils/test_truncated_censoring.py
+++ b/surpyval/tests/utils/test_truncated_censoring.py
@@ -1,0 +1,257 @@
+"""Censored observations under truncation (#310).
+
+A censored observation is only ever known to lie inside its own
+truncation window -- it could not have been observed otherwise -- so its
+likelihood numerator has to be the probability of that intersection. The
+package used the unconditional form (``F(x)`` for left censoring,
+``S(x)`` for right), which counts territory the truncation has already
+ruled out. That makes the contribution exceed one, and the excess grows
+without bound as the fitted distribution's mass slides out of the
+window, so every likelihood had an unbounded direction and the optimiser
+ran off down it and reported success at nonsense parameters.
+
+The fix hands such rows to the likelihood as *intervals* -- ``[tl, x]``
+and ``[x, tr]`` -- so the existing interval term, already a difference of
+CDFs, computes the right thing. These tests pin the routing, the
+resulting numerator, the boundedness, and above all that untruncated
+data is untouched.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval import (
+    Exponential,
+    Gamma,
+    Gumbel,
+    LogLogistic,
+    LogNormal,
+    Logistic,
+    Normal,
+    Weibull,
+)
+from surpyval.utils.surpyval_data import SurpyvalData
+
+INF = np.inf
+
+
+# -- routing -----------------------------------------------------------
+
+
+def _mixed_data():
+    # one of each: left censored with a finite tl, right censored with a
+    # finite tr, right censored with no truncation, and an observation.
+    return SurpyvalData(
+        x=np.array([5.0, 3.0, 7.0, 4.0]),
+        c=np.array([-1, 1, 1, 0]),
+        n=np.ones(4, dtype=np.int64),
+        tl=np.array([2.0, -INF, -INF, 2.0]),
+        tr=np.array([INF, 9.0, INF, 9.0]),
+    )
+
+
+def test_censored_rows_with_a_finite_bound_are_recast_as_intervals():
+    d = _mixed_data()
+    # The left-censored row (x=5, tl=2) and the right-censored row
+    # (x=3, tr=9) become intervals; the right-censored row with no right
+    # truncation stays put.
+    assert sorted(zip(d.x_il, d.x_ir)) == [(2.0, 5.0), (3.0, 9.0)]
+    np.testing.assert_array_equal(d.x_r, [7.0])
+    np.testing.assert_array_equal(d.x_l, [])
+    np.testing.assert_array_equal(d.x_o, [4.0])
+
+
+def test_recast_interval_is_the_correct_conditional_numerator():
+    d = _mixed_data()
+    model = Weibull.from_params([6.0, 2.0])
+
+    def F(v):
+        return model.ff(np.atleast_1d(v))[0]
+
+    got = dict(zip(d.x_il, d.x_ir))
+    # left censored at 5, entered at 2: P(2 < X <= 5) = F(5) - F(2)
+    assert got[2.0] == 5.0
+    np.testing.assert_allclose(
+        F(5.0) - F(2.0), F(got[2.0]) - F(2.0), rtol=0, atol=0
+    )
+    # right censored at 3, right truncated at 9: P(3 < X <= 9)
+    assert got[3.0] == 9.0
+    np.testing.assert_allclose(
+        F(9.0) - F(3.0), F(got[3.0]) - F(3.0), rtol=0, atol=0
+    )
+
+
+def test_right_censoring_without_truncation_keeps_the_exact_path():
+    # Expressing right censoring as 1 - F(x) loses all precision once
+    # F(x) rounds to one -- log_sf of -49 comes back as -inf -- and the
+    # optimiser does evaluate the likelihood that far out. Untruncated
+    # right-censored rows must stay on log_sf.
+    d = SurpyvalData(
+        x=np.array([1.0, 2.0, 3.0]),
+        c=np.array([0, 1, 1]),
+        n=np.ones(3, dtype=np.int64),
+    )
+    np.testing.assert_array_equal(d.x_r, [2.0, 3.0])
+    assert d.x_il.size == 0
+
+
+def test_untruncated_data_is_split_exactly_as_before():
+    d = SurpyvalData(
+        x=np.array([1.0, 2.0, 3.0, 4.0]),
+        c=np.array([0, 1, -1, 0]),
+        n=np.ones(4, dtype=np.int64),
+    )
+    np.testing.assert_array_equal(d.x_o, [1.0, 4.0])
+    np.testing.assert_array_equal(d.x_r, [2.0])
+    np.testing.assert_array_equal(d.x_l, [3.0])
+    assert d.x_il.size == 0
+
+
+def test_covariates_follow_their_rows_into_the_interval_bucket():
+    # If a row changes bucket and its covariates do not follow, the
+    # regression likelihood pairs every observation with the wrong
+    # covariate row.
+    Z = np.array([[10.0], [20.0], [30.0], [40.0]])
+    d = SurpyvalData(
+        x=np.array([5.0, 3.0, 7.0, 4.0]),
+        c=np.array([-1, 1, 1, 0]),
+        n=np.ones(4, dtype=np.int64),
+        tl=np.array([2.0, -INF, -INF, 2.0]),
+        tr=np.array([INF, 9.0, INF, 9.0]),
+        Z=Z,
+    )
+    assert d.Z_i.shape[0] == d.x_il.shape[0]
+    assert d.Z_r.shape[0] == d.x_r.shape[0]
+    assert d.Z_o.shape[0] == d.x_o.shape[0]
+    # The two recast rows are the ones carrying 10 and 20.
+    assert sorted(d.Z_i.ravel().tolist()) == [10.0, 20.0]
+    assert d.Z_r.ravel().tolist() == [30.0]
+    assert d.Z_o.ravel().tolist() == [40.0]
+
+
+# -- the bug itself ----------------------------------------------------
+
+
+def _heavy_left_censored(seed=7, size=200):
+    rng = np.random.default_rng(seed)
+    base = rng.lognormal(0.0, 0.6, size)  # true mu = 0
+    cut = np.quantile(base, 0.85)
+    c = np.where(base < cut, -1, 0)
+    x = np.where(c == -1, cut, base)
+    return x, c, np.full(size, x.min() * 0.5)
+
+
+def test_issue_310_lognormal_no_longer_runs_away():
+    # Fitted mu was -7.81 with neg_ll = -inf and res.success True.
+    x, c, tl = _heavy_left_censored()
+    model = LogNormal.fit(x, c=c, tl=tl)
+    assert np.isfinite(model.neg_ll())
+    assert -2.0 < model.params[0] < 1.0
+    assert 0.0 < model.params[1] < 3.0
+
+
+def test_the_truncated_likelihood_is_bounded_above():
+    # The sharp version: walking mu away from the data used to raise the
+    # log-likelihood without limit. It must now fall off.
+    x, c, tl = _heavy_left_censored()
+    fitted = LogNormal.fit(x, c=c, tl=tl)
+    best = -fitted.neg_ll()
+    data = SurpyvalData(
+        x=x,
+        c=c,
+        n=np.ones(x.size, dtype=np.int64),
+        tl=tl,
+        tr=np.full(x.size, INF),
+    )
+    for mu in (-3.0, -5.0, -8.0, -15.0, -40.0):
+        ll = LogNormal._log_likelihood(data, mu, 0.6, 0.0, 0.0, 1.0)
+        assert not (ll > best), f"log-likelihood at mu={mu} beats the fit"
+
+
+def test_right_censoring_under_right_truncation_recovers_the_truth():
+    # The combination that used to warn as contradictory (#195). It is
+    # the ordinary flux-limited setup: a detector registers an event --
+    # so it happened at or before ``tr`` -- but cannot resolve where in
+    # the remaining window it fell, so it is censored at ``x``. The
+    # event is simply in ``(x, tr]``, and the fit must be consistent.
+    alpha, beta, tr_bound, cens_at = 10.0, 2.0, 14.0, 8.0
+    draws = Weibull.random(200_000, alpha, beta)
+    detected = draws[draws <= tr_bound][:50_000]  # right truncation
+
+    c = (detected > cens_at).astype(int)
+    x = np.where(c == 1, cens_at, detected)
+    assert 0.3 < c.mean() < 0.6, "test needs substantial right censoring"
+
+    model = Weibull.fit(
+        x,
+        c=c,
+        n=np.ones(x.size, dtype=np.int64),
+        tr=np.full(x.size, tr_bound),
+    )
+    np.testing.assert_allclose(model.params[0], alpha, rtol=0.05)
+    np.testing.assert_allclose(model.params[1], beta, rtol=0.05)
+
+    # And the correction earns its keep: ignoring the truncation biases
+    # the scale down, because only the shorter-lived units are seen.
+    naive = Weibull.fit(x, c=c, n=np.ones(x.size, dtype=np.int64))
+    assert naive.params[0] < alpha * 0.95
+
+
+DISTRIBUTIONS = [
+    Weibull,
+    LogNormal,
+    Normal,
+    Gamma,
+    LogLogistic,
+    Gumbel,
+    Exponential,
+    Logistic,
+]
+
+
+def _sample(dist, rng, size):
+    if dist in (Normal, Logistic, Gumbel):
+        return rng.normal(5.0, 1.0, size)
+    return rng.lognormal(0.0, 0.6, size)
+
+
+@pytest.mark.parametrize(
+    "dist", DISTRIBUTIONS, ids=[d.name for d in DISTRIBUTIONS]
+)
+@pytest.mark.parametrize("side", ["left", "right", "both"])
+@pytest.mark.parametrize("censoring", ["heavy_left", "heavy_right"])
+def test_every_distribution_gives_a_finite_fit(dist, side, censoring):
+    # 21 of these 48 combinations returned a non-finite neg_ll, with
+    # parameters like Weibull alpha = 1.3e81.
+    #
+    # The right-censored-with-right-truncation combinations raise the
+    # contradictory-data warning from ``xcnt_handler`` -- that data is
+    # odd and stays flagged. What changes here is that it now yields the
+    # coherent conditional P(x < X <= tr) instead of an unbounded
+    # direction for the optimiser to run down.
+    rng = np.random.default_rng(7)
+    size = 200
+    x = _sample(dist, rng, size)
+    if censoring == "heavy_left":
+        cut = np.quantile(x, 0.85)
+        c = np.where(x < cut, -1, 0)
+        x = np.where(c == -1, cut, x)
+    else:
+        cut = np.quantile(x, 0.12)
+        c = (x > cut).astype(int)
+        x = np.where(c == 1, cut, x)
+
+    kwargs = {"c": c, "n": np.ones(size, dtype=np.int64)}
+    lo = x.min() - abs(x.min()) * 0.5
+    hi = x.max() + abs(x.max())
+    if side in ("left", "both"):
+        kwargs["tl"] = np.full(size, lo)
+    if side in ("right", "both"):
+        kwargs["tr"] = np.full(size, hi)
+
+    model = dist.fit(x, **kwargs)
+    assert np.isfinite(model.neg_ll())
+    assert np.isfinite(np.asarray(model.params, dtype=float)).all()
+    # No runaway: every fitted parameter stays within a sane magnitude of
+    # the data it came from.
+    assert (np.abs(np.asarray(model.params, dtype=float)) < 1e6).all()

--- a/surpyval/tests/utils/test_truncated_censoring.py
+++ b/surpyval/tests/utils/test_truncated_censoring.py
@@ -174,9 +174,12 @@ def test_right_censoring_under_right_truncation_recovers_the_truth():
     # so it happened at or before ``tr`` -- but cannot resolve where in
     # the remaining window it fell, so it is censored at ``x``. The
     # event is simply in ``(x, tr]``, and the fit must be consistent.
+    # 15,000 retained draws land inside 1% of the truth, which the 5%
+    # tolerance below covers comfortably; 50,000 took twice as long for
+    # no extra confidence.
     alpha, beta, tr_bound, cens_at = 10.0, 2.0, 14.0, 8.0
-    draws = Weibull.random(200_000, alpha, beta)
-    detected = draws[draws <= tr_bound][:50_000]  # right truncation
+    draws = Weibull.random(60_000, alpha, beta)
+    detected = draws[draws <= tr_bound][:15_000]  # right truncation
 
     c = (detected > cens_at).astype(int)
     x = np.where(c == 1, cens_at, detected)

--- a/surpyval/tests/utils/test_utils.py
+++ b/surpyval/tests/utils/test_utils.py
@@ -334,21 +334,20 @@ def test_xcnt_handler():
         xcnt_handler(x=[1, 2], t=[[0, 3], [1, 4]], tl=[0, 1])
 
 
-def test_xcnt_handler_warns_on_right_censored_with_finite_tr():
-    # A right-censored observation with a finite right-truncation time
-    # is contradictory (the event is after the censoring time, yet
-    # truncation says it was seen before tr) and can make
-    # truncation-adjusted likelihoods unbounded -- issue #195.
+def test_right_censored_with_finite_tr_is_accepted_without_warning():
+    # This used to warn as contradictory data (#195). It is not: the
+    # unit was detected, so its event is at or before tr, and it was
+    # censored, so the event is after x -- together simply x < X <= tr.
+    # A detector that registers an event but cannot resolve where in the
+    # remaining window it fell produces exactly this.
+    #
+    # The unbounded likelihoods that motivated the warning came from
+    # giving those rows the unconditional S(x), which includes the
+    # X > tr region truncation excludes (#310), not from the data.
     x = [1.0, 2.0, 3.0]
     c = [0, 1, 0]
-    with pytest.warns(UserWarning, match="right-censored"):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         xcnt_handler(x=x, c=c, tr=[10.0, 10.0, 10.0])
-
-    # No warning when the right-censored row's truncation is infinite
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
         xcnt_handler(x=x, c=c, tr=[10.0, np.inf, 10.0])
-    # ... or when there is no right censoring at all
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
         xcnt_handler(x=x, c=[0, 0, 0], tr=[10.0, 10.0, 10.0])

--- a/surpyval/tests/utils/test_xcnt_to_xrd.py
+++ b/surpyval/tests/utils/test_xcnt_to_xrd.py
@@ -1,0 +1,135 @@
+"""``xcnt_to_xrd`` and its at-risk-entry helper.
+
+The entry count used to be built as an ``N x K`` comparison matrix, which
+was quadratic in time and memory (a ``MemoryError`` past ~50k
+observations). These tests pin the values it must produce -- including the
+``(entry, exit]`` convention from #260 -- against the direct matrix form,
+so the linear-time replacement cannot drift from it.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval.utils import _entered_before, xcnt_to_xrd
+
+INF = np.inf
+
+
+def matrix_form(tl, x, n):
+    """The original quadratic expression, kept here as the oracle."""
+    return ((tl[:, np.newaxis] < x[np.newaxis, :]) * n[:, np.newaxis]).sum(0)
+
+
+EDGE_CASES = [
+    ("no truncation", [-INF, -INF, -INF], [1.0, 2.0, 3.0], [1, 1, 1]),
+    ("no truncation weighted", [-INF, -INF], [1.0, 2.0], [5, 3]),
+    ("entry equals event time", [0.0, 1.0, 2.0], [1.0, 2.0, 3.0], [1, 1, 1]),
+    ("common entry time", [1.0, 1.0, 1.0], [2.0, 3.0, 4.0], [2, 2, 2]),
+    (
+        "mixed -inf and finite",
+        [-INF, 1.0, -INF, 3.0],
+        [2.0, 4.0, 5.0],
+        [1, 2, 3, 4],
+    ),
+    ("ties in entry times", [1.0, 1.0, 2.0, 2.0], [2.0, 3.0], [1, 1, 1, 1]),
+    ("entries after all events", [5.0, 6.0], [1.0, 2.0], [1, 1]),
+    ("entries before all events", [0.0, 1.0], [9.0, 10.0], [2, 3]),
+    ("single observation", [-INF], [1.0], [7]),
+    ("large weights", [-INF, 0.0], [1.0, 2.0], [10**6, 10**7]),
+    # nan entry times are accepted upstream; `nan < x` is False, and the
+    # replacement must reproduce that rather than silently differ.
+    ("all nan", [np.nan, np.nan], [1.0, 2.0], [1, 1]),
+    ("mixed nan", [0.0, np.nan, 1.0], [1.0, 2.0, 3.0], [1, 2, 3]),
+]
+
+
+@pytest.mark.parametrize(
+    "tl,x,n", [c[1:] for c in EDGE_CASES], ids=[c[0] for c in EDGE_CASES]
+)
+def test_entered_before_matches_matrix_form(tl, x, n):
+    tl = np.asarray(tl, dtype=float)
+    x = np.asarray(x, dtype=float)
+    n = np.asarray(n, dtype=np.int64)
+    expected = matrix_form(tl, x, n)
+    actual = _entered_before(tl, x, n)
+    np.testing.assert_array_equal(actual, expected)
+    assert actual.dtype == expected.dtype
+
+
+def test_entered_before_matches_matrix_form_randomised():
+    # A broad differential sweep: the two forms must agree exactly on
+    # every shape of truncation, not just the tidy cases above.
+    rng = np.random.default_rng(4242)
+    for _ in range(300):
+        n_obs = int(rng.integers(1, 25))
+        x = np.unique(
+            rng.choice(
+                np.arange(0.0, 12.0, 0.5), size=int(rng.integers(1, 12))
+            )
+        )
+        n = rng.integers(1, 6, size=n_obs).astype(np.int64)
+        mode = rng.integers(0, 4)
+        if mode == 0:
+            tl = np.full(n_obs, -INF)
+        elif mode == 1:
+            tl = rng.choice(np.arange(-2.0, 12.0, 0.5), size=n_obs)
+        elif mode == 2:
+            tl = np.where(
+                rng.random(n_obs) < 0.5,
+                -INF,
+                rng.choice(np.arange(0.0, 12.0, 0.5), size=n_obs),
+            )
+        else:
+            tl = np.full(n_obs, float(rng.choice(np.arange(0.0, 6.0, 0.5))))
+        np.testing.assert_array_equal(
+            _entered_before(tl, x, n), matrix_form(tl, x, n)
+        )
+
+
+def test_docstring_examples():
+    x, r, d = xcnt_to_xrd(np.array([1, 2, 3, 4, 5]), np.array([0, 1, 1, 0, 0]))
+    np.testing.assert_array_equal(x, [1, 2, 3, 4, 5])
+    np.testing.assert_array_equal(r, [5, 4, 3, 2, 1])
+    np.testing.assert_array_equal(d, [1, 0, 0, 1, 1])
+
+
+def test_entry_exit_convention_preserved():
+    # (entry, exit]: a subject entering exactly at an event time is NOT at
+    # risk for that event (#260). Each subject here enters at the previous
+    # subject's event time, so exactly one is at risk at each time.
+    x, r, d = xcnt_to_xrd(
+        x=np.array([1, 2, 3, 4, 5]), tl=np.array([0, 1, 2, 3, 4])
+    )
+    np.testing.assert_array_equal(r, [1, 1, 1, 1, 1])
+    np.testing.assert_array_equal(d, [1, 1, 1, 1, 1])
+
+
+def test_return_dtypes():
+    x, r, d = xcnt_to_xrd(x=[1.0, 2.0, 3.0], c=[0, 1, 0])
+    assert x.dtype == np.float64
+    assert r.dtype == int
+    assert d.dtype == int
+
+
+def test_scales_beyond_the_quadratic_wall():
+    # 60k distinct observations needed a 28 GB intermediate under the
+    # matrix form and raised MemoryError; it must now simply work.
+    n_obs = 60_000
+    x = np.arange(1.0, n_obs + 1.0)
+    x_out, r, d = xcnt_to_xrd(x=x)
+    assert x_out.shape == (n_obs,)
+    # No censoring or truncation: the risk set falls by one at each time.
+    np.testing.assert_array_equal(r, np.arange(n_obs, 0, -1))
+    np.testing.assert_array_equal(d, np.ones(n_obs, dtype=int))
+
+
+def test_scales_with_truncation():
+    # The searchsorted branch must scale too, not just the constant one.
+    n_obs = 60_000
+    x = np.arange(1.0, n_obs + 1.0)
+    tl = x - 1.0
+    x_out, r, d = xcnt_to_xrd(x=x, tl=tl)
+    assert x_out.shape == (n_obs,)
+    # Every subject enters at the previous event time, so exactly one is
+    # at risk at each event.
+    np.testing.assert_array_equal(r, np.ones(n_obs, dtype=int))

--- a/surpyval/univariate/parametric/distributions/expo_weibull.py
+++ b/surpyval/univariate/parametric/distributions/expo_weibull.py
@@ -26,8 +26,23 @@ class ExpoWeibull_(ParametricFitter):
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         log_x = np.log(x)
         log_x[np.isnan(log_x)] = 0
-        gumb = para.Gumbel.fit(log_x, c, n, how="MLE")
-        if not gumb.res.success:
+        if offset:
+            # The offset path keeps the nested MLE. It reads log(x) of the
+            # *unshifted* data, so a large shift compresses the logs into a
+            # narrow band and the probability plot alone is a poor seed --
+            # the extra refinement earns its keep there. Dropping it moved
+            # one fit in twelve to a worse optimum (861.898 -> 861.962) and
+            # made that fit seven times slower.
+            gumb = para.Gumbel.fit(log_x, c, n, how="MLE")
+            if not gumb.res.success:
+                gumb = para.Gumbel.fit(log_x, c, n, how="MPP")
+        else:
+            # Without an offset the probability plot is already a good
+            # enough seed: running a whole optimiser ladder to refine a
+            # starting point cost 15-30% of the fit and changed nothing.
+            # Checked over 54 parameter combinations plus right, left and
+            # heavily tied data -- every fit reached the same optimum, to
+            # the optimiser's own tolerance.
             gumb = para.Gumbel.fit(log_x, c, n, how="MPP")
         mu, sigma = gumb.params
         alpha, beta = np.exp(mu), 1.0 / sigma

--- a/surpyval/univariate/parametric/distributions/expo_weibull.py
+++ b/surpyval/univariate/parametric/distributions/expo_weibull.py
@@ -23,26 +23,27 @@ class ExpoWeibull_(ParametricFitter):
         )
         self.supports_mpp = False
 
-    def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
+    def _gumbel_seed(self, x, c, n, refine):
+        """
+        Seed alpha and beta from a Gumbel fit to log(x).
+
+        The ExpoWeibull with mu = 1 is a Weibull, and a Weibull's logs
+        are Gumbel distributed with mu = log(alpha) and sigma = 1 / beta,
+        so a fit of log(x) gives both shape parameters at once.
+
+        ``refine`` runs the Gumbel MLE rather than reading the
+        probability plot alone. Without an offset the plot is already
+        good enough: refining cost 15-30% of the fit and changed nothing
+        over 54 parameter combinations plus right, left and heavily tied
+        data, every fit reaching the same optimum to the optimiser's own
+        tolerance. With an offset the plot alone is measurably worse --
+        five of 48 offset fits landed on a worse optimum, one of them at
+        685.85 against 622.26 -- so the offset path refines.
+        """
         log_x = np.log(x)
         log_x[np.isnan(log_x)] = 0
-        if offset:
-            # The offset path keeps the nested MLE. It reads log(x) of the
-            # *unshifted* data, so a large shift compresses the logs into a
-            # narrow band and the probability plot alone is a poor seed --
-            # the extra refinement earns its keep there. Dropping it moved
-            # one fit in twelve to a worse optimum (861.898 -> 861.962) and
-            # made that fit seven times slower.
-            gumb = para.Gumbel.fit(log_x, c, n, how="MLE")
-            if not gumb.res.success:
-                gumb = para.Gumbel.fit(log_x, c, n, how="MPP")
-        else:
-            # Without an offset the probability plot is already a good
-            # enough seed: running a whole optimiser ladder to refine a
-            # starting point cost 15-30% of the fit and changed nothing.
-            # Checked over 54 parameter combinations plus right, left and
-            # heavily tied data -- every fit reached the same optimum, to
-            # the optimiser's own tolerance.
+        gumb = para.Gumbel.fit(log_x, c, n, how="MLE" if refine else "MPP")
+        if refine and not gumb.res.success:
             gumb = para.Gumbel.fit(log_x, c, n, how="MPP")
         mu, sigma = gumb.params
         alpha, beta = np.exp(mu), 1.0 / sigma
@@ -50,11 +51,26 @@ class ExpoWeibull_(ParametricFitter):
             alpha = np.median(x)
         if np.isinf(beta) | np.isnan(beta):
             beta = 1.0
+        return alpha, beta
+
+    def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         if offset:
-            gamma = np.min(x) - (np.max(x) - np.min(x)) / 10.0
+            # Estimate the offset first and seed alpha and beta from the
+            # shifted data. Taking logs before removing the shift reads
+            # log(x) instead of log(x - gamma), and a large shift
+            # compresses those logs into a narrow band: at gamma = 100
+            # with a true beta of 2 the seed came back at beta = 23 and
+            # the MLE then failed outright, falling back to MPP.
+            #
+            # min(x) - 1 rather than a fraction of the range because the
+            # fitter overwrites the returned offset with exactly that
+            # (see ParametricFitter.fit_from_surpyval_data); seeding
+            # alpha and beta against a different shift than the one
+            # actually installed defeats the point of shifting at all.
+            gamma = np.min(x) - 1.0
+            alpha, beta = self._gumbel_seed(x - gamma, c, n, refine=True)
             return gamma, alpha, beta, 1.0
-        else:
-            return alpha, beta, 1.0
+        return (*self._gumbel_seed(x, c, n, refine=False), 1.0)
 
     def sf(self, x, alpha, beta, mu):
         r"""

--- a/surpyval/univariate/parametric/distributions/exponential.py
+++ b/surpyval/univariate/parametric/distributions/exponential.py
@@ -3,6 +3,9 @@ import warnings
 from scipy.special import factorial
 from surpyval import np
 from surpyval.univariate.nonparametric import plotting_positions
+from surpyval.univariate.parametric.fitters.closed_form import (
+    entry_times,
+)
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
 
 
@@ -39,6 +42,45 @@ class Exponential_(ParametricFitter):
                 0.9999,
             ],
         )
+
+    def _closed_form_mle(self, data):
+        r"""Exact MLE: total events over total exposure.
+
+        With only exact and right-censored observations the
+        log-likelihood is
+        :math:`d\log\lambda - \lambda\sum n_i (x_i - tl_i)`, whose
+        score is linear in :math:`1/\lambda`, giving
+
+        .. math::
+            \hat{\lambda} = \frac{\sum_i n_i 1[c_i = 0]}
+                                   {\sum_i n_i (x_i - tl_i)} .
+
+        Left truncation is admissible because it only moves each unit's
+        exposure from :math:`x` to :math:`x - tl`. Left censoring,
+        interval censoring and right truncation each introduce a
+        :math:`\log(1 - e^{-\lambda t})` term and make the score
+        transcendental, so those fall back to the optimiser.
+        """
+        c = np.asarray(data.c)
+        if not np.isin(c, (0, 1)).all():
+            # Left (-1) or interval (2) censoring: no closed form.
+            return None
+        if np.isfinite(np.asarray(data.t[:, 1])).any():
+            # Right truncation: no closed form.
+            return None
+
+        x = np.asarray(data.x, dtype=float)
+        if x.ndim != 1:
+            return None
+        n = np.asarray(data.n, dtype=float)
+
+        events = n[c == 0].sum()
+        exposure = (n * (x - entry_times(data))).sum()
+        if not (events > 0 and exposure > 0):
+            # A boundary estimate (no events, or no exposure) sits outside
+            # the open bound on the rate; let the optimiser report it.
+            return None
+        return np.array([events / exposure])
 
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
         rate = 1.0 / x[np.isfinite(x)].mean()

--- a/surpyval/univariate/parametric/distributions/gamma.py
+++ b/surpyval/univariate/parametric/distributions/gamma.py
@@ -36,18 +36,38 @@ class Gamma_(ParametricFitter):
             plot_x_scale="linear",
         )
 
+    @staticmethod
+    def _moment_estimate(x):
+        """Closed-form approximation to the Gamma MLE.
+
+        The shape solves ``log(alpha) - digamma(alpha) = s`` with
+        ``s = log(mean x) - mean(log x)``; this is the standard
+        approximation to that root (Minka 2002, after Thom 1958), good
+        to about 1.5% and used only as a starting point.
+        """
+        s = np.log(x.sum() / len(x)) - np.log(x).sum() / len(x)
+        alpha = (3 - s + np.sqrt((s - 3) ** 2 + 24 * s)) / (12 * s)
+        beta = x.sum() / (len(x) * alpha)
+        return alpha, 1.0 / beta
+
     def _parameter_initialiser(self, x, c=None, n=None, t=None, offset=False):
-        # These equations are truly magical
         if offset:
-            s = np.log(x.sum() / len(x)) - np.log(x).sum() / len(x)
-            alpha = (3 - s + np.sqrt((s - 3) ** 2 + 24 * s)) / (12 * s)
-            beta = x.sum() / (len(x) * alpha)
-            return alpha, 1.0 / beta, np.min(x) - 1
-        else:
-            s = np.log(x.sum() / len(x)) - np.log(x).sum() / len(x)
-            alpha = (3 - s + np.sqrt((s - 3) ** 2 + 24 * s)) / (12 * s)
-            beta = x.sum() / (len(x) * alpha)
-            return alpha, 1.0 / beta
+            # ``gamma`` leads the vector, as it does for every other
+            # offset-capable distribution. Returning it last put the
+            # shape in slot 0, where ``_initial_guess`` overwrites that
+            # slot with the offset seed -- so the shape estimate was
+            # destroyed and the offset written into the scale as well.
+            #
+            # The moments must also be taken *after* the shift. On
+            # offset data ``s = log(mean x) - mean(log x)`` is squashed
+            # towards zero by the constant, and since alpha grows like
+            # ``1 / 12s`` the estimate explodes: 649 for a true shape of
+            # 3. Together these made MSE and MOM offset fits return
+            # silent nonsense.
+            gamma_init = np.min(x) - 1.0
+            alpha, beta = self._moment_estimate(x - gamma_init)
+            return gamma_init, alpha, beta
+        return self._moment_estimate(x)
 
     def sf(self, x, alpha, beta):
         r"""

--- a/surpyval/univariate/parametric/distributions/lognormal.py
+++ b/surpyval/univariate/parametric/distributions/lognormal.py
@@ -3,6 +3,10 @@ from scipy.stats import norm as scipy_norm
 
 from surpyval import np
 from surpyval.univariate import parametric as para
+from surpyval.univariate.parametric.fitters.closed_form import (
+    is_uncensored_and_untruncated,
+    weighted_mean_and_std,
+)
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
 
 
@@ -48,6 +52,19 @@ class LogNormal_(ParametricFitter):
         norm_mod = para.Normal.fit(np.log(x), c=c, n=n, how="MLE")
         mu, sigma = norm_mod.params
         return mu, sigma
+
+    def _closed_form_mle(self, data):
+        r"""Exact MLE on complete data: the Normal closed form applied to
+        :math:`\log x`, since the parameters are those of the underlying
+        normal. Censoring or truncation fall back to the optimiser for
+        the same reason they do for the Normal.
+        """
+        if not is_uncensored_and_untruncated(data):
+            return None
+        x = np.asarray(data.x, dtype=float)
+        if x.ndim != 1 or not (x > 0).all():
+            return None
+        return weighted_mean_and_std(np.log(x), data.n)
 
     def sf(self, x, mu, sigma):
         r"""

--- a/surpyval/univariate/parametric/distributions/normal.py
+++ b/surpyval/univariate/parametric/distributions/normal.py
@@ -2,6 +2,10 @@ from autograd.scipy.stats import norm
 from scipy.stats import norm as scipy_norm
 from surpyval import np
 from surpyval.univariate import parametric as para
+from surpyval.univariate.parametric.fitters.closed_form import (
+    is_uncensored_and_untruncated,
+    weighted_mean_and_std,
+)
 from surpyval.univariate.parametric.parametric_fitter import ParametricFitter
 
 
@@ -48,6 +52,23 @@ class Normal_(ParametricFitter):
         return para.Normal.fit(
             x[c != -1], c[c != -1], n[c != -1], how="MPP"
         ).params
+
+    def _closed_form_mle(self, data):
+        r"""Exact MLE on complete data: the sample mean and (MLE)
+        standard deviation, dividing by the total weight rather than
+        ``total - 1``.
+
+        Any censoring makes this the Tobit model and any truncation
+        introduces a :math:`\Phi` normaliser; in both cases the score
+        picks up :math:`\phi/\Phi` ratios with no analytic solution, so
+        those fall back to the optimiser.
+        """
+        if not is_uncensored_and_untruncated(data):
+            return None
+        x = np.asarray(data.x, dtype=float)
+        if x.ndim != 1:
+            return None
+        return weighted_mean_and_std(x, data.n)
 
     def sf(self, x, mu, sigma):
         r"""

--- a/surpyval/univariate/parametric/distributions/uniform.py
+++ b/surpyval/univariate/parametric/distributions/uniform.py
@@ -200,6 +200,21 @@ class Uniform_(ParametricFitter):
         """
         return self.df(x, a, b) / self.sf(x, a, b)
 
+    def log_df(self, x, a, b):
+        r"""Log density, :math:`-\ln(b - a)` on the support.
+
+        Defined directly rather than through the generic
+        :math:`\ln h(x) - H(x)` identity, which is ``nan`` at the upper
+        support edge: there ``sf`` is 0, so the identity evaluates
+        ``log(inf) - inf``. The MLE puts ``b`` exactly at the largest
+        observation, so that edge is always hit and the whole
+        log-likelihood came out ``nan`` -- taking ``neg_ll``, ``aic``,
+        ``bic`` and ``aic_c`` with it.
+        """
+        x = np.asarray(x, dtype=float)
+        inside = (x >= a) & (x <= b)
+        return np.where(inside, -np.log(b - a), -np.inf)
+
     def Hf(self, x, a, b):
         r"""
 
@@ -366,7 +381,7 @@ class Uniform_(ParametricFitter):
         """
         return np.log(b - a)
 
-    def mle(self, data):
+    def _closed_form_mle(self, data):
         if np.asarray(data.x).ndim == 2 or (data.c == 2).any():
             # The closed-form min/max estimator is not the MLE with
             # interval-censored rows (an interval term favours shrinking
@@ -404,10 +419,7 @@ class Uniform_(ParametricFitter):
                 " the lowest value is left truncated"
             )
 
-        params = np.array([np.min(data.x), np.max(data.x)])
-        results = {}
-        results["params"] = params
-        return results
+        return np.array([np.min(data.x), np.max(data.x)])
 
     def mpp_x_transform(self, x):
         return x

--- a/surpyval/univariate/parametric/fitters/__init__.py
+++ b/surpyval/univariate/parametric/fitters/__init__.py
@@ -5,18 +5,40 @@ from surpyval import np
 
 def fallback_minimize(fun, init, args, jac, hess, newton_tol=None):
     """
-    Minimise ``fun`` trying Newton-CG with the supplied jacobian and
-    hessian first, then falling back to BFGS, then Nelder-Mead, whenever
-    a method fails or returns nan parameters.
+    Minimise ``fun`` with BFGS and the supplied jacobian, escalating to
+    Newton-CG with the hessian and then to Nelder-Mead whenever a method
+    fails or returns nan parameters.
 
-    Some distributions have all-shape parameters whose autograd second
-    derivatives are zero (see autograd_gamma_compat); a zero hessian
-    makes Newton-CG terminate at the initial guess while reporting
-    success, so skip straight to BFGS in that case.
+    Newton-CG used to go first. It reaches the same answers, but it
+    needs the hessian, and building one is disproportionately expensive
+    for the distributions whose derivatives autograd cannot take
+    analytically: the incomplete gamma is central-differenced (see
+    ``autograd_gamma_compat``), so every second-order entry costs a
+    difference of differences. An offset Gamma MSE fit at n=5000 spent
+    8.2 of its 8.3 seconds there, and BFGS reached a marginally better
+    optimum in half a second.
+
+    Measured over 132 fits -- MSE and MPS, nine distributions, plain,
+    right censored, left censored and offset -- reversing the order left
+    129 objectives identical and improved three, none worse, for 3.9x
+    less time.
+
+    The hessian is still consulted before escalating. Some distributions
+    have all-shape parameters whose autograd second derivatives are
+    zero, and a zero hessian makes Newton-CG stop at the initial guess
+    while reporting success, so there is nothing to escalate to and
+    Nelder-Mead should take over instead.
     """
     with np.errstate(all="ignore"):
-        if np.any(hess(np.array(init, dtype=float), *args)):
-            res = minimize(
+        res = minimize(fun, init, method="BFGS", jac=jac, args=args)
+
+        failed = (
+            (res.success is False)
+            or np.isnan(res.x).any()
+            or (not np.isfinite(res.fun))
+        )
+        if failed and np.any(hess(np.array(init, dtype=float), *args)):
+            newton = minimize(
                 fun,
                 init,
                 method="Newton-CG",
@@ -25,11 +47,8 @@ def fallback_minimize(fun, init, args, jac, hess, newton_tol=None):
                 tol=newton_tol,
                 args=args,
             )
-        else:
-            res = None
-
-        if (res is None) or (res.success is False) or (np.isnan(res.x).any()):
-            res = minimize(fun, init, method="BFGS", jac=jac, args=args)
+            if newton.success and np.isfinite(newton.fun):
+                res = newton
 
         if (res.success is False) or (np.isnan(res.x).any()):
             res = minimize(fun, init, args=args)

--- a/surpyval/univariate/parametric/fitters/closed_form.py
+++ b/surpyval/univariate/parametric/fitters/closed_form.py
@@ -1,0 +1,163 @@
+"""Closed-form maximum likelihood estimation.
+
+A few distributions have an exact analytic MLE for particular data
+shapes -- the Exponential's events-over-exposure ratio, the Normal's
+mean and standard deviation. Where one applies it is not merely faster
+than the optimiser ladder, it is exact, so there is no reason to seed an
+initial guess and iterate.
+
+A distribution opts in by defining ``_closed_form_mle(data)``, which
+returns either the parameter vector or ``None`` to mean "not solvable in
+closed form for *this* data; use the optimiser". Returning ``None``
+rather than raising keeps the applicability condition next to the
+computation that relies on it, so the two cannot drift apart, and leaves
+exceptions to mean what they have always meant: the fit is impossible,
+not merely non-analytic.
+
+The result is completed here rather than by each distribution, so every
+closed-form fit carries the same information as an optimised one --
+``_neg_ll`` and a parameter covariance. Without them ``aic``, ``bic``,
+``aic_c`` and ``cb`` break on the fitted model.
+"""
+
+import numpy as onp
+from autograd import hessian
+from numdifftools import Hessian  # type: ignore
+from numpy.linalg import LinAlgError, inv, pinv
+
+from surpyval import np
+
+
+def _neg_ll_at(dist, data, params):
+    """The model's negative log-likelihood at ``params`` (no offset,
+    zero-inflation or limited-failure component -- the closed-form gate
+    excludes all three)."""
+    return dist._neg_ll_func(data, *params, 0.0, 0.0, 1.0)
+
+
+def parameter_covariance(dist, data, params):
+    """Asymptotic parameter covariance, the inverse observed information.
+
+    Computed directly in the natural parameter space: the closed-form
+    gate rules out fixed, offset, limited-failure and zero-inflation
+    parameters, so there is no transform to undo and no delta step --
+    unlike the optimiser path, which must work in the unbounded
+    transformed space it searched.
+    """
+    params = onp.asarray(params, dtype=float)
+
+    def fun(p):
+        return _neg_ll_at(dist, data, p)
+
+    with onp.errstate(all="ignore"):
+        information = onp.atleast_2d(hessian(fun)(params))
+        # autograd propagates nan through infinite truncation bounds even
+        # where they cannot affect the derivative (the caveat noted at the
+        # top of ``mle.py``), and a corrupted primitive shows up as
+        # asymmetry (#270). Either way, recompute numerically rather than
+        # invert nonsense.
+        asymmetric = onp.max(
+            onp.abs(information - information.T)
+        ) > 1e-4 * max(onp.max(onp.abs(information)), 1.0)
+        if onp.isnan(information).any() or asymmetric:
+            information = onp.atleast_2d(Hessian(fun)(params))
+        if onp.isnan(information).any():
+            return None
+        try:
+            cov = inv(information)
+        except LinAlgError:
+            cov = pinv(information)
+        if onp.isnan(cov).any():
+            try:
+                cov = pinv(information)
+            except LinAlgError:
+                return None
+    return cov
+
+
+def closed_form_results(dist, data, params):
+    """Complete a closed-form parameter vector into a full results dict.
+
+    Mirrors what the optimiser path returns, so a closed-form fit
+    supports the same model methods.
+    """
+    params = onp.atleast_1d(onp.asarray(params, dtype=float))
+    with onp.errstate(all="ignore"):
+        neg_ll = float(_neg_ll_at(dist, data, params))
+
+    try:
+        cov = parameter_covariance(dist, data, params)
+    except (LinAlgError, ValueError, FloatingPointError):
+        cov = None
+
+    # Not every MLE is regular. The Uniform's is an order statistic --
+    # the estimate sits *on* the support edge rather than at an interior
+    # stationary point -- so the observed information is not positive
+    # definite and its inverse carries negative variances. Reporting that
+    # would turn into silent nan confidence bounds downstream, so no
+    # covariance is offered at all and ``cb`` refuses with its usual
+    # message.
+    if cov is not None:
+        diagonal = onp.diag(onp.atleast_2d(cov))
+        if not onp.isfinite(diagonal).all() or (diagonal <= 0).any():
+            cov = None
+
+    return {
+        "params": params,
+        "gamma": 0.0,
+        "f0": 0.0,
+        "p": 1.0,
+        "_neg_ll": neg_ll,
+        "log_likelihood": -neg_ll,
+        "cov_matrix": cov,
+        "hess_inv": cov,
+        "res": None,
+        "optimizer": "closed-form",
+    }
+
+
+def entry_times(data):
+    """Left-truncation times with non-finite entries replaced by 0.
+
+    ``-inf`` marks "not truncated"; for a lifetime distribution supported
+    on ``[0, inf)`` that is entry at time zero, which is what the
+    exposure calculation needs (``x - tl`` would otherwise be infinite).
+    """
+    tl = onp.asarray(data.t[:, 0], dtype=float)
+    return onp.where(onp.isfinite(tl), tl, 0.0)
+
+
+def is_uncensored_and_untruncated(data):
+    """Every observation exact, with no truncation of either kind."""
+    return bool(
+        (onp.asarray(data.c) == 0).all()
+        and onp.isneginf(onp.asarray(data.t[:, 0])).all()
+        and onp.isposinf(onp.asarray(data.t[:, 1])).all()
+    )
+
+
+def weighted_mean_and_std(values, n):
+    """MLE mean and standard deviation (dividing by the total weight, not
+    by ``total - 1``), or ``None`` if the spread is degenerate."""
+    values = onp.asarray(values, dtype=float)
+    n = onp.asarray(n, dtype=float)
+    total = n.sum()
+    if not total > 0:
+        return None
+    mu = (n * values).sum() / total
+    var = (n * (values - mu) ** 2).sum() / total
+    if not var > 0:
+        # sigma is bounded strictly positive; a degenerate sample has no
+        # interior maximum, so leave it to the optimiser to report.
+        return None
+    return onp.array([mu, onp.sqrt(var)])
+
+
+__all__ = [
+    "closed_form_results",
+    "entry_times",
+    "is_uncensored_and_untruncated",
+    "parameter_covariance",
+    "weighted_mean_and_std",
+    "np",
+]

--- a/surpyval/univariate/parametric/fitters/mle.py
+++ b/surpyval/univariate/parametric/fitters/mle.py
@@ -23,14 +23,6 @@ def mle(model):
     # Offset, Limited Failure Population, Zero Inflated logic.
     offset, lfp, zi = model.offset, model.lfp, model.zi
 
-    if hasattr(model.dist, "mle"):
-        results = model.dist.mle(model.surv_data)
-        results["params"] = np.atleast_1d(results["params"])
-        results.setdefault("gamma", 0.0)
-        results.setdefault("f0", 0.0)
-        results.setdefault("p", 1.0)
-        return results
-
     results = {}
 
     """

--- a/surpyval/univariate/parametric/fitters/mom.py
+++ b/surpyval/univariate/parametric/fitters/mom.py
@@ -1,15 +1,71 @@
 import warnings
+from math import comb
 
 from scipy.optimize import minimize
 
 from surpyval import np
 
 
+def raw_to_central(moments):
+    """``(mean, var, mu3, ...)`` from raw moments ``E[X], E[X^2], ...``.
+
+    ``mu_k = sum_j C(k, j) (-1)^(k-j) E[X^j] mean^(k-j)``, with the mean
+    kept in the leading slot because the first central moment is zero by
+    construction and carries no information.
+
+    The transform is exact and bijective, so matching the first ``k``
+    central moments is the same estimator as matching the first ``k``
+    raw ones -- it is only better conditioned. See ``mom_fun``.
+    """
+    mean = moments[0]
+    central = [mean]
+    for k in range(2, len(moments) + 1):
+        acc = (-1) ** k * mean**k  # the j = 0 term, where E[X^0] = 1
+        for j in range(1, k + 1):
+            acc = acc + comb(k, j) * (-1) ** (k - j) * moments[j - 1] * (
+                mean ** (k - j)
+            )
+        central.append(acc)
+    return np.array(central)
+
+
 def mom_fun(params, dist, inv_trans, const, offset, moments):
+    """Squared mismatch between the sample and model moments.
+
+    Compared as *central* moments scaled by the sample's own standard
+    deviation, so every term is dimensionless and of comparable size:
+    the mean in units of sigma, then the relative variance error, then
+    the skewness difference, and so on.
+
+    Raw moments describe the same estimator but hide it. Once a
+    distribution is offset, ``E[X^k]`` is dominated by ``gamma^k`` and
+    the shape contributes only a fractional correction -- 0.5% of
+    ``E[X^3]`` for a Gamma(3, 4) shifted by 10. The optimiser is then
+    reading three parameters off the third decimal place of a large
+    number, and offset fits converged to parameter sets that matched the
+    sample moments *better than the true parameters did* while being
+    nowhere near them: a shape of 17.7 against a true 3.
+
+    Central moments remove the offset by construction, so the shape
+    information is the whole of ``mu_3`` rather than a rounding error in
+    it. For unshifted fits the two agree to several decimal places,
+    because there the conditioning was never the problem.
+    """
     dist_moments = dist.mom_moment_gen(
         *inv_trans(const(params)), offset=offset
     )
-    return ((moments - dist_moments) ** 2 / moments).sum()
+    sample = raw_to_central(moments)
+    model = raw_to_central(dist_moments)
+
+    # sigma^k puts every term on a common footing. Taken from the sample
+    # alone so the scale is a constant of the problem, not something the
+    # optimiser can shrink to flatter itself.
+    sigma = np.sqrt(np.abs(sample[1])) if len(sample) > 1 else 1.0
+    if not np.isfinite(sigma) or sigma <= 0:
+        sigma = 1.0
+    scale = np.array([sigma ** (k + 1) for k in range(len(sample))])
+
+    return (((sample - model) / scale) ** 2).sum()
 
 
 def mom(model):
@@ -62,11 +118,22 @@ def mom(model):
         )
         if np.isfinite(res_nm.fun) and res_nm.fun < res.fun:
             res = res_nm
-    if res.fun > 1e-4:
+    # The objective is a sum of squared standardised-moment differences
+    # (see ``mom_fun``), so this threshold is in those units. Healthy
+    # fits land in one of two places: ~1e-12 when the moment equations
+    # have an exact solution, or ~1e-3 when sampling noise means no
+    # parameter vector reproduces the sample moments exactly and the
+    # optimiser returns the closest one -- a third central moment is
+    # noisy enough at n=5000 for that to be routine. A fit that has
+    # actually failed sits near 0.5. 1e-2 separates them with roughly an
+    # order of magnitude of clearance on either side; the previous 1e-4
+    # was calibrated against the old raw-moment objective and fires on
+    # ordinary sampling noise under this one.
+    if res.fun > 1e-2:
         warnings.warn(
-            "MOM optimisation did not match the sample moments (relative "
-            f"squared mismatch {res.fun:.3g}); the returned parameters may "
-            "be unreliable. Consider how='MLE'."
+            "MOM optimisation did not match the sample moments (squared "
+            f"standardised-moment mismatch {res.fun:.3g}); the returned "
+            "parameters may be unreliable. Consider how='MLE'."
         )
 
     params = inv_trans(const(res.x))

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -14,6 +14,7 @@ from ..nonparametric import plotting_positions as pp
 from .fitters import bounds_convert
 from .fitters.mle import mle
 from .fitters.mom import mom
+from .fitters.closed_form import closed_form_results
 from .fitters.mpp import mpp, mpp_from_ecfd
 from .fitters.mps import mps
 from .fitters.mse import mse
@@ -64,9 +65,16 @@ class ParametricFitter:
     *params)`` and ``mpp_inv_y_transform(y, *params)``.
 
     A subclass can take over an entire estimation method by defining
-    ``mle(data)`` or ``mpp(x, c, n, heuristic, rr, on_d_is_0, offset)``,
-    both returning a results dict with at least a ``params`` numpy
-    array.
+    ``mpp(x, c, n, heuristic, rr, on_d_is_0, offset)``, returning a
+    results dict with at least a ``params`` numpy array.
+
+    A subclass with an exact analytic MLE may also define
+    ``_closed_form_mle(data)``, returning the parameter vector, or
+    ``None`` when the closed form does not apply to *that* data. It is
+    consulted before any initial guess or optimisation, so an eligible
+    fit skips both entirely; ``init`` has no effect on that path because
+    the closed form is exact. Structural requests (an offset, limited
+    failure population, zero inflation, or fixed parameters) bypass it.
 
     Implementations must do their math with ``surpyval.np``, which is
     ``autograd.numpy``: maximum likelihood estimation differentiates
@@ -1039,8 +1047,114 @@ class ParametricFitter:
 
         model = Parametric(self, how, data, offset, lfp, zi)
         model.surv_data = surv_data
-        fitting_info = {}
+        fitting_info: dict = {}
 
+        # An exact analytic MLE, where one exists for this distribution and
+        # this data, is attempted *before* the initial guess and bounds
+        # machinery below -- both of which exist only to seed and run the
+        # optimiser. Returns None whenever the closed form does not apply,
+        # and the numerical path proceeds untouched.
+        results = self._try_closed_form_mle(
+            surv_data, how, offset, lfp, zi, fixed
+        )
+
+        if results is None:
+            results = self._fit_numerically(
+                model,
+                fitting_info,
+                x,
+                c,
+                n,
+                tl,
+                tr,
+                how,
+                offset,
+                zi,
+                lfp,
+                fixed,
+                heuristic,
+                init,
+                rr,
+                on_d_is_0,
+                turnbull_estimator,
+            )
+        else:
+            model.fitting_info = fitting_info
+
+        for k, v in results.items():
+            setattr(model, k, v)
+
+        # Expose each fitted parameter by name (e.g. ``model.alpha``), but
+        # never overwrite the reserved offset / limited-failure /
+        # zero-inflation attributes, which the survival functions rely on.
+        # A distribution may legitimately name a parameter ``p`` (e.g.
+        # ``Geometric``, ``NegativeBinomial``); those remain available via
+        # ``model.params``.
+        reserved = {"gamma", "p", "f0"}
+        for k, v in zip(self.param_names, model.params):
+            if k not in reserved:
+                setattr(model, k, v)
+
+        self._set_support(model, offset)
+
+        return model
+
+    def _try_closed_form_mle(
+        self, surv_data, how, offset, lfp, zi, fixed
+    ) -> "dict | None":
+        """An exact analytic MLE, or ``None`` to use the optimiser.
+
+        Two conditions have to hold, and they live in different places
+        because they are different kinds of question.
+
+        The *structural* ones are checked here: an offset ``gamma``, a
+        limited-failure ``p``, zero-inflation ``f0`` or any user-fixed
+        parameter each adds structure the analytic solutions do not
+        solve for. These are properties of the requested model rather
+        than of the data, and they are identical for every distribution.
+
+        The *data-shape* condition is left to the distribution's own
+        ``_closed_form_mle``, which alone knows what it can solve -- the
+        Exponential accepts right censoring and left truncation, the
+        Normal needs complete data -- and which signals inapplicability
+        by returning ``None``.
+        """
+        if how != "MLE":
+            return None
+        if offset or lfp or zi or fixed:
+            return None
+
+        solver = getattr(self, "_closed_form_mle", None)
+        if solver is None:
+            return None
+
+        params = solver(surv_data)
+        if params is None:
+            return None
+
+        return closed_form_results(self, surv_data, params)
+
+    def _fit_numerically(
+        self,
+        model,
+        fitting_info,
+        x,
+        c,
+        n,
+        tl,
+        tr,
+        how,
+        offset,
+        zi,
+        lfp,
+        fixed,
+        heuristic,
+        init,
+        rr,
+        on_d_is_0,
+        turnbull_estimator,
+    ) -> dict:
+        """Seed an initial guess, convert bounds and run the estimator."""
         if how == "MPS":
             # Need to set the scalar truncation values
             # if the MPS method is used.
@@ -1084,25 +1198,7 @@ class ParametricFitter:
 
         model.fitting_info = fitting_info
 
-        results = METHOD_FUNC_DICT[how](model)
-
-        for k, v in results.items():
-            setattr(model, k, v)
-
-        # Expose each fitted parameter by name (e.g. ``model.alpha``), but
-        # never overwrite the reserved offset / limited-failure /
-        # zero-inflation attributes, which the survival functions rely on.
-        # A distribution may legitimately name a parameter ``p`` (e.g.
-        # ``Geometric``, ``NegativeBinomial``); those remain available via
-        # ``model.params``.
-        reserved = {"gamma", "p", "f0"}
-        for k, v in zip(self.param_names, model.params):
-            if k not in reserved:
-                setattr(model, k, v)
-
-        self._set_support(model, offset)
-
-        return model
+        return METHOD_FUNC_DICT[how](model)
 
     def from_params(self, params, gamma=None, p=None, f0=None):
         r"""

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -1084,6 +1084,32 @@ class ParametricFitter:
         for k, v in results.items():
             setattr(model, k, v)
 
+        # Only maximum likelihood and the closed forms report a
+        # log-likelihood, because only they compute one on the way to
+        # the answer. That left ``neg_ll``, ``aic``, ``bic`` and
+        # ``aic_c`` raising AttributeError for every MPS, MSE, MOM and
+        # MPP fit -- so the usual way of choosing between distributions
+        # was unavailable for four of the five methods.
+        #
+        # The log-likelihood is a property of the parameters and the
+        # data, not of the search that found them, so evaluate it here.
+        # Guarded by ``hasattr`` so the methods that already report one
+        # keep theirs untouched: maximum likelihood's is the optimiser's
+        # own final objective, which on its fallback path is deliberately
+        # taken at the initial guess rather than at the failed result
+        # (#261), and recomputing would quietly undo that.
+        if not hasattr(model, "_neg_ll"):
+            with np.errstate(all="ignore"):
+                model._neg_ll = float(
+                    self._neg_ll_func(
+                        surv_data,
+                        *model.params,
+                        model.gamma,
+                        model.f0,
+                        model.p,
+                    )
+                )
+
         # Expose each fitted parameter by name (e.g. ``model.alpha``), but
         # never overwrite the reserved offset / limited-failure /
         # zero-inflation attributes, which the survival functions rely on.

--- a/surpyval/utils/__init__.py
+++ b/surpyval/utils/__init__.py
@@ -63,28 +63,73 @@ def validate_float_array(arr, name):
         )
 
 
+def _group_ids(key):
+    """Group id per row, plus the row at which each group first appears.
+
+    ``np.lexsort`` rather than ``np.unique(axis=0)``: the latter takes a
+    structured-void view of the array, which is several times slower.
+    Because lexsort is stable, the first row of each run in sorted order
+    is also the group's earliest row in the original ordering, which is
+    what the caller needs. Rows containing ``nan`` never compare equal
+    and so stay in their own groups -- matching the dictionary keying
+    this replaced, where a ``nan`` key never matched another.
+    """
+    order = np.lexsort(key.T[::-1])
+    ordered = key[order]
+    starts = np.empty(len(ordered), dtype=bool)
+    starts[0] = True
+    if len(ordered) > 1:
+        starts[1:] = (ordered[1:] != ordered[:-1]).any(axis=1)
+    group = np.empty(len(ordered), dtype=np.intp)
+    group[order] = np.cumsum(starts) - 1
+    return group, order[starts]
+
+
 def group_xcnt(x, c, n, t):
-    grouped = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
-    if x.ndim == 2:
-        for vx, vc, vn, vt in zip(x, c, n, t):
-            grouped[tuple(vx)][vc][tuple(vt)] += vn
-    else:
-        for vx, vc, vn, vt in zip(x, c, n, t):
-            grouped[vx][vc][tuple(vt)] += vn
+    """Collapse identical ``(x, c, t)`` rows, summing their counts.
 
-    x_out = []
-    c_out = []
-    n_out = []
-    t_out = []
+    This used to walk every observation in Python, accumulating into a
+    triple-nested ``defaultdict``. That is O(N) but with a very large
+    constant -- roughly 13 microseconds per observation -- which made it
+    the dominant cost of fitting: 94% of a 50,000-point Normal fit, and
+    two seconds at 100,000 points. It is now done by sorting and
+    ``np.bincount``.
 
-    for xv, level2 in grouped.items():
-        for cv, level3 in level2.items():
-            for tv, nv in level3.items():
-                x_out.append(xv)
-                c_out.append(cv)
-                n_out.append(nv)
-                t_out.append(tv)
-    return np.array(x_out), np.array(c_out), np.array(n_out), np.array(t_out)
+    The group *order* is preserved exactly, which is subtler than it
+    looks. The nested dictionary iterated x-major: outer by first
+    appearance of ``x``, then of ``(x, c)`` within it, then of the full
+    key. ``xcnt_sort`` runs immediately after this and re-sorts on
+    ``c``, ``t.min(axis=1)`` and ``x`` -- but it is a *stable* sort, so
+    rows tying on all three of those keep whatever order arrived. Rows
+    sharing an ``x`` and ``c`` with different ``tr`` but an equal
+    ``t.min()`` are exactly such a tie, so a plain sorted ``np.unique``
+    would silently reorder them. The lexsort below reproduces the
+    original nesting instead.
+    """
+    x_columns = x.reshape(-1, 1) if x.ndim == 1 else x
+    group, first_full = _group_ids(np.column_stack([x_columns, c, t]))
+    by_x, first_x = _group_ids(x_columns)
+    by_xc, first_xc = _group_ids(np.column_stack([x_columns, c]))
+
+    # One representative row per group: the row it first appeared at.
+    representative = first_full
+    # np.lexsort takes its *last* key as primary, so this orders by first
+    # appearance of x, then of (x, c), then of the whole key.
+    order = np.lexsort(
+        (
+            first_full,
+            first_xc[by_xc[representative]],
+            first_x[by_x[representative]],
+        )
+    )
+    representative = representative[order]
+
+    totals = np.bincount(group, weights=n, minlength=first_full.size)[order]
+    # ``bincount`` always returns float64; the counts were integers going
+    # in and callers rely on that (an integer ``n`` must stay integer).
+    totals = totals.astype(n.dtype)
+
+    return x[representative], c[representative], totals, t[representative]
 
 
 def xcnt_sort(x, c, n, t):

--- a/surpyval/utils/__init__.py
+++ b/surpyval/utils/__init__.py
@@ -712,22 +712,20 @@ def xcnt_handler(
     n = n.astype(int)
     t = t.astype(float)
 
-    # A right-censored observation cannot carry finite right truncation:
-    # right-truncation sampling only admits units whose event occurred
-    # before ``tr``, while right censoring says the event is after the
-    # censoring time -- possibly beyond ``tr``. Such rows can make
-    # truncation-adjusted likelihoods unbounded (the fitted rate is
-    # driven towards zero), so flag them loudly.
-    if ((c == 1) & np.isfinite(t[:, 1])).any():
-        warnings.warn(
-            "Some right-censored observations have a finite right "
-            "truncation time. This is contradictory: right truncation "
-            "means the unit was only observable because its event "
-            "occurred before `tr`, while right censoring says the event "
-            "is after the censoring time. Such rows can make "
-            "truncation-adjusted likelihoods unbounded; check the data.",
-            stacklevel=2,
-        )
+    # Right censoring with a finite right truncation used to warn here
+    # as contradictory data (#195). It is not: the unit was detected, so
+    # its event is at or before ``tr``, and it was censored, so the
+    # event is after ``x``. Together that is simply ``x < X <= tr`` --
+    # the ordinary setup of a flux-limited or reporting-delay sample,
+    # e.g. a detector that registers an event but cannot resolve where
+    # in the remaining window it fell.
+    #
+    # The unbounded likelihoods that motivated the warning were not
+    # caused by the data. Right-censored rows were being given the
+    # unconditional ``S(x)``, which includes the ``X > tr`` region the
+    # truncation excludes, and that is what had no maximum (#310). With
+    # the conditional ``F(tr) - F(x)`` the fit is well posed and
+    # consistent, so the warning has been withdrawn.
 
     if group_and_sort:
         x, c, n, t = group_xcnt(x, c, n, t)

--- a/surpyval/utils/__init__.py
+++ b/surpyval/utils/__init__.py
@@ -77,7 +77,8 @@ def _group_ids(key):
     order = np.lexsort(key.T[::-1])
     ordered = key[order]
     starts = np.empty(len(ordered), dtype=bool)
-    starts[0] = True
+    if len(ordered) > 0:
+        starts[0] = True
     if len(ordered) > 1:
         starts[1:] = (ordered[1:] != ordered[:-1]).any(axis=1)
     group = np.empty(len(ordered), dtype=np.intp)
@@ -105,7 +106,24 @@ def group_xcnt(x, c, n, t):
     ``t.min()`` are exactly such a tie, so a plain sorted ``np.unique``
     would silently reorder them. The lexsort below reproduces the
     original nesting instead.
+
+    When nothing needs grouping the inputs are returned as they are,
+    rather than copied. Callers inside the package sort immediately
+    afterwards, which copies, so nothing aliases in practice.
     """
+    # Continuous data has nothing to group: every row is already its own
+    # group, and since the ordering is x-major and each x occurs once,
+    # that order *is* the input order. So the answer is the input,
+    # untouched. Establishing this costs one sort of a single column,
+    # against three sorts of the full key -- and it is the common case,
+    # since only tied (rounded, discrete, or heavily weighted) data
+    # groups at all. Distinct values in the first column are enough:
+    # they make whole rows distinct whatever c and t hold. Empty input
+    # trivially satisfies this and is likewise handed straight back.
+    leading = x if x.ndim == 1 else x[:, 0]
+    if np.unique(leading).size == leading.size:
+        return x, c, n, t
+
     x_columns = x.reshape(-1, 1) if x.ndim == 1 else x
     group, first_full = _group_ids(np.column_stack([x_columns, c, t]))
     by_x, first_x = _group_ids(x_columns)

--- a/surpyval/utils/__init__.py
+++ b/surpyval/utils/__init__.py
@@ -688,6 +688,47 @@ def xcn_to_fs(x, c=None, n=None):
     return f, s
 
 
+def _entered_before(tl, x, n):
+    """Weighted count of observations that entered strictly before each ``x``.
+
+    ``e[j] = sum_i n_i * 1[tl_i < x_j]`` -- the ``(entry, exit]``
+    risk-interval convention (#260): a subject entering exactly at an event
+    time is not at risk for that event.
+
+    Written directly this is
+    ``((tl[:, None] < x[None, :]) * n[:, None]).sum(0)``, which materialises
+    an ``N x K`` matrix and so costs quadratic time *and* memory: at 20,000
+    observations that is a 3.2 GB intermediate taking ~15 s, and past ~50,000
+    it raised ``MemoryError`` outright. Two cheap branches give identical
+    counts:
+
+    * **nothing is left truncated** -- the default and by far the common
+      case. Every observation has entered before every event time, so the
+      whole matrix is ``True`` and ``e`` collapses to the constant
+      ``n.sum()``. The matrix was being built to recompute a scalar.
+    * **otherwise** -- sort the entry times once and read off the cumulative
+      weight below each ``x`` with ``searchsorted``. ``side="left"`` counts
+      entries *strictly* less than ``x``, matching the ``<`` above exactly,
+      so the ``(entry, exit]`` convention is preserved unchanged.
+
+    Counts are integers (``xcnt_handler`` rejects non-integer ``n``), so the
+    cumulative sum is exact and equals the summation it replaces bit for
+    bit. ``np.sort`` orders ``nan`` last and ``searchsorted`` treats it as
+    larger than every value, which reproduces ``nan < x == False`` -- the
+    behaviour of the form this replaces.
+    """
+    if np.isneginf(tl).all():
+        # No left truncation: everything is at risk from the outset.
+        return np.full(x.shape, n.sum(), dtype=n.dtype)
+
+    order = np.argsort(tl, kind="stable")
+    tl_sorted = tl[order]
+    cumulative = np.concatenate(
+        [np.zeros(1, dtype=n.dtype), np.cumsum(n[order])]
+    )
+    return cumulative[np.searchsorted(tl_sorted, x, side="left")]
+
+
 def xcnt_to_xrd(x, c=None, n=None, t=None, **kwargs):
     """
     Converts the xcn format to the xrd format.
@@ -768,7 +809,7 @@ def xcnt_to_xrd(x, c=None, n=None, t=None, **kwargs):
     # risk for that event. The previous inclusive comparison put surpyval's
     # KM on the nonstandard side and made it disagree with Turnbull's NPMLE
     # at exact entry/event ties (#260).
-    e = ((tl[:, np.newaxis] < x[np.newaxis, :]) * n[:, np.newaxis]).sum(0)
+    e = _entered_before(tl, x, n)
     # r is the number of people at risk at each x
     r = e + d - d.cumsum() + do - do.cumsum()
     # change to correct data types

--- a/surpyval/utils/surpyval_data.py
+++ b/surpyval/utils/surpyval_data.py
@@ -133,28 +133,94 @@ class SurpyvalData:
         """
         Z_arr: np.ndarray = np.asarray(Z)
         self.Z = Z_arr
-        self.Z_o = Z_arr[self.c == 0]
-        self.Z_r = Z_arr[self.c == 1]
-        self.Z_l = Z_arr[self.c == -1]
-        self.Z_i = Z_arr[self.c == 2]
+        # The same masks the observation split used, not fresh ``c``
+        # comparisons: censored rows with a finite truncation bound are
+        # handed to the likelihood as intervals (#310), and their
+        # covariates have to move with them or every observation in the
+        # regression likelihood is paired with the wrong covariate row.
+        self.Z_o = Z_arr[self.mask_o]
+        self.Z_r = Z_arr[self.mask_r]
+        self.Z_l = Z_arr[self.mask_l]
+        self.Z_i = Z_arr[self.mask_i]
         # Covariates of the truncated subset, aligned with x_tl/x_tr/n_t so
         # that regression likelihoods can apply the truncation correction
         # using each truncated observation's own covariates.
         self.Z_t = Z_arr[self.truncated_mask]
 
     def _split_to_observation_types(self) -> None:
-        self.x_o, self.n_o = self._split_by_mask(self.c == 0)
-        self.x_r, self.n_r = self._split_by_mask(self.c == 1)
-        self.x_l, self.n_l = self._split_by_mask(self.c == -1)
-        if self.x.ndim == 2:
-            interval_mask = self.c == 2
-            self.x_il = self.x[interval_mask, 0]
-            self.x_ir = self.x[interval_mask, 1]
-            self.n_i = self.n[interval_mask]
+        """Split the data into the buckets the likelihoods consume.
+
+        A censored observation is only ever known to lie *inside its own
+        truncation window* -- it could not have been observed otherwise.
+        Its likelihood numerator must therefore be the probability of
+        that intersection, not of the raw censoring event:
+
+        =========================  =================  ===============
+        row                        correct numerator  unconditional
+        =========================  =================  ===============
+        left censored at x, tl     F(x) - F(tl)       F(x)
+        right censored at x, tr    F(tr) - F(x)       S(x)
+        =========================  =================  ===============
+
+        Using the unconditional form makes the contribution exceed one
+        -- it counts territory the truncation has already ruled out --
+        and the excess grows without bound as the fitted distribution's
+        mass slides outside the window. Every likelihood in the package
+        then has an unbounded direction and the optimiser runs off down
+        it, reporting success at nonsense parameters (#310).
+
+        Rather than teach each likelihood about truncation, such rows
+        are handed over as *intervals*: a left-censored row truncated at
+        ``tl`` becomes ``[tl, x]``, a right-censored row truncated at
+        ``tr`` becomes ``[x, tr]``. The interval term is already a
+        difference of CDFs, so it computes the correct numerator with no
+        change to any likelihood -- which is why interval-censored data
+        never had the bug.
+
+        Only rows with a *finite* bound on the relevant side are
+        recast. That is exactly where the defect lives, and it keeps
+        right censoring on the exact ``log_sf`` path: expressing it as
+        ``1 - F(x)`` loses all precision once ``F(x)`` rounds to one
+        (``log_sf`` of -49 comes back as ``-inf``), and the optimiser
+        evaluates the likelihood at parameters far enough from the data
+        for that to bite. Untruncated fits are therefore bit-identical.
+        """
+        t = self.t
+        has_tl = np.isfinite(t[:, 0])
+        has_tr = np.isfinite(t[:, 1])
+        recast_l = (self.c == -1) & has_tl
+        recast_r = (self.c == 1) & has_tr
+
+        # Kept as attributes because ``add_covariates`` must slice Z with
+        # the *same* masks: if a row changes bucket here and its
+        # covariates do not follow, the regression likelihood pairs every
+        # observation with the wrong covariate row.
+        self.mask_o = self.c == 0
+        self.mask_r = (self.c == 1) & ~has_tr
+        self.mask_l = (self.c == -1) & ~has_tl
+        self.mask_i = (self.c == 2) | recast_l | recast_r
+
+        self.x_o, self.n_o = self._split_by_mask(self.mask_o)
+        self.x_r, self.n_r = self._split_by_mask(self.mask_r)
+        self.x_l, self.n_l = self._split_by_mask(self.mask_l)
+
+        if self.mask_i.any():
+            lead = self.x if self.x.ndim == 1 else self.x[:, 0]
+            trail = self.x if self.x.ndim == 1 else self.x[:, -1]
+            # Interval rows keep their own bounds; recast rows take the
+            # truncation bound on the censored side.
+            lo = np.where(recast_l, t[:, 0], lead)
+            hi = np.where(
+                recast_r, t[:, 1], np.where(self.c == 2, trail, lead)
+            )
+            self.x_il = lo[self.mask_i]
+            self.x_ir = hi[self.mask_i]
+            self.n_i = self.n[self.mask_i]
         else:
             self.x_il = np.array([], dtype=float)
             self.x_ir = np.array([], dtype=float)
             self.n_i = np.array([], dtype=int)
+
         self.truncated_mask = np.isfinite(self.t).any(axis=1)
         self.x_tl, self.x_tr, self.n_t = (
             self.t[self.truncated_mask, 0],


### PR DESCRIPTION
Merges `develop` into `master` for the v0.18.0 release — 29 commits since
v0.17.0. The version bump and dated changelog already landed on `develop` in
#319; this is the release merge.

Merging does **not** publish. `publish.yml` triggers on `push: tags: v*`, so
PyPI ships only when a `v0.18.0` tag is pushed at this merge commit — the same
shape as `v0.17.0`, which points at `c39f4d9`.

## Why a minor release

- **Fitted results change.** The truncated-likelihood fix alters parameters for
  any dataset with observations that are both censored and truncated. The old
  likelihood was unbounded in that case and could return garbage with
  `success=True`.
- **New API surface.** `neg_ll`, `aic`, `bic` and `aic_c` previously raised
  `AttributeError` on four of the five fit methods.

## Contents

Correctness:

- Censored *and* truncated observations are conditioned on their own truncation
  window, via an internal recast to interval censoring
- Offset `ExpoWeibull` seeded from shifted data — 54 of 120 offset fits were
  returning `nan` and falling back to MPP
- Offset `Gamma` no longer starts from a corrupted initial guess
- Method of moments matches scaled central rather than raw moments
- Exact closed-form MLE for the Exponential, Normal and LogNormal
- `Uniform` fits gained a usable log-likelihood; closed-form fits no longer
  silently ignore `lfp`, `zi` and `offset`

Performance:

- MSE and MPS try BFGS before Newton-CG (3.9x less time over 132 fits)
- ARI likelihood evaluated for the whole sample at once
- `group_xcnt` no longer walks every observation in Python
- `xcnt_to_xrd` no longer quadratic in time and memory

Documentation:

- Estimation notes cover the censored-and-truncated case, central moments, and
  information criteria across all five fit methods
- The offset-unidentifiability section was corrected: it claimed `MPP` returned
  a negative `gamma` with a shape inflated by two orders of magnitude, which
  has not been true since #257 and #313, and contradicted the tolerances its own
  cited test file asserts

Known issue carried forward: left censoring combined with left truncation
(#308).

## Verification

Full suite on the `develop` tip: **2046 passed, 1 skipped, 5 xfailed**. Lint
clean. Docs build succeeds. `surpyval.__version__` and `pyproject.toml` both
report `0.18.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_