### PR TITLE
Number the pending release 0.19.0, not 0.18.1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-v0.18.1 (unreleased)
+v0.19.0 (unreleased)
 --------------------
 
 - **Confidence bounds no longer turn silently to nan on data measured

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "surpyval"
-version = "0.18.0"
+version = "0.19.0"
 description = "A python package for survival analysis"
 readme = "README.md"
 license = {text = "MIT"}

--- a/surpyval/__init__.py
+++ b/surpyval/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.18.0"
+__version__ = "0.19.0"
 
 from autograd import numpy as np
 


### PR DESCRIPTION
Three lines: the changelog heading, `pyproject.toml`, and `surpyval/__init__.py`.

## Why minor rather than patch

The batch accumulated on `develop` since v0.18.0 isn't patch-shaped, even though every item in it is a fix or a speed-up rather than a feature.

**Fitted parameters move.** The truncated-regression underflow (#326) was worth 38 430 log-likelihood on the case that exposed it. Preconditioning (#323, #328) changes any fit on large-magnitude data. Three `test_real_data` golden values changed during this work. Anyone with pinned outputs gets different numbers from the same code and the same data.

**Input that used to raise now fits.** Turnbull with left censoring under left truncation.

**New warning.** Turnbull's identifiability warning fires on data that previously fitted silently — anything running under `-W error`, or asserting a warning-free fit, will now fail.

**New output field and changed exception.** `exploitable_mass` on the Turnbull result; degenerate data raises with an explanation instead of dying inside numdifftools, so the exception a caller catches is not the one it was.

The case for 0.18.1 is that none of this is a capability anyone asked for, and 0.x promises nothing anyway. I weighted the other way because the changes are invisible at the call site.

The repo's own precedent points the same way: v0.15.1 was a single hang fix and v0.15.2 four small hardening items plus docs pins, while v0.18.0 carried a comparable batch of fixes and perf work — including "fitted parameters change for censored *and* truncated data" — as a minor. The unreleased section is 570 changelog lines against v0.18.0's 406.

## Deliberately not touched

`SCHEMA_VERSION` in `surpyval/serialisation.py` stays at 1. It tracks the serialised model format, which has not changed in this batch, and is not coupled to the package version.

## Checked

`surpyval.__version__` and the `pyproject.toml` metadata both report 0.19.0, and no other file in the tree referenced the old version — no test pins it, and `docs/conf.py` reads it rather than hardcoding it.

Still marked `(unreleased)`. Cutting the release to `master` and tagging is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_