### PR TITLE
Cut v0.19.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-v0.19.0 (unreleased)
---------------------
+v0.19.0 (4 August 2026)
+-----------------------
 
 - **Confidence bounds no longer turn silently to nan on data measured
   in large units, and those fits are around 17x faster.** A Weibull fit


### PR DESCRIPTION
Dates the changelog heading, `v0.19.0 (unreleased)` → `v0.19.0 (4 August 2026)`. Two lines, heading and its underline.

The version numbers themselves went in with #334, along with the reasoning for a minor rather than a patch.

This is the last step before `develop` merges to `master` and the tag goes on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_