### PR TITLE
Release v0.19.0

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -74,9 +74,13 @@ jobs:
         # Invoked as ``python -m`` so the plugins resolve against the
         # interpreter the dependencies were installed into, rather than
         # whichever ``pytest`` happens to be first on PATH.
+        #
+        # ``--run-ml`` opts the beta survival tree and forest tests back
+        # in. They are skipped by default because they are 97 of the
+        # suite's 180 seconds locally, but deployment still tests them.
         run:
           python -m pytest -n auto --cov=surpyval --cov-report=
-          --ignore=surpyval/tests/alpha
+          --ignore=surpyval/tests/alpha --run-ml
 
       - name: coverage
         run: |

--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,13 @@ locally after touching a likelihood, an initialiser or an optimiser.
 
 Marks are applied by path so the test modules themselves stay free of
 suite-management boilerplate.
+
+This lives at the repository root rather than beside the tests because
+``pytest_addoption`` is only honoured in *initial* conftest files -- the
+rootdir's, and those in directories named as arguments. The CI
+invocation selects with ``--ignore`` and passes no path, so a conftest
+under ``surpyval/tests`` is loaded too late to register the flags and
+the run dies on "unrecognized arguments".
 """
 
 import pytest

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -232,8 +232,17 @@ v0.18.1 (unreleased)
   case, which is structurally exploitable but converges given the
   iterations.
 
-  This is the second half of #308. The first half, an off-time-index
-  error that made these same inputs raise, is above.
+  This is the second half of #308, which closes with it; the first half,
+  an off-by-one that made these same inputs raise, is above. The
+  threshold is a measured cut-off standing in for a property that is
+  actually decidable: Vardi (1985) and Wang (1991) give a graphical
+  condition on the data that settles whether the NPMLE exists, exists
+  but is not unique, or does not exist at all, with nothing to tune.
+  Adopting it, and the question of what a non-identifiable fit should
+  *return* rather than merely report, are #327. Worth noting alongside
+  that left truncation with interval censoring is documented as yielding
+  an inconsistent NPMLE, so this is a known limit of the estimator for
+  this data shape rather than something particular to surpyval.
 
 - **Truncated parametric regression fits could report a log-likelihood
   tens of thousands higher than their parameters earn, and be optimised

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,10 +51,14 @@ v0.18.1 (unreleased)
 
   Fitted results are unchanged: all 330 reference fits across thirteen
   distributions and five methods are bit-identical, and BFGS now wins
-  every truncated fit where Nelder-Mead used to. Note that truncated
-  fits have had no working gradient until now, so the covariance matrix
-  and confidence bounds on truncated data came from a nan-poisoned
-  hessian path; whether those were degraded is not yet established.
+  every truncated fit where Nelder-Mead used to.
+
+  Confidence bounds were never affected. The covariance step already
+  recomputes a numerical hessian whenever the autograd one comes back
+  nan or asymmetric (#270), so it caught this on every truncated fit and
+  produced correct bounds by the slow route -- checked against
+  ``906f0cb~1``, where the standard errors are identical to eight
+  figures. That fallback was part of what made these fits slow.
 
 - **The slow parts of the test suite are opt in, and there is a new
   invariant sweep behind the same mechanism.** ``pytest`` alone now runs

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,33 @@ Changelog
 v0.18.1 (unreleased)
 --------------------
 
+- **The slow parts of the test suite are opt in, and there is a new
+  invariant sweep behind the same mechanism.** ``pytest`` alone now runs
+  in about two minutes rather than three: the beta survival tree and
+  forest tests were 97 of the suite's 180 seconds for 85 of its 2000-odd
+  tests. They run with ``--run-ml``, and continuous integration passes
+  the flag, so coverage is unchanged.
+
+  ``--run-invariants`` adds ``test_fit_invariants.py``, a wide net over
+  the fitting API. Every defect found in this release cycle slipped past
+  the whole suite, and each lived at an *intersection* of dimensions the
+  suite tests one at a time -- a censored observation that was also
+  truncated, an offset combined with a particular method, an offset
+  combined with a large shift magnitude, a sample below the 1000 floor
+  of ``FIT_SIZES``. The full cross of distributions, methods, censoring,
+  truncation, structural flags, sizes and scales is around 600,000
+  cells, so the sweep does not attempt it. It asserts cheap invariants
+  instead -- finite parameters, finite ``neg_ll``, a survival function
+  that stays in [0, 1] and never increases, and maximum likelihood
+  attaining the lowest negative log-likelihood of the five methods --
+  over a seeded sample of that space. Four of the five defects would
+  have failed the first two assertions.
+
+  Data *scale* is included as an axis because it was previously untested
+  anywhere, despite the maximum likelihood failure warning itself
+  advising users to rescale towards 1. 270 cases, three and a half
+  minutes.
+
 - **Maximum likelihood fits are about 2.2x faster.** Every MLE fit ran
   five optimisers -- Nelder-Mead, Powell, BFGS, TNC and Newton-CG -- and
   kept the best result. Over 102 fits across eleven distributions, five

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,96 @@ Changelog
 v0.18.1 (unreleased)
 --------------------
 
+- **Confidence bounds no longer turn silently to nan on data measured
+  in large units, and those fits are around 17x faster.** A Weibull fit
+  to the same lifetimes expressed in hours had standard errors; in
+  seconds it returned ``nan`` for every one of them, with no warning and
+  a perfectly good set of parameters alongside.
+
+  The cause is the ``np.where`` trap again, this time in the parameter
+  transform rather than a likelihood. Every parameter bounded on
+  ``(0, inf)`` is mapped to the unbounded space the optimiser searches
+  by ``adj_relu``, which chose between ``x + 1`` and ``exp(x)`` with
+  ``np.where``. Autograd evaluates both branches, so ``exp(x)`` was
+  taped even where ``x + 1`` was selected, and above ``x = 709.78`` it
+  overflows to inf. The inf then poisoned the derivative of the branch
+  that *was* chosen, so the jacobian of the transform came back nan --
+  and with it ``cov_matrix``, which is that jacobian either side of the
+  inverse hessian.
+
+  The threshold is a property of the fitted parameter, not of the sample
+  size or the conditioning, which is why it looked so arbitrary: a fit
+  died as soon as any ``(0, inf)`` parameter exceeded about 710. A
+  Weibull with ``alpha = 10`` lost its bounds once the data was scaled
+  past about 70x, while a Gumbel, whose location is unbounded and so
+  untransformed, survived to 350x on the same data. The Gamma failed at
+  the *small* end instead, its rate parameter growing as the data
+  shrinks. The Normal, LogNormal and Exponential were immune throughout
+  because they have closed-form estimators and never touch the
+  transform; the Uniform reports no covariance at any scale by design,
+  its MLE being an order statistic rather than a stationary point.
+
+  Clamping the dead branch's argument fixes it: the branch is
+  responsible only for ``x < 0``, so restricting what it may be handed
+  leaves its value and derivative untouched where it is used, and
+  bounded where it is not.
+
+  The hessian was never the problem -- the numerical fallback (#270)
+  produced a finite, well conditioned matrix at every scale -- which is
+  why this presented as nan bounds rather than as a warning or a
+  failure. It also explains the speed: the same nan reached the
+  objective's gradient, so BFGS, TNC and Newton-CG each gave up and
+  Nelder-Mead finished the fit derivative free. Across twelve
+  distributions at seven scales the sweep goes from 19.59s to 1.18s, and
+  every fit that used to end on Nelder-Mead now ends on BFGS.
+
+  Results that already worked are unchanged: 65 of 96 reference fits are
+  bit-identical, and the other 31 are the restorations, where the
+  objective agrees to fifteen significant figures and the parameters to
+  nine.
+
+  Restoring the gradient exposed a second, smaller scale problem
+  underneath, now fixed with it. scipy stops BFGS when
+  ``max|grad| < gtol``, and its default of 1e-5 is an absolute threshold
+  on a quantity that is not scale free: a log-likelihood's gradient
+  shrinks like ``1/theta``, so on data measured in tens of thousands the
+  test is met well short of the optimum and BFGS reports success on its
+  first check. This had been invisible because those fits used to end on
+  Nelder-Mead, which is derivative free and so kept going. Three
+  reference fits on real data of that magnitude landed 1e-2 away in
+  relative terms, at a likelihood 2e-3 below the answer they had been
+  recorded from.
+
+  ``gtol`` is now scaled by the gradient at the point the search starts,
+  which asks that the gradient fall by a fixed number of orders of
+  magnitude -- the same requirement at every scale. A fixed tighter
+  constant is not equivalent and does not work: 1e-8 fixes the large
+  fits but is unreachable for small samples, dropping an n=8 Weibull out
+  of BFGS and into TNC. At 1e-7 relative both ends converge on BFGS, the
+  large fits to 2e-8 and the small one to 4e-9.
+
+  With both in place the restored standard errors satisfy the
+  scale-equivariance law ``se(theta * c) = c * se(theta)`` to 1e-5 or
+  better across every distribution and scale tested, most to 1e-8, and
+  to machine precision for the Rayleigh and Normal.
+
+  Two consequences worth noting. Fits now converge slightly further than
+  before wherever BFGS wins, so a handful of pinned numbers moved in
+  their last few digits -- always towards a better likelihood. The two
+  Monte Carlo simulation tests in ``test_counting.py`` also had their
+  tolerance loosened from ``allclose``'s 1e-5 to 1e-3: they drive a
+  5000-run simulation from an optimiser's output, where a change in the
+  seventh significant figure of a parameter moves the simulated MCF in
+  the fourth. That is convergence noise, and what those tests exist to
+  catch would break far more loudly.
+
+  #323 is now rescoped. It had proposed internal rescaling to fix both
+  the bounds and the speed; neither needs it. Re-measured with the
+  gradient working, rescaling is between 4.2x faster and 6x *slower*
+  depending on the distribution, so the twelve per-distribution
+  back-transforms it would require are no longer obviously worth their
+  risk.
+
 - **A truncated fit is around 60x faster, and the truncation term is
   evaluated once per distinct window rather than once per row.** Any fit
   with a truncation bound on one side only had no usable gradient. The
@@ -65,7 +155,11 @@ v0.18.1 (unreleased)
   in about two minutes rather than three: the beta survival tree and
   forest tests were 97 of the suite's 180 seconds for 85 of its 2000-odd
   tests. They run with ``--run-ml``, and continuous integration passes
-  the flag, so coverage is unchanged.
+  the flag, so coverage is unchanged. The ``conftest.py`` that defines
+  the flags lives at the repository root: ``pytest_addoption`` is only
+  honoured in *initial* conftest files, and the CI invocation selects
+  with ``--ignore`` and names no path, so one under ``surpyval/tests``
+  would be loaded too late to register them.
 
   ``--run-invariants`` adds ``test_fit_invariants.py``, a wide net over
   the fitting API. Every defect found in this release cycle slipped past

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-v0.19.0 (unreleased)
---------------------
+v0.19.0 (4 August 2026)
+-----------------------
 
 - **Confidence bounds no longer turn silently to nan on data measured
   in large units, and those fits are around 17x faster.** A Weibull fit

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -190,19 +190,50 @@ v0.18.1 (unreleased)
   between them, and does so exactly, because every finite truncation
   time is itself in ``bounds``.
 
-  Half of #308 is still open. Convergence on data mixing all four
-  censoring types with left truncation is unaffected by this, and the
-  cause is not the one the issue supposed: the expected event counts
-  come back inflated -- about 3.1 events at every observation time for
-  thirty observations -- so the estimator ladder exhausts its risk set
-  within a handful of steps and the survival curve collapses. That is
-  the ghost/normalisation step rather than the index arithmetic.
+- **A Turnbull fit that is not identifiable now says so instead of
+  returning a collapsed curve quietly.** Left-censored observations
+  combined with two or more distinct entry times admit a flat direction
+  in the likelihood, and where the data leans on it the estimate is
+  worthless while looking ordinary.
 
-  What is new is the trigger. A *common* entry time round-trips exactly;
-  entry times that *differ* are what activate it, since only then does a
-  later-entering row have unseen deaths imputed below its own window.
-  That narrows the reproducer from thirty points to six, which is in the
-  suite as a strict ``xfail`` alongside the diagnosis.
+  An interval that one observation could have failed in, but that
+  precedes another observation's entry, is worth mass to the first and
+  costs the second nothing. The second's contribution is conditional on
+  its own entry, so mass it never had the chance to see divides out of
+  both its numerator and its denominator exactly. On a six-point example
+  the estimator drives 99.995% of the mass into a single such interval,
+  reaching a log-likelihood of -6.14 against -9.36 for the sensible
+  answer.
+
+  So the estimator is not misbehaving. It is maximising correctly, and
+  the likelihood has no interior maximum to find -- it climbs towards
+  the boundary, which is why raising ``max_iter`` never helps. Both
+  ingredients are needed: left censoring, the only kind whose support
+  reaches back into the entry region, and two distinct entry times, so
+  that such an interval exists at all. Six distinct entry times with no
+  left censoring fit flawlessly; one common entry time with left
+  censoring round-trips exactly.
+
+  The fit is still returned, because meeting the condition does not mean
+  the data is spoilt. Across 240 simulated samples that all met it, the
+  proportion actually degenerating ran from 8% to 72%, rising with the
+  share left censored -- rejecting on structure would refuse far more
+  good data than bad. What separates the two is how much mass ends up on
+  the flat direction: healthy fits reached at most 0.836 of it, spoilt
+  ones a median of 0.994. Warning above 0.9 caught them without a single
+  false alarm across those samples; 0.7 would have cost 9% and 0.5
+  40%.
+
+  The share is reported as ``model.exploitable_mass`` so a borderline
+  fit can be judged rather than guessed at. Note that the structural
+  condition is *not* used as a trigger on its own: ordinary
+  staggered-entry data meets it routinely and estimates perfectly well,
+  and pairing it with non-convergence would have mis-advised the #203
+  case, which is structurally exploitable but converges given the
+  iterations.
+
+  This is the second half of #308. The first half, an off-time-index
+  error that made these same inputs raise, is above.
 
 - **Truncated parametric regression fits could report a log-likelihood
   tens of thousands higher than their parameters earn, and be optimised

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,42 @@ Changelog
 v0.18.1 (unreleased)
 --------------------
 
+- **Maximum likelihood fits are about 2.2x faster.** Every MLE fit ran
+  five optimisers -- Nelder-Mead, Powell, BFGS, TNC and Newton-CG -- and
+  kept the best result. Over 102 fits across eleven distributions, five
+  data shapes and two sample sizes, all five agreed on the objective to
+  1e-10. The last four were confirming what an earlier one had already
+  found.
+
+  That confirmation was not cheap. Nelder-Mead and Powell are derivative
+  free, so they pay for robustness in function evaluations -- 50 and 22
+  against BFGS's 21 -- and every evaluation costs O(n). On a million
+  observations those two alone were 42% of the fit.
+
+  The gradient methods now run first and the search stops at the first
+  that converges, with the derivative-free pair kept as the fallback.
+  Order and early exit had to change together: stopping early without
+  reordering halts at Nelder-Mead, which is both the most expensive rung
+  and the one with the worst objective, while reordering without
+  stopping early saves nothing. Cold-start BFGS now wins 83 of 102 fits,
+  TNC takes 10 and Newton-CG one; the eight that Nelder-Mead or Powell
+  used to win now land on a gradient method at the same objective, so
+  they were winning ties on ordering rather than finding better optima.
+  The derivative-free methods still start from the cold initial guess
+  when they are reached, so the multi-start behaviour survives for the
+  fits that need it.
+
+  **Fitted parameters can move in about the seventh significant digit.**
+  All 102 objectives are identical to 1e-10 and one improved, so this is
+  optimiser tolerance rather than a change of answer, but it is not
+  bit-identical: the median shift is 3e-8 and the 90th percentile 8e-7.
+  The documented ``GeneralizedOneRenewal`` example and the two tests
+  that pin it have been regenerated. Those numbers were always a
+  snapshot of the library's own output rather than an external
+  reference, and their tolerance has deliberately been left tight, so
+  that any future change to the optimiser surfaces as a decision rather
+  than passing unnoticed.
+
 - **Degenerate data is rejected with an explanation instead of an
   ``IndexError`` from inside numdifftools.** ``Weibull.fit`` on three
   tied observations died four steps from the cause: a probability plot

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -221,8 +221,8 @@ v0.18.1 (unreleased)
   40MB apiece at that size, several per iteration. Getting past that
   means accumulating the ``p x p`` information incrementally per event
   time instead of building per-observation outer products, which is a
-  change of algorithm rather than of implementation, and is left for
-  its own piece of work.
+  change of algorithm rather than of implementation, and is tracked
+  separately as #332.
 
   Timings are single runs and drift by 10–20% between them; the
   ``lifelines`` column moves about as much as the surpyval one does.
@@ -268,9 +268,10 @@ v0.18.1 (unreleased)
   unchanged.
 
   ``optimise_nm_tnc``, which serves AFT and PO, has the same missing
-  gradient and missing preconditioning. Its Nelder-Mead first rung means
-  the failure mode may differ, so it is being measured before it is
-  changed.
+  gradient and missing preconditioning. Its first rung is Nelder-Mead,
+  which is derivative free and so cannot fail the way BFGS did here, so
+  it is being measured before it is changed rather than assumed to need
+  the same fix — #331.
 
 - **Turnbull no longer rejects left-censored observations under left
   truncation.** An entry time below every observation excludes nobody,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -147,20 +147,8 @@ v0.18.1 (unreleased)
   fourth. That is convergence noise, and what those tests exist to catch
   would break far more loudly.
 
-  The second consequence is a known wrong answer, and it is worth being
-  plain about. ``WeibullPH.fit_tvc`` now returns a degenerate fit on the
-  fixture in ``test_episode_split_is_an_identity``, which is marked
-  ``xfail(strict=True)`` against #326. The parametric regression path
-  has its own optimiser, so nothing here touched it; the seed it gets
-  moved by six parts in ten million, and that was enough to tip it. Its
-  first stage still finds the right answer (``neg_ll`` 927.83) and TNC
-  then walks into the region where a left-truncated likelihood is
-  unbounded, returning -21311.40 and reporting success -- which
-  ``optimise_ph`` keeps unconditionally. Neither a success check nor a
-  comparison of objectives would catch it, since the divergent answer
-  has the lower one. That fit has been sitting beside this basin all
-  along with only its starting point keeping it out; #326 carries the
-  diagnosis and the two candidate defences.
+  The second is that it flushed out a separate defect, which is fixed
+  alongside it and described next.
 
   #323 is now rescoped. It had proposed rescaling the *model* -- fit on
   transformed data, then map the parameters and the covariance back --
@@ -170,6 +158,55 @@ v0.18.1 (unreleased)
   *slower* depending on the distribution. What was left, the convergence
   criterion, is what preconditioning the search addresses, so the twelve
   per-distribution back-transforms are not needed for any of it.
+
+- **Truncated parametric regression fits could report a log-likelihood
+  tens of thousands higher than their parameters earn, and be optimised
+  towards it.** ``truncation_correction`` computed the mass in each
+  observation's truncation window as a difference of CDFs, floored at
+  the smallest positive float:
+
+  .. code-block:: python
+
+      np.log(np.maximum(right - left, _TINY))
+
+  Under left truncation that difference is ``1 - F(tl)``, the survival
+  probability at the truncation bound, which underflows to exactly zero
+  as the fitted scale shrinks. The floor then capped the correction at
+  ``log(tiny) = -708`` rather than letting it grow without bound -- and
+  since the correction is *subtracted*, every truncated row appeared to
+  contribute +708 to the log-likelihood. A region the data rules out
+  entirely became the best fit on offer, and the optimiser walked
+  straight into it.
+
+  A ``WeibullPH`` fit to left-truncated data reported ``neg_ll``
+  -21311.40 at parameters whose true value is +17118.30, against 927.83
+  at the correct answer: wrong by 38,000, and pointing the wrong way.
+  Recomputing the likelihood by hand from the model definition is what
+  settled it -- at the correct parameters surpyval agrees to the digit,
+  so the objective is right everywhere except where the floor engages.
+
+  One-sided windows are now evaluated in log space through ``log_sf``
+  and ``log_ff``, which stay finite where the difference cannot, so
+  there is nothing to floor. Only a genuinely two-sided window still
+  takes a difference, and there both bounds are finite and the mass is
+  not driven to zero by the scale alone. As elsewhere, the ``np.where``
+  branches are evaluated at substituted-finite arguments so that an
+  infinity in an unselected branch cannot poison the gradient of the
+  selected one.
+
+  This is in ``_likelihood.py``, which serves proportional hazards,
+  proportional odds, accelerated failure time and accelerated life
+  alike, so any left- or right-truncated parametric regression fit was
+  exposed -- it needed only the optimiser to wander far enough for the
+  underflow to bite. Nothing warned when it did.
+
+  Found by the rescaling change above, which perturbed an initial guess
+  by six parts in ten million and was enough to tip one fit over. The
+  first diagnosis was wrong: it looked like a genuinely unbounded
+  truncated likelihood being followed legitimately, and the arithmetic
+  disproved that. #326 records both. The regression test asserts the
+  reported objective equals an independently computed one and that
+  shrinking the scale below the truncation bounds always scores worse.
 
 - **A truncated fit is around 60x faster, and the truncation term is
   evaluated once per distinct window rather than once per row.** Any fit

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -64,53 +64,112 @@ v0.18.1 (unreleased)
   relative terms, at a likelihood 2e-3 below the answer they had been
   recorded from.
 
-  ``gtol`` is now scaled by the gradient at the point the search starts,
-  at 1e-7 relative. A fixed tighter constant does not work: 1e-8 fixes
-  the large fits but is unreachable for small samples, dropping an n=8
-  Weibull out of BFGS and into TNC, where it lands 5e-5 away. At 1e-7
-  relative both ends converge on BFGS, the large fits to 2e-8 and the
-  small one to 4e-9.
+  There is a second dimension to the same problem, in the opposite
+  direction. A log-likelihood is a *sum* over observations, so its
+  gradient grows like ``n`` as well as shrinking like ``1/theta``. At
+  n = 1e5 it is five orders of magnitude larger, the same absolute
+  threshold is correspondingly unreachable, and BFGS gives up on
+  censored samples it should handle easily -- found by benchmarking
+  against lifelines with censoring, where it was the one configuration
+  in 64 where surpyval was slower.
 
-  With both in place the restored standard errors satisfy the
-  scale-equivariance law ``se(theta * c) = c * se(theta)`` to 1e-9 or
-  better up to data scale 1e4, and to machine precision for the Rayleigh
-  and Normal. At 1e6 most distributions hold to 1e-6 or better; the
-  Weibull is an outlier at around 1e-3.
+  So the problem is rescaled in both of its dimensions, and a single
+  constant then means the same thing for every fit:
 
-  That outlier is worth stating plainly, because it marks the limit of
-  what a tolerance constant can do. Scaling ``gtol`` by the gradient at
-  the initial guess does *not* make the criterion scale free the way it
-  first appears to: the initialiser scales with the data too, so the
-  gradient at the starting point is itself roughly scale invariant and
-  the resulting threshold barely moves. There is no constant that serves
-  every case -- 1e-8 relative fixes the Weibull at 1e6 but breaks the
-  n=8 fit, and 1e-9 breaks both small fits by pushing them to TNC. 1e-7
-  is the setting where everything the test suite covers passes.
+      s = max(|u0|, 1)        f0 = max(|f(u0)|, 1)
+      v = u / s               g(v) = f(s v) / f0
 
-  So this is a better tolerance, not a scale-free one. Solving a
-  well-scaled problem, where a single absolute tolerance means the same
-  thing everywhere, is the actual fix; the measurements above are
-  recorded in #323 as the case for it.
+  The starting point is order 1 in every component and so is the
+  objective, whatever the units and whatever the sample size. Since
+  ``dg/dv = s * df/du / f0``, with ``s`` growing exactly as ``df/du``
+  shrinks and ``f0`` growing like ``n``, so is the gradient. The
+  ``gtol`` of 1e-6 applied there is a genuine relative tolerance rather
+  than the dimensioned constant scipy's default is.
 
-  Two consequences worth noting. Fits now converge slightly further than
-  before wherever BFGS wins, so a handful of pinned numbers moved in
-  their last few digits -- always towards a better likelihood. The two
-  Monte Carlo simulation tests in ``test_counting.py`` also had their
-  tolerance loosened from ``allclose``'s 1e-5 to 1e-3: they drive a
-  5000-run simulation from an optimiser's output, where a change in the
-  seventh significant figure of a parameter moves the simulated MCF in
-  the fourth. That is convergence noise, and what those tests exist to
-  catch would break far more loudly.
+  Tuning the threshold was tried first and does not work. Three
+  criteria were measured against the same reference set: an absolute
+  ``gtol``, a ``gtol`` scaled by the gradient at the initial guess, and
+  BFGS's step-size test ``xrtol``. Swapping the whole method for
+  L-BFGS-B to reach its relative ``ftol`` was measured too. None is
+  scale free in practice.
 
-  #323 is now rescoped. It had proposed internal rescaling to fix both
-  the bounds and the speed; neither needs it. Re-measured with the
-  gradient working, rescaling is between 4.2x faster and 6x *slower*
-  depending on the distribution, so the twelve per-distribution
-  back-transforms it would require are no longer obviously worth their
-  risk. What remains there is the convergence criterion, and the
-  cheapest form of it is preconditioning the optimiser's search alone --
-  no back-transforms, because nothing outside the optimiser ever sees
-  scaled units.
+  Scaling ``gtol`` by the initial gradient in particular *looks* scale
+  free and is not: the initialiser scales with the data too, so that
+  gradient is itself roughly scale invariant -- a Weibull at scale 1,
+  1e4 and 1e6 all came out with ``gtol = 1.86e-6``. Nor is there a
+  constant that serves every case: tight enough for a Weibull at 1e6 is
+  unreachable for an n=8 sample, which then drops out of BFGS into TNC.
+  ``xrtol`` and ``ftol`` fail differently -- both stop on how the
+  optimiser is behaving rather than on the quantity that is zero at the
+  answer, so they quit early along flat directions, which is precisely
+  where the standard error is largest and most needs to be right. The
+  ExpoWeibull, three parameters and a flat surface, was 17% out under
+  both. The full measurements are in #323.
+
+  Rescaling beats every one of them, and is faster than the tolerance it
+  replaces:
+
+  ==============================================  ==========  ==========
+  scale-equivariance of ``se`` (8 distributions)  relative    rescaled
+                                                  ``gtol``    problem
+  ==============================================  ==========  ==========
+  worst deviation                                 1.6e-3      2.0e-5
+  cases above 1e-5                                1 of 16     1 of 16
+  Weibull n=1e5, 30% censored, scale 1            0.163s      0.153s
+  Weibull n=1e5, 60% censored, scale 1e6          0.250s      0.119s
+  ==============================================  ==========  ==========
+
+  Rescaling the parameters alone reaches 2.8e-8 on the first row, better
+  than the 2.0e-5 above, but is the version that leaves BFGS failing at
+  large ``n``: those two censored fits take 0.370s and 0.590s under it.
+  Normalising the objective as well trades a little of that accuracy for
+  a criterion that holds across sample sizes too, which is the point.
+
+  Both mappings are fixed before the search begins and neither can move
+  the optimum: a diagonal linear change of variable relocates a minimum
+  no more than dividing the objective by a positive constant does. They
+  change the route taken and the units of the convergence test, nothing
+  else. ``res.x`` and ``res.fun`` are both mapped back inside the
+  helper, so no scaled quantity exists anywhere else in the package, not
+  even transiently: the covariance step, ``cb`` and serialisation all
+  receive exactly what they received before. Nothing needs to know which
+  parameter is a scale and which a shape, which is what made the
+  internal-rescaling proposal in #323 risky; preconditioning needs none
+  of it.
+
+  Two consequences worth noting. Fits now converge further than before
+  wherever BFGS wins, so a handful of pinned numbers moved in their last
+  few digits -- always towards a better likelihood. The two Monte Carlo
+  simulation tests in ``test_counting.py`` also had their tolerance
+  loosened from ``allclose``'s 1e-5 to 1e-3: they drive a 5000-run
+  simulation from an optimiser's output, where a change in the seventh
+  significant figure of a parameter moves the simulated MCF in the
+  fourth. That is convergence noise, and what those tests exist to catch
+  would break far more loudly.
+
+  The second consequence is a known wrong answer, and it is worth being
+  plain about. ``WeibullPH.fit_tvc`` now returns a degenerate fit on the
+  fixture in ``test_episode_split_is_an_identity``, which is marked
+  ``xfail(strict=True)`` against #326. The parametric regression path
+  has its own optimiser, so nothing here touched it; the seed it gets
+  moved by six parts in ten million, and that was enough to tip it. Its
+  first stage still finds the right answer (``neg_ll`` 927.83) and TNC
+  then walks into the region where a left-truncated likelihood is
+  unbounded, returning -21311.40 and reporting success -- which
+  ``optimise_ph`` keeps unconditionally. Neither a success check nor a
+  comparison of objectives would catch it, since the divergent answer
+  has the lower one. That fit has been sitting beside this basin all
+  along with only its starting point keeping it out; #326 carries the
+  diagnosis and the two candidate defences.
+
+  #323 is now rescoped. It had proposed rescaling the *model* -- fit on
+  transformed data, then map the parameters and the covariance back --
+  to fix both the bounds and the speed. Neither needs it. The bounds
+  were the ``np.where`` overflow above, and re-measured with the
+  gradient working, rescaling the data is between 4.2x faster and 6x
+  *slower* depending on the distribution. What was left, the convergence
+  criterion, is what preconditioning the search addresses, so the twelve
+  per-distribution back-transforms are not needed for any of it.
 
 - **A truncated fit is around 60x faster, and the truncation term is
   evaluated once per distinct window rather than once per row.** Any fit

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,51 @@
 Changelog
 =========
 
+v0.18.1 (unreleased)
+--------------------
+
+- **Degenerate data is rejected with an explanation instead of an
+  ``IndexError`` from inside numdifftools.** ``Weibull.fit`` on three
+  tied observations died four steps from the cause: a probability plot
+  has no slope through a single distinct abscissa, so ``polyfit``
+  returned a nan; the nan seeded the maximum likelihood fit, which
+  started at nan and produced a nan hessian; the numerical fallback then
+  asked numdifftools for one, and its list of finite-difference steps
+  came back empty. Neither truncation nor censoring was involved,
+  despite where the symptom was first seen.
+
+  ``Gamma`` and ``Beta`` failed the same way but in silence. Their
+  moment-based initialisers divide by a variance that is exactly zero
+  for tied data, giving ``(inf, inf)``, and since a failed optimiser
+  reports its initial guess (#261) those infinities were returned as a
+  fitted model.
+
+  Three changes. The probability-plot regression falls back to a unit
+  slope through the centroid when it is rank deficient -- zero slope
+  would be the more literal reading, but every ``unpack_rr`` divides by
+  the slope to recover a scale, so it only moves the nan one step later.
+  ``Gamma`` and ``Beta`` seed the exponential and uniform cases rather
+  than dividing by zero. And a fit now refuses to return a non-finite
+  parameter whatever produced it.
+
+  The fit is then rejected when the data cannot pin down the free
+  parameters: fewer distinct non-right-censored values than free
+  parameters means a flat -- for a Weibull on tied data, unbounded --
+  direction in the likelihood, and the answer would be wherever the
+  optimiser stopped. Three tied observations returned ``beta = 512``
+  with ``success=True`` and no warning once the nan was fixed.
+
+  The count is of *free* parameters, so fixing one buys back a degree
+  of freedom: ``Weibull.fit([10.], fixed={'beta': 2})`` is well posed
+  and now returns ``alpha = 10``, where before it raised. One-parameter
+  distributions are unaffected -- ``Exponential`` and ``Rayleigh`` fit
+  tied data exactly as they should. Probability plotting is exempt,
+  being a regression rather than a likelihood maximisation, and is how
+  several distributions seed themselves.
+
+  All 330 reference fits across thirteen distributions, five methods and
+  plain, right-censored and offset data are bit-identical.
+
 v0.18.0 (2 August 2026)
 -----------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-v0.18.1 (unreleased)
+v0.19.0 (unreleased)
 --------------------
 
 - **Confidence bounds no longer turn silently to nan on data measured

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,58 @@ Changelog
 v0.18.1 (unreleased)
 --------------------
 
+- **A truncated fit is around 60x faster, and the truncation term is
+  evaluated once per distinct window rather than once per row.** Any fit
+  with a truncation bound on one side only had no usable gradient. The
+  window probability chose between the CDF and an analytic limit with
+  ``np.where``, which picks the right *value* but evaluates both
+  branches -- so ``ff(inf)`` was still recorded by autograd, and its nan
+  derivative propagated through the selection whichever side won.
+
+  Nothing warned. The objective was correct throughout; only the
+  gradient was nan. So BFGS and Newton-CG each gave up after a single
+  evaluation, TNC spent its whole 1000-evaluation budget discovering the
+  same thing, and Nelder-Mead finished the job derivative free. A
+  Weibull that fits in 0.014s took 1.36s, and a ``tl`` of 0 -- a no-op,
+  since ``F(0) = 0`` -- cost exactly as much as a real truncation, which
+  is what gives the cause away. Windows with *both* bounds finite were
+  always fast, because no infinity ever reached the tape.
+
+  The infinity is now substituted out of the *argument* before the CDF
+  sees it, so a single vectorised call covers every row whatever its
+  pattern of bounds, and the surviving ``np.where`` only ever chooses
+  between two values that are already finite. The stand-in cannot be an
+  arbitrary constant: zero looks natural and is wrong, because a Weibull
+  with ``beta < 1`` has an unbounded density derivative at the origin,
+  which would swap one nan gradient for another. Reusing a bound that is
+  genuinely present keeps it inside the support and at the data's own
+  magnitude; its value never reaches the result, only its derivative has
+  to be finite.
+
+  Separately, the truncation correction depends only on the observation
+  *window*, not on where in it the observation fell, so it is now
+  evaluated once per distinct window. Truncation is nearly always common
+  to a whole sample -- one burn-in time, one study entry date -- which
+  collapsed 360 CDF evaluations per likelihood call to one in the test
+  case, and the likelihood is called hundreds of times per fit.
+
+  ==============================  ==========  =========
+  fit                             before      after
+  ==============================  ==========  =========
+  plain                           0.014s      0.015s
+  left truncated                  1.398s      0.022s
+  ``tl = 0`` (a no-op)            1.362s      0.041s
+  right truncated                 1.344s      0.024s
+  both bounds finite              0.019s      0.025s
+  ==============================  ==========  =========
+
+  Fitted results are unchanged: all 330 reference fits across thirteen
+  distributions and five methods are bit-identical, and BFGS now wins
+  every truncated fit where Nelder-Mead used to. Note that truncated
+  fits have had no working gradient until now, so the covariance matrix
+  and confidence bounds on truncated data came from a nan-poisoned
+  hessian path; whether those were degraded is not yet established.
+
 - **The slow parts of the test suite are opt in, and there is a new
   invariant sweep behind the same mechanism.** ``pytest`` alone now runs
   in about two minutes rather than three: the beta survival tree and

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -74,7 +74,7 @@ v0.18.1 (unreleased)
   in 64 where surpyval was slower.
 
   So the problem is rescaled in both of its dimensions, and a single
-  constant then means the same thing for every fit:
+  constant then means the same thing for every fit::
 
       s = max(|u0|, 1)        f0 = max(|f(u0)|, 1)
       v = u / s               g(v) = f(s v) / f0
@@ -158,6 +158,74 @@ v0.18.1 (unreleased)
   *slower* depending on the distribution. What was left, the convergence
   criterion, is what preconditioning the search addresses, so the twelve
   per-distribution back-transforms are not needed for any of it.
+
+- **Cox fits are 3x to 10x faster, with the answers unchanged to every
+  digit.** None of this is a change to the maths; the coefficients still
+  match ``lifelines`` to between 1e-06 and 1e-12, exactly as before.
+
+  Four things were costing the time (#329).
+
+  ``_GroupBy.sum`` used ``np.add.at`` for its multi-dimensional case, an
+  unbuffered scatter with no fast path, called about ten times per
+  ``jac_hess`` on arrays of shape ``(n, p, p)``. It is now a sorted
+  ``np.add.reduceat``, with two shortcuts: nothing to permute when the
+  keys already arrive grouped, and nothing to *add* when every key is
+  distinct — one-element groups in order are the input array, which is
+  what continuous event times give you.
+
+  The hessian was a Python double loop over event times and tied deaths,
+  with an ``np.outer`` inside it. The sum over tied deaths turns out to
+  factor out of the ``p x p`` part entirely: only ``c = j / d`` depends
+  on ``j``, so five scalar sums per event time carry the whole ragged
+  axis and the covariate blocks are formed once. That drops the cost from
+  ``O(times x ties x p^2)`` to ``O(times x ties + times x p^2)``, and it
+  removes the separate no-ties case rather than special-casing it — an
+  untied time is a single ``j = 0`` term with ``c = 0``.
+
+  ``np.einsum("ij,ik->ijk", Z, Z)`` was rebuilt inside ``jac_hess`` on
+  every root-finding iteration, though ``Z`` is fixed for the life of the
+  fit. It is hoisted, and the two remaining weighted-outer einsums are
+  plain broadcasts.
+
+  Finally the rows are put in event-time order once when the closures are
+  built, so ``_GroupBy`` never has to permute an ``(n, p, p)`` array
+  again. Nothing downstream depends on row order — every quantity is
+  aggregated to unique event times first — and the model still stores the
+  caller's unsorted arrays for the residual and diagnostic code.
+
+  Wall clock, Efron ties, 40% censored, against ``lifelines``:
+
+  ===========  ======  =========  ========  ===========
+  n            p       before     after     lifelines
+  ===========  ======  =========  ========  ===========
+  500          2       0.038s     0.012s    0.060s
+  2 000        2       0.146s     0.024s    0.146s
+  10 000       2       0.890s     0.105s    0.619s
+  50 000       2       5.71s      0.663s    3.13s
+  10 000       5       1.379s     0.339s    0.656s
+  50 000       5       7.57s      2.01s     3.18s
+  2 000        10      0.378s     0.107s    0.164s
+  50 000       10      15.39s     8.31s     4.03s
+  ===========  ======  =========  ========  ===========
+
+  Heavily tied event times — dates, rounded durations — gain the most:
+  n=20 000 with five covariates goes from 1.91s to 0.33s. Breslow, which
+  shares ``_GroupBy`` and the einsum hoist, improves alongside it. The
+  delayed-entry and time-varying-covariate paths, already well ahead,
+  roughly halve again: 43 384 rows with delayed entry from 6.86s to
+  2.62s, and 20 000 start-stop rows from 1.07s to 0.44s.
+
+  Two cases remain slower than ``lifelines``: fifty thousand rows with
+  ten covariates (8.3s against 4.0s), and heavy ties (0.33s against
+  0.08s). Both are now dominated by materialising ``(n, p, p)`` arrays —
+  40MB apiece at that size, several per iteration. Getting past that
+  means accumulating the ``p x p`` information incrementally per event
+  time instead of building per-observation outer products, which is a
+  change of algorithm rather than of implementation, and is left for
+  its own piece of work.
+
+  Timings are single runs and drift by 10–20% between them; the
+  ``lifelines`` column moves about as much as the surpyval one does.
 
 - **Parametric proportional hazards fits are up to 6x faster and no
   longer degrade on data measured in large units.** A ``WeibullPH`` fit

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -65,17 +65,32 @@ v0.18.1 (unreleased)
   recorded from.
 
   ``gtol`` is now scaled by the gradient at the point the search starts,
-  which asks that the gradient fall by a fixed number of orders of
-  magnitude -- the same requirement at every scale. A fixed tighter
-  constant is not equivalent and does not work: 1e-8 fixes the large
-  fits but is unreachable for small samples, dropping an n=8 Weibull out
-  of BFGS and into TNC. At 1e-7 relative both ends converge on BFGS, the
-  large fits to 2e-8 and the small one to 4e-9.
+  at 1e-7 relative. A fixed tighter constant does not work: 1e-8 fixes
+  the large fits but is unreachable for small samples, dropping an n=8
+  Weibull out of BFGS and into TNC, where it lands 5e-5 away. At 1e-7
+  relative both ends converge on BFGS, the large fits to 2e-8 and the
+  small one to 4e-9.
 
   With both in place the restored standard errors satisfy the
-  scale-equivariance law ``se(theta * c) = c * se(theta)`` to 1e-5 or
-  better across every distribution and scale tested, most to 1e-8, and
-  to machine precision for the Rayleigh and Normal.
+  scale-equivariance law ``se(theta * c) = c * se(theta)`` to 1e-9 or
+  better up to data scale 1e4, and to machine precision for the Rayleigh
+  and Normal. At 1e6 most distributions hold to 1e-6 or better; the
+  Weibull is an outlier at around 1e-3.
+
+  That outlier is worth stating plainly, because it marks the limit of
+  what a tolerance constant can do. Scaling ``gtol`` by the gradient at
+  the initial guess does *not* make the criterion scale free the way it
+  first appears to: the initialiser scales with the data too, so the
+  gradient at the starting point is itself roughly scale invariant and
+  the resulting threshold barely moves. There is no constant that serves
+  every case -- 1e-8 relative fixes the Weibull at 1e6 but breaks the
+  n=8 fit, and 1e-9 breaks both small fits by pushing them to TNC. 1e-7
+  is the setting where everything the test suite covers passes.
+
+  So this is a better tolerance, not a scale-free one. Solving a
+  well-scaled problem, where a single absolute tolerance means the same
+  thing everywhere, is the actual fix; the measurements above are
+  recorded in #323 as the case for it.
 
   Two consequences worth noting. Fits now converge slightly further than
   before wherever BFGS wins, so a handful of pinned numbers moved in
@@ -92,7 +107,10 @@ v0.18.1 (unreleased)
   gradient working, rescaling is between 4.2x faster and 6x *slower*
   depending on the distribution, so the twelve per-distribution
   back-transforms it would require are no longer obviously worth their
-  risk.
+  risk. What remains there is the convergence criterion, and the
+  cheapest form of it is preconditioning the optimiser's search alone --
+  no back-transforms, because nothing outside the optimiser ever sees
+  scaled units.
 
 - **A truncated fit is around 60x faster, and the truncation term is
   evaluated once per distinct window rather than once per row.** Any fit

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -159,6 +159,51 @@ v0.18.1 (unreleased)
   criterion, is what preconditioning the search addresses, so the twelve
   per-distribution back-transforms are not needed for any of it.
 
+- **Parametric proportional hazards fits are up to 6x faster and no
+  longer degrade on data measured in large units.** A ``WeibullPH`` fit
+  at data scale 1e6 settled 1.5 nats of log-likelihood short of the
+  optimum, and 1e-2 away in the covariate coefficients -- a different
+  fitted model, not a tolerance artefact. The same data in unit scale
+  fitted correctly, so nothing about it looked wrong.
+
+  The PH ladder was ``minimize(fun, init_t)`` followed by TNC, and three
+  things were the matter with it. The objective closes over
+  ``regression_neg_ll``, which is written in ``autograd.numpy`` and is
+  therefore differentiable, but no ``jac`` was passed -- so scipy fell
+  back to a two-point finite difference and paid ``p + 1`` extra
+  objective evaluations per gradient, which is what made the fit slow
+  down as the covariate count rose. The search was not preconditioned,
+  so PH inherited the scale sensitivity fixed for univariate MLE
+  elsewhere in this release: scipy stops BFGS on an absolute threshold
+  applied to a gradient that shrinks with the data magnitude and grows
+  with the sample size. And TNC's answer was returned whether or not it
+  had converged, so a rung that can only ever be an improvement was free
+  to be a regression -- the AFT and PO ladder, defined immediately
+  below it, already guarded against exactly that.
+
+  The ladder is now preconditioned BFGS on the analytic gradient, then
+  TNC, then Nelder-Mead, stopping at the first rung that converges and
+  never returning a worse point than it started from. The
+  derivative-free rung stays for fits where the gradient is unusable.
+
+  Measured against ``lifelines``, scoring both packages' answers on an
+  independently written Weibull PH log-likelihood: the scale-1e6
+  shortfall goes from 1.468 nats to 1.1e-08, and a 50 000 x 10 fit drops
+  from 1.53s to 0.40s against ``lifelines``' 2.38s. ``ExponentialPH`` at
+  the same size goes from 1.21s to 0.14s. Coefficients continue to agree
+  with ``lifelines`` to around 1e-06.
+
+  ``preconditioned_bfgs`` moved from ``fitters/mle.py`` up to
+  ``fitters/__init__.py``, alongside ``bounds_convert`` and
+  ``fallback_minimize``, so the univariate and regression ladders share
+  one copy rather than two. Behaviour of the univariate ladder is
+  unchanged.
+
+  ``optimise_nm_tnc``, which serves AFT and PO, has the same missing
+  gradient and missing preconditioning. Its Nelder-Mead first rung means
+  the failure mode may differ, so it is being measured before it is
+  changed.
+
 - **Turnbull no longer rejects left-censored observations under left
   truncation.** An entry time below every observation excludes nobody,
   so it should leave a fit untouched. With any left-censored row present

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -159,6 +159,51 @@ v0.18.1 (unreleased)
   criterion, is what preconditioning the search addresses, so the twelve
   per-distribution back-transforms are not needed for any of it.
 
+- **Turnbull no longer rejects left-censored observations under left
+  truncation.** An entry time below every observation excludes nobody,
+  so it should leave a fit untouched. With any left-censored row present
+  it raised instead:
+
+  .. code-block:: text
+
+      ValueError: An observation's censoring interval does not intersect
+      its own truncation window ...
+
+  A support index ``j`` stands for the half-open interval
+  ``(bounds[j], bounds[j+1]]``, so an event placed there is already
+  strictly after ``bounds[j]``. The first index a row entering at ``tl``
+  may use is therefore the *last* bound equal to ``tl`` -- that interval
+  is ``(tl, next]``. The window construction took one index further on,
+  discarding it.
+
+  It mattered most for left censoring because such an event lies in
+  ``(-inf, xr]``, which under an entry at ``tl`` is the single interval
+  ``(tl, xr]`` -- frequently the only one the row has. Dropping it left
+  the row with an empty support, hence the rejection.
+
+  Neither endpoint of the search alone is correct, which is what made
+  this awkward. ``side="left"`` keeps the zero-width ``(tl, tl]``
+  interval that a duplicated exact event time creates, readmitting an
+  event at exactly the entry time and breaking the strict
+  ``(entry, exit]`` convention (#260); ``side="right"`` discards
+  ``(tl, next]`` as well, one too many. ``side="right" - 1`` lands
+  between them, and does so exactly, because every finite truncation
+  time is itself in ``bounds``.
+
+  Half of #308 is still open. Convergence on data mixing all four
+  censoring types with left truncation is unaffected by this, and the
+  cause is not the one the issue supposed: the expected event counts
+  come back inflated -- about 3.1 events at every observation time for
+  thirty observations -- so the estimator ladder exhausts its risk set
+  within a handful of steps and the survival curve collapses. That is
+  the ghost/normalisation step rather than the index arithmetic.
+
+  What is new is the trigger. A *common* entry time round-trips exactly;
+  entry times that *differ* are what activate it, since only then does a
+  later-entering row have unseen deaths imputed below its own window.
+  That narrows the reproducer from thirty points to six, which is in the
+  suite as a strict ``xfail`` alongside the diagnosis.
+
 - **Truncated parametric regression fits could report a log-likelihood
   tens of thousands higher than their parameters earn, and be optimised
   towards it.** ``truncation_correction`` computed the mass in each

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "surpyval"
-version = "0.18.0"
+version = "0.19.0"
 description = "A python package for survival analysis"
 readme = "README.md"
 license = {text = "MIT"}

--- a/surpyval/__init__.py
+++ b/surpyval/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.18.0"
+__version__ = "0.19.0"
 
 from autograd import numpy as np
 

--- a/surpyval/recurrent/renewal/generalized_one_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_one_renewal.py
@@ -60,16 +60,16 @@ class GeneralizedOneRenewal(RenewalFitMixin):
     =========================
     Distribution        : Weibull
     Fitted by           : MLE
-    Restoration Factor  : -0.1730184624683848
+    Restoration Factor  : -0.1730179893443181
     Parameters          :
-        alpha: 1.3919045967886952
-         beta: 5.0088611892336115
+        alpha: 1.3919016662855024
+         beta: 5.008872636271443
     >>>
     >>> np.random.seed(0)
     >>> np_model = model.count_terminated_simulation(len(x), 5000)
     >>> np_model.mcf(np.array([1, 2, 3, 4, 5, 6]))
-    array([0.1696    , 1.181     , 2.287     , 3.6694    , 5.58237925,
-           8.54474531])
+    array([0.1696    , 1.181     , 2.287     , 3.6696    , 5.58237921,
+           8.54474127])
     """
 
     @staticmethod

