### PR TITLE
Reject degenerate data instead of dying inside numdifftools

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,51 @@
 Changelog
 =========
 
+v0.18.1 (unreleased)
+--------------------
+
+- **Degenerate data is rejected with an explanation instead of an
+  ``IndexError`` from inside numdifftools.** ``Weibull.fit`` on three
+  tied observations died four steps from the cause: a probability plot
+  has no slope through a single distinct abscissa, so ``polyfit``
+  returned a nan; the nan seeded the maximum likelihood fit, which
+  started at nan and produced a nan hessian; the numerical fallback then
+  asked numdifftools for one, and its list of finite-difference steps
+  came back empty. Neither truncation nor censoring was involved,
+  despite where the symptom was first seen.
+
+  ``Gamma`` and ``Beta`` failed the same way but in silence. Their
+  moment-based initialisers divide by a variance that is exactly zero
+  for tied data, giving ``(inf, inf)``, and since a failed optimiser
+  reports its initial guess (#261) those infinities were returned as a
+  fitted model.
+
+  Three changes. The probability-plot regression falls back to a unit
+  slope through the centroid when it is rank deficient -- zero slope
+  would be the more literal reading, but every ``unpack_rr`` divides by
+  the slope to recover a scale, so it only moves the nan one step later.
+  ``Gamma`` and ``Beta`` seed the exponential and uniform cases rather
+  than dividing by zero. And a fit now refuses to return a non-finite
+  parameter whatever produced it.
+
+  The fit is then rejected when the data cannot pin down the free
+  parameters: fewer distinct non-right-censored values than free
+  parameters means a flat -- for a Weibull on tied data, unbounded --
+  direction in the likelihood, and the answer would be wherever the
+  optimiser stopped. Three tied observations returned ``beta = 512``
+  with ``success=True`` and no warning once the nan was fixed.
+
+  The count is of *free* parameters, so fixing one buys back a degree
+  of freedom: ``Weibull.fit([10.], fixed={'beta': 2})`` is well posed
+  and now returns ``alpha = 10``, where before it raised. One-parameter
+  distributions are unaffected -- ``Exponential`` and ``Rayleigh`` fit
+  tied data exactly as they should. Probability plotting is exempt,
+  being a regression rather than a likelihood maximisation, and is how
+  several distributions seed themselves.
+
+  All 330 reference fits across thirteen distributions, five methods and
+  plain, right-censored and offset data are bit-identical.
+
 v0.18.0 (2 August 2026)
 -----------------------
 

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -623,3 +623,68 @@ def test_maximum_likelihood_attains_the_largest_likelihood():
     best = Weibull.fit(x, how="MLE").neg_ll()
     for how in ("MPS", "MSE", "MOM", "MPP"):
         assert Weibull.fit(x, how=how).neg_ll() >= best - 1e-9, how
+
+
+# -- degenerate data ----------------------------------------------------
+#
+# Fitting three tied observations used to die with an IndexError raised
+# from inside numdifftools, four steps removed from the cause. The
+# probability plot has no slope through a single distinct abscissa, so
+# polyfit returned a nan; that nan seeded the MLE, which started at nan,
+# produced a nan hessian, and finally asked numdifftools for a numerical
+# one, whose list of finite-difference steps came back empty.
+#
+# Gamma and Beta failed the same way but silently: their moment-based
+# initialisers divide by a variance that is zero for tied data, and a
+# failed optimiser returns its initial guess (#261), so (inf, inf) was
+# handed back as a fitted model.
+
+
+def test_degenerate_data_is_rejected_with_a_clear_error():
+    for dist in (Weibull, Gamma):
+        with pytest.raises(ValueError, match="free parameter"):
+            dist.fit(np.array([10.0, 10.0, 10.0]))
+    with pytest.raises(ValueError, match="free parameter"):
+        Beta.fit(np.array([0.2, 0.2, 0.2]))
+
+
+def test_fixing_a_parameter_buys_back_a_degree_of_freedom():
+    # The count is of *free* parameters, not of the distribution's, so a
+    # single observation is enough once beta is fixed. The MLE of alpha
+    # with beta known is (sum x**beta / n) ** (1 / beta) = 10.
+    model = Weibull.fit(np.array([10.0]), fixed={"beta": 2.0})
+    assert model.params[0] == pytest.approx(10.0, rel=1e-6)
+    assert model.params[1] == pytest.approx(2.0)
+
+    tied = Weibull.fit(np.array([10.0, 10.0, 10.0]), fixed={"beta": 2.0})
+    assert tied.params[0] == pytest.approx(10.0, rel=1e-6)
+
+
+def test_one_parameter_distributions_fit_tied_data():
+    # A tied sample identifies a single parameter perfectly well, so
+    # these must not be caught by the degeneracy check.
+    assert Exponential.fit(np.array([10.0] * 3)).params[0] == pytest.approx(
+        0.1
+    )
+    assert Rayleigh.fit(np.array([10.0] * 3)).params[0] == pytest.approx(
+        np.sqrt(50.0)
+    )
+
+
+def test_probability_plotting_survives_a_degenerate_regression():
+    # MPP is exempt from the degeneracy check: it is a regression, not a
+    # likelihood maximisation, and it is how several distributions seed
+    # themselves. It must return finite parameters rather than nan.
+    model = Weibull.fit(np.array([10.0, 10.0, 10.0]), how="MPP")
+    assert np.isfinite(np.asarray(model.params, dtype=float)).all()
+
+
+def test_a_fit_never_returns_non_finite_parameters():
+    # The backstop: whatever the cause, non-finite parameters are not a
+    # valid answer. Gamma used to return (inf, inf) here in silence.
+    for dist, x in (
+        (Weibull, np.array([10.0, 10.0, 10.0])),
+        (Gamma, np.array([10.0, 10.0, 10.0])),
+    ):
+        with pytest.raises(ValueError):
+            dist.fit(x)

--- a/surpyval/univariate/parametric/distributions/beta.py
+++ b/surpyval/univariate/parametric/distributions/beta.py
@@ -419,9 +419,21 @@ class Beta_(ParametricFitter):
         """
         mean = x.mean()
         var = x.var()
+        # Zero (or near zero) variance divides through to a shape pair of
+        # order 1e31 rather than an error, and since a failed optimiser
+        # falls back to its initial guess (#261) that pair is what gets
+        # returned to the caller. A tied sample says nothing about the
+        # shapes, so seed the uniform Beta and let the optimiser move if
+        # the data can move it.
+        if not np.isfinite(var) or var <= np.finfo(float).tiny:
+            return 1.0, 1.0
         term1 = (mean * (1 - mean) / var) - 1
         alpha = term1 * mean
         beta = term1 * (1 - mean)
+        if not (np.isfinite(alpha) and np.isfinite(beta)) or (
+            alpha <= 0 or beta <= 0
+        ):
+            return 1.0, 1.0
 
         return alpha, beta
 

--- a/surpyval/univariate/parametric/distributions/gamma.py
+++ b/surpyval/univariate/parametric/distributions/gamma.py
@@ -46,6 +46,15 @@ class Gamma_(ParametricFitter):
         to about 1.5% and used only as a starting point.
         """
         s = np.log(x.sum() / len(x)) - np.log(x).sum() / len(x)
+        # s is exactly zero for a tied sample -- the log of the mean and
+        # the mean of the logs coincide -- and alpha divides by it, so
+        # the seed comes back as (inf, inf). A failed optimiser falls
+        # back to its initial guess (#261), so those infinities are
+        # returned to the caller as the fitted parameters. Seed the
+        # exponential case instead: a tied sample carries no information
+        # about the shape.
+        if not np.isfinite(s) or s <= np.finfo(float).tiny:
+            return 1.0, len(x) / x.sum()
         alpha = (3 - s + np.sqrt((s - 3) ** 2 + 24 * s)) / (12 * s)
         beta = x.sum() / (len(x) * alpha)
         return alpha, 1.0 / beta

--- a/surpyval/univariate/parametric/fitters/mpp.py
+++ b/surpyval/univariate/parametric/fitters/mpp.py
@@ -7,6 +7,42 @@ from surpyval import np
 from surpyval.univariate.nonparametric import plotting_positions
 
 
+def _rr_fit(a, b):
+    """
+    Least-squares line of ``b`` on ``a``, guarding the degenerate case.
+
+    A probability plot needs at least two distinct abscissae to have a
+    slope. With fewer -- a single observation, or a sample whose values
+    are all tied -- ``polyfit`` is rank deficient and returns a nan
+    slope. That nan is not caught anywhere: it becomes the seed for the
+    maximum likelihood fit, which then starts at nan, produces a nan
+    hessian, and finally dies inside numdifftools with an ``IndexError``
+    from an empty list of finite difference steps. The cause is four
+    steps removed from the symptom.
+
+    The fallback is a unit slope through the centroid. A *zero* slope
+    would be the more literal reading of "no information", but every
+    ``unpack_rr`` divides by the slope to recover a scale -- Weibull
+    takes ``alpha = exp(-intercept / slope)`` -- so zero merely moves the
+    nan one step later. Unit slope keeps each distribution's own
+    ``unpack_rr`` in charge of turning the line into correctly typed
+    parameters, and lands on a usable seed: three tied observations at 10
+    give ``alpha = 11.2, beta = 1`` rather than ``nan``.
+    """
+    a = np.asarray(a, dtype=float)
+    b = np.asarray(b, dtype=float)
+    finite = np.isfinite(a) & np.isfinite(b)
+    if finite.sum() >= 2 and np.unique(a[finite]).size >= 2:
+        params = np.polyfit(a[finite], b[finite], 1)
+        if np.isfinite(params).all():
+            return params
+    if finite.any():
+        intercept = float(np.mean(b[finite]) - np.mean(a[finite]))
+    else:
+        intercept = 0.0
+    return np.array([1.0, intercept])
+
+
 def mpp_from_ecfd(dist, x, F):
     x_pp = copy(x)
     y_pp = copy(F)
@@ -18,7 +54,7 @@ def mpp_from_ecfd(dist, x, F):
     with np.errstate(all="ignore"):
         y_pp = dist.mpp_y_transform(y_pp)
         x_pp = dist.mpp_x_transform(x_pp)
-        params = np.polyfit(x_pp, y_pp, 1)
+        params = _rr_fit(x_pp, y_pp)
 
     params = np.array(dist.unpack_rr(params, "y"))
 
@@ -108,9 +144,9 @@ def mpp(model):
     x_pp = dist.mpp_x_transform(x_pp)
 
     if rr == "y":
-        params = np.polyfit(x_pp, y_pp, 1)
+        params = _rr_fit(x_pp, y_pp)
     elif rr == "x":
-        params = np.polyfit(y_pp, x_pp, 1)
+        params = _rr_fit(y_pp, x_pp)
 
     params = np.array(dist.unpack_rr(params, rr))
 

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -335,6 +335,58 @@ class ParametricFitter:
             moments[i] = self._moment(n, *params, offset=offset)
         return moments
 
+    def _check_identifiable(self, surv_data, offset, lfp, zi, fixed):
+        """
+        Reject data that cannot pin down the free parameters.
+
+        A right censored observation says only "later than this", so it
+        constrains a fitted curve without locating a point on it. What
+        locates a point is an exact observation, a left censored one, or
+        an interval. Fewer *distinct* such values than there are free
+        parameters and the likelihood has a flat direction: for a
+        Weibull on a tied sample it is unbounded, since a spike of
+        arbitrary height can sit on the repeated value, and the reported
+        answer is wherever the optimiser happened to stop. Three tied
+        observations at 10 returned ``beta = 512`` with ``success=True``
+        and no warning.
+
+        The count is of *free* parameters, not of the distribution's
+        parameters, so fixing one buys back a degree of freedom: a
+        Weibull fit to a single observation with ``beta`` fixed is well
+        posed and recovers ``alpha = (sum x^beta / n) ** (1 / beta)``.
+        That is why this cannot be a per-distribution constant.
+        """
+        n_free = (
+            self.k
+            + int(bool(offset))
+            + int(bool(lfp))
+            + int(bool(zi))
+            - len(fixed or {})
+        )
+        if n_free <= 0:
+            return
+
+        x, c = surv_data.x, surv_data.c
+        informative = np.asarray(c) != 1
+        if not informative.any():
+            return
+        rows = np.asarray(x)[informative]
+        if rows.ndim == 1:
+            distinct = np.unique(rows).size
+        else:
+            distinct = np.unique(rows, axis=0).shape[0]
+
+        if distinct < n_free:
+            raise ValueError(
+                f"{self.name} has {n_free} free parameter(s) but the data "
+                f"contains only {distinct} distinct non-right-censored "
+                f"value(s). The likelihood has a flat (or unbounded) "
+                f"direction, so no unique fit exists. Provide more "
+                f"distinct observations, fix a parameter with "
+                f"`fixed=`, or choose a distribution with fewer "
+                f"parameters."
+            )
+
     def _validate_fit_inputs(
         self,
         surv_data,
@@ -357,6 +409,15 @@ class ParametricFitter:
         if offset and not offsettable:
             detail = f"{self.name} distribution cannot be offset"
             raise ValueError(detail)
+
+        # Probability plotting is exempt. It is a regression through the
+        # plotting positions, not a likelihood maximisation, so it has no
+        # unbounded direction to fall into and now always returns finite
+        # parameters. It is also how several distributions seed
+        # themselves, and that internal call does not carry the caller's
+        # ``fixed``, so checking it would reject well posed fits.
+        if how != "MPP":
+            self._check_identifiable(surv_data, offset, lfp, zi, fixed)
 
         if fixed and how == "MPP":
             detail = (
@@ -1083,6 +1144,25 @@ class ParametricFitter:
 
         for k, v in results.items():
             setattr(model, k, v)
+
+        # A fit must never hand back a non-finite parameter. When the
+        # optimiser fails, the reported parameters are the initial guess
+        # (#261), so any initialiser that produced a nan or an inf had
+        # it laundered into what looked like a fitted model: an offset
+        # Gamma on a tied sample returned ``(inf, inf)`` in silence. The
+        # initialisers that could do that are fixed, but this is the
+        # backstop, since a non-finite parameter is never a valid answer
+        # whatever produced it.
+        _params = np.atleast_1d(np.asarray(model.params, dtype=float))
+        _extra = [getattr(model, name, None) for name in ("gamma", "p", "f0")]
+        _extra = [float(v) for v in _extra if v is not None]
+        if not (np.isfinite(_params).all() and np.isfinite(_extra).all()):
+            raise ValueError(
+                f"{self.name} fit produced non-finite parameters "
+                f"({np.asarray(model.params)}). The optimiser did not "
+                f"reach a valid solution; check the data for degenerate "
+                f"or extreme values."
+            )
 
         # Only maximum likelihood and the closed forms report a
         # log-likelihood, because only they compute one on the way to


### PR DESCRIPTION
## The bug

`Weibull.fit(np.array([10., 10., 10.]))` raised `IndexError: list index out of
range` from inside `numdifftools/finite_difference.py:591`. The cause was four
steps away:

1. a probability plot has no slope through a single distinct abscissa, so
   `polyfit` returns a **nan** (this is the long-standing `RankWarning: Polyfit
   may be poorly conditioned`)
2. that nan becomes the seed for the MLE, which starts at nan
3. the autograd hessian at nan is nan, so the code falls back to numdifftools
4. numdifftools evaluates its finite-difference steps, gets nan at every one,
   filters them all out, and indexes the resulting empty list

Neither truncation nor censoring is involved — this reproduces with plain
uncensored data — despite the symptom having first been noticed on a truncated
fit.

`Gamma` and `Beta` failed the same way but **silently**. Their moment-based
initialisers divide by a variance that is exactly zero for tied data, giving
`(inf, inf)`, and a failed optimiser reports its initial guess (#261) — so
those infinities were returned as a fitted model with no error at all.

## The fix

**Probability plotting** falls back to a unit slope through the centroid when
the regression is rank deficient. A *zero* slope is the more literal reading of
"no information", but every `unpack_rr` divides by the slope to recover a scale
(Weibull takes `alpha = exp(-intercept / slope)`), so zero merely relocates the
nan. Unit slope keeps each distribution's own `unpack_rr` in charge of
producing correctly typed parameters.

**Gamma and Beta** seed the exponential and uniform cases instead of dividing
by a zero variance.

**A fit refuses to return a non-finite parameter**, whatever produced it.

**Fixing the nan was not sufficient on its own.** With a finite seed the same
fit returned `beta = 512` with `success=True` and no warning — the optimiser
having walked part way along an unbounded direction before stopping. Silent
nonsense is worse than a loud crash, so a fit is now also rejected when the data
cannot pin down the free parameters: fewer distinct non-right-censored values
than free parameters means a flat, or here unbounded, direction in the
likelihood.

## Why the count is of *free* parameters

Because a per-distribution constant would be wrong. Fixing a parameter buys back
a degree of freedom:

```python
Weibull.fit(np.array([10.]), fixed={'beta': 2})   # was: IndexError
                                                   # now: alpha = 10
```

That is well posed — the MLE of `alpha` with `beta` known is
`(Σxᵝ/n)^(1/β) = 10` — and it now returns the exact closed form.

One-parameter distributions are untouched: `Exponential` and `Rayleigh` fit tied
data correctly (`0.1` and `√50`) and must not be caught.

Probability plotting is exempt. It is a regression rather than a likelihood
maximisation, so it has no unbounded direction, and it is how several
distributions seed themselves — that internal call does not carry the caller's
`fixed`, so checking it rejected well posed fits.

## Behaviour

| call | before | after |
|---|---|---|
| `Weibull.fit([10,10,10])` | `IndexError` | clear `ValueError` |
| `Weibull.fit([10.], fixed={'beta':2})` | `IndexError` | `alpha = 10` |
| `Gamma.fit([10,10,10])` | `(inf, inf)` silently | clear `ValueError` |
| `Beta.fit([.2,.2,.2])` | `[4.2e31, 1.7e32]` silently | clear `ValueError` |
| `Exponential.fit([10,10,10])` | `0.1` | `0.1` unchanged |
| `Rayleigh.fit([10,10,10])` | `7.071` | `7.071` unchanged |

## Verification

**330 reference fits bit-identical** — thirteen distributions × five methods ×
plain, right-censored and offset data, captured before the change and compared
after with zero tolerance.

Full suite **2051 passed, 1 skipped, 5 xfailed** (2046 before, plus 5 new
tests). `flake8`, `black` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_