### PR TITLE
Correct an overstated claim about scale-equivariant standard errors

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -65,17 +65,32 @@ v0.18.1 (unreleased)
   recorded from.
 
   ``gtol`` is now scaled by the gradient at the point the search starts,
-  which asks that the gradient fall by a fixed number of orders of
-  magnitude -- the same requirement at every scale. A fixed tighter
-  constant is not equivalent and does not work: 1e-8 fixes the large
-  fits but is unreachable for small samples, dropping an n=8 Weibull out
-  of BFGS and into TNC. At 1e-7 relative both ends converge on BFGS, the
-  large fits to 2e-8 and the small one to 4e-9.
+  at 1e-7 relative. A fixed tighter constant does not work: 1e-8 fixes
+  the large fits but is unreachable for small samples, dropping an n=8
+  Weibull out of BFGS and into TNC, where it lands 5e-5 away. At 1e-7
+  relative both ends converge on BFGS, the large fits to 2e-8 and the
+  small one to 4e-9.
 
   With both in place the restored standard errors satisfy the
-  scale-equivariance law ``se(theta * c) = c * se(theta)`` to 1e-5 or
-  better across every distribution and scale tested, most to 1e-8, and
-  to machine precision for the Rayleigh and Normal.
+  scale-equivariance law ``se(theta * c) = c * se(theta)`` to 1e-9 or
+  better up to data scale 1e4, and to machine precision for the Rayleigh
+  and Normal. At 1e6 most distributions hold to 1e-6 or better; the
+  Weibull is an outlier at around 1e-3.
+
+  That outlier is worth stating plainly, because it marks the limit of
+  what a tolerance constant can do. Scaling ``gtol`` by the gradient at
+  the initial guess does *not* make the criterion scale free the way it
+  first appears to: the initialiser scales with the data too, so the
+  gradient at the starting point is itself roughly scale invariant and
+  the resulting threshold barely moves. There is no constant that serves
+  every case -- 1e-8 relative fixes the Weibull at 1e6 but breaks the
+  n=8 fit, and 1e-9 breaks both small fits by pushing them to TNC. 1e-7
+  is the setting where everything the test suite covers passes.
+
+  So this is a better tolerance, not a scale-free one. Solving a
+  well-scaled problem, where a single absolute tolerance means the same
+  thing everywhere, is the actual fix; the measurements above are
+  recorded in #323 as the case for it.
 
   Two consequences worth noting. Fits now converge slightly further than
   before wherever BFGS wins, so a handful of pinned numbers moved in
@@ -92,7 +107,10 @@ v0.18.1 (unreleased)
   gradient working, rescaling is between 4.2x faster and 6x *slower*
   depending on the distribution, so the twelve per-distribution
   back-transforms it would require are no longer obviously worth their
-  risk.
+  risk. What remains there is the convergence criterion, and the
+  cheapest form of it is preconditioning the optimiser's search alone --
+  no back-transforms, because nothing outside the optimiser ever sees
+  scaled units.
 
 - **A truncated fit is around 60x faster, and the truncation term is
   evaluated once per distinct window rather than once per row.** Any fit


### PR DESCRIPTION
Docs only. #324 shipped a changelog claim that does not hold for the code it shipped with.

## The error

The changelog said the restored standard errors satisfy `se(theta * c) = c * se(theta)` "to 1e-5 or better across every distribution and scale tested". That was measured against a fixed `gtol = 1e-8`, which I then replaced with a relative criterion without re-running the sweep. Re-measured against what actually merged, the Weibull at data scale 1e6 sits at around **1e-3**.

Everywhere else the truth is *better* than what was claimed — 1e-9 or better up to scale 1e4, several distributions at 1e-11, machine precision for the Rayleigh and Normal. The old wording was wrong in both directions at once, and it hid the one case that matters.

## Why the outlier is the interesting part

Scaling `gtol` by the gradient at the initial guess does not make the criterion scale free the way it appears to. The initialiser scales with the data too, so the gradient at the starting point is itself roughly scale invariant — a Weibull at scale 1, 1e4 and 1e6 all come out with `gtol = 1.86e-6`. It bought a better constant, not scale independence.

Nor is there a constant that serves every case:

| `gtol_rel` | `test_real_data` (3 fits, ~7.6e4) | n=8 Weibull | Weibull @ 1e6 |
|---|---|---|---|
| **1e-7** (shipped) | pass, all BFGS | 4.3e-9, BFGS | **1.6e-3 off** |
| 1e-8 | pass, all BFGS | **5.2e-5, drops to TNC** | 3.2e-10 ok |
| 1e-9 | **pass but drops to TNC** | **5.2e-5, TNC** | 2.0e-8 ok |

1e-7 is simply where everything the suite covers passes. No code change here — that value stands.

## Consequence for #323

Rescoped again, and narrowed rather than widened: **precondition the optimiser's search, not the reported model.** Rescale inside `mle.py` only, so parameters and covariance stay in native units and a single absolute tolerance means the same thing at every scale.

That is materially cheaper than the original proposal — no per-distribution back-transforms, no knowing which parameter is a scale and which a shape, no `LogNormal` special case. Those twelve pieces of knowledge were the risky part, and preconditioning needs none of them.

Also flagged there: `fallback_minimize` in `fitters/__init__.py` serves MSE, MPS and MOM and still uses scipy's defaults throughout. #324 only touched the MLE ladder, so it is not known whether the same problem reaches those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_