### PR TITLE
Consolidate the package's duplicated numeric helpers into utils

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,54 @@ Changelog
 v0.19.1 (unreleased)
 --------------------
 
+- **The duplicated numeric helpers are consolidated into two new utils
+  modules.** A sweep of every module-level helper in the package found
+  the same functions written repeatedly, three of them verbatim.
+
+  ``surpyval.utils.linalg`` now holds the single copy of each:
+  ``numerical_hessian``, ``delta_method_se``, ``bound_signs`` and
+  ``log_transformed_cb`` were duplicated wholesale between
+  ``recurrent.inference`` and ``univariate.regression._bounds`` -- the
+  drift-prone verbatim-copy pattern that produced <#288> -- with two
+  *further* hand-rolled Hessians (a different step rule, ``1e-5`` against
+  cube-root-of-epsilon) on ``royston_parmar`` and the frailty fitter,
+  which now pass their step explicitly. The ``inv``-then-``pinv``
+  fallback, written out at seven call sites, is ``safe_inv`` and
+  ``safe_quadform`` (the latter the ``u'V^{-1}u`` test-statistic shape
+  shared by the log-rank and Gray's tests). The eigenvalue-surgery family
+  from the degradation package -- symmetrise, ``eigh``, repair the
+  spectrum, reconstruct, five sites in three flavours -- is
+  ``psd_project``, ``psd_floor``, ``psd_precision`` and ``psd_root``,
+  with each call site's own floor convention preserved as arguments.
+
+  ``surpyval.utils.ipcw`` holds the censoring-distribution Kaplan-Meier
+  (``censoring_survival``) and the right-continuous step lookup
+  (``step_at``) that Gray's test, Fine-Gray and the prediction metrics
+  each carried privately -- three copies of each, under three names
+  (``_G_at``/``_step``/``_g_at`` for the same four lines). The copies had
+  begun to drift: the metrics copy silently ignored count weights,
+  consistent with its callers today but a trap for the next reuse. The
+  shared implementation is weighted, with no ``n`` as the unweighted
+  case. ``utils.validate_1d`` joins the wrangling helpers for the 1-D
+  float coercion the metrics module had as ``_as_1d``.
+
+  The bodies are transplants, not rewrites, and behaviour was checked
+  rather than assumed: 37 fingerprints across every touched path --
+  Gray's test (both ``rho``), Fine-Gray coefficients/covariance/CIF, the
+  competing-risks PH wrapper, Brier/IBS/AUC, a three-group log-rank, Cox
+  ``check_ph`` and dfbeta residuals, additive-hazards fit, Royston-Parmar
+  and frailty covariances, Crow-AMSAA/HPP standard errors and bounds,
+  WeibullPH ``sf``/``hf`` bounds, the degradation fit with its corrected
+  life covariance, REML, and the seeded induced-life sample -- are
+  bit-identical before and after. One caller-facing rename:
+  ``delta_method_std_errors`` (the ``recurrent.inference`` spelling) is
+  now ``delta_method_se`` everywhere, matching the regression package's
+  name for the identical function.
+
+  Both new modules are fully annotated and under the mypy ratchet
+  (<#143>) from birth, so the coming ``utils`` typing pass types each of
+  these once instead of three times.
+
 - **A behavioural consistency sweep across the base distributions.** The
   previous sweep compared annotations; this one compares what the
   distributions actually compute. Every identity that should hold for all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,8 @@ module = [
     'surpyval.univariate.parametric.distributions.fixed_event_probability',
     # Already fully annotated; listed so they cannot slip back.
     'surpyval.fit_best',
+    'surpyval.utils.linalg',
+    'surpyval.utils.ipcw',
     'surpyval.utils.recurrent_utils',
     'surpyval.utils.score',
     'surpyval.recurrent.tests',

--- a/surpyval/degradation/_bounds.py
+++ b/surpyval/degradation/_bounds.py
@@ -34,15 +34,16 @@ Two ways to fix this are provided:
 import numpy as np
 from scipy.stats import norm
 
+from surpyval.utils.linalg import bound_signs as _bound_signs
+from surpyval.utils.linalg import delta_method_se as _delta_se
+from surpyval.utils.linalg import numerical_hessian as _num_hessian
+from surpyval.utils.linalg import (
+    safe_inv,
+)
+
 # -- delta-method helpers shared with the recurrent package (the two
 # packages used to carry verbatim copies of these, the drift-prone
 # pattern that produced #288) ---------------------------------------------
-
-from surpyval.recurrent.inference import (
-    _bound_signs,
-    delta_method_std_errors as _delta_se,
-    numerical_hessian as _num_hessian,
-)
 
 
 def _logit_bound(p_hat, se, alpha_ci, bound):
@@ -100,10 +101,7 @@ def pseudo_time_variances(model):
         theta = model.path_params[idx]
         x_unit = model.x[model.i == unit]
         J = np.atleast_2d(model.path_model.jacobian(x_unit, *theta))
-        try:
-            cov_theta = sigma2 * np.linalg.inv(J.T @ J)
-        except np.linalg.LinAlgError:
-            cov_theta = sigma2 * np.linalg.pinv(J.T @ J)
+        cov_theta = sigma2 * safe_inv(J.T @ J)
         g = _inv_path_grad(model.path_model, model.threshold, theta)
         v[idx] = float(g @ cov_theta @ g)
     return v
@@ -149,10 +147,7 @@ def life_parameter_covariance(model, method="analytic"):
     t = np.asarray(model.pseudo_failure_times, dtype=float)
 
     H = -_num_hessian(lambda p: _life_loglik(model, p, t), phi)
-    try:
-        Hinv = np.linalg.inv(H)
-    except np.linalg.LinAlgError:
-        Hinv = np.linalg.pinv(H)
+    Hinv = safe_inv(H)
 
     v = pseudo_time_variances(model)
     events = np.where((model.c == 0) & (v > 0))[0]

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -21,11 +21,18 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
+from surpyval.serialisation import SerialisableMixin, stamp_schema
 from surpyval.univariate.parametric import Weibull
 from surpyval.univariate.parametric.parametric import Parametric
 from surpyval.univariate.regression import AFT
 from surpyval.univariate.regression.parametric_regression_model import (
     ParametricRegressionModel,
+)
+from surpyval.utils.linalg import (
+    psd_precision,
+    psd_project,
+    psd_root,
+    safe_inv,
 )
 
 from ._bounds import (
@@ -35,7 +42,6 @@ from ._bounds import (
 )
 from .path_models import PATH_MODELS, PathModel, get_path_model
 from .population import reml_estimate, reml_estimate_nonlinear
-from surpyval.serialisation import SerialisableMixin, stamp_schema
 
 
 def _is_regression_fitter(fitter) -> bool:
@@ -46,22 +52,6 @@ def _is_regression_fitter(fitter) -> bool:
         return "Z" in inspect.signature(fitter.fit).parameters
     except (TypeError, ValueError):
         return False
-
-
-def _clip_psd(matrix: npt.NDArray) -> tuple[npt.NDArray, bool]:
-    """
-    Project a symmetric matrix onto the positive semi-definite cone
-    by clipping negative eigenvalues to zero.
-
-    Returns the projected matrix and whether any eigenvalue was
-    *materially* negative (beyond floating-point noise).
-    """
-    matrix = (matrix + matrix.T) / 2.0
-    eigvals, eigvecs = np.linalg.eigh(matrix)
-    tol = 1e-10 * max(np.abs(eigvals).max(), np.finfo(float).tiny)
-    clipped = bool((eigvals < -tol).any())
-    eigvals = np.clip(eigvals, 0.0, None)
-    return eigvecs @ np.diag(eigvals) @ eigvecs.T, clipped
 
 
 @dataclass
@@ -713,11 +703,7 @@ class DegradationModel(SerialisableMixin):
         # floor the prior covariance's eigenvalues so a clipped
         # (rank-deficient) covariance still gives a proper, very tight
         # prior in the deficient directions
-        eigvals, eigvecs = np.linalg.eigh(self.path_param_cov)
-        floor = max(eigvals.max() * 1e-8, np.finfo(float).tiny)
-        prior_precision = (
-            eigvecs @ np.diag(1.0 / np.clip(eigvals, floor, None)) @ eigvecs.T
-        )
+        prior_precision = psd_precision(self.path_param_cov, 1e-8, 0.0)
         noise_var = self.measurement_var
 
         theta = prior_mean.copy()
@@ -893,9 +879,7 @@ class DegradationModel(SerialisableMixin):
         cov = np.asarray(self.path_param_cov, dtype=float)
         # Robust MVN sampling: symmetrise and clip the (possibly PSD-clipped)
         # covariance's eigenvalues to be non-negative before taking its root.
-        cov = (cov + cov.T) / 2.0
-        eigvals, eigvecs = np.linalg.eigh(cov)
-        root = eigvecs @ np.diag(np.sqrt(np.clip(eigvals, 0.0, None)))
+        root = psd_root(cov)
         z = rng.standard_normal((n_samples, mean.size))
         theta = mean + z @ root.T
 
@@ -1335,10 +1319,7 @@ class DegradationAnalysis_:
             dof_total += len(x_unit) - n_params
             jacobian = path_model.jacobian(x_unit, *params)
             jtj = jacobian.T @ jacobian
-            try:
-                estimation_cov_sum += np.linalg.inv(jtj)
-            except np.linalg.LinAlgError:
-                estimation_cov_sum += np.linalg.pinv(jtj)
+            estimation_cov_sum += safe_inv(jtj)
             y_by_unit.append(y_unit)
             x_by_unit.append(x_unit)
             design_by_unit.append(jacobian)
@@ -1352,7 +1333,7 @@ class DegradationAnalysis_:
             np.cov(path_params, rowvar=False, ddof=1)
         )
         mean_estimation_cov = measurement_var * estimation_cov_sum / len(units)
-        path_param_cov, was_clipped = _clip_psd(
+        path_param_cov, was_clipped = psd_project(
             path_param_sample_cov - mean_estimation_cov
         )
         if was_clipped and population_method == "moments":

--- a/surpyval/degradation/population.py
+++ b/surpyval/degradation/population.py
@@ -47,6 +47,8 @@ import numpy.typing as npt
 from scipy.linalg import cho_factor, cho_solve
 from scipy.optimize import minimize
 
+from surpyval.utils.linalg import psd_floor, psd_precision
+
 _LARGE = 1e30
 
 
@@ -68,11 +70,7 @@ def _z_from_init(
     cov_init: npt.NDArray, sigma2_init: float, p: int
 ) -> npt.NDArray:
     """Starting z vector from (possibly rank-deficient) moment estimates."""
-    cov_init = (cov_init + cov_init.T) / 2.0
-    eigvals, eigvecs = np.linalg.eigh(cov_init)
-    floor = max(eigvals.max() * 1e-4, sigma2_init * 1e-6, 1e-12)
-    eigvals = np.clip(eigvals, floor, None)
-    cov_init = eigvecs @ np.diag(eigvals) @ eigvecs.T
+    cov_init = psd_floor(cov_init, 1e-4, max(sigma2_init * 1e-6, 1e-12))
     chol = np.linalg.cholesky(cov_init)
     z = np.empty(_n_z(p))
     z[:p] = np.log(np.diag(chol))
@@ -173,11 +171,7 @@ def _prior_precision(cov: npt.NDArray, sigma2: float) -> npt.NDArray:
     A rank-deficient or tiny ``Sigma`` gives a very tight (but proper)
     prior in the deficient directions rather than a singular precision.
     """
-    cov = (cov + cov.T) / 2.0
-    eigvals, eigvecs = np.linalg.eigh(cov)
-    floor = max(eigvals.max() * 1e-8, sigma2 * 1e-12, np.finfo(float).tiny)
-    inv_eigvals = 1.0 / np.clip(eigvals, floor, None)
-    return eigvecs @ np.diag(inv_eigvals) @ eigvecs.T
+    return psd_precision(cov, 1e-8, sigma2 * 1e-12)
 
 
 def _conditional_mode(

--- a/surpyval/metrics/validation.py
+++ b/surpyval/metrics/validation.py
@@ -33,52 +33,15 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 
+from surpyval.utils import validate_1d as _as_1d
+from surpyval.utils.ipcw import censoring_survival, step_at
+
 __all__ = [
     "survival_probability",
     "brier_score",
     "integrated_brier_score",
     "auc_td",
 ]
-
-
-def _as_1d(a: npt.ArrayLike, name: str) -> npt.NDArray:
-    arr = np.atleast_1d(np.asarray(a, dtype=float))
-    if arr.ndim != 1:
-        raise ValueError("'{}' must be one-dimensional".format(name))
-    return arr
-
-
-def _censoring_km(
-    x_train: npt.NDArray, c_train: npt.NDArray
-) -> tuple[npt.NDArray, npt.NDArray]:
-    """Kaplan-Meier estimate of the *censoring* survival ``G(t) = P(C > t)``.
-
-    Censoring is treated as the event of interest: an originally right-censored
-    observation (``c == 1``) is a censoring "event", an originally observed
-    event (``c == 0``) is "censored" for ``G``. Returns the sorted unique times
-    and the right-continuous step values of ``G`` on them.
-    """
-    order = np.argsort(x_train)
-    xs = x_train[order]
-    cs = c_train[order]
-    uniq = np.unique(xs)
-    g = np.empty(uniq.size)
-    surv = 1.0
-    for i, t in enumerate(uniq):
-        n_cens = np.count_nonzero((xs == t) & (cs == 1))
-        n_risk = np.count_nonzero(xs >= t)
-        if n_risk > 0:
-            surv *= 1.0 - n_cens / n_risk
-        g[i] = surv
-    return uniq, g
-
-
-def _g_at(
-    uniq: npt.NDArray, g: npt.NDArray, query: npt.NDArray
-) -> npt.NDArray:
-    """Right-continuous step evaluation of ``G`` at ``query`` (``G(0)=1``)."""
-    idx = np.searchsorted(uniq, query, side="right") - 1
-    return np.where(idx >= 0, g[np.clip(idx, 0, g.size - 1)], 1.0)
 
 
 def survival_probability(
@@ -184,8 +147,8 @@ def brier_score(
     xt = x if x_train is None else _as_1d(x_train, "x_train")
     ct = c if c_train is None else _as_1d(c_train, "c_train")
 
-    uniq, g = _censoring_km(xt, ct)
-    g_xi = _g_at(uniq, g, x)
+    uniq, g = censoring_survival(xt, ct == 1)
+    g_xi = step_at(uniq, g, x, before=1.0)
     with np.errstate(divide="ignore", invalid="ignore"):
         w_case = np.where(g_xi > 0, 1.0 / g_xi, 0.0)
 
@@ -193,7 +156,7 @@ def brier_score(
     bs = np.empty(times.size)
     for k, t in enumerate(times):
         s = survival[:, k]
-        g_t = float(_g_at(uniq, g, np.array([t]))[0])
+        g_t = float(step_at(uniq, g, np.array([t]), before=1.0)[0])
         w_ctrl = 1.0 / g_t if g_t > 0 else 0.0
         died = (x <= t) & (c == 0)
         alive = x > t
@@ -290,8 +253,8 @@ def auc_td(
     xt = x if x_train is None else _as_1d(x_train, "x_train")
     ct = c if c_train is None else _as_1d(c_train, "c_train")
 
-    uniq, g = _censoring_km(xt, ct)
-    g_xi = _g_at(uniq, g, x)
+    uniq, g = censoring_survival(xt, ct == 1)
+    g_xi = step_at(uniq, g, x, before=1.0)
     with np.errstate(divide="ignore", invalid="ignore"):
         w = np.where(g_xi > 0, 1.0 / g_xi, 0.0)
 

--- a/surpyval/recurrent/inference.py
+++ b/surpyval/recurrent/inference.py
@@ -3,95 +3,12 @@ import warnings
 import numpy as np
 from scipy.stats import norm
 
-
-def numerical_hessian(func, x):
-    """
-    Central finite-difference Hessian of a scalar ``func`` at ``x``. Used to
-    approximate the observed Fisher information from the negative
-    log-likelihood of the renewal models, which are fitted with a derivative
-    -free optimiser.
-    """
-    x = np.asarray(x, dtype=float)
-    n = x.size
-    # Step scaled to each parameter; cube-root of machine epsilon is the usual
-    # choice for a second-derivative central difference.
-    step = (np.finfo(float).eps ** (1.0 / 3.0)) * np.maximum(np.abs(x), 1e-2)
-    H = np.zeros((n, n))
-    for i in range(n):
-        for j in range(i, n):
-            ei = np.zeros(n)
-            ei[i] = step[i]
-            ej = np.zeros(n)
-            ej[j] = step[j]
-            H[i, j] = H[j, i] = (
-                func(x + ei + ej)
-                - func(x + ei - ej)
-                - func(x - ei + ej)
-                + func(x - ei - ej)
-            ) / (4.0 * step[i] * step[j])
-    return H
-
-
-def delta_method_std_errors(func, mle, cov):
-    """
-    Standard errors of the (possibly vector-valued) function ``func`` of the
-    parameters, evaluated at the MLE, via the delta method with a
-    central-difference Jacobian: ``se_i = sqrt(J_i' cov J_i)``.
-    """
-    mle = np.asarray(mle, dtype=float)
-    step = (np.finfo(float).eps ** (1.0 / 3.0)) * np.maximum(np.abs(mle), 1e-2)
-    cols = []
-    for i in range(mle.size):
-        ei = np.zeros(mle.size)
-        ei[i] = step[i]
-        cols.append(
-            (
-                np.asarray(func(mle + ei), dtype=float)
-                - np.asarray(func(mle - ei), dtype=float)
-            )
-            / (2.0 * step[i])
-        )
-    J = np.stack(cols, axis=-1)
-    var = np.einsum("...i,ij,...j->...", J, cov, J)
-    with np.errstate(invalid="ignore"):
-        return np.sqrt(var)
-
-
-def _bound_signs(alpha_ci, bound):
-    """
-    The one-sided tail probability and the signs of the normal quantile for
-    each requested bound: ``[-1, 1]`` (lower, upper) for two-sided bounds,
-    a single sign otherwise.
-    """
-    if bound == "two-sided":
-        return alpha_ci / 2.0, np.array([-1.0, 1.0])
-    elif bound == "lower":
-        return alpha_ci, np.array([-1.0])
-    elif bound == "upper":
-        return alpha_ci, np.array([1.0])
-    raise ValueError("`bound` must be 'two-sided', 'lower' or 'upper'")
-
-
-def log_transformed_cb(estimate, se, alpha_ci=0.05, bound="two-sided"):
-    """
-    Log-transformed normal confidence bounds ``est * exp(+/- z * se / est)``
-    for a positive curve (the same construction as the exponential Greenwood
-    bounds on the nonparametric MCF). Where the estimate is zero (e.g. a CIF
-    at ``x = 0``) both bounds are zero.
-
-    For two-sided bounds the last axis holds ``[lower, upper]``; one-sided
-    bounds are returned with the shape of ``estimate``.
-    """
-    estimate = np.asarray(estimate, dtype=float)
-    se = np.asarray(se, dtype=float)
-    alpha, signs = _bound_signs(alpha_ci, bound)
-    z = norm.ppf(1.0 - alpha)
-    with np.errstate(divide="ignore", invalid="ignore"):
-        ratio = np.where(estimate > 0, se / estimate, 0.0)
-    cb = estimate[..., None] * np.exp(signs * z * ratio[..., None])
-    if bound == "two-sided":
-        return cb
-    return cb[..., 0]
+# The finite-difference Hessian and the bound-sign helper live in
+# ``surpyval.utils.linalg`` -- shared with the parametric-regression
+# bounds machinery, which used to carry verbatim copies of them (the
+# drift-prone pattern that produced #288).
+from surpyval.utils.linalg import bound_signs as _bound_signs
+from surpyval.utils.linalg import numerical_hessian
 
 
 class LikelihoodInferenceMixin:

--- a/surpyval/recurrent/parametric/parametric_recurrence.py
+++ b/surpyval/recurrent/parametric/parametric_recurrence.py
@@ -2,14 +2,11 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from surpyval.recurrent import diagnostics
-from surpyval.recurrent.inference import (
-    LikelihoodInferenceMixin,
-    delta_method_std_errors,
-    log_transformed_cb,
-)
+from surpyval.recurrent.inference import LikelihoodInferenceMixin
 from surpyval.recurrent.serialisation import intensity_dist_by_name
 from surpyval.recurrent.simulation import RecurrenceSimulationMixin
 from surpyval.serialisation import SerialisableMixin, stamp_schema
+from surpyval.utils.linalg import delta_method_se, log_transformed_cb
 
 
 class ParametricRecurrenceModel(
@@ -319,7 +316,7 @@ class ParametricRecurrenceModel(
         """
         self._check_fitted()
         x = np.atleast_1d(np.asarray(x, dtype=float))
-        se = delta_method_std_errors(
+        se = delta_method_se(
             lambda params: self.dist.cif(x, *params),
             self._mle,
             self.covariance(),

--- a/surpyval/recurrent/regression/proportional_intensity.py
+++ b/surpyval/recurrent/regression/proportional_intensity.py
@@ -2,14 +2,11 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from surpyval.recurrent import diagnostics
-from surpyval.recurrent.inference import (
-    LikelihoodInferenceMixin,
-    delta_method_std_errors,
-    log_transformed_cb,
-)
+from surpyval.recurrent.inference import LikelihoodInferenceMixin
 from surpyval.recurrent.serialisation import intensity_dist_by_name
 from surpyval.recurrent.simulation import RecurrenceSimulationMixin
 from surpyval.serialisation import SerialisableMixin, stamp_schema
+from surpyval.utils.linalg import delta_method_se, log_transformed_cb
 
 
 class ProportionalIntensityModel(
@@ -316,7 +313,7 @@ class ProportionalIntensityModel(
                 Z @ theta[n_dist_params:]
             )
 
-        se = delta_method_std_errors(cif_at, self._mle, self.covariance())
+        se = delta_method_se(cif_at, self._mle, self.covariance())
         return log_transformed_cb(self.cif(x, Z), se, alpha_ci, bound)
 
     def plot(self, ax=None, plot_bounds=True, confidence=0.95):

--- a/surpyval/tests/degradation/test_degradation_analysis.py
+++ b/surpyval/tests/degradation/test_degradation_analysis.py
@@ -221,7 +221,7 @@ def test_noise_correction_recovers_between_unit_covariance():
 
 
 def test_clip_psd():
-    from surpyval.degradation.degradation_analysis import _clip_psd
+    from surpyval.utils.linalg import psd_project as _clip_psd
 
     # eigenvalues 3 and -1: must be clipped
     clipped_matrix, clipped = _clip_psd(np.array([[1.0, 2.0], [2.0, 1.0]]))

--- a/surpyval/univariate/competing_risks/nonparametric/gray_test.py
+++ b/surpyval/univariate/competing_risks/nonparametric/gray_test.py
@@ -23,6 +23,8 @@ from scipy.stats import chi2
 from surpyval.univariate.competing_risks.aalen_johansen import (
     aalen_johansen_iif,
 )
+from surpyval.utils.ipcw import censoring_survival, step_at
+from surpyval.utils.linalg import safe_quadform
 
 
 class GrayTestResult(NamedTuple):
@@ -31,30 +33,6 @@ class GrayTestResult(NamedTuple):
     p_value: float
     cause: Any
     groups: list
-
-
-def _censoring_survival(x: np.ndarray, censored: np.ndarray, n: np.ndarray):
-    """Kaplan-Meier estimate of the censoring-time survival ``G(t)`` on the
-    pooled sample (treating censorings as the events), returned as the unique
-    times and the right-continuous ``G`` at those times."""
-    times = np.unique(x)
-    G = np.ones(times.size)
-    surv = 1.0
-    for i, t in enumerate(times):
-        at_risk = n[x >= t].sum()
-        cens_here = n[(x == t) & censored].sum()
-        if at_risk > 0:
-            surv *= 1.0 - cens_here / at_risk
-        G[i] = surv
-    return times, G
-
-
-def _G_at(times: np.ndarray, G: np.ndarray, q: np.ndarray) -> np.ndarray:
-    """Right-continuous ``G`` evaluated at query times ``q`` (1 before the
-    first event time)."""
-    idx = np.searchsorted(times, q, side="right") - 1
-    out = np.where(idx < 0, 1.0, G[np.clip(idx, 0, times.size - 1)])
-    return out
 
 
 def gray_test(
@@ -118,8 +96,9 @@ def gray_test(
         raise ValueError("Gray's test needs at least two groups.")
 
     # Censoring-distribution survival for the IPCW subdistribution weights.
-    ctimes, Gsurv = _censoring_survival(x, censored, n)
-    G_at_x = _G_at(ctimes, Gsurv, x)  # G at each subject's own time
+    ctimes, Gsurv = censoring_survival(x, censored, n)
+    # G at each subject's own time.
+    G_at_x = step_at(ctimes, Gsurv, x, before=1.0)
 
     # Pooled cumulative incidence of the cause, for the (optional) rho weight.
     cause_times = np.unique(x[is_cause])
@@ -131,7 +110,7 @@ def gray_test(
     F_pooled = _pooled_cif(x, all_event, is_cause, n, cause_times)
     weights = (1.0 - np.concatenate([[0.0], F_pooled[:-1]])) ** rho
 
-    G_at_tau = _G_at(ctimes, Gsurv, cause_times)
+    G_at_tau = step_at(ctimes, Gsurv, cause_times, before=1.0)
 
     grp_idx = {g: i for i, g in enumerate(groups)}
     gi = np.array([grp_idx[g] for g in group])
@@ -176,10 +155,7 @@ def gray_test(
     # Drop the last group for a full-rank (G-1) quadratic form.
     U_r = U[:-1]
     V_r = V[:-1, :-1]
-    try:
-        stat = float(U_r @ np.linalg.solve(V_r, U_r))
-    except np.linalg.LinAlgError:
-        stat = float(U_r @ np.linalg.pinv(V_r) @ U_r)
+    stat = safe_quadform(V_r, U_r)
     df = G_count - 1
     return GrayTestResult(
         statistic=stat,

--- a/surpyval/univariate/competing_risks/regression/competing_risks_proportional_hazard.py
+++ b/surpyval/univariate/competing_risks/regression/competing_risks_proportional_hazard.py
@@ -18,8 +18,9 @@ from surpyval.utils import (
     validate_fine_gray_inputs,
     wrangle_and_check_form_and_Z_cols,
 )
+from surpyval.utils.ipcw import step_at as _step
 
-from .fine_gray import FineGray, _step
+from .fine_gray import FineGray
 
 
 class CompetingRisksProportionalHazards:

--- a/surpyval/univariate/competing_risks/regression/fine_gray.py
+++ b/surpyval/univariate/competing_risks/regression/fine_gray.py
@@ -36,40 +36,10 @@ from autograd import numpy as anp
 from scipy.optimize import minimize
 from scipy.stats import norm
 
-from surpyval.utils import validate_fine_gray_inputs
 from surpyval.serialisation import SerialisableMixin, stamp_schema
-
-
-def _censoring_survival(x, c, n):
-    """
-    Kaplan-Meier estimate of the censoring survival ``G(t) = P(C > t)``.
-
-    The roles are reversed relative to an ordinary survival fit: right-censored
-    rows (``c == 1``) are the "events" for the censoring distribution and
-    observed events (``c == 0``) are treated as censored. Returns the sorted
-    unique times and the right-continuous ``G`` evaluated at each.
-    """
-    times = np.unique(x)
-    G = np.ones(times.shape[0])
-    surv = 1.0
-    for k, t in enumerate(times):
-        at_risk = n[x >= t].sum()
-        censored = n[(x == t) & (c == 1)].sum()
-        if at_risk > 0:
-            surv = surv * (1.0 - censored / at_risk)
-        G[k] = surv
-    return times, G
-
-
-def _step(times, values, query, before):
-    """
-    Right-continuous step function: the value carried by the largest ``times``
-    entry ``<= query``; ``before`` is returned where ``query`` precedes the
-    first time.
-    """
-    idx = np.searchsorted(times, query, side="right") - 1
-    out = np.where(idx < 0, before, values[np.clip(idx, 0, len(values) - 1)])
-    return out
+from surpyval.utils import validate_fine_gray_inputs
+from surpyval.utils.ipcw import censoring_survival, step_at
+from surpyval.utils.linalg import safe_inv
 
 
 def _fit_cause(x, Z, e, c, n, cause):
@@ -86,14 +56,14 @@ def _fit_cause(x, Z, e, c, n, cause):
     is_competing = (c == 0) & (e != cause)
 
     # Censoring-survival for the IPCW weights.
-    g_times, g_vals = _censoring_survival(x, c, n)
+    g_times, g_vals = censoring_survival(x, c == 1, n)
     # G is >= its last positive value; guard the ratio against division by a
     # zero tail (times beyond the last censoring-KM step).
     g_floor = g_vals[g_vals > 0].min() if np.any(g_vals > 0) else 1.0
-    G_x = np.maximum(_step(g_times, g_vals, x, before=1.0), g_floor)
+    G_x = np.maximum(step_at(g_times, g_vals, x, before=1.0), g_floor)
 
     event_times = x[is_event]
-    G_t = _step(g_times, g_vals, event_times, before=1.0)
+    G_t = step_at(g_times, g_vals, event_times, before=1.0)
 
     # Subdistribution risk-set weight matrix W (n_events x N), independent of
     # beta: 1 for the ordinary risk set (x_i >= t_j); G(t_j)/G(x_i) for a
@@ -124,10 +94,7 @@ def _fit_cause(x, Z, e, c, n, cause):
 
     # Standard errors from the inverse observed information.
     H = hessian(neg_ll)(beta)
-    try:
-        cov = np.linalg.inv(H)
-    except np.linalg.LinAlgError:
-        cov = np.linalg.pinv(H)
+    cov = safe_inv(H)
     var = np.diag(cov)
     with np.errstate(invalid="ignore"):
         se = np.sqrt(np.where(var > 0, var, np.nan))
@@ -246,7 +213,7 @@ class FineGrayModel(SerialisableMixin):
         """
         x = np.atleast_1d(np.asarray(x, dtype=float))
         Z = np.asarray(Z, dtype=float).ravel()
-        H0 = _step(self._times, self._cumhaz, x, before=0.0)
+        H0 = step_at(self._times, self._cumhaz, x, before=0.0)
         return 1.0 - np.exp(-H0 * np.exp(Z @ self.beta))
 
     def sf(self, x, Z):

--- a/surpyval/univariate/nonparametric/logrank.py
+++ b/surpyval/univariate/nonparametric/logrank.py
@@ -4,6 +4,7 @@ from scipy.stats import chi2
 
 from surpyval.univariate.nonparametric.kaplan_meier import kaplan_meier
 from surpyval.utils import xcnt_handler
+from surpyval.utils.linalg import safe_quadform
 
 
 class LogRankResult:
@@ -284,10 +285,7 @@ def logrank(
     # last group
     z_r = z[:-1]
     V_r = V[:-1, :-1]
-    try:
-        statistic = float(z_r @ np.linalg.solve(V_r, z_r))
-    except np.linalg.LinAlgError:
-        statistic = float(z_r @ np.linalg.pinv(V_r) @ z_r)
+    statistic = safe_quadform(V_r, z_r)
 
     dof = k - 1
     p_value = float(chi2.sf(statistic, dof))

--- a/surpyval/univariate/parametric/royston_parmar.py
+++ b/surpyval/univariate/parametric/royston_parmar.py
@@ -37,7 +37,7 @@ right-truncation. Right-censored contribute ``log S``, left-censored
 each observation's contribution by ``S(t_l) - S(t_r)``.
 """
 
-from typing import Any, Callable
+from typing import Any
 
 import numpy as np
 from scipy.optimize import brentq, minimize
@@ -45,6 +45,7 @@ from scipy.special import ndtri as _ndtri
 from scipy.stats import norm
 
 from surpyval.serialisation import SerialisableMixin, stamp_schema, to_native
+from surpyval.utils.linalg import numerical_hessian
 
 _SCALES = ("hazard", "odds", "normal")
 
@@ -327,32 +328,6 @@ class RoystonParmarModel(SerialisableMixin):
         return out
 
 
-def _numerical_hessian(
-    f: Callable[..., Any], x: npt.NDArray, eps: float = 1e-05
-) -> npt.NDArray:
-    n = len(x)
-    H = np.zeros((n, n))
-    steps = np.maximum(np.abs(x), 1.0) * eps
-    for i in range(n):
-        for j in range(i, n):
-            xpp = x.copy()
-            xpp[i] += steps[i]
-            xpp[j] += steps[j]
-            xpm = x.copy()
-            xpm[i] += steps[i]
-            xpm[j] -= steps[j]
-            xmp = x.copy()
-            xmp[i] -= steps[i]
-            xmp[j] += steps[j]
-            xmm = x.copy()
-            xmm[i] -= steps[i]
-            xmm[j] -= steps[j]
-            H[i, j] = H[j, i] = (f(xpp) - f(xpm) - f(xmp) + f(xmm)) / (
-                4 * steps[i] * steps[j]
-            )
-    return H
-
-
 class RoystonParmar_:
     """Fitter for :class:`RoystonParmarModel`. Use the singleton
     :data:`RoystonParmar`.
@@ -534,7 +509,10 @@ class RoystonParmar_:
         covariance = None
         with np.errstate(all="ignore"):
             try:
-                cov = np.linalg.inv(_numerical_hessian(neg_ll, gamma))
+                steps = 1e-05 * np.maximum(np.abs(gamma), 1.0)
+                cov = np.linalg.inv(
+                    numerical_hessian(neg_ll, gamma, step=steps)
+                )
                 if np.all(np.isfinite(cov)):
                     covariance = cov
             except np.linalg.LinAlgError:

--- a/surpyval/univariate/regression/_bounds.py
+++ b/surpyval/univariate/regression/_bounds.py
@@ -11,95 +11,16 @@ These helpers turn that covariance into
 * delta-method bounds on the predicted ``sf``/``ff``/``Hf``/``hf``/``df`` at a
   covariate vector ``Z``.
 
-The functions here are deliberately self-contained (numpy + scipy only) so the
-regression package does not depend on any other fitted-model machinery.
+The numeric machinery -- ``numerical_hessian``, ``delta_method_se``,
+``bound_signs`` and ``log_transformed_cb`` -- lives in
+``surpyval.utils.linalg`` and is shared with the recurrent-event inference
+mixin; this module used to carry verbatim copies of all four (the
+drift-prone pattern that produced #288) and now keeps only the logit-scale
+survival bound, which is its own.
 """
 
 import numpy as np
 from scipy.stats import norm
-
-
-def numerical_hessian(func, x):
-    """
-    Central finite-difference Hessian of a scalar ``func`` at ``x``. Used to
-    approximate the observed Fisher information from the negative
-    log-likelihood, which the regression fitters minimise with a derivative
-    -free optimiser.
-    """
-    x = np.asarray(x, dtype=float)
-    n = x.size
-    step = (np.finfo(float).eps ** (1.0 / 3.0)) * np.maximum(np.abs(x), 1e-2)
-    H = np.zeros((n, n))
-    for i in range(n):
-        for j in range(i, n):
-            ei = np.zeros(n)
-            ei[i] = step[i]
-            ej = np.zeros(n)
-            ej[j] = step[j]
-            H[i, j] = H[j, i] = (
-                func(x + ei + ej)
-                - func(x + ei - ej)
-                - func(x - ei + ej)
-                + func(x - ei - ej)
-            ) / (4.0 * step[i] * step[j])
-    return H
-
-
-def delta_method_se(func, mle, cov):
-    """
-    Standard errors of the (vector-valued) ``func`` of the parameters at the
-    MLE via the delta method with a central-difference Jacobian:
-    ``se_i = sqrt(J_i' cov J_i)``.
-    """
-    mle = np.asarray(mle, dtype=float)
-    step = (np.finfo(float).eps ** (1.0 / 3.0)) * np.maximum(np.abs(mle), 1e-2)
-    cols = []
-    for i in range(mle.size):
-        ei = np.zeros(mle.size)
-        ei[i] = step[i]
-        cols.append(
-            (
-                np.asarray(func(mle + ei), dtype=float)
-                - np.asarray(func(mle - ei), dtype=float)
-            )
-            / (2.0 * step[i])
-        )
-    J = np.stack(cols, axis=-1)
-    var = np.einsum("...i,ij,...j->...", J, cov, J)
-    with np.errstate(invalid="ignore"):
-        return np.sqrt(var)
-
-
-def bound_signs(alpha_ci, bound):
-    """
-    The per-bound one-sided tail probability and normal-quantile signs:
-    ``[-1, 1]`` (lower, upper) for two-sided bounds, a single sign otherwise.
-    """
-    if bound == "two-sided":
-        return alpha_ci / 2.0, np.array([-1.0, 1.0])
-    elif bound == "lower":
-        return alpha_ci, np.array([-1.0])
-    elif bound == "upper":
-        return alpha_ci, np.array([1.0])
-    raise ValueError("`bound` must be 'two-sided', 'lower' or 'upper'")
-
-
-def log_transformed_cb(estimate, se, alpha_ci=0.05, bound="two-sided"):
-    """
-    Log-transformed normal bounds ``est * exp(+/- z se / est)`` for a positive
-    quantity (used for ``hf`` and ``df``). Two-sided bounds put ``[lower,
-    upper]`` on the last axis; one-sided bounds keep the shape of ``estimate``.
-    """
-    estimate = np.asarray(estimate, dtype=float)
-    se = np.asarray(se, dtype=float)
-    alpha, signs = bound_signs(alpha_ci, bound)
-    z = norm.ppf(1.0 - alpha)
-    with np.errstate(divide="ignore", invalid="ignore"):
-        ratio = np.where(estimate > 0, se / estimate, 0.0)
-    cb = estimate[..., None] * np.exp(signs * z * ratio[..., None])
-    if bound == "two-sided":
-        return cb
-    return cb[..., 0]
 
 
 def logit_sf_bound(sf_hat, se, sign, alpha_tail):

--- a/surpyval/univariate/regression/additive_hazards/additive_hazards.py
+++ b/surpyval/univariate/regression/additive_hazards/additive_hazards.py
@@ -45,13 +45,13 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
-from numpy.linalg import LinAlgError, inv, pinv
 from scipy.stats import norm
 
+from surpyval.serialisation import SerialisableMixin, stamp_schema
 from surpyval.utils import check_Z_and_x, wrangle_Z, xcnt_handler
+from surpyval.utils.linalg import safe_inv
 
 from ..regression_data import design_matrix_from_df, prepare_Z
-from surpyval.serialisation import SerialisableMixin, stamp_schema
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -360,10 +360,7 @@ class AdditiveHazards_:
         np.add.at(E1_at, bucket, w_event[:, None] * Z)
         b = (E1_at - d_at[:, None] * Zbar).sum(axis=0)
 
-        try:
-            A_inv = inv(A)
-        except LinAlgError:
-            A_inv = pinv(A)
+        A_inv = safe_inv(A)
         beta = A_inv @ b
 
         # Lin-Ying sandwich variance: B = sum over events of the centered

--- a/surpyval/univariate/regression/frailty/frailty_fitter.py
+++ b/surpyval/univariate/regression/frailty/frailty_fitter.py
@@ -29,6 +29,8 @@ import pandas as pd
 from scipy.optimize import minimize
 from scipy.special import gammaln
 
+from surpyval.utils.linalg import numerical_hessian
+
 from ..regression_data import design_matrix_from_df
 from .frailty_model import FrailtyModel
 
@@ -81,39 +83,6 @@ def _make_transforms(dist: Any, k_dist: int) -> tuple[
         return np.array(out, dtype=float)
 
     return to_unc, to_nat
-
-
-def _numerical_hessian(
-    f: Callable[[npt.NDArray], float],
-    x: npt.NDArray,
-    eps: float = 1e-5,
-) -> npt.NDArray:
-    """Finite-difference Hessian of scalar ``f`` at ``x``."""
-    n = len(x)
-    H = np.zeros((n, n))
-    steps = np.maximum(np.abs(x), 1.0) * eps
-    for i in range(n):
-        for j in range(i, n):
-            xi = x.copy()
-            xi[i] += steps[i]
-            xi[j] += steps[j]
-            fpp = f(xi)
-            xi = x.copy()
-            xi[i] += steps[i]
-            xi[j] -= steps[j]
-            fpm = f(xi)
-            xi = x.copy()
-            xi[i] -= steps[i]
-            xi[j] += steps[j]
-            fmp = f(xi)
-            xi = x.copy()
-            xi[i] -= steps[i]
-            xi[j] -= steps[j]
-            fmm = f(xi)
-            H[i, j] = H[j, i] = (fpp - fpm - fmp + fmm) / (
-                4 * steps[i] * steps[j]
-            )
-    return H
 
 
 class FrailtyFitter:
@@ -293,7 +262,8 @@ class FrailtyFitter:
         covariance = None
         with np.errstate(all="ignore"):
             try:
-                Hmat = _numerical_hessian(nll_nat, nat)
+                steps = 1e-5 * np.maximum(np.abs(nat), 1.0)
+                Hmat = numerical_hessian(nll_nat, nat, step=steps)
                 cov = np.linalg.inv(Hmat)
                 if np.all(np.isfinite(cov)):
                     covariance = cov

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -8,14 +8,14 @@ from scipy.stats import norm
 
 from surpyval.serialisation import SerialisableMixin, stamp_schema
 from surpyval.univariate.information_criteria import InformationCriteriaMixin
-
-from ._bounds import (
+from surpyval.utils.linalg import (
     bound_signs,
     delta_method_se,
     log_transformed_cb,
-    logit_sf_bound,
     numerical_hessian,
 )
+
+from ._bounds import logit_sf_bound
 from .regression_data import (
     model_spec_to_meta,
     prepare_Z,

--- a/surpyval/univariate/regression/proportional_hazards/diagnostics.py
+++ b/surpyval/univariate/regression/proportional_hazards/diagnostics.py
@@ -16,8 +16,9 @@ References
 from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy.linalg import inv, pinv
 from scipy.stats import chi2
+
+from surpyval.utils.linalg import safe_inv
 
 from .cox_ph import cox_at_risk_mask
 
@@ -235,7 +236,7 @@ def compute_residuals(
         # the coefficient covariance and d the number of events. Centring on
         # beta makes the plot read directly as beta(t).
         n_events = int(d.sum())
-        V = _safe_inv(_information(model))
+        V = safe_inv(_information(model))
         return beta + n_events * (sch @ V)
 
     # Score / dfbeta residuals. The score residual for observation i is
@@ -267,17 +268,7 @@ def compute_residuals(
     score = score * n[:, None]
     if kind == "score":
         return score
-    return score @ _safe_inv(_information(model))  # dfbeta
-
-
-def _safe_inv(m: np.ndarray) -> np.ndarray:
-    try:
-        out = inv(m)
-        if not np.all(np.isfinite(out)):
-            raise np.linalg.LinAlgError
-        return out
-    except np.linalg.LinAlgError:
-        return pinv(m)
+    return score @ safe_inv(_information(model))  # dfbeta
 
 
 def robust_covariance(
@@ -486,7 +477,7 @@ def check_ph(
         }
 
     # Global joint test: T = (d / Sgc2) u' I^{-1} u ~ chi2_p.
-    V = _safe_inv(info)
+    V = safe_inv(info)
     global_stat = float((n_events / Sgc2) * (u @ V @ u))
     global_p = float(chi2.sf(global_stat, df=p))
 

--- a/surpyval/utils/__init__.py
+++ b/surpyval/utils/__init__.py
@@ -63,6 +63,18 @@ def validate_float_array(arr, name):
         )
 
 
+def validate_1d(arr, name: str) -> npt.NDArray:
+    """
+    Coerce ``arr`` to a one-dimensional float array, naming it in the
+    error when it is not. A scalar becomes a length-one array; anything
+    two-dimensional or higher is rejected.
+    """
+    out = np.atleast_1d(np.asarray(arr, dtype=float))
+    if out.ndim != 1:
+        raise ValueError("'{}' must be one-dimensional".format(name))
+    return out
+
+
 def _group_ids(key):
     """Group id per row, plus the row at which each group first appears.
 

--- a/surpyval/utils/ipcw.py
+++ b/surpyval/utils/ipcw.py
@@ -1,0 +1,73 @@
+"""
+The inverse-probability-of-censoring-weighting (IPCW) toolkit: the
+Kaplan-Meier estimate of the *censoring* distribution and the
+right-continuous step lookup used to evaluate it.
+
+Three modules -- Gray's test, Fine-Gray regression and the prediction
+metrics -- each carried their own copy of both functions. The copies had
+already started to drift: the metrics copy silently ignored count
+weights, consistent with its callers but a trap for the next reuse. This
+module is the single, weighted implementation; passing no ``n`` is the
+unweighted case.
+
+The bodies are transplants from the competing-risks copies, kept
+bit-identical so consolidating changed no fitted numbers.
+"""
+
+import numpy as np
+import numpy.typing as npt
+
+
+def censoring_survival(
+    x: npt.NDArray,
+    censored: npt.NDArray,
+    n: "npt.NDArray | None" = None,
+) -> tuple[npt.NDArray, npt.NDArray]:
+    """
+    Kaplan-Meier estimate of the censoring survival ``G(t) = P(C > t)``.
+
+    The roles are reversed relative to an ordinary survival fit:
+    right-censored rows (``censored`` true) are the "events" for the
+    censoring distribution and observed events are treated as censored.
+    Returns the sorted unique times and the right-continuous ``G``
+    evaluated at each.
+
+    Parameters
+    ----------
+    x : ndarray
+        Observed times.
+    censored : ndarray of bool
+        True where the observation was right-censored.
+    n : ndarray, optional
+        Count weight per observation; default 1 each.
+    """
+    x = np.asarray(x, dtype=float)
+    censored = np.asarray(censored, dtype=bool)
+    if n is None:
+        n = np.ones(x.size)
+    times = np.unique(x)
+    G = np.ones(times.size)
+    surv = 1.0
+    for i, t in enumerate(times):
+        at_risk = n[x >= t].sum()
+        cens_here = n[(x == t) & censored].sum()
+        if at_risk > 0:
+            surv *= 1.0 - cens_here / at_risk
+        G[i] = surv
+    return times, G
+
+
+def step_at(
+    times: npt.NDArray,
+    values: npt.NDArray,
+    query: npt.ArrayLike,
+    before: float,
+) -> npt.NDArray:
+    """
+    Right-continuous step function: the value carried by the largest
+    ``times`` entry ``<= query``; ``before`` is returned where ``query``
+    precedes the first time. For a survival curve ``before`` is 1, for a
+    cumulative hazard it is 0.
+    """
+    idx = np.searchsorted(times, query, side="right") - 1
+    return np.where(idx < 0, before, values[np.clip(idx, 0, values.size - 1)])

--- a/surpyval/utils/linalg.py
+++ b/surpyval/utils/linalg.py
@@ -1,0 +1,236 @@
+"""
+Shared numeric helpers: guarded linear algebra, finite-difference
+derivatives, and the normal-approximation confidence-bound transforms
+built on them.
+
+Every function here existed first as a module-local helper -- several of
+them as verbatim copies of each other. ``numerical_hessian``,
+``delta_method_se``, ``bound_signs`` and ``log_transformed_cb`` were
+duplicated wholesale between ``recurrent.inference`` and
+``univariate.regression._bounds`` (the drift-prone pattern that produced
+#288), the ``inv``-then-``pinv`` fallback was written out at seven call
+sites, and the eigenvalue-surgery family below appeared five times across
+the degradation package. This module is the single copy; the call sites
+import it.
+
+The implementations are transplants, not rewrites: each body is kept
+bit-identical to the copies it replaced, so consolidating changed no
+fitted numbers anywhere.
+"""
+
+from typing import Any, Callable
+
+import numpy as np
+import numpy.typing as npt
+from scipy.stats import norm
+
+# -- guarded linear algebra ------------------------------------------------
+
+
+def safe_inv(m: npt.NDArray) -> npt.NDArray:
+    """
+    Inverse of ``m``, falling back to the Moore-Penrose pseudo-inverse
+    when ``m`` is singular -- or when ``inv`` "succeeds" but returns
+    non-finite entries, which a near-singular matrix can do without
+    raising.
+    """
+    try:
+        out = np.linalg.inv(m)
+        if not np.all(np.isfinite(out)):
+            raise np.linalg.LinAlgError
+        return out
+    except np.linalg.LinAlgError:
+        return np.linalg.pinv(m)
+
+
+def safe_quadform(V: npt.NDArray, u: npt.NDArray) -> float:
+    """
+    The quadratic form ``u' V^{-1} u`` via ``solve``, falling back to the
+    pseudo-inverse when ``V`` is singular. This is the test-statistic
+    shape shared by the log-rank and Gray's tests, where a degenerate
+    group leaves ``V`` without full rank.
+    """
+    try:
+        return float(u @ np.linalg.solve(V, u))
+    except np.linalg.LinAlgError:
+        return float(u @ np.linalg.pinv(V) @ u)
+
+
+# -- finite differences ----------------------------------------------------
+
+
+def numerical_hessian(
+    func: Callable[[npt.NDArray], float],
+    x: npt.NDArray,
+    step: "npt.NDArray | None" = None,
+) -> npt.NDArray:
+    """
+    Central finite-difference Hessian of a scalar ``func`` at ``x``. Used
+    to approximate the observed Fisher information from a negative
+    log-likelihood minimised with a derivative-free optimiser.
+
+    ``step`` is the per-parameter step array; the default is the usual
+    cube-root-of-machine-epsilon rule for a second-derivative central
+    difference, ``eps**(1/3) * max(|x|, 1e-2)``. Callers with their own
+    convention (Royston-Parmar and the frailty fitter use
+    ``1e-5 * max(|x|, 1)``) pass it explicitly.
+    """
+    x = np.asarray(x, dtype=float)
+    n = x.size
+    if step is None:
+        step = (np.finfo(float).eps ** (1.0 / 3.0)) * np.maximum(
+            np.abs(x), 1e-2
+        )
+    H = np.zeros((n, n))
+    for i in range(n):
+        for j in range(i, n):
+            ei = np.zeros(n)
+            ei[i] = step[i]
+            ej = np.zeros(n)
+            ej[j] = step[j]
+            H[i, j] = H[j, i] = (
+                func(x + ei + ej)
+                - func(x + ei - ej)
+                - func(x - ei + ej)
+                + func(x - ei - ej)
+            ) / (4.0 * step[i] * step[j])
+    return H
+
+
+def delta_method_se(
+    func: Callable[[npt.NDArray], Any],
+    mle: npt.NDArray,
+    cov: npt.NDArray,
+) -> npt.NDArray:
+    """
+    Standard errors of the (possibly vector-valued) function ``func`` of
+    the parameters, evaluated at the MLE, via the delta method with a
+    central-difference Jacobian: ``se_i = sqrt(J_i' cov J_i)``.
+    """
+    mle = np.asarray(mle, dtype=float)
+    step = (np.finfo(float).eps ** (1.0 / 3.0)) * np.maximum(np.abs(mle), 1e-2)
+    cols = []
+    for i in range(mle.size):
+        ei = np.zeros(mle.size)
+        ei[i] = step[i]
+        cols.append(
+            (
+                np.asarray(func(mle + ei), dtype=float)
+                - np.asarray(func(mle - ei), dtype=float)
+            )
+            / (2.0 * step[i])
+        )
+    J = np.stack(cols, axis=-1)
+    var = np.einsum("...i,ij,...j->...", J, cov, J)
+    with np.errstate(invalid="ignore"):
+        return np.sqrt(var)
+
+
+# -- normal-approximation confidence bounds --------------------------------
+
+
+def bound_signs(alpha_ci: float, bound: str) -> tuple[float, npt.NDArray]:
+    """
+    The one-sided tail probability and the signs of the normal quantile
+    for each requested bound: ``[-1, 1]`` (lower, upper) for two-sided
+    bounds, a single sign otherwise.
+    """
+    if bound == "two-sided":
+        return alpha_ci / 2.0, np.array([-1.0, 1.0])
+    elif bound == "lower":
+        return alpha_ci, np.array([-1.0])
+    elif bound == "upper":
+        return alpha_ci, np.array([1.0])
+    raise ValueError("`bound` must be 'two-sided', 'lower' or 'upper'")
+
+
+def log_transformed_cb(
+    estimate: npt.ArrayLike,
+    se: npt.ArrayLike,
+    alpha_ci: float = 0.05,
+    bound: str = "two-sided",
+) -> npt.NDArray:
+    """
+    Log-transformed normal confidence bounds ``est * exp(+/- z * se / est)``
+    for a positive curve (the same construction as the exponential
+    Greenwood bounds on the nonparametric MCF). Where the estimate is zero
+    (e.g. a CIF at ``x = 0``) both bounds are zero.
+    """
+    estimate = np.asarray(estimate, dtype=float)
+    se = np.asarray(se, dtype=float)
+    alpha, signs = bound_signs(alpha_ci, bound)
+    z = norm.ppf(1.0 - alpha)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratio = np.where(estimate > 0, se / estimate, 0.0)
+    cb = estimate[..., None] * np.exp(signs * z * ratio[..., None])
+    return cb if bound == "two-sided" else cb[..., 0]
+
+
+# -- eigenvalue surgery on symmetric matrices ------------------------------
+#
+# Three operations of one family: symmetrise, eigendecompose, repair the
+# spectrum, reconstruct. They differ only in the repair and in what is
+# rebuilt (the matrix, its inverse, or its square root). The floor
+# conventions are the call sites' own and are preserved exactly:
+# ``psd_precision`` includes the float-tiny guard in its floor where
+# ``psd_floor`` does not, because the sites they replaced did the same.
+
+
+def psd_project(matrix: npt.NDArray) -> tuple[npt.NDArray, bool]:
+    """
+    Project a symmetric matrix onto the positive semi-definite cone
+    by clipping negative eigenvalues to zero.
+
+    Returns the projected matrix and whether any eigenvalue was
+    *materially* negative (beyond floating-point noise).
+    """
+    matrix = (matrix + matrix.T) / 2.0
+    eigvals, eigvecs = np.linalg.eigh(matrix)
+    tol = 1e-10 * max(np.abs(eigvals).max(), np.finfo(float).tiny)
+    clipped = bool((eigvals < -tol).any())
+    eigvals = np.clip(eigvals, 0.0, None)
+    return eigvecs @ np.diag(eigvals) @ eigvecs.T, clipped
+
+
+def psd_floor(
+    matrix: npt.NDArray, rel_floor: float, abs_floor: float
+) -> npt.NDArray:
+    """
+    Symmetrise ``matrix`` and floor its eigenvalues at
+    ``max(eigmax * rel_floor, abs_floor)``, so a rank-deficient moment
+    estimate becomes safely positive definite (e.g. before a Cholesky
+    factorisation).
+    """
+    matrix = (matrix + matrix.T) / 2.0
+    eigvals, eigvecs = np.linalg.eigh(matrix)
+    floor = max(eigvals.max() * rel_floor, abs_floor)
+    eigvals = np.clip(eigvals, floor, None)
+    return eigvecs @ np.diag(eigvals) @ eigvecs.T
+
+
+def psd_precision(
+    matrix: npt.NDArray, rel_floor: float, abs_floor: float
+) -> npt.NDArray:
+    """
+    Inverse of a symmetric ``matrix`` with its eigenvalues floored at
+    ``max(eigmax * rel_floor, abs_floor, tiny)`` before inversion: a
+    rank-deficient or tiny matrix gives a very tight (but proper)
+    precision in the deficient directions rather than a singular one.
+    """
+    matrix = (matrix + matrix.T) / 2.0
+    eigvals, eigvecs = np.linalg.eigh(matrix)
+    floor = max(eigvals.max() * rel_floor, abs_floor, np.finfo(float).tiny)
+    inv_eigvals = 1.0 / np.clip(eigvals, floor, None)
+    return eigvecs @ np.diag(inv_eigvals) @ eigvecs.T
+
+
+def psd_root(matrix: npt.NDArray) -> npt.NDArray:
+    """
+    A square-root factor ``R`` of a symmetric ``matrix`` with its
+    eigenvalues clipped non-negative, such that ``R R' = matrix`` (after
+    the clip). Robust for multivariate-normal sampling from a covariance
+    that may itself have been PSD-clipped: ``mean + z @ R.T``.
+    """
+    matrix = (matrix + matrix.T) / 2.0
+    eigvals, eigvecs = np.linalg.eigh(matrix)
+    return eigvecs @ np.diag(np.sqrt(np.clip(eigvals, 0.0, None)))


### PR DESCRIPTION
Preparation for the `utils` typing pass: a sweep of every module-level helper in the package found the same functions written repeatedly — three clusters of them verbatim — so each is consolidated to a single copy before the ratchet types it once instead of three times.

## What was duplicated

**The inference toolkit, wholesale.** `recurrent/inference.py` and `univariate/regression/_bounds.py` each carried `numerical_hessian`, `delta_method_se`, `bound_signs` and `log_transformed_cb` — verbatim copies, confirmed by AST comparison with docstrings stripped. This is exactly the drift-prone verbatim-copy pattern that produced #288, and `degradation/_bounds.py`'s own comment already named it while importing from `recurrent` across package lines. Beyond those two, `royston_parmar` and the frailty fitter each hand-rolled a *third and fourth* Hessian with a different step rule (`1e-5 · max(|x|, 1)` against cube-root-of-epsilon).

**The censoring-distribution Kaplan-Meier, three times.** Gray's test, Fine-Gray and the prediction metrics each had their own KM-of-censoring (`G(t) = P(C > t)`) plus a private right-continuous step evaluator — `_G_at`, `_step`, `_g_at`: three names for the same four lines. The copies had already drifted: the metrics copy silently ignored count weights. And the "private" `_step` was already being imported across module boundaries by `competing_risks_proportional_hazard.py`.

**The `inv`-then-`pinv` fallback, seven times**, plus the degradation package's eigenvalue surgery (symmetrise → `eigh` → repair the spectrum → reconstruct) at five sites in three flavours.

## What this PR does

- **`surpyval/utils/linalg.py`** — `safe_inv`, `safe_quadform`, `numerical_hessian` (per-parameter `step` override so Royston-Parmar and frailty keep their own rule), `delta_method_se`, `bound_signs`, `log_transformed_cb`, `psd_project`, `psd_floor`, `psd_precision`, `psd_root`. Each call site's floor and step conventions are preserved as arguments rather than silently unified.
- **`surpyval/utils/ipcw.py`** — `censoring_survival` (weighted; no `n` is the unweighted case) and `step_at`.
- **`utils.validate_1d`** joins the wrangling helpers (was the metrics module's `_as_1d`).
- Twelve modules across competing-risks, regression, recurrent, degradation, metrics and nonparametric now import these instead of defining them.
- One caller-facing rename: `delta_method_std_errors` → `delta_method_se` everywhere, adopting the regression package's name for the identical function.
- Both new modules are fully annotated and under the mypy ratchet (#143) from birth.

## Verification

The bodies are transplants, not rewrites, and behaviour was checked rather than assumed: **37 fingerprints across every touched path are bit-identical** against `develop` — Gray's test (plain and `rho=1`), Fine-Gray coefficients/covariance/CIF, the competing-risks PH wrapper, Brier/IBS/AUC, a three-group log-rank, Cox `check_ph` and dfbeta residuals, additive-hazards fit, Royston-Parmar and frailty covariances, Crow-AMSAA/HPP standard errors and bounds, WeibullPH `sf`/`hf` bounds, the degradation fit with corrected life covariance, REML, and the seeded induced-life sample.

Suite green in a clean run: 2204 passed, 364 skipped, 5 xfailed. mypy clean on 310 files (the two new modules included); flake8/black clean.

One observation for later, not changed here: `DegradationModel.random` accepts `random_state` but ignores it on the non-accelerated path (`life_model.random(size)` is unseeded) — surfaced while fingerprinting the seeded sampling paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_