### PR TITLE
Fix two autograd np.where traps: truncated fits and the parameter transform

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -74,9 +74,13 @@ jobs:
         # Invoked as ``python -m`` so the plugins resolve against the
         # interpreter the dependencies were installed into, rather than
         # whichever ``pytest`` happens to be first on PATH.
+        #
+        # ``--run-ml`` opts the beta survival tree and forest tests back
+        # in. They are skipped by default because they are 97 of the
+        # suite's 180 seconds locally, but deployment still tests them.
         run:
           python -m pytest -n auto --cov=surpyval --cov-report=
-          --ignore=surpyval/tests/alpha
+          --ignore=surpyval/tests/alpha --run-ml
 
       - name: coverage
         run: |

--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,13 @@ locally after touching a likelihood, an initialiser or an optimiser.
 
 Marks are applied by path so the test modules themselves stay free of
 suite-management boilerplate.
+
+This lives at the repository root rather than beside the tests because
+``pytest_addoption`` is only honoured in *initial* conftest files -- the
+rootdir's, and those in directories named as arguments. The CI
+invocation selects with ``--ignore`` and passes no path, so a conftest
+under ``surpyval/tests`` is loaded too late to register the flags and
+the run dies on "unrecognized arguments".
 """
 
 import pytest

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,10 +51,14 @@ v0.18.1 (unreleased)
 
   Fitted results are unchanged: all 330 reference fits across thirteen
   distributions and five methods are bit-identical, and BFGS now wins
-  every truncated fit where Nelder-Mead used to. Note that truncated
-  fits have had no working gradient until now, so the covariance matrix
-  and confidence bounds on truncated data came from a nan-poisoned
-  hessian path; whether those were degraded is not yet established.
+  every truncated fit where Nelder-Mead used to.
+
+  Confidence bounds were never affected. The covariance step already
+  recomputes a numerical hessian whenever the autograd one comes back
+  nan or asymmetric (#270), so it caught this on every truncated fit and
+  produced correct bounds by the slow route -- checked against
+  ``906f0cb~1``, where the standard errors are identical to eight
+  figures. That fallback was part of what made these fits slow.
 
 - **The slow parts of the test suite are opt in, and there is a new
   invariant sweep behind the same mechanism.** ``pytest`` alone now runs

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,33 @@ Changelog
 v0.18.1 (unreleased)
 --------------------
 
+- **The slow parts of the test suite are opt in, and there is a new
+  invariant sweep behind the same mechanism.** ``pytest`` alone now runs
+  in about two minutes rather than three: the beta survival tree and
+  forest tests were 97 of the suite's 180 seconds for 85 of its 2000-odd
+  tests. They run with ``--run-ml``, and continuous integration passes
+  the flag, so coverage is unchanged.
+
+  ``--run-invariants`` adds ``test_fit_invariants.py``, a wide net over
+  the fitting API. Every defect found in this release cycle slipped past
+  the whole suite, and each lived at an *intersection* of dimensions the
+  suite tests one at a time -- a censored observation that was also
+  truncated, an offset combined with a particular method, an offset
+  combined with a large shift magnitude, a sample below the 1000 floor
+  of ``FIT_SIZES``. The full cross of distributions, methods, censoring,
+  truncation, structural flags, sizes and scales is around 600,000
+  cells, so the sweep does not attempt it. It asserts cheap invariants
+  instead -- finite parameters, finite ``neg_ll``, a survival function
+  that stays in [0, 1] and never increases, and maximum likelihood
+  attaining the lowest negative log-likelihood of the five methods --
+  over a seeded sample of that space. Four of the five defects would
+  have failed the first two assertions.
+
+  Data *scale* is included as an axis because it was previously untested
+  anywhere, despite the maximum likelihood failure warning itself
+  advising users to rescale towards 1. 270 cases, three and a half
+  minutes.
+
 - **Maximum likelihood fits are about 2.2x faster.** Every MLE fit ran
   five optimisers -- Nelder-Mead, Powell, BFGS, TNC and Newton-CG -- and
   kept the best result. Over 102 fits across eleven distributions, five

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,96 @@ Changelog
 v0.18.1 (unreleased)
 --------------------
 
+- **Confidence bounds no longer turn silently to nan on data measured
+  in large units, and those fits are around 17x faster.** A Weibull fit
+  to the same lifetimes expressed in hours had standard errors; in
+  seconds it returned ``nan`` for every one of them, with no warning and
+  a perfectly good set of parameters alongside.
+
+  The cause is the ``np.where`` trap again, this time in the parameter
+  transform rather than a likelihood. Every parameter bounded on
+  ``(0, inf)`` is mapped to the unbounded space the optimiser searches
+  by ``adj_relu``, which chose between ``x + 1`` and ``exp(x)`` with
+  ``np.where``. Autograd evaluates both branches, so ``exp(x)`` was
+  taped even where ``x + 1`` was selected, and above ``x = 709.78`` it
+  overflows to inf. The inf then poisoned the derivative of the branch
+  that *was* chosen, so the jacobian of the transform came back nan --
+  and with it ``cov_matrix``, which is that jacobian either side of the
+  inverse hessian.
+
+  The threshold is a property of the fitted parameter, not of the sample
+  size or the conditioning, which is why it looked so arbitrary: a fit
+  died as soon as any ``(0, inf)`` parameter exceeded about 710. A
+  Weibull with ``alpha = 10`` lost its bounds once the data was scaled
+  past about 70x, while a Gumbel, whose location is unbounded and so
+  untransformed, survived to 350x on the same data. The Gamma failed at
+  the *small* end instead, its rate parameter growing as the data
+  shrinks. The Normal, LogNormal and Exponential were immune throughout
+  because they have closed-form estimators and never touch the
+  transform; the Uniform reports no covariance at any scale by design,
+  its MLE being an order statistic rather than a stationary point.
+
+  Clamping the dead branch's argument fixes it: the branch is
+  responsible only for ``x < 0``, so restricting what it may be handed
+  leaves its value and derivative untouched where it is used, and
+  bounded where it is not.
+
+  The hessian was never the problem -- the numerical fallback (#270)
+  produced a finite, well conditioned matrix at every scale -- which is
+  why this presented as nan bounds rather than as a warning or a
+  failure. It also explains the speed: the same nan reached the
+  objective's gradient, so BFGS, TNC and Newton-CG each gave up and
+  Nelder-Mead finished the fit derivative free. Across twelve
+  distributions at seven scales the sweep goes from 19.59s to 1.18s, and
+  every fit that used to end on Nelder-Mead now ends on BFGS.
+
+  Results that already worked are unchanged: 65 of 96 reference fits are
+  bit-identical, and the other 31 are the restorations, where the
+  objective agrees to fifteen significant figures and the parameters to
+  nine.
+
+  Restoring the gradient exposed a second, smaller scale problem
+  underneath, now fixed with it. scipy stops BFGS when
+  ``max|grad| < gtol``, and its default of 1e-5 is an absolute threshold
+  on a quantity that is not scale free: a log-likelihood's gradient
+  shrinks like ``1/theta``, so on data measured in tens of thousands the
+  test is met well short of the optimum and BFGS reports success on its
+  first check. This had been invisible because those fits used to end on
+  Nelder-Mead, which is derivative free and so kept going. Three
+  reference fits on real data of that magnitude landed 1e-2 away in
+  relative terms, at a likelihood 2e-3 below the answer they had been
+  recorded from.
+
+  ``gtol`` is now scaled by the gradient at the point the search starts,
+  which asks that the gradient fall by a fixed number of orders of
+  magnitude -- the same requirement at every scale. A fixed tighter
+  constant is not equivalent and does not work: 1e-8 fixes the large
+  fits but is unreachable for small samples, dropping an n=8 Weibull out
+  of BFGS and into TNC. At 1e-7 relative both ends converge on BFGS, the
+  large fits to 2e-8 and the small one to 4e-9.
+
+  With both in place the restored standard errors satisfy the
+  scale-equivariance law ``se(theta * c) = c * se(theta)`` to 1e-5 or
+  better across every distribution and scale tested, most to 1e-8, and
+  to machine precision for the Rayleigh and Normal.
+
+  Two consequences worth noting. Fits now converge slightly further than
+  before wherever BFGS wins, so a handful of pinned numbers moved in
+  their last few digits -- always towards a better likelihood. The two
+  Monte Carlo simulation tests in ``test_counting.py`` also had their
+  tolerance loosened from ``allclose``'s 1e-5 to 1e-3: they drive a
+  5000-run simulation from an optimiser's output, where a change in the
+  seventh significant figure of a parameter moves the simulated MCF in
+  the fourth. That is convergence noise, and what those tests exist to
+  catch would break far more loudly.
+
+  #323 is now rescoped. It had proposed internal rescaling to fix both
+  the bounds and the speed; neither needs it. Re-measured with the
+  gradient working, rescaling is between 4.2x faster and 6x *slower*
+  depending on the distribution, so the twelve per-distribution
+  back-transforms it would require are no longer obviously worth their
+  risk.
+
 - **A truncated fit is around 60x faster, and the truncation term is
   evaluated once per distinct window rather than once per row.** Any fit
   with a truncation bound on one side only had no usable gradient. The
@@ -65,7 +155,11 @@ v0.18.1 (unreleased)
   in about two minutes rather than three: the beta survival tree and
   forest tests were 97 of the suite's 180 seconds for 85 of its 2000-odd
   tests. They run with ``--run-ml``, and continuous integration passes
-  the flag, so coverage is unchanged.
+  the flag, so coverage is unchanged. The ``conftest.py`` that defines
+  the flags lives at the repository root: ``pytest_addoption`` is only
+  honoured in *initial* conftest files, and the CI invocation selects
+  with ``--ignore`` and names no path, so one under ``surpyval/tests``
+  would be loaded too late to register them.
 
   ``--run-invariants`` adds ``test_fit_invariants.py``, a wide net over
   the fitting API. Every defect found in this release cycle slipped past

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,58 @@ Changelog
 v0.18.1 (unreleased)
 --------------------
 
+- **A truncated fit is around 60x faster, and the truncation term is
+  evaluated once per distinct window rather than once per row.** Any fit
+  with a truncation bound on one side only had no usable gradient. The
+  window probability chose between the CDF and an analytic limit with
+  ``np.where``, which picks the right *value* but evaluates both
+  branches -- so ``ff(inf)`` was still recorded by autograd, and its nan
+  derivative propagated through the selection whichever side won.
+
+  Nothing warned. The objective was correct throughout; only the
+  gradient was nan. So BFGS and Newton-CG each gave up after a single
+  evaluation, TNC spent its whole 1000-evaluation budget discovering the
+  same thing, and Nelder-Mead finished the job derivative free. A
+  Weibull that fits in 0.014s took 1.36s, and a ``tl`` of 0 -- a no-op,
+  since ``F(0) = 0`` -- cost exactly as much as a real truncation, which
+  is what gives the cause away. Windows with *both* bounds finite were
+  always fast, because no infinity ever reached the tape.
+
+  The infinity is now substituted out of the *argument* before the CDF
+  sees it, so a single vectorised call covers every row whatever its
+  pattern of bounds, and the surviving ``np.where`` only ever chooses
+  between two values that are already finite. The stand-in cannot be an
+  arbitrary constant: zero looks natural and is wrong, because a Weibull
+  with ``beta < 1`` has an unbounded density derivative at the origin,
+  which would swap one nan gradient for another. Reusing a bound that is
+  genuinely present keeps it inside the support and at the data's own
+  magnitude; its value never reaches the result, only its derivative has
+  to be finite.
+
+  Separately, the truncation correction depends only on the observation
+  *window*, not on where in it the observation fell, so it is now
+  evaluated once per distinct window. Truncation is nearly always common
+  to a whole sample -- one burn-in time, one study entry date -- which
+  collapsed 360 CDF evaluations per likelihood call to one in the test
+  case, and the likelihood is called hundreds of times per fit.
+
+  ==============================  ==========  =========
+  fit                             before      after
+  ==============================  ==========  =========
+  plain                           0.014s      0.015s
+  left truncated                  1.398s      0.022s
+  ``tl = 0`` (a no-op)            1.362s      0.041s
+  right truncated                 1.344s      0.024s
+  both bounds finite              0.019s      0.025s
+  ==============================  ==========  =========
+
+  Fitted results are unchanged: all 330 reference fits across thirteen
+  distributions and five methods are bit-identical, and BFGS now wins
+  every truncated fit where Nelder-Mead used to. Note that truncated
+  fits have had no working gradient until now, so the covariance matrix
+  and confidence bounds on truncated data came from a nan-poisoned
+  hessian path; whether those were degraded is not yet established.
+
 - **The slow parts of the test suite are opt in, and there is a new
   invariant sweep behind the same mechanism.** ``pytest`` alone now runs
   in about two minutes rather than three: the beta survival tree and

--- a/surpyval/tests/conftest.py
+++ b/surpyval/tests/conftest.py
@@ -1,0 +1,67 @@
+"""Opt-in gating for the slow parts of the test suite.
+
+Two groups are skipped unless asked for, because both are expensive and
+neither guards a regression that the default run would miss quickly:
+
+``ml``
+    The beta-stage survival tree and forest tests. They fit hundreds of
+    small Weibulls per test and take 97 of the suite's ~180 seconds --
+    over half the runtime for 85 of its 2000-odd tests.
+
+``invariants``
+    The combinatorial fit-invariant sweep. It is a wide net rather than
+    a targeted regression test, so it belongs in a deliberate run rather
+    than in every edit-test cycle.
+
+Continuous integration passes both flags; see ``.github/workflows``. The
+default local run stays fast, which is the point.
+
+Marks are applied by path so the test modules themselves stay free of
+suite-management boilerplate.
+"""
+
+import pytest
+
+OPT_IN = {
+    "ml": (
+        "--run-ml",
+        "beta ML tree/forest tests",
+        "surpyval/tests/beta/ml",
+    ),
+    "invariants": (
+        "--run-invariants",
+        "combinatorial fit-invariant sweep",
+        "surpyval/tests/univariate/parametric/test_fit_invariants.py",
+    ),
+}
+
+
+def pytest_addoption(parser):
+    for _, (flag, description, _path) in OPT_IN.items():
+        parser.addoption(
+            flag,
+            action="store_true",
+            default=False,
+            help=f"run the {description} (skipped by default)",
+        )
+
+
+def pytest_configure(config):
+    for mark, (flag, description, _path) in OPT_IN.items():
+        config.addinivalue_line(
+            "markers", f"{mark}: {description}; opt in with {flag}"
+        )
+
+
+def pytest_collection_modifyitems(config, items):
+    for mark, (flag, description, path) in OPT_IN.items():
+        wanted = config.getoption(flag)
+        for item in items:
+            location = str(item.fspath).replace("\\", "/")
+            if path not in location:
+                continue
+            item.add_marker(getattr(pytest.mark, mark))
+            if not wanted:
+                item.add_marker(
+                    pytest.mark.skip(reason=f"needs {flag} ({description})")
+                )

--- a/surpyval/tests/conftest.py
+++ b/surpyval/tests/conftest.py
@@ -13,8 +13,12 @@ neither guards a regression that the default run would miss quickly:
     a targeted regression test, so it belongs in a deliberate run rather
     than in every edit-test cycle.
 
-Continuous integration passes both flags; see ``.github/workflows``. The
-default local run stays fast, which is the point.
+Continuous integration passes ``--run-ml`` only, so its coverage is
+unchanged. The invariant sweep is deliberately *not* run there: it is a
+net for exploring, cast deliberately when the fitting paths are being
+worked on, and three and a half minutes on every pull request across
+three Python versions buys little when its assertions hold. Run it
+locally after touching a likelihood, an initialiser or an optimiser.
 
 Marks are applied by path so the test modules themselves stay free of
 suite-management boilerplate.

--- a/surpyval/tests/recurrent/test_counting.py
+++ b/surpyval/tests/recurrent/test_counting.py
@@ -159,8 +159,16 @@ def test_count_terminated_simulation_via_mixin():
     model = GeneralizedOneRenewal.fit(x, dist=Weibull)
     np.random.seed(0)
     np_model = model.count_terminated_simulation(len(x), 5000)
-    expected = np.array([0.1696, 1.181, 2.287, 3.6696, 5.58237921, 8.54474127])
-    assert np.allclose(np_model.mcf(np.array([1, 2, 3, 4, 5, 6])), expected)
+    expected = np.array([0.1696, 1.181, 2.287, 3.6694, 5.58237925, 8.54474531])
+    # rtol here rather than allclose's 1e-5, because these numbers are a
+    # 5000-run simulation driven by an optimiser's output: a change in
+    # the fitted parameters at the seventh significant figure moves the
+    # simulated MCF in the fourth. That is convergence noise, not a
+    # change in behaviour. What this test is for -- that the shared
+    # mixin still drives the simulation -- would break far more loudly.
+    assert np.allclose(
+        np_model.mcf(np.array([1, 2, 3, 4, 5, 6])), expected, rtol=1e-3
+    )
 
 
 def test_count_terminated_simulation_data_is_recurrent_data():
@@ -277,8 +285,11 @@ def test_seed_none_defers_to_global_rng():
     got = model.count_terminated_simulation(len(x), 5000).mcf(
         np.array([1, 2, 3, 4, 5, 6])
     )
-    expected = np.array([0.1696, 1.181, 2.287, 3.6696, 5.58237921, 8.54474127])
-    assert np.allclose(got, expected)
+    expected = np.array([0.1696, 1.181, 2.287, 3.6694, 5.58237925, 8.54474531])
+    # See the note on rtol in test_count_terminated_simulation_via_mixin.
+    # What this test pins is that seed=None still defers to the global
+    # RNG, which a regression would break outright rather than subtly.
+    assert np.allclose(got, expected, rtol=1e-3)
 
 
 @pytest.mark.parametrize(

--- a/surpyval/tests/univariate/parametric/test_confidence_bounds.py
+++ b/surpyval/tests/univariate/parametric/test_confidence_bounds.py
@@ -525,3 +525,82 @@ def test_lr_bounds_respect_user_fixed_parameters():
     point = m.sf(t)
     assert np.all(band[:, 0] <= point + 1e-9)
     assert np.all(point <= band[:, 1] + 1e-9)
+
+
+# The unit a measurement happens to be recorded in must not decide
+# whether a fit has confidence bounds at all.
+#
+# Every parameter bounded on (0, inf) is mapped to the unbounded space
+# the optimiser searches by ``adj_relu``, which chose between ``x + 1``
+# and ``exp(x)`` with ``np.where``. Autograd evaluates both branches, so
+# ``exp(x)`` was taped even where ``x + 1`` was selected, and above
+# x = 709.78 it overflowed to inf -- poisoning the derivative of the
+# branch that *was* chosen. The transform's jacobian came back nan, and
+# ``cov_matrix`` is that jacobian either side of the inverse hessian.
+#
+# The threshold is a property of the fitted parameter, not the sample
+# size, so a Weibull with alpha = 10 lost its bounds once the data was
+# scaled past about 70x while a Gumbel, whose location is unbounded and
+# therefore untransformed, survived to 350x on the same sample.
+SCALE_SENSITIVE = [
+    ("Weibull", (10.0, 2.0)),
+    ("LogLogistic", (10.0, 3.0)),
+    ("ExpoWeibull", (10.0, 2.0, 1.5)),
+    ("Logistic", (10.0, 2.0)),
+    ("Gumbel", (10.0, 2.0)),
+    ("GumbelLEV", (10.0, 2.0)),
+    ("Rayleigh", (5.0,)),
+    ("Gamma", (3.0, 2.0)),
+]
+
+
+@pytest.mark.parametrize("name,params", SCALE_SENSITIVE)
+@pytest.mark.parametrize("scale", [1e-3, 1.0, 1e2, 1e4, 1e6])
+def test_standard_errors_survive_the_units_of_the_data(name, params, scale):
+    dist = getattr(surv, name)
+    np.random.seed(5)
+    x = np.asarray(dist.random(200, *params), dtype=float) * scale
+
+    model = dist.fit(x)
+    cov = model.cov_matrix
+
+    assert cov is not None, f"{name} at scale {scale:g} reported no covariance"
+    se = np.sqrt(np.diag(np.atleast_2d(np.asarray(cov, dtype=float))))
+    assert np.isfinite(se).all(), f"{name} at scale {scale:g} gave se {se}"
+    assert (se > 0).all(), f"{name} at scale {scale:g} gave se {se}"
+
+
+@pytest.mark.parametrize("name,params", SCALE_SENSITIVE)
+def test_standard_errors_are_scale_equivariant(name, params):
+    # A parameter that rescaling carries by a factor f has its standard
+    # error carried by the same f, whatever f happens to be: the data's
+    # units for a scale parameter, their reciprocal for a rate like the
+    # Gamma's, and 1 for a shape. That the restored numbers obey this is
+    # what distinguishes a real covariance from a merely finite one.
+    dist = getattr(surv, name)
+    scale = 1e4
+
+    np.random.seed(5)
+    sample = np.asarray(dist.random(200, *params), dtype=float)
+
+    base = dist.fit(sample)
+    scaled = dist.fit(sample * scale)
+
+    def se_of(model):
+        cov = np.atleast_2d(np.asarray(model.cov_matrix, dtype=float))
+        return np.sqrt(np.diag(cov))
+
+    se_base, se_scaled = se_of(base), se_of(scaled)
+    p_base = np.asarray(base.params, dtype=float)
+    p_scaled = np.asarray(scaled.params, dtype=float)
+
+    factor = np.abs(p_scaled / p_base)
+
+    # Whatever each parameter did under rescaling, it can only have been
+    # carried by the scale, by its reciprocal, or not at all.
+    allowed = np.array([scale, 1.0 / scale, 1.0])
+    assert (
+        np.isclose(factor[:, None], allowed, rtol=1e-3).any(axis=1).all()
+    ), f"{name} parameters moved by {factor}, which is none of {allowed}"
+
+    assert se_scaled == pytest.approx(se_base * factor, rel=1e-3)

--- a/surpyval/tests/univariate/parametric/test_fit_invariants.py
+++ b/surpyval/tests/univariate/parametric/test_fit_invariants.py
@@ -1,0 +1,287 @@
+"""A wide net over the fitting API, asserting only what must always hold.
+
+Every defect found in the v0.18.x round slipped past the whole suite, and
+each one lived at an *intersection* of dimensions the suite tests one at
+a time:
+
+- a censored observation that is also truncated (the likelihood was
+  unbounded, and returned garbage with ``success=True``)
+- an offset combined with a particular method (Gamma's moment
+  initialiser returned ``(inf, inf)``, which #261's fallback then
+  reported as the fit)
+- an offset combined with a large *shift magnitude* (54 of 120
+  ExpoWeibull fits returned ``nan``)
+- a sample smaller than the 1000 floor of ``FIT_SIZES`` (a rank
+  deficient probability plot seeded the optimiser with ``nan``)
+
+The full cross of distributions, methods, censoring, truncation,
+structural flags, sizes and scales is around 600,000 cells, so this does
+not attempt it. Instead it asserts cheap invariants -- finiteness,
+boundedness, monotonicity -- over a broad seeded sample of that space.
+Four of the five defects above would have failed the first two
+assertions here, without anyone having to guess where to look.
+
+Accuracy is deliberately not asserted. Recovery of known parameters is
+already covered by ``test_fit.py``; the point of this file is to catch
+answers that are not answers at all.
+
+Opt in with ``--run-invariants``.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval import (
+    Exponential,
+    ExpoWeibull,
+    Gamma,
+    Gumbel,
+    Logistic,
+    LogLogistic,
+    LogNormal,
+    Normal,
+    Rayleigh,
+    Weibull,
+)
+
+DISTS = [
+    Weibull,
+    Gamma,
+    LogNormal,
+    Normal,
+    Logistic,
+    LogLogistic,
+    Gumbel,
+    ExpoWeibull,
+    Exponential,
+    Rayleigh,
+]
+TRUE = {
+    "Weibull": (10.0, 2.0),
+    "Gamma": (3.0, 2.0),
+    "LogNormal": (2.0, 0.5),
+    "Normal": (10.0, 2.0),
+    "Logistic": (10.0, 2.0),
+    "LogLogistic": (10.0, 3.0),
+    "Gumbel": (10.0, 2.0),
+    "ExpoWeibull": (10.0, 2.0, 1.5),
+    "Exponential": (0.1,),
+    "Rayleigh": (5.0,),
+}
+POSITIVE_ONLY = {
+    "Weibull",
+    "Gamma",
+    "LogNormal",
+    "LogLogistic",
+    "ExpoWeibull",
+    "Exponential",
+    "Rayleigh",
+}
+
+METHODS = ["MLE", "MPS", "MSE", "MOM", "MPP"]
+SHAPES = ["plain", "right", "left", "interval", "tl", "tr", "right+tl"]
+# Scale is the least covered axis in the suite, and the MLE failure
+# warning itself advises rescaling towards 1 -- so exercise both ends.
+SCALES = [1e-3, 1.0, 1e3]
+# One representative size per cell. Sweeping sizes inside each cell
+# multiplied the run by three for almost no extra coverage -- the size
+# axis is exercised on its own in ``test_tiny_samples_never_return_junk``.
+N = 120
+TINY = [1, 2, 5, 40]
+
+
+def _make(dist, n, shape, scale, seed):
+    """Return (kwargs for fit) for one cell of the grid, or None to skip."""
+    rng = np.random.default_rng(seed)
+    np.random.seed(seed)
+    x = np.asarray(dist.random(n, *TRUE[dist.name]), dtype=float) * scale
+    if dist.name not in POSITIVE_ONLY:
+        pass
+    c = np.zeros(n, dtype=int)
+    kw = {}
+    if shape == "right":
+        cut = np.quantile(x, 0.75)
+        c = np.where(x > cut, 1, 0)
+        x = np.minimum(x, cut)
+    elif shape == "left":
+        cut = np.quantile(x, 0.25)
+        c = np.where(x < cut, -1, 0)
+        x = np.maximum(x, cut)
+    elif shape == "interval":
+        counts, edges = np.histogram(x, bins=max(3, n // 4))
+        keep = counts > 0
+        xi = np.vstack([edges[:-1], edges[1:]]).T[keep]
+        return dict(x=xi, n=counts[keep])
+    elif shape == "tl":
+        lo = float(np.quantile(x, 0.10))
+        x = x[x > lo]
+        if x.size < 3:
+            return None
+        c = np.zeros(x.size, dtype=int)
+        kw["tl"] = lo
+    elif shape == "tr":
+        hi = float(np.quantile(x, 0.90))
+        x = x[x < hi]
+        if x.size < 3:
+            return None
+        c = np.zeros(x.size, dtype=int)
+        kw["tr"] = hi
+    elif shape == "right+tl":
+        # The combination that #310/#311 was about: an observation that
+        # is both censored and truncated.
+        lo = float(np.quantile(x, 0.10))
+        x = x[x > lo]
+        if x.size < 4:
+            return None
+        cut = float(np.quantile(x, 0.75))
+        c = np.where(x > cut, 1, 0)
+        x = np.minimum(x, cut)
+        kw["tl"] = lo
+    _ = rng
+    return dict(x=x, c=c, **kw)
+
+
+def _fit_or_reason(dist, how, kwargs, **extra):
+    """Fit, returning (model, None) or (None, exception).
+
+    A raised exception is not a failure here. Several combinations are
+    legitimately rejected -- a distribution that cannot be offset, data
+    that cannot identify the free parameters, a method that does not
+    support left censoring. What must never happen is a *returned* model
+    that is not a model.
+    """
+    try:
+        return dist.fit(how=how, **kwargs, **extra), None
+    except Exception as exc:  # noqa: BLE001 - any rejection is acceptable
+        return None, exc
+
+
+def _assert_model_is_usable(model, label):
+    params = np.atleast_1d(np.asarray(model.params, dtype=float))
+    assert np.isfinite(params).all(), f"{label}: non-finite params {params}"
+
+    for name in ("gamma", "p", "f0"):
+        value = getattr(model, name, None)
+        if value is not None:
+            assert np.isfinite(float(value)), f"{label}: {name}={value}"
+
+    nll = float(model.neg_ll())
+    assert np.isfinite(nll), f"{label}: neg_ll={nll}"
+
+
+def _assert_survival_is_a_survival_function(model, label):
+    lo, hi = model.dist.support
+    probe = np.asarray(model.surv_data.x, dtype=float)
+    probe = probe[np.isfinite(probe)]
+    if probe.size == 0:
+        return
+    grid = np.quantile(np.ravel(probe), np.linspace(0.05, 0.95, 12))
+    grid = np.clip(grid, max(lo, -1e300), min(hi, 1e300))
+    with np.errstate(all="ignore"):
+        sf = np.asarray(model.sf(grid), dtype=float)
+    assert np.isfinite(sf).all(), f"{label}: non-finite sf {sf}"
+    inside = ((sf >= -1e-9) & (sf <= 1 + 1e-9)).all()
+    assert inside, f"{label}: sf outside [0, 1]"
+    assert np.all(np.diff(sf) <= 1e-9), f"{label}: sf not non-increasing"
+
+
+@pytest.mark.parametrize("dist", DISTS, ids=lambda d: d.name)
+@pytest.mark.parametrize("shape", SHAPES)
+@pytest.mark.parametrize("scale", SCALES, ids=lambda s: f"scale{s:g}")
+def test_a_returned_fit_is_always_a_usable_model(dist, shape, scale):
+    """Finite parameters, finite neg_ll, and a valid survival function.
+
+    This is the assertion that four of the five v0.18.x defects would
+    have tripped.
+    """
+    for how in METHODS:
+        kwargs = _make(dist, N, shape, scale, seed=N + len(shape))
+        if kwargs is None:
+            continue
+        label = f"{dist.name}|{how}|{shape}|scale={scale:g}|n={N}"
+        model, exc = _fit_or_reason(dist, how, kwargs)
+        if model is None:
+            continue  # a refusal is a valid outcome; a bad model is not
+        _assert_model_is_usable(model, label)
+        _assert_survival_is_a_survival_function(model, label)
+
+
+@pytest.mark.parametrize("dist", DISTS, ids=lambda d: d.name)
+@pytest.mark.parametrize("n", TINY)
+def test_tiny_samples_never_return_junk(dist, n):
+    """Below the 1000 floor of ``FIT_SIZES``, where the crashes were.
+
+    A refusal is fine -- one or two points cannot identify two free
+    parameters, and the fitter now says so. What must not happen is a
+    returned model carrying nan or inf, which is what Gamma and Beta
+    used to do here.
+    """
+    for how in METHODS:
+        kwargs = _make(dist, n, "plain", 1.0, seed=n)
+        if kwargs is None:
+            continue
+        model, _ = _fit_or_reason(dist, how, kwargs)
+        if model is None:
+            continue
+        _assert_model_is_usable(model, f"{dist.name}|{how}|n={n}")
+
+
+@pytest.mark.parametrize("dist", DISTS, ids=lambda d: d.name)
+def test_structural_flags_pairwise(dist):
+    """Offset, lfp, zi and fixed, alone and in pairs.
+
+    The suite exercises these almost exclusively on their own -- only a
+    handful of places combine two. Pairwise is where interaction bugs
+    live, and it is a small fraction of the full cross.
+    """
+    combos = [
+        {"offset": True},
+        {"lfp": True},
+        {"zi": True},
+        {"offset": True, "lfp": True},
+        {"offset": True, "zi": True},
+        {"lfp": True, "zi": True},
+    ]
+    if dist.k >= 2:
+        first = dist.param_names[0]
+        combos.append({"fixed": {first: float(TRUE[dist.name][0])}})
+        combos.append(
+            {"offset": True, "fixed": {first: float(TRUE[dist.name][0])}}
+        )
+    for extra in combos:
+        for shape in ("plain", "right"):
+            kwargs = _make(dist, 200, shape, 1.0, seed=7)
+            if kwargs is None:
+                continue
+            label = f"{dist.name}|{shape}|{extra}"
+            model, exc = _fit_or_reason(dist, "MLE", kwargs, **extra)
+            if model is None:
+                continue
+            _assert_model_is_usable(model, label)
+
+
+@pytest.mark.parametrize("dist", DISTS, ids=lambda d: d.name)
+def test_mle_attains_the_lowest_negative_log_likelihood(dist):
+    """The defining property of the estimator, checkable since #316.
+
+    Maximum likelihood minimises the negative log-likelihood, so no other
+    method may beat it on its own objective. A tolerance is allowed
+    because the others stop on different criteria, but a real defeat
+    means the MLE did not converge.
+    """
+    np.random.seed(3)
+    x = np.asarray(dist.random(500, *TRUE[dist.name]), dtype=float)
+    mle, exc = _fit_or_reason(dist, "MLE", dict(x=x))
+    if mle is None:
+        pytest.skip(f"{dist.name}: MLE unavailable ({exc})")
+    best = float(mle.neg_ll())
+    for how in ("MPS", "MSE", "MOM", "MPP"):
+        other, _ = _fit_or_reason(dist, how, dict(x=x))
+        if other is None:
+            continue
+        rival = float(other.neg_ll())
+        if not np.isfinite(rival):
+            continue
+        assert rival >= best - 1e-6 * max(
+            abs(best), 1.0
+        ), f"{dist.name}: {how} reached {rival} against MLE's {best}"

--- a/surpyval/univariate/parametric/fitters/__init__.py
+++ b/surpyval/univariate/parametric/fitters/__init__.py
@@ -56,16 +56,34 @@ def fallback_minimize(fun, init, args, jac, hess, newton_tol=None):
     return res
 
 
+def _dead_branch_safe_exp(x):
+    """``exp(x)`` for the ``x < 0`` half, with the other half clamped.
+
+    ``np.where`` picks the right value but autograd evaluates *both*
+    branches, so ``exp(x)`` is taped even where ``x + 1`` is the one
+    selected. Above x = 709.78 that overflows to inf, and the inf then
+    poisons the derivative of the branch that *was* selected, turning
+    the parameter transform's jacobian -- and with it every confidence
+    bound -- into nan.
+
+    Clamping the argument to the half this branch is responsible for
+    leaves it untouched where it is used and bounded where it is not.
+    """
+    return np.exp(np.minimum(x, 0.0))
+
+
 def adj_relu(x):
-    return np.where(x >= 0, x + 1, np.exp(x))
+    return np.where(x >= 0, x + 1, _dead_branch_safe_exp(x))
 
 
 def inv_adj_relu(x):
+    # No clamp needed here, unlike ``adj_relu``: this dead branch is
+    # ``x >= 1``, which is precisely where ``log`` is best behaved.
     return np.where(x >= 1, x - 1, np.log(x))
 
 
 def rev_adj_relu(x):
-    return -np.where(x >= 0, x + 1, np.exp(x))
+    return -np.where(x >= 0, x + 1, _dead_branch_safe_exp(x))
 
 
 def inv_rev_adj_relu(x):

--- a/surpyval/univariate/parametric/fitters/mle.py
+++ b/surpyval/univariate/parametric/fitters/mle.py
@@ -109,12 +109,45 @@ def mle(model):
         # motivated the original order survives for the fits that
         # actually need it -- they are simply no longer paid for by the
         # fits that do not.
+        # scipy stops BFGS when max|grad| < gtol, and its default of 1e-5
+        # is an absolute threshold on a quantity that is not scale free.
+        # A log-likelihood's gradient shrinks like 1/theta, so on data
+        # measured in tens of thousands the test is met well short of
+        # the optimum and BFGS reports success on its first check --
+        # three reference fits on real data of that magnitude landed
+        # 1e-2 away in relative terms, at a likelihood 2e-3 below the
+        # answer they were recorded from. It had been invisible only
+        # because those fits used to end on Nelder-Mead, which is
+        # derivative free and so kept going (#323).
+        #
+        # Scaling the threshold by the gradient where the search starts
+        # asks instead that the gradient fall by a fixed number of
+        # orders of magnitude, which means the same thing at every
+        # scale. A fixed tighter constant does not: 1e-8 fixes the large
+        # fits but is unreachable for small samples, dropping an n=8
+        # Weibull out of BFGS and into TNC. At 1e-7 relative both ends
+        # converge on BFGS -- the large fits to 2e-8 and the small one
+        # to 4e-9.
+        gtol_rel = 1e-7
+
+        def bfgs_gtol(x0):
+            g0 = np.max(
+                np.abs(jac(np.asarray(x0, dtype=float), offset, lfp, zi, True))
+            )
+            if not np.isfinite(g0) or g0 <= 0:
+                return None
+            return max(gtol_rel * float(g0), 1e-12)
+
         for method, jac_i, hess_i in methods:
             opts = {"maxfun": 1000} if method == "TNC" else {"maxiter": 1000}
             if method in ("Nelder-Mead", "Powell") or best_result is None:
                 x0 = init
             else:
                 x0 = best_result.x
+            if method == "BFGS":
+                gtol = bfgs_gtol(x0)
+                if gtol is not None:
+                    opts["gtol"] = gtol
             res = minimize(
                 fun,
                 x0,

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -214,23 +214,69 @@ class ParametricFitter:
 
     @_check_x_not_empty
     def ll_interval_or_truncated(self, xl, xr, n, *params):
+        """
+        Log probability of falling inside each window ``(xl, xr]``.
+
+        An infinite bound is replaced by its analytic limit rather than
+        handed to the CDF. ``np.where`` selects the *value* correctly but
+        evaluates both branches, so ``ff(inf)`` was still taped by
+        autograd, and its nan derivative then propagated through the
+        selection regardless of which side was chosen. The objective was
+        right and the gradient was nan.
+
+        The consequence was not subtle. Every singly-truncated fit lost
+        all three gradient optimisers -- BFGS and Newton-CG each failed
+        after a single evaluation and TNC burned its whole 1000
+        evaluation budget -- leaving Nelder-Mead to finish derivative
+        free. A Weibull that fits in 0.014s took 1.36s, and a ``tl`` of 0
+        (a no-op, since ``F(0) = 0``) cost exactly the same as a real
+        truncation, which is what gives the cause away. Windows with
+        *both* bounds finite were always fast, because no infinity ever
+        reached the tape.
+
+        The infinity is substituted out of the *argument* before the CDF
+        sees it, so a single vectorised call covers every row whatever
+        its pattern of bounds. The outer ``np.where`` then selects
+        between two values that are both already finite, which is safe.
+
+        The stand-in cannot be an arbitrary constant. Zero looks natural
+        and is wrong: a Weibull with ``beta < 1`` has an unbounded
+        density derivative at the origin, so ``ff(0)`` would swap one nan
+        gradient for another. Reusing a bound that is genuinely present
+        keeps the stand-in inside the support and at the data's own
+        magnitude. Its value never reaches the result -- ``np.where``
+        discards it -- only its derivative has to be finite.
+
+        Probabilities come from the mixture CDF
+        ``F_mix(t) = f0 + (p - f0) * F0(t)``: with no right bound the
+        window probability is the mixture survival ``1 - F_mix(tl)``,
+        which includes the never-failing mass ``1 - p``. The old
+        ``(p - f0) * (1 - F0(tl))`` form made the LFP plus
+        left-truncation likelihood unbounded (#269). For finite-bound
+        intervals the ``f0`` terms cancel, so plain fits are unchanged.
+        """
         *params, gamma, f0, p = params
-        xr = xr - gamma
-        xl = xl - gamma
-        # Probabilities must come from the mixture CDF
-        # F_mix(t) = f0 + (p - f0) * F0(t), not (p - f0) * F0(t): with no
-        # right bound (tr = inf) the window probability is the mixture
-        # survival 1 - F_mix(tl), which includes the never-failing mass
-        # (1 - p). The old (p - f0) * (1 - F0(tl)) form made the LFP +
-        # left-truncation likelihood unbounded (#269). For finite-bound
-        # intervals the f0 terms cancel, so plain fits are unchanged.
-        right = np.where(
-            np.isfinite(xr), f0 + (p - f0) * self.ff(xr, *params), 1.0
+        if len(n) == 0:
+            return 0.0
+
+        lo_finite = np.isfinite(xl)
+        hi_finite = np.isfinite(xr)
+
+        # ``xl`` and ``xr`` are data, never traced, so this substitution
+        # is invisible to autograd -- it only changes what the CDF is
+        # asked to evaluate.
+        present = np.concatenate([xl[lo_finite], xr[hi_finite]])
+        stand_in = float(present[0]) if present.size else 1.0
+        xl_safe = np.where(lo_finite, xl, stand_in)
+        xr_safe = np.where(hi_finite, xr, stand_in)
+
+        upper = np.where(
+            hi_finite, f0 + (p - f0) * self.ff(xr_safe - gamma, *params), 1.0
         )
-        left = np.where(
-            np.isfinite(xl), f0 + (p - f0) * self.ff(xl, *params), 0.0
+        lower = np.where(
+            lo_finite, f0 + (p - f0) * self.ff(xl_safe - gamma, *params), 0.0
         )
-        return np.sum(n * np.log(np.maximum(right - left, 0.0)))
+        return np.sum(n * np.log(np.maximum(upper - lower, 0.0)))
 
     def _log_likelihood(self, data, *params):
         return (
@@ -241,7 +287,7 @@ class ParametricFitter:
                 data.x_il, data.x_ir, data.n_i, *params
             )
             - self.ll_interval_or_truncated(
-                data.x_tl, data.x_tr, data.n_t, *params
+                data.tl_unique, data.tr_unique, data.n_t_unique, *params
             )
         )
 

--- a/surpyval/utils/surpyval_data.py
+++ b/surpyval/utils/surpyval_data.py
@@ -228,6 +228,24 @@ class SurpyvalData:
             self.n[self.truncated_mask],
         )
 
+        # The truncation correction depends only on the observation
+        # *window*, not on where in it the observation fell, so it needs
+        # evaluating once per distinct window rather than once per row.
+        # Truncation is nearly always common to the whole sample -- a
+        # single burn-in time, one study entry date -- so this typically
+        # collapses hundreds of CDF evaluations per likelihood call into
+        # one, and the likelihood is called hundreds of times per fit.
+        if self.x_tl.size:
+            windows = np.column_stack([self.x_tl, self.x_tr])
+            unique, inverse = np.unique(windows, axis=0, return_inverse=True)
+            self.tl_unique = unique[:, 0]
+            self.tr_unique = unique[:, 1]
+            self.n_t_unique = np.bincount(inverse.ravel(), weights=self.n_t)
+        else:
+            self.tl_unique = np.array([])
+            self.tr_unique = np.array([])
+            self.n_t_unique = np.array([])
+
     def to_xrd(self, estimator="Nelson-Aalen") -> tuple:
         """
         Converts the data into the xrd format. If the data has right truncated


### PR DESCRIPTION
Two defects with the same shape, plus the test-suite gating that found them.

`np.where` picks the right *value*, but autograd evaluates **both** branches. Where the unselected branch produces an `inf` or a `nan`, that poisons the derivative of the branch that was actually chosen. Both bugs below are that, in different places, and both were silent: correct parameters, no warning, and a fit that merely looked slow.

## Truncated fits have a working gradient (~60x)

The window probability chose between the CDF and an analytic limit with `np.where`, so `ff(inf)` was still taped on any fit truncated on one side only. The objective was right throughout; only the gradient was `nan`. BFGS and Newton-CG each gave up after one evaluation, TNC burned its full 1000-evaluation budget, and Nelder-Mead finished derivative free.

The tell was that `tl = 0` — a no-op, since `F(0) = 0` — cost exactly as much as a real truncation, while windows with *both* bounds finite were always fast.

| fit | before | after |
|---|---|---|
| plain | 0.014s | 0.015s |
| left truncated | 1.398s | 0.022s |
| `tl = 0` (a no-op) | 1.362s | 0.041s |
| right truncated | 1.344s | 0.024s |
| both bounds finite | 0.019s | 0.025s |

The infinity is now substituted out of the *argument* before the CDF sees it, so one vectorised call covers every row whatever its pattern of bounds. The stand-in cannot be arbitrary: zero looks natural and is wrong, because a Weibull with `beta < 1` has an unbounded density derivative at the origin, which trades one `nan` gradient for another. Reusing a bound that is genuinely present keeps it inside the support and at the data's own magnitude.

Separately, the truncation correction depends only on the observation *window*, not on where in it the observation fell, so it is evaluated once per distinct window — 360 CDF evaluations collapsed to one in the test case, on a likelihood called hundreds of times per fit.

All 330 reference fits across thirteen distributions and five methods are bit-identical.

## Confidence bounds survive data measured in large units (~17x)

Every parameter bounded on `(0, inf)` reaches the optimiser through `adj_relu`, which chose between `x + 1` and `exp(x)`. Above `x = 709.78` the unselected `exp` overflows, and the resulting `nan` jacobian is exactly what `cov_matrix` is built from. A Weibull fit to lifetimes in hours had standard errors; the same lifetimes in seconds returned `nan` for every one.

The threshold is a property of the fitted parameter, not the sample size or the conditioning, which is why it looked arbitrary. A fit died as soon as any `(0, inf)` parameter passed ~710, and that predicts every distribution:

| distribution | first bad scale | why |
|---|---|---|
| Weibull, LogLogistic, ExpoWeibull | 100 | `alpha` ≈ 10·s |
| Rayleigh | 1000 | `sigma` ≈ 5·s |
| Logistic, Gumbel, GumbelLEV | 1000 | location is unbounded, so only `sigma` transforms |
| Gamma | 0.001 | fails at the *small* end; its rate grows as data shrinks |
| Normal, LogNormal, Exponential | never | closed-form, never touch the transform |
| Uniform | n/a | no covariance at any scale by design (order-statistic MLE) |

The hessian was never at fault — the numerical fallback (#270) returned a finite, well conditioned matrix at every scale, condition number 1.0 for the Rayleigh at 1e6 — which is why this surfaced as silent `nan` rather than a failure. The same `nan` reaching the objective's gradient is also what made these fits slow: twelve distributions at seven scales go from 19.59s to 1.18s.

Restoring the gradient exposed a second problem underneath. scipy stops BFGS on `max|grad| < gtol`, and the default 1e-5 is an *absolute* threshold on a quantity that is not scale free: a log-likelihood's gradient shrinks like `1/theta`. On data in the tens of thousands the test is met well short of the optimum — invisible while those fits ended on Nelder-Mead, which kept going. Three reference fits landed 1e-2 away at a likelihood 2e-3 *below* the answer they had been recorded from. `gtol` is now scaled by the gradient where the search starts. A fixed tighter constant is not equivalent: 1e-8 fixes the large fits but is unreachable for small samples, dropping an n=8 Weibull into TNC.

65 of 96 reference fits are bit-identical; the other 31 are the restorations, agreeing on the objective to fifteen significant figures. Restored standard errors satisfy `se(theta * c) = c * se(theta)` to 1e-5 or better everywhere tested, most to 1e-8.

## Test suite gating and a fit-invariant sweep

`pytest` alone runs in ~1m36 rather than ~3m: the beta tree and forest tests were 97 of 180 seconds for 85 of 2000-odd tests. They run under `--run-ml`, which CI passes, so coverage is unchanged.

`--run-invariants` adds `test_fit_invariants.py`, deliberately *not* run in CI. Every defect found this cycle slipped past the whole suite, and each lived at an *intersection* of dimensions the suite tests one at a time. The full cross is ~600,000 cells, so the sweep asserts cheap invariants over a seeded sample instead — finite parameters, finite `neg_ll`, an SF in [0, 1] that never increases, and MLE attaining the lowest negative log-likelihood of the five methods. Four of the five defects would have failed the first two assertions. Data scale is an axis because nothing tested it before, which is how the transform bug surfaced.

## Things to look at rather than take on trust

- `conftest.py` sits at the repository root, not beside the tests. `pytest_addoption` is only honoured in *initial* conftest files, and the CI invocation selects with `--ignore` and names no path — under `surpyval/tests` the flags were never registered and CI would have died on `unrecognized arguments: --run-ml`. That bug was introduced and fixed within this branch.
- Two Monte Carlo tests in `test_counting.py` are loosened from `allclose`'s 1e-5 to `rtol=1e-3`. They drive a 5000-run simulation from an optimiser's output, where a seventh-significant-figure parameter change moves the MCF in the fourth. The new fit is better (`res.fun` −5.235176588780 vs −5.235176588566), but this is a tolerance change, not just a number change.
- The suite is ~7s *slower* (91.5s → 98.5s, ±4s noise). About 3s is the 48 new regression tests; the rest is the tighter convergence. These changes are correctness at scale, not suite speed.

## #323 rescoped, not closed

It had proposed internal rescaling to fix both the `nan` bounds and the speed. Neither needs it. Its 50–160x speedup table was measuring the broken gradient; re-measured, rescaling is between 4.2x faster and 6x *slower* depending on the distribution. The issue is now "convergence criteria are absolute where they should be relative", with the cheap relative criterion recommended and full rescaling demoted.

## Verification

2099 passed, 271 skipped, 5 xfailed with `--run-ml`. flake8, black and mypy clean on every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_