### PR TITLE
Point the changelog's two follow-ups at their issues

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -221,8 +221,8 @@ v0.18.1 (unreleased)
   40MB apiece at that size, several per iteration. Getting past that
   means accumulating the ``p x p`` information incrementally per event
   time instead of building per-observation outer products, which is a
-  change of algorithm rather than of implementation, and is left for
-  its own piece of work.
+  change of algorithm rather than of implementation, and is tracked
+  separately as #332.
 
   Timings are single runs and drift by 10–20% between them; the
   ``lifelines`` column moves about as much as the surpyval one does.
@@ -268,9 +268,10 @@ v0.18.1 (unreleased)
   unchanged.
 
   ``optimise_nm_tnc``, which serves AFT and PO, has the same missing
-  gradient and missing preconditioning. Its Nelder-Mead first rung means
-  the failure mode may differ, so it is being measured before it is
-  changed.
+  gradient and missing preconditioning. Its first rung is Nelder-Mead,
+  which is derivative free and so cannot fail the way BFGS did here, so
+  it is being measured before it is changed rather than assumed to need
+  the same fix — #331.
 
 - **Turnbull no longer rejects left-censored observations under left
   truncation.** An entry time below every observation excludes nobody,


### PR DESCRIPTION
Docs only. One file, six lines.

Both paragraphs were written in #330 before the follow-up issues existed, so they described work that had been deliberately deferred without saying where it had gone — a reader would have had no way to find it.

- The Cox `(n, p, p)` materialisation, which is why two cases are still slower than `lifelines`, is now labelled **#332**.
- Measuring `optimise_nm_tnc` before changing it is now labelled **#331**.

The AFT/PO sentence also gained the reason it is being measured rather than fixed by analogy with the PH ladder: Nelder-Mead is derivative free, so it cannot fail the way BFGS did on large-magnitude data, and assuming it needs the same change would be a guess. That was the substance of my note in #328 and it was worth keeping in the changelog too, not just the issue.

No code changed, so nothing to test beyond the docs build. Verified the changelog still parses with no new reStructuredText errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_