--- a/surpyval/tests/conftest.py
+++ b/surpyval/tests/conftest.py
@@ -1,0 +1,67 @@
+"""Opt-in gating for the slow parts of the test suite.
+
+Two groups are skipped unless asked for, because both are expensive and
+neither guards a regression that the default run would miss quickly:
+
+``ml``
+    The beta-stage survival tree and forest tests. They fit hundreds of
+    small Weibulls per test and take 97 of the suite's ~180 seconds --
+    over half the runtime for 85 of its 2000-odd tests.
+
+``invariants``
+    The combinatorial fit-invariant sweep. It is a wide net rather than
+    a targeted regression test, so it belongs in a deliberate run rather
+    than in every edit-test cycle.
+
+Continuous integration passes both flags; see ``.github/workflows``. The
+default local run stays fast, which is the point.
+
+Marks are applied by path so the test modules themselves stay free of
+suite-management boilerplate.
+"""
+
+import pytest
+
+OPT_IN = {
+    "ml": (
+        "--run-ml",
+        "beta ML tree/forest tests",
+        "surpyval/tests/beta/ml",
+    ),
+    "invariants": (
+        "--run-invariants",
+        "combinatorial fit-invariant sweep",
+        "surpyval/tests/univariate/parametric/test_fit_invariants.py",
+    ),
+}
+
+
+def pytest_addoption(parser):
+    for _, (flag, description, _path) in OPT_IN.items():
+        parser.addoption(
+            flag,
+            action="store_true",
+            default=False,
+            help=f"run the {description} (skipped by default)",
+        )
+
+
+def pytest_configure(config):
+    for mark, (flag, description, _path) in OPT_IN.items():
+        config.addinivalue_line(
+            "markers", f"{mark}: {description}; opt in with {flag}"
+        )
+
+
+def pytest_collection_modifyitems(config, items):
+    for mark, (flag, description, path) in OPT_IN.items():
+        wanted = config.getoption(flag)
+        for item in items:
+            location = str(item.fspath).replace("\\", "/")
+            if path not in location:
+                continue
+            item.add_marker(getattr(pytest.mark, mark))
+            if not wanted:
+                item.add_marker(
+                    pytest.mark.skip(reason=f"needs {flag} ({description})")
+                )

--- a/surpyval/tests/conftest.py
+++ b/surpyval/tests/conftest.py
@@ -13,8 +13,12 @@ neither guards a regression that the default run would miss quickly:
     a targeted regression test, so it belongs in a deliberate run rather
     than in every edit-test cycle.
 
-Continuous integration passes both flags; see ``.github/workflows``. The
-default local run stays fast, which is the point.
+Continuous integration passes ``--run-ml`` only, so its coverage is
+unchanged. The invariant sweep is deliberately *not* run there: it is a
+net for exploring, cast deliberately when the fitting paths are being
+worked on, and three and a half minutes on every pull request across
+three Python versions buys little when its assertions hold. Run it
+locally after touching a likelihood, an initialiser or an optimiser.
 
 Marks are applied by path so the test modules themselves stay free of
 suite-management boilerplate.

--- a/surpyval/tests/recurrent/test_counting.py
+++ b/surpyval/tests/recurrent/test_counting.py
@@ -159,7 +159,7 @@ def test_count_terminated_simulation_via_mixin():
     model = GeneralizedOneRenewal.fit(x, dist=Weibull)
     np.random.seed(0)
     np_model = model.count_terminated_simulation(len(x), 5000)
-    expected = np.array([0.1696, 1.181, 2.287, 3.6694, 5.58237925, 8.54474531])
+    expected = np.array([0.1696, 1.181, 2.287, 3.6696, 5.58237921, 8.54474127])
     assert np.allclose(np_model.mcf(np.array([1, 2, 3, 4, 5, 6])), expected)
 
 
@@ -277,7 +277,7 @@ def test_seed_none_defers_to_global_rng():
     got = model.count_terminated_simulation(len(x), 5000).mcf(
         np.array([1, 2, 3, 4, 5, 6])
     )
-    expected = np.array([0.1696, 1.181, 2.287, 3.6694, 5.58237925, 8.54474531])
+    expected = np.array([0.1696, 1.181, 2.287, 3.6696, 5.58237921, 8.54474127])
     assert np.allclose(got, expected)
 
 

--- a/surpyval/tests/recurrent/test_counting.py
+++ b/surpyval/tests/recurrent/test_counting.py
@@ -159,8 +159,16 @@ def test_count_terminated_simulation_via_mixin():
     model = GeneralizedOneRenewal.fit(x, dist=Weibull)
     np.random.seed(0)
     np_model = model.count_terminated_simulation(len(x), 5000)
-    expected = np.array([0.1696, 1.181, 2.287, 3.6696, 5.58237921, 8.54474127])
-    assert np.allclose(np_model.mcf(np.array([1, 2, 3, 4, 5, 6])), expected)
+    expected = np.array([0.1696, 1.181, 2.287, 3.6694, 5.58237925, 8.54474531])
+    # rtol here rather than allclose's 1e-5, because these numbers are a
+    # 5000-run simulation driven by an optimiser's output: a change in
+    # the fitted parameters at the seventh significant figure moves the
+    # simulated MCF in the fourth. That is convergence noise, not a
+    # change in behaviour. What this test is for -- that the shared
+    # mixin still drives the simulation -- would break far more loudly.
+    assert np.allclose(
+        np_model.mcf(np.array([1, 2, 3, 4, 5, 6])), expected, rtol=1e-3
+    )
 
 
 def test_count_terminated_simulation_data_is_recurrent_data():
@@ -277,8 +285,11 @@ def test_seed_none_defers_to_global_rng():
     got = model.count_terminated_simulation(len(x), 5000).mcf(
         np.array([1, 2, 3, 4, 5, 6])
     )
-    expected = np.array([0.1696, 1.181, 2.287, 3.6696, 5.58237921, 8.54474127])
-    assert np.allclose(got, expected)
+    expected = np.array([0.1696, 1.181, 2.287, 3.6694, 5.58237925, 8.54474531])
+    # See the note on rtol in test_count_terminated_simulation_via_mixin.
+    # What this test pins is that seed=None still defers to the global
+    # RNG, which a regression would break outright rather than subtly.
+    assert np.allclose(got, expected, rtol=1e-3)
 
 
 @pytest.mark.parametrize(

--- a/surpyval/tests/univariate/nonparametric/test_turnbull_input_sweep.py
+++ b/surpyval/tests/univariate/nonparametric/test_turnbull_input_sweep.py
@@ -92,16 +92,21 @@ KINDS = [
     "right_truncated",
     "both_truncated",
     "interval_left_truncated",
-    # Left censoring together with left truncation is currently broken
-    # (#308): the support-window intersection drops the (-inf, x] bound a
-    # left-censored row lives on whenever an entry time sits above its
-    # lower edge, so the fit either raises or wanders to a degenerate
-    # estimate. Marked xfail rather than dropped so this sweep reports the
-    # day it starts working.
+    # Left censoring together with left truncation still does not
+    # converge (#308, second half). The support-window off-by-one that
+    # made these inputs *raise* is fixed, and a vacuous entry time is now
+    # an exact no-op; what remains is the EM inflating its expected event
+    # counts. On this case every observation time comes back carrying
+    # ~3.1 expected events for 30 observations, so the estimator ladder
+    # exhausts the risk set within a handful of steps and the survival
+    # curve collapses. That is the ghost/normalisation step, not the
+    # index arithmetic. Marked xfail rather than dropped so this sweep
+    # reports the day it starts working.
     pytest.param(
         "all_censoring_types_truncated",
         marks=pytest.mark.xfail(
-            reason="left censoring + left truncation, see #308",
+            reason="left censoring + left truncation, EM does not "
+            "converge; see #308",
             strict=True,
         ),
     ),
@@ -155,9 +160,6 @@ def test_estimator_choice_is_honoured(kind):
     ), f"{kind}: Nelson-Aalen and Kaplan-Meier gave identical curves"
 
 
-@pytest.mark.xfail(
-    reason="left censoring + left truncation, see #308", strict=True
-)
 def test_vacuous_left_truncation_does_not_change_a_left_censored_fit():
     # Every entry time is 0 and every observation is above 0, so no unit is
     # excluded and the truncated fit must equal the untruncated one. It
@@ -211,3 +213,101 @@ def test_fleming_harrington_matches_nelson_aalen_only_without_ties():
         rtol=1e-6,
         atol=1e-6,
     )
+
+
+def test_left_censored_row_keeps_the_interval_starting_at_its_entry_time():
+    """The support index at the entry time is admissible, not excluded.
+
+    A support index ``j`` stands for ``(bounds[j], bounds[j+1]]``, so an
+    event placed there is already strictly after ``bounds[j]``. The first
+    index a row entering at ``tl`` may use is therefore the *last* one
+    whose bound equals ``tl`` -- that interval is ``(tl, next]``.
+
+    A left-censored event lies in ``(-inf, xr]``, which under an entry at
+    ``tl`` is the single interval ``(tl, xr]``. Excluding it left such a
+    row with an empty support, and the fit raised (#308).
+
+    A *common* entry time below every observation excludes nobody and
+    introduces no differential risk, so the estimate must equal the
+    untruncated one exactly. Distinct entry times below every observation
+    also exclude nobody, but do not yet round-trip -- see the reproducer
+    below.
+    """
+    x = np.array([2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+    c = np.array([-1, 0, 0, -1, 0, 0])
+    grid = [1.5, 2.5, 4.5, 6.5, 8.0]
+
+    untruncated = np.ravel(
+        Turnbull.fit(x=x, c=c, turnbull_estimator="Kaplan-Meier").sf(grid)
+    )
+    for entry in (np.zeros(6), np.full(6, 0.5), np.full(6, 1.9)):
+        truncated = np.ravel(
+            Turnbull.fit(
+                x=x, c=c, tl=entry, turnbull_estimator="Kaplan-Meier"
+            ).sf(grid)
+        )
+        assert np.allclose(truncated, untruncated, atol=1e-9), (
+            f"entry times {entry} exclude nobody, so the fit must be "
+            f"unchanged; got {truncated} against {untruncated}"
+        )
+
+
+@pytest.mark.xfail(
+    reason="left censoring + distinct entry times, EM does not converge; "
+    "see #308",
+    strict=True,
+)
+def test_distinct_entry_times_with_left_censoring_round_trip():
+    """Minimal reproducer for the half of #308 that is still open.
+
+    Six observations, two of them left censored, and six *distinct* entry
+    times all below the earliest observation. Nobody is excluded, so the
+    estimate should again be the untruncated one; instead the survival
+    curve collapses to the order of 1e-3.
+
+    A common entry time (the test above) round-trips exactly, so the
+    trigger is entry times that *differ*. That is what activates the
+    ghost step: a row entering later than another has unseen deaths
+    imputed below its own window, and the expected event counts come back
+    inflated -- the sweep case sees ~3.1 expected events at every
+    observation time for 30 observations, which exhausts the risk set
+    within a few steps of the estimator ladder.
+
+    Six points rather than the thirty in the issue, and the failure is
+    the same, so this is the cheaper thing to debug against.
+    """
+    x = np.array([2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+    c = np.array([-1, 0, 0, -1, 0, 0])
+    grid = [1.5, 2.5, 4.5, 6.5, 8.0]
+
+    untruncated = np.ravel(
+        Turnbull.fit(x=x, c=c, turnbull_estimator="Kaplan-Meier").sf(grid)
+    )
+    truncated = np.ravel(
+        Turnbull.fit(
+            x=x,
+            c=c,
+            tl=np.linspace(0.1, 1.0, 6),
+            turnbull_estimator="Kaplan-Meier",
+            max_iter=MAX_ITER,
+        ).sf(grid)
+    )
+    assert np.allclose(truncated, untruncated, atol=1e-9)
+
+
+def test_entry_exactly_at_an_event_time_stays_strict():
+    """Widening the entry window must not readmit the event at the entry.
+
+    The fix above must not reach the zero-width interval ``(tl, tl]`` that
+    a duplicated exact event time creates: a subject entering exactly at
+    an event time is not at risk for that event (#260). Taking
+    ``side="left"`` rather than ``side="right" - 1`` would have readmitted
+    it.
+    """
+    x = np.array([2.0, 3.0, 3.0, 4.0, 5.0, 6.0])
+    tl = np.array([0.0, 0.0, 1.0, 1.0, 2.0, 2.0])
+
+    model = Turnbull.fit(x=x, tl=tl, turnbull_estimator="Kaplan-Meier")
+    # Two subjects enter at 2.0 and so are not at risk for the event at
+    # 2.0: four at risk, one event, 1 - 1/4.
+    assert float(np.ravel(model.sf(2.0))[0]) == pytest.approx(0.75, abs=1e-6)

--- a/surpyval/tests/univariate/nonparametric/test_turnbull_input_sweep.py
+++ b/surpyval/tests/univariate/nonparametric/test_turnbull_input_sweep.py
@@ -11,6 +11,8 @@ break one corner of the input space while the targeted tests keep
 passing.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -253,8 +255,9 @@ def test_left_censored_row_keeps_the_interval_starting_at_its_entry_time():
 
 
 @pytest.mark.xfail(
-    reason="left censoring + distinct entry times, EM does not converge; "
-    "see #308",
+    reason="left censoring + distinct entry times is not identifiable; the "
+    "fit now warns, but the estimate itself is still the boundary one. "
+    "See #308",
     strict=True,
 )
 def test_distinct_entry_times_with_left_censoring_round_trip():
@@ -311,3 +314,86 @@ def test_entry_exactly_at_an_event_time_stays_strict():
     # Two subjects enter at 2.0 and so are not at risk for the event at
     # 2.0: four at risk, one event, 1 - 1/4.
     assert float(np.ravel(model.sf(2.0))[0]) == pytest.approx(0.75, abs=1e-6)
+
+
+def test_non_identifiable_entry_windows_are_reported():
+    """A fit resting on the flat direction must say so.
+
+    Left censoring together with two or more distinct entry times creates
+    intervals that one observation could have failed in but that precede
+    another's entry. Mass there raises the first's likelihood and costs
+    the others nothing, because their contributions are conditional on
+    their own entry. The likelihood has no interior maximum, so the
+    estimate is not identifiable and the EM cannot settle (#308).
+
+    Rejecting the data would be wrong -- over 240 simulated samples that
+    all met the structural condition, most fitted perfectly well -- so
+    the fit is returned with a warning and a reported share.
+    """
+    x = np.array([2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+    c = np.array([-1, 0, 0, -1, 0, 0])
+
+    with pytest.warns(UserWarning, match="not identifiable"):
+        model = Turnbull.fit(
+            x=x,
+            c=c,
+            tl=np.linspace(0.1, 1.0, 6),
+            turnbull_estimator="Kaplan-Meier",
+            max_iter=MAX_ITER,
+        )
+    assert model.exploitable_mass > 0.9
+
+
+@pytest.mark.parametrize(
+    "tl",
+    [
+        pytest.param(np.zeros(6), id="common_entry_at_zero"),
+        pytest.param(np.full(6, 0.5), id="common_entry_below_data"),
+        pytest.param(None, id="no_truncation"),
+    ],
+)
+def test_identifiable_fits_are_not_warned_about(tl):
+    """The warning must not fire on data that is perfectly estimable.
+
+    One common entry time gives every observation the same window, so no
+    interval is inside one and outside another and the flat direction
+    does not exist.
+    """
+    x = np.array([2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+    c = np.array([-1, 0, 0, -1, 0, 0])
+    kwargs = {} if tl is None else {"tl": tl}
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        model = Turnbull.fit(
+            x=x, c=c, turnbull_estimator="Kaplan-Meier", **kwargs
+        )
+    assert model.exploitable_mass == 0.0
+
+
+def test_distinct_entry_times_alone_are_identifiable():
+    """Distinct entry times are not themselves the problem.
+
+    Without a left-censored row nothing reaches down into the entry
+    region, so six distinct entry times estimate cleanly.
+    """
+    x = np.array([2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+    c = np.zeros(6, dtype=int)
+
+    untruncated = np.ravel(
+        Turnbull.fit(x=x, c=c, turnbull_estimator="Kaplan-Meier").sf(
+            [2.5, 4.5]
+        )
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        model = Turnbull.fit(
+            x=x,
+            c=c,
+            tl=np.linspace(0.1, 1.0, 6),
+            turnbull_estimator="Kaplan-Meier",
+        )
+    assert model.exploitable_mass == 0.0
+    np.testing.assert_allclose(
+        np.ravel(model.sf([2.5, 4.5])), untruncated, rtol=1e-9, atol=1e-9
+    )

--- a/surpyval/tests/univariate/nonparametric/test_turnbull_input_sweep.py
+++ b/surpyval/tests/univariate/nonparametric/test_turnbull_input_sweep.py
@@ -94,21 +94,19 @@ KINDS = [
     "right_truncated",
     "both_truncated",
     "interval_left_truncated",
-    # Left censoring together with left truncation still does not
-    # converge (#308, second half). The support-window off-by-one that
-    # made these inputs *raise* is fixed, and a vacuous entry time is now
-    # an exact no-op; what remains is the EM inflating its expected event
-    # counts. On this case every observation time comes back carrying
-    # ~3.1 expected events for 30 observations, so the estimator ladder
-    # exhausts the risk set within a handful of steps and the survival
-    # curve collapses. That is the ghost/normalisation step, not the
-    # index arithmetic. Marked xfail rather than dropped so this sweep
-    # reports the day it starts working.
+    # Left censoring together with two or more distinct entry times is
+    # not identifiable: the likelihood has a flat direction with its
+    # supremum on the boundary, so the NPMLE is not attained and the EM
+    # cannot settle. The fit now warns and reports the share of mass
+    # resting there (#308), but the estimate it returns is still the
+    # boundary one, so this sweep's assertions still fail. Deciding the
+    # case exactly, rather than by a mass threshold, is #327. Marked
+    # xfail rather than dropped so the sweep reports the day it changes.
     pytest.param(
         "all_censoring_types_truncated",
         marks=pytest.mark.xfail(
-            reason="left censoring + left truncation, EM does not "
-            "converge; see #308",
+            reason="left censoring + distinct entry times is not "
+            "identifiable; see #327",
             strict=True,
         ),
     ),
@@ -257,7 +255,7 @@ def test_left_censored_row_keeps_the_interval_starting_at_its_entry_time():
 @pytest.mark.xfail(
     reason="left censoring + distinct entry times is not identifiable; the "
     "fit now warns, but the estimate itself is still the boundary one. "
-    "See #308",
+    "See #327",
     strict=True,
 )
 def test_distinct_entry_times_with_left_censoring_round_trip():

--- a/surpyval/tests/univariate/parametric/test_confidence_bounds.py
+++ b/surpyval/tests/univariate/parametric/test_confidence_bounds.py
@@ -525,3 +525,82 @@ def test_lr_bounds_respect_user_fixed_parameters():
     point = m.sf(t)
     assert np.all(band[:, 0] <= point + 1e-9)
     assert np.all(point <= band[:, 1] + 1e-9)
+
+
+# The unit a measurement happens to be recorded in must not decide
+# whether a fit has confidence bounds at all.
+#
+# Every parameter bounded on (0, inf) is mapped to the unbounded space
+# the optimiser searches by ``adj_relu``, which chose between ``x + 1``
+# and ``exp(x)`` with ``np.where``. Autograd evaluates both branches, so
+# ``exp(x)`` was taped even where ``x + 1`` was selected, and above
+# x = 709.78 it overflowed to inf -- poisoning the derivative of the
+# branch that *was* chosen. The transform's jacobian came back nan, and
+# ``cov_matrix`` is that jacobian either side of the inverse hessian.
+#
+# The threshold is a property of the fitted parameter, not the sample
+# size, so a Weibull with alpha = 10 lost its bounds once the data was
+# scaled past about 70x while a Gumbel, whose location is unbounded and
+# therefore untransformed, survived to 350x on the same sample.
+SCALE_SENSITIVE = [
+    ("Weibull", (10.0, 2.0)),
+    ("LogLogistic", (10.0, 3.0)),
+    ("ExpoWeibull", (10.0, 2.0, 1.5)),
+    ("Logistic", (10.0, 2.0)),
+    ("Gumbel", (10.0, 2.0)),
+    ("GumbelLEV", (10.0, 2.0)),
+    ("Rayleigh", (5.0,)),
+    ("Gamma", (3.0, 2.0)),
+]
+
+
+@pytest.mark.parametrize("name,params", SCALE_SENSITIVE)
+@pytest.mark.parametrize("scale", [1e-3, 1.0, 1e2, 1e4, 1e6])
+def test_standard_errors_survive_the_units_of_the_data(name, params, scale):
+    dist = getattr(surv, name)
+    np.random.seed(5)
+    x = np.asarray(dist.random(200, *params), dtype=float) * scale
+
+    model = dist.fit(x)
+    cov = model.cov_matrix
+
+    assert cov is not None, f"{name} at scale {scale:g} reported no covariance"
+    se = np.sqrt(np.diag(np.atleast_2d(np.asarray(cov, dtype=float))))
+    assert np.isfinite(se).all(), f"{name} at scale {scale:g} gave se {se}"
+    assert (se > 0).all(), f"{name} at scale {scale:g} gave se {se}"
+
+
+@pytest.mark.parametrize("name,params", SCALE_SENSITIVE)
+def test_standard_errors_are_scale_equivariant(name, params):
+    # A parameter that rescaling carries by a factor f has its standard
+    # error carried by the same f, whatever f happens to be: the data's
+    # units for a scale parameter, their reciprocal for a rate like the
+    # Gamma's, and 1 for a shape. That the restored numbers obey this is
+    # what distinguishes a real covariance from a merely finite one.
+    dist = getattr(surv, name)
+    scale = 1e4
+
+    np.random.seed(5)
+    sample = np.asarray(dist.random(200, *params), dtype=float)
+
+    base = dist.fit(sample)
+    scaled = dist.fit(sample * scale)
+
+    def se_of(model):
+        cov = np.atleast_2d(np.asarray(model.cov_matrix, dtype=float))
+        return np.sqrt(np.diag(cov))
+
+    se_base, se_scaled = se_of(base), se_of(scaled)
+    p_base = np.asarray(base.params, dtype=float)
+    p_scaled = np.asarray(scaled.params, dtype=float)
+
+    factor = np.abs(p_scaled / p_base)
+
+    # Whatever each parameter did under rescaling, it can only have been
+    # carried by the scale, by its reciprocal, or not at all.
+    allowed = np.array([scale, 1.0 / scale, 1.0])
+    assert (
+        np.isclose(factor[:, None], allowed, rtol=1e-3).any(axis=1).all()
+    ), f"{name} parameters moved by {factor}, which is none of {allowed}"
+
+    assert se_scaled == pytest.approx(se_base * factor, rel=1e-3)

--- a/surpyval/tests/univariate/parametric/test_fit.py
+++ b/surpyval/tests/univariate/parametric/test_fit.py
@@ -623,3 +623,68 @@ def test_maximum_likelihood_attains_the_largest_likelihood():
     best = Weibull.fit(x, how="MLE").neg_ll()
     for how in ("MPS", "MSE", "MOM", "MPP"):
         assert Weibull.fit(x, how=how).neg_ll() >= best - 1e-9, how
+
+
+# -- degenerate data ----------------------------------------------------
+#
+# Fitting three tied observations used to die with an IndexError raised
+# from inside numdifftools, four steps removed from the cause. The
+# probability plot has no slope through a single distinct abscissa, so
+# polyfit returned a nan; that nan seeded the MLE, which started at nan,
+# produced a nan hessian, and finally asked numdifftools for a numerical
+# one, whose list of finite-difference steps came back empty.
+#
+# Gamma and Beta failed the same way but silently: their moment-based
+# initialisers divide by a variance that is zero for tied data, and a
+# failed optimiser returns its initial guess (#261), so (inf, inf) was
+# handed back as a fitted model.
+
+
+def test_degenerate_data_is_rejected_with_a_clear_error():
+    for dist in (Weibull, Gamma):
+        with pytest.raises(ValueError, match="free parameter"):
+            dist.fit(np.array([10.0, 10.0, 10.0]))
+    with pytest.raises(ValueError, match="free parameter"):
+        Beta.fit(np.array([0.2, 0.2, 0.2]))
+
+
+def test_fixing_a_parameter_buys_back_a_degree_of_freedom():
+    # The count is of *free* parameters, not of the distribution's, so a
+    # single observation is enough once beta is fixed. The MLE of alpha
+    # with beta known is (sum x**beta / n) ** (1 / beta) = 10.
+    model = Weibull.fit(np.array([10.0]), fixed={"beta": 2.0})
+    assert model.params[0] == pytest.approx(10.0, rel=1e-6)
+    assert model.params[1] == pytest.approx(2.0)
+
+    tied = Weibull.fit(np.array([10.0, 10.0, 10.0]), fixed={"beta": 2.0})
+    assert tied.params[0] == pytest.approx(10.0, rel=1e-6)
+
+
+def test_one_parameter_distributions_fit_tied_data():
+    # A tied sample identifies a single parameter perfectly well, so
+    # these must not be caught by the degeneracy check.
+    assert Exponential.fit(np.array([10.0] * 3)).params[0] == pytest.approx(
+        0.1
+    )
+    assert Rayleigh.fit(np.array([10.0] * 3)).params[0] == pytest.approx(
+        np.sqrt(50.0)
+    )
+
+
+def test_probability_plotting_survives_a_degenerate_regression():
+    # MPP is exempt from the degeneracy check: it is a regression, not a
+    # likelihood maximisation, and it is how several distributions seed
+    # themselves. It must return finite parameters rather than nan.
+    model = Weibull.fit(np.array([10.0, 10.0, 10.0]), how="MPP")
+    assert np.isfinite(np.asarray(model.params, dtype=float)).all()
+
+
+def test_a_fit_never_returns_non_finite_parameters():
+    # The backstop: whatever the cause, non-finite parameters are not a
+    # valid answer. Gamma used to return (inf, inf) here in silence.
+    for dist, x in (
+        (Weibull, np.array([10.0, 10.0, 10.0])),
+        (Gamma, np.array([10.0, 10.0, 10.0])),
+    ):
+        with pytest.raises(ValueError):
+            dist.fit(x)

--- a/surpyval/tests/univariate/parametric/test_fit_invariants.py
+++ b/surpyval/tests/univariate/parametric/test_fit_invariants.py
@@ -1,0 +1,287 @@
+"""A wide net over the fitting API, asserting only what must always hold.
+
+Every defect found in the v0.18.x round slipped past the whole suite, and
+each one lived at an *intersection* of dimensions the suite tests one at
+a time:
+
+- a censored observation that is also truncated (the likelihood was
+  unbounded, and returned garbage with ``success=True``)
+- an offset combined with a particular method (Gamma's moment
+  initialiser returned ``(inf, inf)``, which #261's fallback then
+  reported as the fit)
+- an offset combined with a large *shift magnitude* (54 of 120
+  ExpoWeibull fits returned ``nan``)
+- a sample smaller than the 1000 floor of ``FIT_SIZES`` (a rank
+  deficient probability plot seeded the optimiser with ``nan``)
+
+The full cross of distributions, methods, censoring, truncation,
+structural flags, sizes and scales is around 600,000 cells, so this does
+not attempt it. Instead it asserts cheap invariants -- finiteness,
+boundedness, monotonicity -- over a broad seeded sample of that space.
+Four of the five defects above would have failed the first two
+assertions here, without anyone having to guess where to look.
+
+Accuracy is deliberately not asserted. Recovery of known parameters is
+already covered by ``test_fit.py``; the point of this file is to catch
+answers that are not answers at all.
+
+Opt in with ``--run-invariants``.
+"""
+
+import numpy as np
+import pytest
+
+from surpyval import (
+    Exponential,
+    ExpoWeibull,
+    Gamma,
+    Gumbel,
+    Logistic,
+    LogLogistic,
+    LogNormal,
+    Normal,
+    Rayleigh,
+    Weibull,
+)
+
+DISTS = [
+    Weibull,
+    Gamma,
+    LogNormal,
+    Normal,
+    Logistic,
+    LogLogistic,
+    Gumbel,
+    ExpoWeibull,
+    Exponential,
+    Rayleigh,
+]
+TRUE = {
+    "Weibull": (10.0, 2.0),
+    "Gamma": (3.0, 2.0),
+    "LogNormal": (2.0, 0.5),
+    "Normal": (10.0, 2.0),
+    "Logistic": (10.0, 2.0),
+    "LogLogistic": (10.0, 3.0),
+    "Gumbel": (10.0, 2.0),
+    "ExpoWeibull": (10.0, 2.0, 1.5),
+    "Exponential": (0.1,),
+    "Rayleigh": (5.0,),
+}
+POSITIVE_ONLY = {
+    "Weibull",
+    "Gamma",
+    "LogNormal",
+    "LogLogistic",
+    "ExpoWeibull",
+    "Exponential",
+    "Rayleigh",
+}
+
+METHODS = ["MLE", "MPS", "MSE", "MOM", "MPP"]
+SHAPES = ["plain", "right", "left", "interval", "tl", "tr", "right+tl"]
+# Scale is the least covered axis in the suite, and the MLE failure
+# warning itself advises rescaling towards 1 -- so exercise both ends.
+SCALES = [1e-3, 1.0, 1e3]
+# One representative size per cell. Sweeping sizes inside each cell
+# multiplied the run by three for almost no extra coverage -- the size
+# axis is exercised on its own in ``test_tiny_samples_never_return_junk``.
+N = 120
+TINY = [1, 2, 5, 40]
+
+
+def _make(dist, n, shape, scale, seed):
+    """Return (kwargs for fit) for one cell of the grid, or None to skip."""
+    rng = np.random.default_rng(seed)
+    np.random.seed(seed)
+    x = np.asarray(dist.random(n, *TRUE[dist.name]), dtype=float) * scale
+    if dist.name not in POSITIVE_ONLY:
+        pass
+    c = np.zeros(n, dtype=int)
+    kw = {}
+    if shape == "right":
+        cut = np.quantile(x, 0.75)
+        c = np.where(x > cut, 1, 0)
+        x = np.minimum(x, cut)
+    elif shape == "left":
+        cut = np.quantile(x, 0.25)
+        c = np.where(x < cut, -1, 0)
+        x = np.maximum(x, cut)
+    elif shape == "interval":
+        counts, edges = np.histogram(x, bins=max(3, n // 4))
+        keep = counts > 0
+        xi = np.vstack([edges[:-1], edges[1:]]).T[keep]
+        return dict(x=xi, n=counts[keep])
+    elif shape == "tl":
+        lo = float(np.quantile(x, 0.10))
+        x = x[x > lo]
+        if x.size < 3:
+            return None
+        c = np.zeros(x.size, dtype=int)
+        kw["tl"] = lo
+    elif shape == "tr":
+        hi = float(np.quantile(x, 0.90))
+        x = x[x < hi]
+        if x.size < 3:
+            return None
+        c = np.zeros(x.size, dtype=int)
+        kw["tr"] = hi
+    elif shape == "right+tl":
+        # The combination that #310/#311 was about: an observation that
+        # is both censored and truncated.
+        lo = float(np.quantile(x, 0.10))
+        x = x[x > lo]
+        if x.size < 4:
+            return None
+        cut = float(np.quantile(x, 0.75))
+        c = np.where(x > cut, 1, 0)
+        x = np.minimum(x, cut)
+        kw["tl"] = lo
+    _ = rng
+    return dict(x=x, c=c, **kw)
+
+
+def _fit_or_reason(dist, how, kwargs, **extra):
+    """Fit, returning (model, None) or (None, exception).
+
+    A raised exception is not a failure here. Several combinations are
+    legitimately rejected -- a distribution that cannot be offset, data
+    that cannot identify the free parameters, a method that does not
+    support left censoring. What must never happen is a *returned* model
+    that is not a model.
+    """
+    try:
+        return dist.fit(how=how, **kwargs, **extra), None
+    except Exception as exc:  # noqa: BLE001 - any rejection is acceptable
+        return None, exc
+
+
+def _assert_model_is_usable(model, label):
+    params = np.atleast_1d(np.asarray(model.params, dtype=float))
+    assert np.isfinite(params).all(), f"{label}: non-finite params {params}"
+
+    for name in ("gamma", "p", "f0"):
+        value = getattr(model, name, None)
+        if value is not None:
+            assert np.isfinite(float(value)), f"{label}: {name}={value}"
+
+    nll = float(model.neg_ll())
+    assert np.isfinite(nll), f"{label}: neg_ll={nll}"
+
+
+def _assert_survival_is_a_survival_function(model, label):
+    lo, hi = model.dist.support
+    probe = np.asarray(model.surv_data.x, dtype=float)
+    probe = probe[np.isfinite(probe)]
+    if probe.size == 0:
+        return
+    grid = np.quantile(np.ravel(probe), np.linspace(0.05, 0.95, 12))
+    grid = np.clip(grid, max(lo, -1e300), min(hi, 1e300))
+    with np.errstate(all="ignore"):
+        sf = np.asarray(model.sf(grid), dtype=float)
+    assert np.isfinite(sf).all(), f"{label}: non-finite sf {sf}"
+    inside = ((sf >= -1e-9) & (sf <= 1 + 1e-9)).all()
+    assert inside, f"{label}: sf outside [0, 1]"
+    assert np.all(np.diff(sf) <= 1e-9), f"{label}: sf not non-increasing"
+
+
+@pytest.mark.parametrize("dist", DISTS, ids=lambda d: d.name)
+@pytest.mark.parametrize("shape", SHAPES)
+@pytest.mark.parametrize("scale", SCALES, ids=lambda s: f"scale{s:g}")
+def test_a_returned_fit_is_always_a_usable_model(dist, shape, scale):
+    """Finite parameters, finite neg_ll, and a valid survival function.
+
+    This is the assertion that four of the five v0.18.x defects would
+    have tripped.
+    """
+    for how in METHODS:
+        kwargs = _make(dist, N, shape, scale, seed=N + len(shape))
+        if kwargs is None:
+            continue
+        label = f"{dist.name}|{how}|{shape}|scale={scale:g}|n={N}"
+        model, exc = _fit_or_reason(dist, how, kwargs)
+        if model is None:
+            continue  # a refusal is a valid outcome; a bad model is not
+        _assert_model_is_usable(model, label)
+        _assert_survival_is_a_survival_function(model, label)
+
+
+@pytest.mark.parametrize("dist", DISTS, ids=lambda d: d.name)
+@pytest.mark.parametrize("n", TINY)
+def test_tiny_samples_never_return_junk(dist, n):
+    """Below the 1000 floor of ``FIT_SIZES``, where the crashes were.
+
+    A refusal is fine -- one or two points cannot identify two free
+    parameters, and the fitter now says so. What must not happen is a
+    returned model carrying nan or inf, which is what Gamma and Beta
+    used to do here.
+    """
+    for how in METHODS:
+        kwargs = _make(dist, n, "plain", 1.0, seed=n)
+        if kwargs is None:
+            continue
+        model, _ = _fit_or_reason(dist, how, kwargs)
+        if model is None:
+            continue
+        _assert_model_is_usable(model, f"{dist.name}|{how}|n={n}")
+
+
+@pytest.mark.parametrize("dist", DISTS, ids=lambda d: d.name)
+def test_structural_flags_pairwise(dist):
+    """Offset, lfp, zi and fixed, alone and in pairs.
+
+    The suite exercises these almost exclusively on their own -- only a
+    handful of places combine two. Pairwise is where interaction bugs
+    live, and it is a small fraction of the full cross.
+    """
+    combos = [
+        {"offset": True},
+        {"lfp": True},
+        {"zi": True},
+        {"offset": True, "lfp": True},
+        {"offset": True, "zi": True},
+        {"lfp": True, "zi": True},
+    ]
+    if dist.k >= 2:
+        first = dist.param_names[0]
+        combos.append({"fixed": {first: float(TRUE[dist.name][0])}})
+        combos.append(
+            {"offset": True, "fixed": {first: float(TRUE[dist.name][0])}}
+        )
+    for extra in combos:
+        for shape in ("plain", "right"):
+            kwargs = _make(dist, 200, shape, 1.0, seed=7)
+            if kwargs is None:
+                continue
+            label = f"{dist.name}|{shape}|{extra}"
+            model, exc = _fit_or_reason(dist, "MLE", kwargs, **extra)
+            if model is None:
+                continue
+            _assert_model_is_usable(model, label)
+
+
+@pytest.mark.parametrize("dist", DISTS, ids=lambda d: d.name)
+def test_mle_attains_the_lowest_negative_log_likelihood(dist):
+    """The defining property of the estimator, checkable since #316.
+
+    Maximum likelihood minimises the negative log-likelihood, so no other
+    method may beat it on its own objective. A tolerance is allowed
+    because the others stop on different criteria, but a real defeat
+    means the MLE did not converge.
+    """
+    np.random.seed(3)
+    x = np.asarray(dist.random(500, *TRUE[dist.name]), dtype=float)
+    mle, exc = _fit_or_reason(dist, "MLE", dict(x=x))
+    if mle is None:
+        pytest.skip(f"{dist.name}: MLE unavailable ({exc})")
+    best = float(mle.neg_ll())
+    for how in ("MPS", "MSE", "MOM", "MPP"):
+        other, _ = _fit_or_reason(dist, how, dict(x=x))
+        if other is None:
+            continue
+        rival = float(other.neg_ll())
+        if not np.isfinite(rival):
+            continue
+        assert rival >= best - 1e-6 * max(
+            abs(best), 1.0
+        ), f"{dist.name}: {how} reached {rival} against MLE's {best}"

--- a/surpyval/tests/univariate/regression/test_parametric_tvc.py
+++ b/surpyval/tests/univariate/regression/test_parametric_tvc.py
@@ -43,7 +43,31 @@ def _constant_covariate_split(seed=0, n=300):
     return (Z, T, c0), (ident, xl, xr, c, Zs)
 
 
-@pytest.mark.parametrize("name", list(TVC_FITTERS))
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param(
+            n,
+            marks=(
+                pytest.mark.xfail(
+                    strict=True,
+                    reason=(
+                        "#326: TNC diverges into the unbounded region of the "
+                        "left-truncated likelihood and optimise_ph returns it "
+                        "unconditionally. Stage one finds the right answer "
+                        "(neg_ll 927.83); TNC replaces it with -21311.40 and "
+                        "reports success, so neither a success check nor an "
+                        "objective comparison rescues it. strict, so this "
+                        "reverses on its own when #326 is fixed."
+                    ),
+                )
+                if n == "WeibullPH"
+                else ()
+            ),
+        )
+        for n in TVC_FITTERS
+    ],
+)
 def test_episode_split_is_an_identity(name):
     fitter = TVC_FITTERS[name]
     (Z, T, c0), (ident, xl, xr, c, Zs) = _constant_covariate_split()

--- a/surpyval/tests/univariate/regression/test_parametric_tvc.py
+++ b/surpyval/tests/univariate/regression/test_parametric_tvc.py
@@ -43,31 +43,7 @@ def _constant_covariate_split(seed=0, n=300):
     return (Z, T, c0), (ident, xl, xr, c, Zs)
 
 
-@pytest.mark.parametrize(
-    "name",
-    [
-        pytest.param(
-            n,
-            marks=(
-                pytest.mark.xfail(
-                    strict=True,
-                    reason=(
-                        "#326: TNC diverges into the unbounded region of the "
-                        "left-truncated likelihood and optimise_ph returns it "
-                        "unconditionally. Stage one finds the right answer "
-                        "(neg_ll 927.83); TNC replaces it with -21311.40 and "
-                        "reports success, so neither a success check nor an "
-                        "objective comparison rescues it. strict, so this "
-                        "reverses on its own when #326 is fixed."
-                    ),
-                )
-                if n == "WeibullPH"
-                else ()
-            ),
-        )
-        for n in TVC_FITTERS
-    ],
-)
+@pytest.mark.parametrize("name", list(TVC_FITTERS))
 def test_episode_split_is_an_identity(name):
     fitter = TVC_FITTERS[name]
     (Z, T, c0), (ident, xl, xr, c, Zs) = _constant_covariate_split()
@@ -191,3 +167,43 @@ def test_po_does_not_expose_tvc():
     # accumulated-age likelihood -- see test_aft_tvc_fit.py.)
     assert not hasattr(PO(Weibull), "fit_tvc")
     assert hasattr(AFT(Weibull), "fit_tvc")
+
+
+def test_left_truncated_likelihood_does_not_reward_a_vanishing_scale():
+    """A region the data rules out must not report a better likelihood.
+
+    The truncation correction used to be a difference of CDFs floored at
+    the smallest positive float. Under left truncation that difference is
+    ``1 - F(tl)``, which underflows to zero as the fitted scale shrinks;
+    the floor then capped the correction at ``log(tiny) = -708`` rather
+    than letting it grow without bound. Since the correction is
+    *subtracted*, every truncated row appeared to contribute +708, and
+    the optimiser walked into a region the data excludes -- reporting a
+    log-likelihood some 38,000 higher than its parameters earn (#326).
+
+    The check is that the reported objective is the real one: a scale far
+    below the truncation bounds must score worse than the fitted answer,
+    not better.
+    """
+    (Z, T, c0), (ident, xl, xr, c, Zs) = _constant_covariate_split()
+    fitter = TVC_FITTERS["WeibullPH"]
+
+    model = fitter.fit_tvc(i=ident, xl=xl, xr=xr, c=c, Z=Zs)
+    fitted = np.asarray(model.params, dtype=float)
+
+    # Same objective the fit minimised, evaluated directly.
+    def neg_ll(params):
+        return float(fitter.neg_ll(model.data, *params))
+
+    assert neg_ll(fitted) == pytest.approx(model._neg_ll, rel=1e-9)
+
+    # Shrinking the scale far below the truncation bounds is where the
+    # floor used to manufacture likelihood. Every such point must be
+    # worse than the fit.
+    for shrink in (10.0, 100.0, 1000.0):
+        degenerate = fitted.copy()
+        degenerate[0] = fitted[0] / shrink
+        assert neg_ll(degenerate) > neg_ll(fitted), (
+            f"scale/{shrink:g} scores better than the fit, so the "
+            f"truncation correction is still being floored"
+        )

--- a/surpyval/tests/univariate/regression/test_proportional_hazards.py
+++ b/surpyval/tests/univariate/regression/test_proportional_hazards.py
@@ -627,3 +627,115 @@ def test_optimise_ph_never_returns_a_worse_point_than_it_started_from():
         res = optimise_ph(rosenbrock, x0)
         assert res.fun <= rosenbrock(x0)
         assert res.fun == pytest.approx(rosenbrock(res.x), rel=1e-8, abs=1e-12)
+
+
+def _efron_hess_reference(n_d, Ri, ZRi, Z2Ri, Di, ZDi, Z2Di):
+    """The literal double loop ``efron_hess`` replaced, kept as an oracle.
+
+    ``efron_hess`` now factors the sum over tied deaths out of the p x p
+    part, which is a real algebraic rearrangement rather than a
+    reorganisation of the same arithmetic (#329). This pins it.
+    """
+    out = np.zeros((len(n_d),) + Z2Ri.shape[1:])
+    for i in range(len(n_d)):
+        val = np.zeros(out.shape[1:])
+        if n_d[i] == 0:
+            continue
+        for j in range(int(n_d[i])):
+            k = j / n_d[i]
+            dRD = Ri[i] - k * Di[i]
+            a = ZRi[i] - k * ZDi[i]
+            val += (dRD * (Z2Ri[i] - k * Z2Di[i]) - np.outer(a, a)) / dRD**2
+        out[i] = val
+    return out
+
+
+@pytest.mark.parametrize(
+    "counts",
+    [
+        [1.0, 1.0, 1.0, 1.0],  # no ties at all -- the continuous case
+        [1.0, 0.0, 3.0, 1.0],  # a time with no deaths mixed in
+        [7.0, 12.0, 1.0, 4.0],  # heavy ties
+        [2.5, 1.0, 3.5, 0.0],  # fractional weights: range(int(d)), c = j/d
+    ],
+)
+def test_efron_hessian_matches_the_loop_it_replaced(counts):
+    from surpyval.univariate.regression.proportional_hazards.cox_ph import (
+        efron_hess,
+    )
+
+    rng = np.random.default_rng(31)
+    m, p = len(counts), 4
+    n_d = np.array(counts)
+
+    # Risk-set sums must dominate the death sums for R - cD to stay
+    # positive, which is what the real aggregation guarantees.
+    Ri = rng.uniform(50, 100, (m, 1))
+    Di = rng.uniform(0, 10, (m, 1))
+    ZRi = rng.normal(size=(m, p))
+    ZDi = rng.normal(size=(m, p))
+    Z2Ri = rng.normal(size=(m, p, p))
+    Z2Di = rng.normal(size=(m, p, p))
+
+    got = efron_hess(n_d, Ri, ZRi, Z2Ri, Di, ZDi, Z2Di)
+    want = _efron_hess_reference(n_d, Ri, ZRi, Z2Ri, Di, ZDi, Z2Di)
+
+    assert got.shape == want.shape
+    np.testing.assert_allclose(got, want, rtol=1e-11, atol=1e-11)
+
+
+@pytest.mark.parametrize(
+    "counts", [[1.0, 1.0, 1.0], [5.0, 1.0, 2.0], [2.5, 0.0, 3.5]]
+)
+def test_efron_log_denominator_matches_the_loop_it_replaced(counts):
+    from surpyval.univariate.regression.proportional_hazards.cox_ph import (
+        efron_log_denominator,
+    )
+
+    rng = np.random.default_rng(37)
+    m = len(counts)
+    n_d = np.array(counts)
+    Ri = rng.uniform(50, 100, (m, 1))
+    Di = rng.uniform(0, 10, (m, 1))
+
+    want = np.zeros(m)
+    for i in range(m):
+        if n_d[i] == 0:
+            continue
+        c_vals = np.arange(int(n_d[i])) / n_d[i]
+        want[i] = np.log(Ri[i] - c_vals[:, None] * Di[i]).sum()
+
+    got = efron_log_denominator(n_d, Ri, Di)
+    np.testing.assert_allclose(got, want, rtol=1e-12, atol=1e-12)
+
+
+def test_cox_fit_is_unaffected_by_the_order_of_the_rows():
+    # ``create_*_ll_jac_hess`` now sorts by event time so ``_GroupBy`` can
+    # skip its permutation (#329). Nothing downstream may depend on that,
+    # so a shuffled copy of the same data must fit identically.
+    rng = np.random.default_rng(41)
+    n, p = 400, 3
+    Z = rng.normal(size=(n, p))
+    t = 10 * (-np.log(rng.random(n)) / np.exp(Z @ [0.6, 0.1, -0.4])) ** (
+        1 / 1.5
+    )
+    cens = rng.exponential(np.quantile(t, 0.6), n)
+    x, c = np.minimum(t, cens), (t > cens).astype(int)
+    tl = rng.uniform(0, 0.4 * np.median(x), n)
+    keep = x > tl
+    x, Z, c, tl = x[keep], Z[keep], c[keep], tl[keep]
+
+    shuffle = rng.permutation(len(x))
+    for method in ("efron", "breslow"):
+        a = CoxPH.fit(x=x, Z=Z, c=c, tl=tl, method=method)
+        b = CoxPH.fit(
+            x=x[shuffle],
+            Z=Z[shuffle],
+            c=c[shuffle],
+            tl=tl[shuffle],
+            method=method,
+        )
+        np.testing.assert_allclose(a.beta, b.beta, rtol=1e-10, atol=1e-12)
+        np.testing.assert_allclose(
+            a.jac(a.beta)[1], b.jac(b.beta)[1], rtol=1e-9, atol=1e-10
+        )

--- a/surpyval/tests/univariate/regression/test_proportional_hazards.py
+++ b/surpyval/tests/univariate/regression/test_proportional_hazards.py
@@ -540,3 +540,90 @@ def test_ph_fixed_covariate_coefficient_pins_correct_parameter():
     # Fixing a distribution parameter by name still works.
     fixed_shape = WeibullPH.fit(x, Z=Z, fixed={"beta": 3.0})
     assert fixed_shape.params[1] == pytest.approx(3.0, abs=1e-12)
+
+
+def _weibull_ph_ll(x, Z, c, alpha, shape, gamma):
+    """Weibull PH log-likelihood, written out independently of the fitter
+    so a test can score two candidate answers against each other."""
+    lin = Z @ np.asarray(gamma)
+    log_h = np.log(shape / alpha) + (shape - 1) * np.log(x / alpha) + lin
+    log_sf = -((x / alpha) ** shape) * np.exp(lin)
+    return log_h[np.asarray(c) == 0].sum() + log_sf.sum()
+
+
+@pytest.mark.parametrize("scale", [1e-3, 1e0, 1e3, 1e6, 1e9])
+def test_weibull_ph_fit_is_invariant_to_the_units_of_x(scale):
+    # Multiplying every event time by k must move alpha by exactly k and
+    # leave the shape and the covariate coefficients alone -- the model is
+    # closed under a change of time units.
+    #
+    # It was not. The PH ladder ran BFGS on a finite-difference gradient
+    # with no preconditioning, so scipy's absolute ``gtol`` was met well
+    # short of the optimum once the data grew: at scale 1e6 the fit gave up
+    # 1.5 nats of log-likelihood and landed ~1e-2 away in the coefficients
+    # (#328).
+    rng = np.random.default_rng(17)
+    n, p = 800, 3
+    Z = rng.normal(size=(n, p))
+    beta = np.array([0.6, 0.1, -0.4])
+    t = 4.0 * (-np.log(rng.random(n)) / np.exp(Z @ beta)) ** (1 / 1.5)
+    cens = rng.exponential(np.quantile(t, 0.6), n)
+    x, c = np.minimum(t, cens), (t > cens).astype(int)
+
+    base = WeibullPH.fit(x=x, Z=Z, c=c)
+    scaled = WeibullPH.fit(x=x * scale, Z=Z, c=c)
+
+    assert scaled.params[0] == pytest.approx(base.params[0] * scale, rel=1e-4)
+    assert scaled.params[1] == pytest.approx(base.params[1], rel=1e-4)
+    assert scaled.params[2:] == pytest.approx(base.params[2:], abs=1e-4)
+
+
+def test_weibull_ph_at_large_scale_reaches_the_optimum():
+    # The invariance test above would also pass if the fit were equally
+    # wrong at both scales, so anchor one end of it. Fit at unit scale,
+    # where the old ladder was fine, then carry that answer over to the
+    # large-scale data by the exact change of units. The large-scale fit
+    # must score at least as well on the large-scale likelihood as the
+    # transported one does -- it had the same optimum available to it.
+    #
+    # Under the old ladder it gave up 1.5 nats here.
+    rng = np.random.default_rng(23)
+    n, p = 800, 3
+    Z = rng.normal(size=(n, p))
+    beta = np.array([0.6, 0.1, -0.4])
+    t = 4.0 * (-np.log(rng.random(n)) / np.exp(Z @ beta)) ** (1 / 1.5)
+    cens = rng.exponential(np.quantile(t, 0.6), n)
+    x, c = np.minimum(t, cens), (t > cens).astype(int)
+
+    scale = 1e6
+    small = np.asarray(WeibullPH.fit(x=x, Z=Z, c=c).params, dtype=float)
+    large = np.asarray(
+        WeibullPH.fit(x=x * scale, Z=Z, c=c).params, dtype=float
+    )
+
+    transported = _weibull_ph_ll(
+        x * scale, Z, c, small[0] * scale, small[1], small[2:]
+    )
+    at_fit = _weibull_ph_ll(x * scale, Z, c, large[0], large[1], large[2:])
+
+    assert at_fit >= transported - 1e-6
+
+
+def test_optimise_ph_never_returns_a_worse_point_than_it_started_from():
+    # A contract guard rather than a reproducer: the old ladder returned
+    # TNC unconditionally, so a rung that could only ever be an improvement
+    # was free to be a regression (#328). On these smooth objectives it
+    # happened not to be, and this test passes either way -- it is here so
+    # that a future rung added to the ladder cannot reintroduce the hazard
+    # unnoticed. Whatever the rungs do individually, the ladder as a whole
+    # must not hand back a point worse than its starting guess.
+    from surpyval.univariate.regression._fit_skeleton import optimise_ph
+
+    def rosenbrock(v):
+        return (1 - v[0]) ** 2 + 100 * (v[1] - v[0] ** 2) ** 2
+
+    for start in ([-1.2, 1.0], [3.0, -4.0], [0.0, 0.0]):
+        x0 = np.array(start)
+        res = optimise_ph(rosenbrock, x0)
+        assert res.fun <= rosenbrock(x0)
+        assert res.fun == pytest.approx(rosenbrock(res.x), rel=1e-8, abs=1e-12)

--- a/surpyval/univariate/nonparametric/turnbull.py
+++ b/surpyval/univariate/nonparametric/turnbull.py
@@ -174,6 +174,38 @@ def turnbull(
     np.add.at(cover, np.minimum(hi + 1, M), -1.0)
     identifiable = np.cumsum(cover[:M]) > 0
 
+    # Intervals where the likelihood can be inflated for free.
+    #
+    # An interval that some observation could have failed in, but that lies
+    # outside *another* observation's truncation window, is worth mass to
+    # the first and costs the second nothing: the second's contribution is
+    # conditional on its own entry, so mass it never had the chance to see
+    # divides out of both its numerator and its denominator exactly.
+    #
+    # That is a genuine flat direction of the likelihood, not a defect in
+    # the iteration. It needs a left-censored (or low interval-censored)
+    # row, whose support reaches down below the later entry times, and it
+    # needs two distinct entry times, so that such an interval exists at
+    # all. With one common entry time every window is identical and no
+    # interval qualifies. Where it does exist the maximum sits on the
+    # boundary -- on a six-point example the EM drives 99.995% of the mass
+    # into a single such interval, reaching a log-likelihood of -6.14
+    # against -9.36 for the sensible answer -- so the EM climbs forever
+    # without settling and the survival estimate collapses (#308).
+    #
+    # Meeting the condition does not mean the fit is spoilt: over 240
+    # simulated samples that all met it, only 8-72% actually degenerated,
+    # rising with the proportion left censored. It is a screen, not a
+    # verdict, so it only sharpens the diagnosis below rather than
+    # rejecting the data.
+    exploitable = np.zeros(M, dtype=bool)
+    if any_truncated:
+        seen = np.zeros(M + 1)
+        np.add.at(seen, w_lo_all, 1.0)
+        np.add.at(seen, np.minimum(w_hi_all + 1, M), -1.0)
+        in_every_window = np.cumsum(seen[:M]) >= N
+        exploitable = identifiable & ~in_every_window
+
     d = np.zeros(M)
     if any_truncated and identifiable.any():
         p = identifiable / identifiable.sum()
@@ -292,6 +324,24 @@ def turnbull(
         ):
             degenerate = True
 
+    # Mass sitting on the flat direction described at ``exploitable``. A
+    # fit can converge and still rest largely there, so it is worth
+    # reporting on its own; 0.9 is where it stops being a healthy fit's
+    # ordinary share. Over 240 simulated samples, non-convergence alone
+    # caught 90% of degenerate fits for a 2% false-alarm rate, and adding
+    # this test took that to 91% without adding a single false alarm.
+    # Looser cut-offs are not free: 0.7 reaches 95% but false-alarms on
+    # 9%, and 0.5 on 40%.
+    exploited = float(p[exploitable].sum()) if exploitable.any() else 0.0
+    # The mass, not the flag, is the evidence. Ordinary staggered-entry
+    # data has exploitable intervals too and fits perfectly well; over 240
+    # simulated samples the healthy fits reached at most 0.836 there,
+    # while the spoilt ones had a median of 0.994. Firing on the flag plus
+    # non-convergence instead would mis-advise a fit that simply needs
+    # more iterations -- the #203 case is exactly that, structurally
+    # exploitable but convergent once given them.
+    on_flat_direction = exploited > 0.9
+
     if degenerate:
         warnings.warn(
             "The Turnbull EM reached a degenerate, non-identifiable fixed "
@@ -300,6 +350,23 @@ def turnbull(
             "left truncation), so the survival estimate has collapsed. The "
             "result is unreliable -- more data or a narrower truncation range "
             "is needed."
+        )
+    elif on_flat_direction:
+        warnings.warn(
+            "The Turnbull estimate is not identifiable from this data, so "
+            "the result is unreliable. {:.1%} of the fitted probability "
+            "mass sits in intervals that some observation could have "
+            "failed in but that lie before another observation's entry "
+            "time. Mass placed there raises the first observation's "
+            "likelihood while costing the others nothing -- their "
+            "contributions are conditional on their own entry, so mass "
+            "they never had the chance to see divides out of both the "
+            "numerator and the denominator. The likelihood therefore has "
+            "no interior maximum and the EM climbs towards the boundary "
+            "instead of settling; raising `max_iter` will not help. This "
+            "needs left-censored observations together with two or more "
+            "distinct entry times -- dropping either, or entering every "
+            "unit at a common time, removes it.".format(exploited)
         )
     elif not converged:
         warnings.warn(
@@ -417,6 +484,13 @@ def turnbull(
     out["iters"] = iters
     out["converged"] = converged
     out["degenerate"] = degenerate
+    # How much of the fitted mass landed where the likelihood can be
+    # inflated for free (see ``exploitable`` above). Reported so a caller
+    # can judge a fit that converged but sits largely on that flat
+    # direction; a healthy fit leaves it near zero.
+    out["exploitable_mass"] = (
+        float(p[exploitable].sum()) if exploitable.any() else 0.0
+    )
 
     np.seterr(**old_err_state)
 

--- a/surpyval/univariate/nonparametric/turnbull.py
+++ b/surpyval/univariate/nonparametric/turnbull.py
@@ -109,9 +109,34 @@ def turnbull(
     # range [w_lo, w_hi]: the bound points at which an event was observable
     # -- strictly after its left truncation time and at or before its right
     # truncation time.
+    #
+    # Index j stands for the half-open interval ``(bounds[j], bounds[j+1]]``,
+    # so an event placed there is already strictly after ``bounds[j]``. The
+    # first admissible index is thus the *last* bound equal to ``tl``: that
+    # interval is ``(tl, next]``, which respects the strict (entry, exit]
+    # convention, while the interval starting one index earlier is the
+    # zero-width ``(tl, tl]`` that an exact event time duplicated into
+    # ``bounds`` creates -- an event at exactly the entry time, which the
+    # convention excludes (#260).
+    #
+    # ``side="right" - 1`` lands there exactly, because every finite
+    # truncation time is itself in ``bounds``. Neither endpoint of the
+    # search alone will do: ``side="left"`` keeps the zero-width interval
+    # and readmits an event at the entry time, while ``side="right"``
+    # discards ``(tl, next]`` as well, one interval too many.
+    #
+    # That over-exclusion is what made left censoring under truncation
+    # fail. A left-censored event lies in ``(-inf, xr]``, which under an
+    # entry at ``tl`` is the single interval ``(tl, xr]`` -- often the only
+    # one such a row has. Dropping it left the row with an empty support,
+    # so a *vacuous* entry time, one below every observation and excluding
+    # nobody, turned a working fit into a raise or drove the EM to the
+    # degenerate all-zero end of the ladder (#308).
     if any_truncated:
         w_lo_all = np.where(
-            np.isfinite(tl), np.searchsorted(bounds, tl, side="right"), 0
+            np.isfinite(tl),
+            np.maximum(np.searchsorted(bounds, tl, side="right") - 1, 0),
+            0,
         )
         w_hi_all = np.where(
             np.isfinite(tr),

--- a/surpyval/univariate/parametric/distributions/beta.py
+++ b/surpyval/univariate/parametric/distributions/beta.py
@@ -419,9 +419,21 @@ class Beta_(ParametricFitter):
         """
         mean = x.mean()
         var = x.var()
+        # Zero (or near zero) variance divides through to a shape pair of
+        # order 1e31 rather than an error, and since a failed optimiser
+        # falls back to its initial guess (#261) that pair is what gets
+        # returned to the caller. A tied sample says nothing about the
+        # shapes, so seed the uniform Beta and let the optimiser move if
+        # the data can move it.
+        if not np.isfinite(var) or var <= np.finfo(float).tiny:
+            return 1.0, 1.0
         term1 = (mean * (1 - mean) / var) - 1
         alpha = term1 * mean
         beta = term1 * (1 - mean)
+        if not (np.isfinite(alpha) and np.isfinite(beta)) or (
+            alpha <= 0 or beta <= 0
+        ):
+            return 1.0, 1.0
 
         return alpha, beta
 

--- a/surpyval/univariate/parametric/distributions/gamma.py
+++ b/surpyval/univariate/parametric/distributions/gamma.py
@@ -46,6 +46,15 @@ class Gamma_(ParametricFitter):
         to about 1.5% and used only as a starting point.
         """
         s = np.log(x.sum() / len(x)) - np.log(x).sum() / len(x)
+        # s is exactly zero for a tied sample -- the log of the mean and
+        # the mean of the logs coincide -- and alpha divides by it, so
+        # the seed comes back as (inf, inf). A failed optimiser falls
+        # back to its initial guess (#261), so those infinities are
+        # returned to the caller as the fitted parameters. Seed the
+        # exponential case instead: a tied sample carries no information
+        # about the shape.
+        if not np.isfinite(s) or s <= np.finfo(float).tiny:
+            return 1.0, len(x) / x.sum()
         alpha = (3 - s + np.sqrt((s - 3) ** 2 + 24 * s)) / (12 * s)
         beta = x.sum() / (len(x) * alpha)
         return alpha, 1.0 / beta

--- a/surpyval/univariate/parametric/fitters/__init__.py
+++ b/surpyval/univariate/parametric/fitters/__init__.py
@@ -56,6 +56,78 @@ def fallback_minimize(fun, init, args, jac, hess, newton_tol=None):
     return res
 
 
+def preconditioned_bfgs(fun, x0, args=(), jac=None, options=None):
+    """BFGS on a diagonally rescaled copy of the search vector.
+
+    scipy stops BFGS when ``max|grad| < gtol``, an absolute threshold on
+    a quantity that is not scale free: a log-likelihood's gradient
+    shrinks like ``1/theta``, so on data measured in tens of thousands
+    the default 1e-5 is met well short of the optimum and BFGS reports
+    success on its first check. Three reference fits on real data of
+    that magnitude landed 1e-2 away in relative terms, at a likelihood
+    2e-3 below the answer they were recorded from (#323). It had been
+    invisible only because those fits used to end on Nelder-Mead, which
+    is derivative free and so kept going.
+
+    Tuning the threshold does not fix it. Scaling ``gtol`` by the
+    gradient at the initial guess looks scale free but is not -- the
+    initialiser scales with the data too, so that gradient is itself
+    roughly scale invariant and the threshold barely moves. Nor is there
+    a constant that serves every case: tight enough for a Weibull at
+    data scale 1e6 is unreachable for an n=8 sample.
+
+    Rescaling the search fixes the cause instead. With
+
+        s = max(|u0|, 1),   v = u / s,   g(v) = f(s v)
+
+    the starting point is order 1 in every component whatever units the
+    data is in, and since ``dg/dv = s * df/du`` -- ``s`` growing like the
+    scale exactly as ``df/du`` shrinks -- the gradient the optimiser
+    tests is order 1 too. scipy's own default then means the same thing
+    at every scale, so no tolerance is passed at all.
+
+    Dividing through by ``|f(x0)|`` does the same job for the other
+    scale: the objective is a sum over observations, so its gradient
+    grows like ``n`` even when the data magnitude is fixed.
+
+    The mapping is linear, diagonal and fixed before the search begins,
+    so it cannot move the optimum; it changes the route taken and the
+    units of the convergence test, nothing else. ``res.x`` is mapped
+    back before returning, so every caller -- including the covariance
+    step, which builds its own hessian at the returned point -- sees
+    exactly what it saw before. scipy's own ``res.hess_inv`` would be in
+    scaled units, and is not used anywhere.
+    """
+    x0 = np.asarray(x0, dtype=float)
+    scale = np.maximum(np.abs(x0), 1.0)
+
+    f0 = float(fun(x0, *args))
+    obj_scale = max(abs(f0), 1.0) if np.isfinite(f0) else 1.0
+
+    def scaled_fun(v, *inner):
+        return fun(scale * v, *inner) / obj_scale
+
+    def scaled_jac(v, *inner):
+        return (
+            scale * np.asarray(jac(scale * v, *inner), dtype=float)
+        ) / obj_scale
+
+    opts = dict(options or {})
+    opts["gtol"] = 1e-6
+
+    res = minimize(
+        scaled_fun,
+        x0 / scale,
+        args=args,
+        method="BFGS",
+        jac=None if jac is None else scaled_jac,
+        options=opts,
+    )
+    res.x = res.x * scale
+    res.fun = res.fun * obj_scale
+    return res
+
+
 def _dead_branch_safe_exp(x):
     """``exp(x)`` for the ``x < 0`` half, with the other half clamped.
 

--- a/surpyval/univariate/parametric/fitters/__init__.py
+++ b/surpyval/univariate/parametric/fitters/__init__.py
@@ -56,16 +56,34 @@ def fallback_minimize(fun, init, args, jac, hess, newton_tol=None):
     return res
 
 
+def _dead_branch_safe_exp(x):
+    """``exp(x)`` for the ``x < 0`` half, with the other half clamped.
+
+    ``np.where`` picks the right value but autograd evaluates *both*
+    branches, so ``exp(x)`` is taped even where ``x + 1`` is the one
+    selected. Above x = 709.78 that overflows to inf, and the inf then
+    poisons the derivative of the branch that *was* selected, turning
+    the parameter transform's jacobian -- and with it every confidence
+    bound -- into nan.
+
+    Clamping the argument to the half this branch is responsible for
+    leaves it untouched where it is used and bounded where it is not.
+    """
+    return np.exp(np.minimum(x, 0.0))
+
+
 def adj_relu(x):
-    return np.where(x >= 0, x + 1, np.exp(x))
+    return np.where(x >= 0, x + 1, _dead_branch_safe_exp(x))
 
 
 def inv_adj_relu(x):
+    # No clamp needed here, unlike ``adj_relu``: this dead branch is
+    # ``x >= 1``, which is precisely where ``log`` is best behaved.
     return np.where(x >= 1, x - 1, np.log(x))
 
 
 def rev_adj_relu(x):
-    return -np.where(x >= 0, x + 1, np.exp(x))
+    return -np.where(x >= 0, x + 1, _dead_branch_safe_exp(x))
 
 
 def inv_rev_adj_relu(x):

--- a/surpyval/univariate/parametric/fitters/mle.py
+++ b/surpyval/univariate/parametric/fitters/mle.py
@@ -80,17 +80,35 @@ def mle(model):
             methods = []
         else:
             methods = [
-                ("Nelder-Mead", None, None),
-                ("Powell", None, None),
-                ("BFGS", None, None),
+                ("BFGS", jac, None),
                 ("TNC", jac, None),
                 ("Newton-CG", jac, hess),
+                ("Nelder-Mead", None, None),
+                ("Powell", None, None),
             ]
 
-        # Try easiest, to most complex optimisations. The derivative
-        # free methods each explore from the cold initial guess so a
-        # poor basin found by one does not trap the rest; the gradient
-        # methods then refine the best point found so far.
+        # Gradient methods first, stopping at the first that converges;
+        # the derivative free pair is the fallback for when they do not.
+        #
+        # All five used to run on every fit, and the last four were
+        # almost always confirming what an earlier one had already found:
+        # over 102 fits across eleven distributions the whole ladder
+        # agreed on the objective to 1e-10. The cost was not small.
+        # Nelder-Mead and Powell are derivative free, so they pay for
+        # their robustness in function evaluations -- 50 and 22 of them
+        # against BFGS's 21 -- and every evaluation is O(n). On a
+        # million observations those two alone were 42% of the fit.
+        #
+        # Order and early exit have to change together. Stopping early
+        # without reordering halts at Nelder-Mead, which is both the
+        # most expensive rung and the one with the worst objective;
+        # reordering without stopping early saves nothing at all.
+        #
+        # The derivative free methods still start from the cold initial
+        # guess when they are reached, so the multi-start behaviour that
+        # motivated the original order survives for the fits that
+        # actually need it -- they are simply no longer paid for by the
+        # fits that do not.
         for method, jac_i, hess_i in methods:
             opts = {"maxfun": 1000} if method == "TNC" else {"maxiter": 1000}
             if method in ("Nelder-Mead", "Powell") or best_result is None:
@@ -110,6 +128,7 @@ def mle(model):
                 best_result = res
                 best_method = method
                 best = res.fun
+                break
 
         if best_result is not None:
             res = best_result

--- a/surpyval/univariate/parametric/fitters/mle.py
+++ b/surpyval/univariate/parametric/fitters/mle.py
@@ -8,6 +8,74 @@ from scipy.optimize import OptimizeResult, minimize
 from surpyval import np
 
 
+def _preconditioned_bfgs(fun, x0, args, jac, options):
+    """BFGS on a diagonally rescaled copy of the search vector.
+
+    scipy stops BFGS when ``max|grad| < gtol``, an absolute threshold on
+    a quantity that is not scale free: a log-likelihood's gradient
+    shrinks like ``1/theta``, so on data measured in tens of thousands
+    the default 1e-5 is met well short of the optimum and BFGS reports
+    success on its first check. Three reference fits on real data of
+    that magnitude landed 1e-2 away in relative terms, at a likelihood
+    2e-3 below the answer they were recorded from (#323). It had been
+    invisible only because those fits used to end on Nelder-Mead, which
+    is derivative free and so kept going.
+
+    Tuning the threshold does not fix it. Scaling ``gtol`` by the
+    gradient at the initial guess looks scale free but is not -- the
+    initialiser scales with the data too, so that gradient is itself
+    roughly scale invariant and the threshold barely moves. Nor is there
+    a constant that serves every case: tight enough for a Weibull at
+    data scale 1e6 is unreachable for an n=8 sample.
+
+    Rescaling the search fixes the cause instead. With
+
+        s = max(|u0|, 1),   v = u / s,   g(v) = f(s v)
+
+    the starting point is order 1 in every component whatever units the
+    data is in, and since ``dg/dv = s * df/du`` -- ``s`` growing like the
+    scale exactly as ``df/du`` shrinks -- the gradient the optimiser
+    tests is order 1 too. scipy's own default then means the same thing
+    at every scale, so no tolerance is passed at all.
+
+    The mapping is linear, diagonal and fixed before the search begins,
+    so it cannot move the optimum; it changes the route taken and the
+    units of the convergence test, nothing else. ``res.x`` is mapped
+    back before returning, so every caller -- including the covariance
+    step, which builds its own hessian at the returned point -- sees
+    exactly what it saw before. scipy's own ``res.hess_inv`` would be in
+    scaled units, and is not used anywhere.
+    """
+    x0 = np.asarray(x0, dtype=float)
+    scale = np.maximum(np.abs(x0), 1.0)
+
+    f0 = float(fun(x0, *args))
+    obj_scale = max(abs(f0), 1.0) if np.isfinite(f0) else 1.0
+
+    def scaled_fun(v, *inner):
+        return fun(scale * v, *inner) / obj_scale
+
+    def scaled_jac(v, *inner):
+        return (
+            scale * np.asarray(jac(scale * v, *inner), dtype=float)
+        ) / obj_scale
+
+    opts = dict(options or {})
+    opts["gtol"] = 1e-6
+
+    res = minimize(
+        scaled_fun,
+        x0 / scale,
+        args=args,
+        method="BFGS",
+        jac=None if jac is None else scaled_jac,
+        options=opts,
+    )
+    res.x = res.x * scale
+    res.fun = res.fun * obj_scale
+    return res
+
+
 def mle(model):
     """
     Maximum Likelihood Estimation (MLE)
@@ -109,35 +177,6 @@ def mle(model):
         # motivated the original order survives for the fits that
         # actually need it -- they are simply no longer paid for by the
         # fits that do not.
-        # scipy stops BFGS when max|grad| < gtol, and its default of 1e-5
-        # is an absolute threshold on a quantity that is not scale free.
-        # A log-likelihood's gradient shrinks like 1/theta, so on data
-        # measured in tens of thousands the test is met well short of
-        # the optimum and BFGS reports success on its first check --
-        # three reference fits on real data of that magnitude landed
-        # 1e-2 away in relative terms, at a likelihood 2e-3 below the
-        # answer they were recorded from. It had been invisible only
-        # because those fits used to end on Nelder-Mead, which is
-        # derivative free and so kept going (#323).
-        #
-        # Scaling the threshold by the gradient where the search starts
-        # asks instead that the gradient fall by a fixed number of
-        # orders of magnitude, which means the same thing at every
-        # scale. A fixed tighter constant does not: 1e-8 fixes the large
-        # fits but is unreachable for small samples, dropping an n=8
-        # Weibull out of BFGS and into TNC. At 1e-7 relative both ends
-        # converge on BFGS -- the large fits to 2e-8 and the small one
-        # to 4e-9.
-        gtol_rel = 1e-7
-
-        def bfgs_gtol(x0):
-            g0 = np.max(
-                np.abs(jac(np.asarray(x0, dtype=float), offset, lfp, zi, True))
-            )
-            if not np.isfinite(g0) or g0 <= 0:
-                return None
-            return max(gtol_rel * float(g0), 1e-12)
-
         for method, jac_i, hess_i in methods:
             opts = {"maxfun": 1000} if method == "TNC" else {"maxiter": 1000}
             if method in ("Nelder-Mead", "Powell") or best_result is None:
@@ -145,18 +184,19 @@ def mle(model):
             else:
                 x0 = best_result.x
             if method == "BFGS":
-                gtol = bfgs_gtol(x0)
-                if gtol is not None:
-                    opts["gtol"] = gtol
-            res = minimize(
-                fun,
-                x0,
-                args=(offset, lfp, zi, True),
-                method=method,
-                jac=jac_i,
-                hess=hess_i,
-                options=opts,
-            )
+                res = _preconditioned_bfgs(
+                    fun, x0, (offset, lfp, zi, True), jac_i, opts
+                )
+            else:
+                res = minimize(
+                    fun,
+                    x0,
+                    args=(offset, lfp, zi, True),
+                    method=method,
+                    jac=jac_i,
+                    hess=hess_i,
+                    options=opts,
+                )
             if res.success and res.fun < best:
                 best_result = res
                 best_method = method

--- a/surpyval/univariate/parametric/fitters/mle.py
+++ b/surpyval/univariate/parametric/fitters/mle.py
@@ -109,12 +109,45 @@ def mle(model):
         # motivated the original order survives for the fits that
         # actually need it -- they are simply no longer paid for by the
         # fits that do not.
+        # scipy stops BFGS when max|grad| < gtol, and its default of 1e-5
+        # is an absolute threshold on a quantity that is not scale free.
+        # A log-likelihood's gradient shrinks like 1/theta, so on data
+        # measured in tens of thousands the test is met well short of
+        # the optimum and BFGS reports success on its first check --
+        # three reference fits on real data of that magnitude landed
+        # 1e-2 away in relative terms, at a likelihood 2e-3 below the
+        # answer they were recorded from. It had been invisible only
+        # because those fits used to end on Nelder-Mead, which is
+        # derivative free and so kept going (#323).
+        #
+        # Scaling the threshold by the gradient where the search starts
+        # asks instead that the gradient fall by a fixed number of
+        # orders of magnitude, which means the same thing at every
+        # scale. A fixed tighter constant does not: 1e-8 fixes the large
+        # fits but is unreachable for small samples, dropping an n=8
+        # Weibull out of BFGS and into TNC. At 1e-7 relative both ends
+        # converge on BFGS -- the large fits to 2e-8 and the small one
+        # to 4e-9.
+        gtol_rel = 1e-7
+
+        def bfgs_gtol(x0):
+            g0 = np.max(
+                np.abs(jac(np.asarray(x0, dtype=float), offset, lfp, zi, True))
+            )
+            if not np.isfinite(g0) or g0 <= 0:
+                return None
+            return max(gtol_rel * float(g0), 1e-12)
+
         for method, jac_i, hess_i in methods:
             opts = {"maxfun": 1000} if method == "TNC" else {"maxiter": 1000}
             if method in ("Nelder-Mead", "Powell") or best_result is None:
                 x0 = init
             else:
                 x0 = best_result.x
+            if method == "BFGS":
+                gtol = bfgs_gtol(x0)
+                if gtol is not None:
+                    opts["gtol"] = gtol
             res = minimize(
                 fun,
                 x0,

--- a/surpyval/univariate/parametric/fitters/mle.py
+++ b/surpyval/univariate/parametric/fitters/mle.py
@@ -6,74 +6,7 @@ from numdifftools import Hessian  # type: ignore
 from scipy.optimize import OptimizeResult, minimize
 
 from surpyval import np
-
-
-def _preconditioned_bfgs(fun, x0, args, jac, options):
-    """BFGS on a diagonally rescaled copy of the search vector.
-
-    scipy stops BFGS when ``max|grad| < gtol``, an absolute threshold on
-    a quantity that is not scale free: a log-likelihood's gradient
-    shrinks like ``1/theta``, so on data measured in tens of thousands
-    the default 1e-5 is met well short of the optimum and BFGS reports
-    success on its first check. Three reference fits on real data of
-    that magnitude landed 1e-2 away in relative terms, at a likelihood
-    2e-3 below the answer they were recorded from (#323). It had been
-    invisible only because those fits used to end on Nelder-Mead, which
-    is derivative free and so kept going.
-
-    Tuning the threshold does not fix it. Scaling ``gtol`` by the
-    gradient at the initial guess looks scale free but is not -- the
-    initialiser scales with the data too, so that gradient is itself
-    roughly scale invariant and the threshold barely moves. Nor is there
-    a constant that serves every case: tight enough for a Weibull at
-    data scale 1e6 is unreachable for an n=8 sample.
-
-    Rescaling the search fixes the cause instead. With
-
-        s = max(|u0|, 1),   v = u / s,   g(v) = f(s v)
-
-    the starting point is order 1 in every component whatever units the
-    data is in, and since ``dg/dv = s * df/du`` -- ``s`` growing like the
-    scale exactly as ``df/du`` shrinks -- the gradient the optimiser
-    tests is order 1 too. scipy's own default then means the same thing
-    at every scale, so no tolerance is passed at all.
-
-    The mapping is linear, diagonal and fixed before the search begins,
-    so it cannot move the optimum; it changes the route taken and the
-    units of the convergence test, nothing else. ``res.x`` is mapped
-    back before returning, so every caller -- including the covariance
-    step, which builds its own hessian at the returned point -- sees
-    exactly what it saw before. scipy's own ``res.hess_inv`` would be in
-    scaled units, and is not used anywhere.
-    """
-    x0 = np.asarray(x0, dtype=float)
-    scale = np.maximum(np.abs(x0), 1.0)
-
-    f0 = float(fun(x0, *args))
-    obj_scale = max(abs(f0), 1.0) if np.isfinite(f0) else 1.0
-
-    def scaled_fun(v, *inner):
-        return fun(scale * v, *inner) / obj_scale
-
-    def scaled_jac(v, *inner):
-        return (
-            scale * np.asarray(jac(scale * v, *inner), dtype=float)
-        ) / obj_scale
-
-    opts = dict(options or {})
-    opts["gtol"] = 1e-6
-
-    res = minimize(
-        scaled_fun,
-        x0 / scale,
-        args=args,
-        method="BFGS",
-        jac=None if jac is None else scaled_jac,
-        options=opts,
-    )
-    res.x = res.x * scale
-    res.fun = res.fun * obj_scale
-    return res
+from surpyval.univariate.parametric.fitters import preconditioned_bfgs
 
 
 def mle(model):
@@ -184,7 +117,7 @@ def mle(model):
             else:
                 x0 = best_result.x
             if method == "BFGS":
-                res = _preconditioned_bfgs(
+                res = preconditioned_bfgs(
                     fun, x0, (offset, lfp, zi, True), jac_i, opts
                 )
             else:

--- a/surpyval/univariate/parametric/fitters/mpp.py
+++ b/surpyval/univariate/parametric/fitters/mpp.py
@@ -7,6 +7,42 @@ from surpyval import np
 from surpyval.univariate.nonparametric import plotting_positions
 
 
+def _rr_fit(a, b):
+    """
+    Least-squares line of ``b`` on ``a``, guarding the degenerate case.
+
+    A probability plot needs at least two distinct abscissae to have a
+    slope. With fewer -- a single observation, or a sample whose values
+    are all tied -- ``polyfit`` is rank deficient and returns a nan
+    slope. That nan is not caught anywhere: it becomes the seed for the
+    maximum likelihood fit, which then starts at nan, produces a nan
+    hessian, and finally dies inside numdifftools with an ``IndexError``
+    from an empty list of finite difference steps. The cause is four
+    steps removed from the symptom.
+
+    The fallback is a unit slope through the centroid. A *zero* slope
+    would be the more literal reading of "no information", but every
+    ``unpack_rr`` divides by the slope to recover a scale -- Weibull
+    takes ``alpha = exp(-intercept / slope)`` -- so zero merely moves the
+    nan one step later. Unit slope keeps each distribution's own
+    ``unpack_rr`` in charge of turning the line into correctly typed
+    parameters, and lands on a usable seed: three tied observations at 10
+    give ``alpha = 11.2, beta = 1`` rather than ``nan``.
+    """
+    a = np.asarray(a, dtype=float)
+    b = np.asarray(b, dtype=float)
+    finite = np.isfinite(a) & np.isfinite(b)
+    if finite.sum() >= 2 and np.unique(a[finite]).size >= 2:
+        params = np.polyfit(a[finite], b[finite], 1)
+        if np.isfinite(params).all():
+            return params
+    if finite.any():
+        intercept = float(np.mean(b[finite]) - np.mean(a[finite]))
+    else:
+        intercept = 0.0
+    return np.array([1.0, intercept])
+
+
 def mpp_from_ecfd(dist, x, F):
     x_pp = copy(x)
     y_pp = copy(F)
@@ -18,7 +54,7 @@ def mpp_from_ecfd(dist, x, F):
     with np.errstate(all="ignore"):
         y_pp = dist.mpp_y_transform(y_pp)
         x_pp = dist.mpp_x_transform(x_pp)
-        params = np.polyfit(x_pp, y_pp, 1)
+        params = _rr_fit(x_pp, y_pp)
 
     params = np.array(dist.unpack_rr(params, "y"))
 
@@ -108,9 +144,9 @@ def mpp(model):
     x_pp = dist.mpp_x_transform(x_pp)
 
     if rr == "y":
-        params = np.polyfit(x_pp, y_pp, 1)
+        params = _rr_fit(x_pp, y_pp)
     elif rr == "x":
-        params = np.polyfit(y_pp, x_pp, 1)
+        params = _rr_fit(y_pp, x_pp)
 
     params = np.array(dist.unpack_rr(params, rr))
 

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -335,6 +335,58 @@ class ParametricFitter:
             moments[i] = self._moment(n, *params, offset=offset)
         return moments
 
+    def _check_identifiable(self, surv_data, offset, lfp, zi, fixed):
+        """
+        Reject data that cannot pin down the free parameters.
+
+        A right censored observation says only "later than this", so it
+        constrains a fitted curve without locating a point on it. What
+        locates a point is an exact observation, a left censored one, or
+        an interval. Fewer *distinct* such values than there are free
+        parameters and the likelihood has a flat direction: for a
+        Weibull on a tied sample it is unbounded, since a spike of
+        arbitrary height can sit on the repeated value, and the reported
+        answer is wherever the optimiser happened to stop. Three tied
+        observations at 10 returned ``beta = 512`` with ``success=True``
+        and no warning.
+
+        The count is of *free* parameters, not of the distribution's
+        parameters, so fixing one buys back a degree of freedom: a
+        Weibull fit to a single observation with ``beta`` fixed is well
+        posed and recovers ``alpha = (sum x^beta / n) ** (1 / beta)``.
+        That is why this cannot be a per-distribution constant.
+        """
+        n_free = (
+            self.k
+            + int(bool(offset))
+            + int(bool(lfp))
+            + int(bool(zi))
+            - len(fixed or {})
+        )
+        if n_free <= 0:
+            return
+
+        x, c = surv_data.x, surv_data.c
+        informative = np.asarray(c) != 1
+        if not informative.any():
+            return
+        rows = np.asarray(x)[informative]
+        if rows.ndim == 1:
+            distinct = np.unique(rows).size
+        else:
+            distinct = np.unique(rows, axis=0).shape[0]
+
+        if distinct < n_free:
+            raise ValueError(
+                f"{self.name} has {n_free} free parameter(s) but the data "
+                f"contains only {distinct} distinct non-right-censored "
+                f"value(s). The likelihood has a flat (or unbounded) "
+                f"direction, so no unique fit exists. Provide more "
+                f"distinct observations, fix a parameter with "
+                f"`fixed=`, or choose a distribution with fewer "
+                f"parameters."
+            )
+
     def _validate_fit_inputs(
         self,
         surv_data,
@@ -357,6 +409,15 @@ class ParametricFitter:
         if offset and not offsettable:
             detail = f"{self.name} distribution cannot be offset"
             raise ValueError(detail)
+
+        # Probability plotting is exempt. It is a regression through the
+        # plotting positions, not a likelihood maximisation, so it has no
+        # unbounded direction to fall into and now always returns finite
+        # parameters. It is also how several distributions seed
+        # themselves, and that internal call does not carry the caller's
+        # ``fixed``, so checking it would reject well posed fits.
+        if how != "MPP":
+            self._check_identifiable(surv_data, offset, lfp, zi, fixed)
 
         if fixed and how == "MPP":
             detail = (
@@ -1083,6 +1144,25 @@ class ParametricFitter:
 
         for k, v in results.items():
             setattr(model, k, v)
+
+        # A fit must never hand back a non-finite parameter. When the
+        # optimiser fails, the reported parameters are the initial guess
+        # (#261), so any initialiser that produced a nan or an inf had
+        # it laundered into what looked like a fitted model: an offset
+        # Gamma on a tied sample returned ``(inf, inf)`` in silence. The
+        # initialisers that could do that are fixed, but this is the
+        # backstop, since a non-finite parameter is never a valid answer
+        # whatever produced it.
+        _params = np.atleast_1d(np.asarray(model.params, dtype=float))
+        _extra = [getattr(model, name, None) for name in ("gamma", "p", "f0")]
+        _extra = [float(v) for v in _extra if v is not None]
+        if not (np.isfinite(_params).all() and np.isfinite(_extra).all()):
+            raise ValueError(
+                f"{self.name} fit produced non-finite parameters "
+                f"({np.asarray(model.params)}). The optimiser did not "
+                f"reach a valid solution; check the data for degenerate "
+                f"or extreme values."
+            )
 
         # Only maximum likelihood and the closed forms report a
         # log-likelihood, because only they compute one on the way to

--- a/surpyval/univariate/parametric/parametric_fitter.py
+++ b/surpyval/univariate/parametric/parametric_fitter.py
@@ -214,23 +214,69 @@ class ParametricFitter:
 
     @_check_x_not_empty
     def ll_interval_or_truncated(self, xl, xr, n, *params):
+        """
+        Log probability of falling inside each window ``(xl, xr]``.
+
+        An infinite bound is replaced by its analytic limit rather than
+        handed to the CDF. ``np.where`` selects the *value* correctly but
+        evaluates both branches, so ``ff(inf)`` was still taped by
+        autograd, and its nan derivative then propagated through the
+        selection regardless of which side was chosen. The objective was
+        right and the gradient was nan.
+
+        The consequence was not subtle. Every singly-truncated fit lost
+        all three gradient optimisers -- BFGS and Newton-CG each failed
+        after a single evaluation and TNC burned its whole 1000
+        evaluation budget -- leaving Nelder-Mead to finish derivative
+        free. A Weibull that fits in 0.014s took 1.36s, and a ``tl`` of 0
+        (a no-op, since ``F(0) = 0``) cost exactly the same as a real
+        truncation, which is what gives the cause away. Windows with
+        *both* bounds finite were always fast, because no infinity ever
+        reached the tape.
+
+        The infinity is substituted out of the *argument* before the CDF
+        sees it, so a single vectorised call covers every row whatever
+        its pattern of bounds. The outer ``np.where`` then selects
+        between two values that are both already finite, which is safe.
+
+        The stand-in cannot be an arbitrary constant. Zero looks natural
+        and is wrong: a Weibull with ``beta < 1`` has an unbounded
+        density derivative at the origin, so ``ff(0)`` would swap one nan
+        gradient for another. Reusing a bound that is genuinely present
+        keeps the stand-in inside the support and at the data's own
+        magnitude. Its value never reaches the result -- ``np.where``
+        discards it -- only its derivative has to be finite.
+
+        Probabilities come from the mixture CDF
+        ``F_mix(t) = f0 + (p - f0) * F0(t)``: with no right bound the
+        window probability is the mixture survival ``1 - F_mix(tl)``,
+        which includes the never-failing mass ``1 - p``. The old
+        ``(p - f0) * (1 - F0(tl))`` form made the LFP plus
+        left-truncation likelihood unbounded (#269). For finite-bound
+        intervals the ``f0`` terms cancel, so plain fits are unchanged.
+        """
         *params, gamma, f0, p = params
-        xr = xr - gamma
-        xl = xl - gamma
-        # Probabilities must come from the mixture CDF
-        # F_mix(t) = f0 + (p - f0) * F0(t), not (p - f0) * F0(t): with no
-        # right bound (tr = inf) the window probability is the mixture
-        # survival 1 - F_mix(tl), which includes the never-failing mass
-        # (1 - p). The old (p - f0) * (1 - F0(tl)) form made the LFP +
-        # left-truncation likelihood unbounded (#269). For finite-bound
-        # intervals the f0 terms cancel, so plain fits are unchanged.
-        right = np.where(
-            np.isfinite(xr), f0 + (p - f0) * self.ff(xr, *params), 1.0
+        if len(n) == 0:
+            return 0.0
+
+        lo_finite = np.isfinite(xl)
+        hi_finite = np.isfinite(xr)
+
+        # ``xl`` and ``xr`` are data, never traced, so this substitution
+        # is invisible to autograd -- it only changes what the CDF is
+        # asked to evaluate.
+        present = np.concatenate([xl[lo_finite], xr[hi_finite]])
+        stand_in = float(present[0]) if present.size else 1.0
+        xl_safe = np.where(lo_finite, xl, stand_in)
+        xr_safe = np.where(hi_finite, xr, stand_in)
+
+        upper = np.where(
+            hi_finite, f0 + (p - f0) * self.ff(xr_safe - gamma, *params), 1.0
         )
-        left = np.where(
-            np.isfinite(xl), f0 + (p - f0) * self.ff(xl, *params), 0.0
+        lower = np.where(
+            lo_finite, f0 + (p - f0) * self.ff(xl_safe - gamma, *params), 0.0
         )
-        return np.sum(n * np.log(np.maximum(right - left, 0.0)))
+        return np.sum(n * np.log(np.maximum(upper - lower, 0.0)))
 
     def _log_likelihood(self, data, *params):
         return (
@@ -241,7 +287,7 @@ class ParametricFitter:
                 data.x_il, data.x_ir, data.n_i, *params
             )
             - self.ll_interval_or_truncated(
-                data.x_tl, data.x_tr, data.n_t, *params
+                data.tl_unique, data.tr_unique, data.n_t_unique, *params
             )
         )
 

--- a/surpyval/univariate/regression/_fit_skeleton.py
+++ b/surpyval/univariate/regression/_fit_skeleton.py
@@ -13,9 +13,13 @@ separate: its life-model parameter juggling does not fit this shape.
 from typing import Any, Callable
 
 import autograd.numpy as np
+from autograd import jacobian
 from scipy.optimize import minimize
 
-from surpyval.univariate.parametric.fitters import bounds_convert
+from surpyval.univariate.parametric.fitters import (
+    bounds_convert,
+    preconditioned_bfgs,
+)
 from surpyval.utils.surpyval_data import SurpyvalData
 
 from .parametric_regression_model import ParametricRegressionModel
@@ -171,9 +175,63 @@ def assemble_regression_model(
 
 
 def optimise_ph(fun: Callable, init_t):
-    """PH's historical ladder: default method, then TNC unconditionally."""
-    res = minimize(fun, init_t)
-    return minimize(fun, res.x, method="TNC")
+    """Preconditioned BFGS on the analytic gradient, TNC as the fallback.
+
+    The historical ladder was ``minimize(fun, init_t)`` followed by TNC
+    kept unconditionally. Three things were wrong with it (#328).
+
+    ``fun`` closes over ``regression_neg_ll``, which is written in
+    ``autograd.numpy`` and is therefore differentiable -- but no ``jac``
+    was passed, so scipy fell back to a two-point finite difference and
+    paid ``p + 1`` extra objective evaluations per gradient. That is
+    what made the fit slow down as the covariate count rose.
+
+    Nor was the search preconditioned, so PH inherited the scale
+    sensitivity ``preconditioned_bfgs`` was written to cure: on a Weibull
+    PH at data scale 1e6 the old ladder settled 1.5 nats of
+    log-likelihood short of the optimum, which is a different fitted
+    model, not a tolerance artefact.
+
+    Finally TNC's answer was returned whether or not it had succeeded --
+    a rung of the ladder that could only ever be an improvement was
+    allowed to be a regression. ``optimise_nm_tnc``, immediately below,
+    already guarded against that.
+
+    The rungs now stop at the first success, matching the univariate MLE
+    ladder, and the derivative-free rung remains for the fits where the
+    gradient is unusable (a distribution whose autograd derivative goes
+    nan on the way, most often).
+    """
+    jac = jacobian(fun)
+
+    best = None
+    for method in ("BFGS", "TNC", "Nelder-Mead"):
+        x0 = init_t if best is None else best.x
+        if method == "BFGS":
+            res = preconditioned_bfgs(
+                fun, x0, jac=jac, options={"maxiter": 1000}
+            )
+        elif method == "TNC":
+            res = minimize(
+                fun, x0, method="TNC", jac=jac, options={"maxfun": 1000}
+            )
+        else:
+            res = minimize(
+                fun, init_t, method="Nelder-Mead", options={"maxiter": 1000}
+            )
+
+        if not np.isfinite(res.fun) or np.isnan(res.x).any():
+            continue
+        if best is None or res.fun < best.fun:
+            best = res
+        if res.success:
+            break
+
+    if best is None:
+        # Every rung produced a nan; hand back the last one so the caller
+        # sees a failed OptimizeResult rather than a None.
+        return res
+    return best
 
 
 def optimise_nm_tnc(fun: Callable, init_t):

--- a/surpyval/univariate/regression/_likelihood.py
+++ b/surpyval/univariate/regression/_likelihood.py
@@ -22,24 +22,6 @@ import autograd.numpy as np
 _TINY = np.finfo(float).tiny
 
 
-def _ff_safe(model, x, Z, fill, *params):
-    """``model.ff(x, Z, *params)`` with non-finite bounds replaced by their
-    limiting probability without ever evaluating ``ff`` at a non-finite
-    value.
-
-    ``fill`` is the probability a non-finite entry maps to: ``0.0`` for a
-    lower/left truncation bound (``F(-inf) = 0``) and ``1.0`` for an
-    upper/right bound (``F(+inf) = 1``). The caller knows which bound it is
-    passing, so the fill is supplied explicitly rather than inferred from
-    the value of ``x``.
-    """
-    finite = np.isfinite(x)
-    # Substitute a finite placeholder so ``ff`` is never called at +/-inf;
-    # the placeholder's result is discarded for those entries below.
-    x_safe = np.where(finite, x, 0.0)
-    return np.where(finite, model.ff(x_safe, Z, *params), fill)
-
-
 def truncation_correction(model, data, *params):
     """Log of the probability mass within each observation's truncation
     interval, summed over the truncated rows.
@@ -48,14 +30,60 @@ def truncation_correction(model, data, *params):
     ``P(tl < X < tr | Z)`` to account for the fact that it could only have
     been observed within that window. In log space this is a subtraction,
     so the caller subtracts the value returned here.
+
+    A window bounded on one side only is evaluated in log space rather
+    than as a difference of CDFs, because the difference underflows and
+    the floor that catches it is worse than the underflow. Left
+    truncation gives ``1 - F(tl)``, which goes to zero as the fitted
+    scale shrinks; once it reaches zero, flooring at the smallest
+    positive float caps the correction at ``log(tiny) = -708`` instead of
+    the unbounded value it should take. Since the caller *subtracts*
+    this, every truncated row then appears to contribute +708 to the
+    log-likelihood, and a region the data rules out entirely starts to
+    look like the best fit available. A WeibullPH fit to left-truncated
+    data walked into exactly that, reporting a log-likelihood 38,000
+    higher than its parameters actually earn (#326).
+
+    ``log_sf`` and ``log_ff`` compute those two cases directly and stay
+    finite where the difference cannot, so there is nothing to floor.
+    Only a genuinely two-sided window still needs the difference, and
+    there both bounds are finite and the mass is not driven to zero by
+    the scale alone.
     """
     if data.x_tl.size == 0:
         return 0.0
 
-    # Upper bound: F(+inf) = 1; lower bound: F(-inf) = 0.
-    right = _ff_safe(model, data.x_tr, data.Z_t, 1.0, *params)
-    left = _ff_safe(model, data.x_tl, data.Z_t, 0.0, *params)
-    return (data.n_t * np.log(np.maximum(right - left, _TINY))).sum()
+    tl, tr, Z = data.x_tl, data.x_tr, data.Z_t
+    lo_finite = np.isfinite(tl)
+    hi_finite = np.isfinite(tr)
+
+    # Substitute a finite stand-in before any distribution function is
+    # called: autograd evaluates every branch of a ``np.where``, so an
+    # infinity reaching one of them would poison the gradient of the
+    # branch that was selected even though its value is discarded.
+    present = np.concatenate([tl[lo_finite], tr[hi_finite]])
+    stand_in = float(present[0]) if present.size else 1.0
+    tl_safe = np.where(lo_finite, tl, stand_in)
+    tr_safe = np.where(hi_finite, tr, stand_in)
+
+    window = np.maximum(
+        model.ff(tr_safe, Z, *params) - model.ff(tl_safe, Z, *params), _TINY
+    )
+
+    log_mass = np.where(
+        lo_finite & hi_finite,
+        np.log(window),
+        np.where(
+            lo_finite,
+            model.log_sf(tl_safe, Z, *params),  # (tl, inf)
+            np.where(
+                hi_finite,
+                model.log_ff(tr_safe, Z, *params),  # (-inf, tr)
+                0.0,  # untruncated: log(1)
+            ),
+        ),
+    )
+    return (data.n_t * log_mass).sum()
 
 
 def regression_neg_ll(model, data, *params):

--- a/surpyval/univariate/regression/proportional_hazards/cox_ph.py
+++ b/surpyval/univariate/regression/proportional_hazards/cox_ph.py
@@ -41,21 +41,61 @@ nonparametric_dists = {
 
 
 class _GroupBy:
-    """Pure-NumPy grouped aggregation, replacing numpy_indexed.group_by."""
+    """Pure-NumPy grouped aggregation, replacing numpy_indexed.group_by.
+
+    The multi-dimensional sum used to be ``np.add.at``, which is an
+    unbuffered scatter with no fast path: at n=50 000 with ten covariates
+    it was 6.3s of a 16.9s Efron fit, called about ten times per
+    ``jac_hess`` on arrays of shape ``(n, p, p)`` (#329).
+
+    Sorting once here turns each of those into ``np.add.reduceat``, a
+    C-level segmented reduction. Every unique key has at least one member
+    by construction, so the group starts strictly increase and
+    ``reduceat`` is well defined.
+
+    Two cases skip work entirely. When the keys already arrive grouped --
+    the common case for start-stop (time-varying covariate) data -- there
+    is nothing to permute. And when every key is distinct there is nothing
+    to *add*: the sum is the permutation and no reduction is needed at
+    all. That second case is continuous event times, where ``reduceat``
+    would otherwise be asked for fifty thousand one-element segments and
+    pay the per-segment overhead on every one of them.
+
+    One consequence to know about: when both shortcuts apply at once --
+    keys already grouped *and* all distinct -- ``sum`` returns the input
+    array itself rather than a copy, because the sum of one-element groups
+    in their existing order is the input. Treat the result as read-only.
+    Every caller in this module builds its argument as a fresh temporary
+    and only ever rebinds the result, never mutates it in place.
+    """
 
     def __init__(self, keys):
         self.unique, self._inv = np.unique(keys, return_inverse=True)
+        self._inv = np.asarray(self._inv).ravel()
         self._n = len(self.unique)
 
+        counts = np.bincount(self._inv, minlength=self._n)
+        self._starts = np.concatenate([[0], np.cumsum(counts)[:-1]])
+        self._all_distinct = self._n == len(self._inv)
+
+        already_grouped = bool(np.all(np.diff(self._inv) >= 0))
+        self._order = (
+            None if already_grouped else np.argsort(self._inv, kind="stable")
+        )
+
     def sum(self, values):
-        values = np.asarray(values)
+        # ``asarray`` rather than ``astype``: no copy when the caller
+        # already handed over float64, which it almost always does.
+        values = np.asarray(values, dtype=float)
         if values.ndim == 1:
-            result = np.bincount(
-                self._inv, weights=values.astype(float), minlength=self._n
-            )
+            result = np.bincount(self._inv, weights=values, minlength=self._n)
         else:
-            result = np.zeros((self._n,) + values.shape[1:], dtype=float)
-            np.add.at(result, self._inv, values)
+            ordered = values if self._order is None else values[self._order]
+            result = (
+                ordered
+                if self._all_distinct
+                else np.add.reduceat(ordered, self._starts, axis=0)
+            )
         return self.unique, result
 
     def max(self, values):
@@ -65,14 +105,46 @@ class _GroupBy:
         return self.unique, result
 
 
-def efron_jit(n_d, Ri, Di, out):
-    for i in range(len(n_d)):
-        if n_d[i] == 0:
-            continue
-        j_vals = np.arange(int(n_d[i]))
-        c_vals = j_vals / n_d[i]
-        v = Ri[i] - c_vals[:, np.newaxis] * Di[i]
-        out[i] = np.log(v).sum()
+def _efron_tie_weights(n_d):
+    """``c = j / d`` for every tied death, with a mask marking the entries
+    that only exist to square off the ragged ``j < d`` ranges.
+
+    The count ``d`` can be fractional -- ``n`` is a weight, not necessarily
+    an integer -- and the loop this replaces ran ``range(int(d))`` while
+    dividing by the unrounded ``d``. The mask therefore truncates and the
+    weights do not; getting that backwards would silently change the
+    Efron correction for weighted data.
+
+    Shared by the log-likelihood denominator and the hessian so the two
+    agree on the ragged-edge convention by construction.
+    """
+    counts = n_d.astype(int)
+    j = np.arange(int(counts.max()) if counts.size else 0)
+    valid = j[None, :] < counts[:, None]
+    weights = np.where(valid, j[None, :] / n_d[:, None], 0.0)
+    return weights, valid
+
+
+def efron_log_denominator(n_d, Ri, Di):
+    """Per event time, ``sum_j log(R - (j/d) D)`` over the ``d`` tied deaths.
+
+    Where at most one death occurs, ``j`` only ever takes the value 0, so
+    ``c = 0`` and this collapses to ``log(R)`` — Breslow's denominator. On
+    continuous data that is every event time, which is why the Efron and
+    Breslow fits agree digit for digit there; splitting the two cases out
+    means that agreement no longer costs a Python loop (#329).
+    """
+    out = np.zeros(len(n_d))
+    R = np.asarray(Ri).reshape(len(n_d))
+    D = np.asarray(Di).reshape(len(n_d))
+
+    active = n_d >= 1
+    if not active.any():
+        return out
+
+    weights, valid = _efron_tie_weights(n_d[active])
+    v = R[active][:, None] - weights * D[active][:, None]
+    out[active] = np.where(valid, np.log(v), 0.0).sum(axis=1)
     return out
 
 
@@ -98,8 +170,8 @@ def efron_jac(n_d, Ri, ZRi, Di, ZDi, masked_array):
     return out
 
 
-def efron_hess_jit(n_d, Ri, ZRi, Z2Ri, Di, ZDi, Z2Di, out):
-    # Per-tied-time contribution to the observed information (the Hessian of
+def efron_hess(n_d, Ri, ZRi, Z2Ri, Di, ZDi, Z2Di):
+    # Per-event-time contribution to the observed information (the Hessian of
     # the negative Efron partial log-likelihood). For each of the ``n_d[i]``
     # tied deaths the Efron correction shrinks the risk set by ``c * D``:
     #
@@ -109,18 +181,80 @@ def efron_hess_jit(n_d, Ri, ZRi, Z2Ri, Di, ZDi, Z2Di, out):
     # (a p x p matrix), which is where this previously went wrong -- an inner
     # product collapses it to a scalar and silently corrupts the off-diagonal
     # information for any model with more than one covariate.
-    for i in range(len(n_d)):
-        val = np.zeros(out.shape[1:])
-        if n_d[i] == 0:
-            continue
-        for j in range(int(n_d[i])):
-            c = j / n_d[i]
-            dRD = Ri[i] - c * Di[i]
-            a = ZRi[i] - c * ZDi[i]
-            a2 = np.outer(a, a)
-            val += (dRD * (Z2Ri[i] - c * Z2Di[i]) - a2) / dRD**2
-        out[i] = val
+    #
+    # This used to be a Python double loop, 4.8s of a 16.9s fit at n=50 000
+    # with ten covariates, plus 370 000 calls to ``np.outer`` (#329).
+    #
+    # The sum over ``j`` factors out of the p x p part entirely, which is
+    # what makes the vectorised form cheap rather than merely loop-free.
+    # Only ``c`` depends on ``j``, so with ``u = 1 / (R - c D)``:
+    #
+    #     sum_j (Z2R - c Z2D) u  =  (sum u) Z2R - (sum c u) Z2D
+    #
+    # and, expanding ``a a' = ZR ZR' - c (ZR ZD' + ZD ZR') + c^2 ZD ZD'``,
+    #
+    #     sum_j a a' u^2 = (sum u^2) ZR ZR'
+    #                    - (sum c u^2) (ZR ZD' + ZD ZR')
+    #                    + (sum c^2 u^2) ZD ZD'.
+    #
+    # The five sums are scalars per event time, so the ragged ``j`` axis
+    # never has to carry a p x p payload: it costs O(times x ties) instead
+    # of O(times x ties x p^2). Untied times fall out of the same formula
+    # with a single j = 0 term and c = 0, so there is no separate branch --
+    # on continuous data the ragged axis is one element wide.
+    m = len(n_d)
+    p = ZRi.shape[1]
+    out = np.zeros((m, p, p))
+
+    active = n_d >= 1
+    if not active.any():
+        return out
+
+    weights, valid = _efron_tie_weights(n_d[active])
+    R = np.asarray(Ri).reshape(m)[active][:, None]
+    D = np.asarray(Di).reshape(m)[active][:, None]
+
+    u = np.where(valid, 1.0 / (R - weights * D), 0.0)
+    u2 = u**2
+
+    s_u = u.sum(axis=1)[:, None, None]
+    s_cu = (weights * u).sum(axis=1)[:, None, None]
+    s_u2 = u2.sum(axis=1)[:, None, None]
+    s_cu2 = (weights * u2).sum(axis=1)[:, None, None]
+    s_c2u2 = (weights**2 * u2).sum(axis=1)[:, None, None]
+
+    ZR = ZRi[active]
+    ZD = ZDi[active]
+    RR = ZR[:, :, None] * ZR[:, None, :]
+    RD = ZR[:, :, None] * ZD[:, None, :]
+    DD = ZD[:, :, None] * ZD[:, None, :]
+
+    out[active] = (
+        s_u * Z2Ri[active]
+        - s_cu * Z2Di[active]
+        - s_u2 * RR
+        + s_cu2 * (RD + RD.transpose(0, 2, 1))
+        - s_c2u2 * DD
+    )
     return out
+
+
+def _sort_by_event_time(x, Z, c, n, tl):
+    """Put the rows in event-time order before building the closures.
+
+    Nothing in the partial likelihood depends on the order of the rows --
+    every quantity is aggregated to unique event times first -- but
+    ``_GroupBy`` gets to skip its permutation when the keys already arrive
+    grouped. One reordering of ``Z`` here replaces a gather of an
+    ``(n, p, p)`` array on every ``jac_hess`` call, roughly ten of them per
+    root-finding iteration (#329).
+
+    The caller keeps the unsorted arrays: ``fit`` stores those on the model
+    for the residual and diagnostic code, and the closures only ever hand
+    back beta-shaped or unique-time-shaped results.
+    """
+    order = np.argsort(x, kind="stable")
+    return x[order], Z[order], c[order], n[order], tl[order]
 
 
 def at_risk_beta_Z(arr, n, gb_x):
@@ -352,6 +486,8 @@ class CoxPH_:
         # Left-truncation is handled by subtracting the pre-entry risk set
         # (``Ri - TRi``) below, so delayed-entry data is fitted correctly.
 
+        x, Z, c, n, tl = _sort_by_event_time(x, Z, c, n, tl)
+
         # Groupby object for repeated use
         gb_x = _GroupBy(x)
         gb_tl = _GroupBy(tl)
@@ -383,8 +519,7 @@ class CoxPH_:
 
             Di = gb_x.sum(n_d_x * e_beta_z)[1]
 
-            efron_denom = np.zeros_like(x_)
-            efron_denom = efron_jit(n_d, Ri, Di, efron_denom)
+            efron_denom = efron_log_denominator(n_d, Ri, Di)
 
             like = S_d.sum() - efron_denom.sum()
             return -like
@@ -396,20 +531,22 @@ class CoxPH_:
 
         masked_array = ma.array(arr, mask=mask)
 
+        # Z is fixed for the life of the fit, so its outer product is too.
+        # It used to be rebuilt inside ``jac_hess`` -- an (n, p, p) einsum
+        # on every root-finding iteration, 1.1s of a 16.9s fit (#329).
+        Z2 = np.einsum("ij, ik -> ijk", Z, Z)
+
         def jac_hess(beta):
             # This line troubled me for longer than I care
             # to admit. I was using n, but it is only the
             # number of deaths at each point, n_d_x
-
-            # Z = Z
-            Z2 = np.einsum("ij, ik -> ijk", Z, Z)
 
             # Only call this once.. Yay.
             beta_z = Z @ beta
 
             e_beta_z = np.exp(beta_z).reshape(-1, 1)
             z_e_beta_z = Z * e_beta_z
-            z2_e_beta_z = np.einsum("ijk, ij -> ijk", Z2, n * e_beta_z)
+            z2_e_beta_z = Z2 * (n * e_beta_z)[:, :, None]
 
             Ri = at_risk_beta_Z(e_beta_z, n, gb_x)
             ZRi = at_risk_beta_Z(z_e_beta_z, n, gb_x)
@@ -438,15 +575,12 @@ class CoxPH_:
             # accumulated per tied time then summed. Same positive-definite
             # convention as the Breslow branch, so ``inv(hess)`` gives the
             # parameter covariance directly.
-            Z2Di = np.einsum("ijk, ij -> ijk", Z2, n_d_x * e_beta_z)
+            Z2Di = Z2 * (n_d_x * e_beta_z)[:, :, None]
             Z2Di = gb_x.sum(Z2Di)[1]
 
-            n_params = Z.shape[1]
-            hess_matrix = np.zeros((len(n_d), n_params, n_params))
-            hess_matrix = efron_hess_jit(
-                n_d, Ri, ZRi, Z2Ri, Di, ZDi, Z2Di, hess_matrix
+            hess_matrix = efron_hess(n_d, Ri, ZRi, Z2Ri, Di, ZDi, Z2Di).sum(
+                axis=0
             )
-            hess_matrix = hess_matrix.sum(axis=0)
 
             return jacobian, hess_matrix
 
@@ -457,6 +591,8 @@ class CoxPH_:
         # was https://mathweb.ucsd.edu/~rxu/math284/slect5.pdf
         # Left-truncation is handled by subtracting the pre-entry risk set
         # (``Ri - TRi``) below, so delayed-entry data is fitted correctly.
+
+        x, Z, c, n, tl = _sort_by_event_time(x, Z, c, n, tl)
 
         gb_x = _GroupBy(x)
         gb_tl = _GroupBy(tl)
@@ -492,15 +628,16 @@ class CoxPH_:
 
         S_d = gb_x.sum(n_d_x.reshape(-1, 1) * Z)[1]
 
-        def jac_hess(beta):
-            Z2 = np.einsum("ij, ik -> ijk", Z, Z)
+        # Constant for the life of the fit; see the Efron branch (#329).
+        Z2 = np.einsum("ij, ik -> ijk", Z, Z)
 
+        def jac_hess(beta):
             # Only call this once.. Yay.
             beta_z = Z @ beta
 
             e_beta_z = np.exp(beta_z).reshape(-1, 1)
             z_e_beta_z = Z * e_beta_z
-            z2_e_beta_z = np.einsum("ijk, ij -> ijk", Z2, n * e_beta_z)
+            z2_e_beta_z = Z2 * (n * e_beta_z)[:, :, None]
 
             Ri = at_risk_beta_Z(e_beta_z, n, gb_x)
             ZRi = at_risk_beta_Z(z_e_beta_z, n, gb_x)
@@ -520,7 +657,7 @@ class CoxPH_:
             jacobian = -(S_d - EZ).sum(axis=0)
 
             # calc term 1
-            term_1 = np.einsum("ijk,ij->ijk", Z2Ri, 1.0 / Ri)
+            term_1 = Z2Ri / Ri[:, :, None]
 
             # calc term 2
             term_2 = ZRi / Ri

--- a/surpyval/utils/surpyval_data.py
+++ b/surpyval/utils/surpyval_data.py
@@ -228,6 +228,24 @@ class SurpyvalData:
             self.n[self.truncated_mask],
         )
 
+        # The truncation correction depends only on the observation
+        # *window*, not on where in it the observation fell, so it needs
+        # evaluating once per distinct window rather than once per row.
+        # Truncation is nearly always common to the whole sample -- a
+        # single burn-in time, one study entry date -- so this typically
+        # collapses hundreds of CDF evaluations per likelihood call into
+        # one, and the likelihood is called hundreds of times per fit.
+        if self.x_tl.size:
+            windows = np.column_stack([self.x_tl, self.x_tr])
+            unique, inverse = np.unique(windows, axis=0, return_inverse=True)
+            self.tl_unique = unique[:, 0]
+            self.tr_unique = unique[:, 1]
+            self.n_t_unique = np.bincount(inverse.ravel(), weights=self.n_t)
+        else:
+            self.tl_unique = np.array([])
+            self.tr_unique = np.array([])
+            self.n_t_unique = np.array([])
+
     def to_xrd(self, estimator="Nelson-Aalen") -> tuple:
         """
         Converts the data into the xrd format. If the data has right truncated


### PR DESCRIPTION
Everything on `develop` since v0.18.0.

## Correctness

**Confidence bounds no longer turn to nan on data in large units** (#4ce0d1d). Every `(0, inf)` parameter goes through `adj_relu`, which chose between `x + 1` and `exp(x)` with `np.where`. Autograd evaluates both branches, so above `x = 709.78` the unselected `exp` overflowed to inf and poisoned the derivative of the branch that *was* chosen. A fit died as soon as any such parameter exceeded ~710 — which is why the threshold looked arbitrary. Also ~17x faster, because the same nan reached the objective's gradient and every optimiser in the ladder gave up.

**The truncation correction could manufacture likelihood out of an underflow** (#326). The CDF difference was floored at `_TINY`; under left truncation that difference is `S(tl)`, which underflows to zero on a wide window, capping the correction at `log(tiny) = -708` — and the caller *subtracts* it, so every truncated row gained 708 log-likelihood. Worth 38 430 on the case that exposed it.

**Turnbull kept the interval starting at an observation's own entry time** (#308). `searchsorted(..., side="left")` is one atom too high when `tl` lands on a support boundary, so a left-censored row entering at an event time could not have failed in the interval beginning there.

**A Turnbull fit resting on a non-identifiable direction now says so** (#308). With left censoring and two or more distinct entry times the likelihood has a flat direction whose supremum sits on the boundary — the degenerate answer scores −6.14 against −9.36 for the sensible one, so this is the likelihood's behaviour, not a fitter bug. The fit warns and reports `exploitable_mass`. The trigger is mass evidence only: over 240 fits, only 8–72% of structurally eligible configurations actually degenerate, so rejecting on structure would refuse ~88% of good data.

**Parametric PH degraded on large-magnitude data** (#328). `optimise_ph` passed no `jac` despite the objective being autograd-traceable, was not preconditioned, and returned TNC's answer whether or not it converged. At data scale 1e6 a `WeibullPH` fit settled 1.5 nats short and 1e-2 away in the coefficients.

**Degenerate data is rejected with an explanation** instead of dying inside numdifftools.

## Performance

- MLE preconditioning replaces tolerance tuning (#323) — the gradient shrinks like `1/theta` *and* grows like `n`, so no absolute `gtol` serves every fit
- Truncated fits ~60x faster, truncation term vectorised
- MLE ~2.2x faster (ladder stops at the first optimiser that converges)
- Cox 3x to 10x faster (#329), coefficients unchanged to every digit
- Parametric PH up to 6x faster (#328)

Against `lifelines`, scoring both packages' answers on independently written log-likelihoods: surpyval now wins on delayed entry (2.62s vs 170s at 43 384 rows), time-varying covariates (0.44s vs 7.8s at 20 000 rows), and every parametric PH cell measured.

## Known limitations, tracked

- **#331** — AFT and PO share the two omissions fixed for PH. Their Nelder-Mead first rung is derivative-free and so cannot fail the same way, so it is being measured before it is changed rather than fixed by analogy.
- **#332** — two Cox cases remain slower than `lifelines` (n=50 000 with ten covariates, and heavy ties). Both are dominated by materialising `(n, p, p)` arrays; getting past it means accumulating the information matrix per event time, which is a change of algorithm.
- **#327** — the Turnbull identifiability trigger is a calibrated mass heuristic (91% caught, 2% false alarms), not a criterion. Replacing it with the Vardi/Wang connectivity criterion needs that criterion extended from truncation-only to truncation-plus-interval-censoring, which is real work.

Five xfails in the suite are the non-identifiable Turnbull configurations, marked strict so that a future change making one converge sensibly will be reported.

## Why minor rather than patch

Every item is a fix or a speed-up, but fitted parameters move, Turnbull accepts input that used to raise and emits a warning on data that previously fitted silently, there is a new output field, and degenerate data raises a different exception. The changes are invisible at the call site: same code, same data, different answer.

`SCHEMA_VERSION` stays at 1 — the serialised model format has not changed.

## Verification

Full suite 2393 passed, 1 skipped, 5 xfailed. CI green on every commit: lint (flake8, mypy, black) and pytest on Python 3.11, 3.12 and 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_