### PR TITLE
Finish the type-hint ratchet: 1750/1750 defs, disallow_untyped_defs package-wide

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,49 @@ Changelog
 v0.19.1 (unreleased)
 --------------------
 
+- **Type-hint ratchet: finished.** Every function in the package is
+  annotated -- 1750 of 1750 defs -- and the per-module ratchet list is
+  gone: ``disallow_untyped_defs`` now holds package-wide, with only the
+  test suite and the alpha tree exempt (they are exercised, not typed,
+  but are still checked against the package's annotations). <#143> can
+  close.
+
+  The final pass covered the remaining seven areas in sequence -- the
+  regression fitters and ``cox_ph``, the ``utils`` wrangling surface and
+  the ``autograd_gamma_compat`` shim, competing risks, the whole
+  recurrent package, degradation, the copulas and the ``beta.ml``
+  forest. The conventions are the ones the earlier passes established:
+  ``Numeric``/``Boxable`` wherever autograd differentiates,
+  ``npt.ArrayLike`` at user entry points and never in arithmetic,
+  declaration blocks for fit-populated model attributes, and
+  ``TYPE_CHECKING`` contract stubs where a mixin calls methods its host
+  supplies.
+
+  Typing the bodies kept finding things, as it has all along:
+
+  - ``SemiParametricRegressionModel.neg_ll``/``jac`` were declared as a
+    float and an array; they hold the fit's closures.
+  - ``Parametric.random`` is documented and annotated to return an
+    array, but returns xcnt-format ``(x, c, n, t)`` arrays for
+    limited-failure-population and zero-inflated models -- now
+    annotated and documented honestly.
+  - ``singleton_fitter`` is typed ``(cls: type[T]) -> T``, so the
+    checker finally knows every fitter singleton is an instance; one
+    ``type(...)``-indirection call site simplified away.
+  - ``NonParametricCounting.var`` is honestly Optional (simulated MCFs
+    carry no variance), and three error paths that crashed with
+    unpacking/attribute errors now raise named ``ValueError``\ s:
+    ``BuckleyJamesModel.bootstrap_ci`` and destructive-degradation
+    bootstrap bounds on models carrying no fit data, and ``mcf_cb`` on
+    a simulated MCF.
+  - The recurrent intensity contract moved off the documented
+    ``ArrayLike`` trap onto the honest ``Boxable`` union -- those
+    functions are differentiated by autograd in the NHPP likelihoods.
+  - A handful of genuine signature divergences (the covariate-extended
+    simulation methods, the named-single-parameter intensity and copula
+    families against their variadic base contracts) are documented at
+    the definition with targeted ignores rather than silently widened.
+
 - **Type-hint ratchet: the regression package's shared plumbing and its
   two model classes.** Coverage moves to 1041/1747 (60%), tracked in
   <#143>. Typed in dependency order -- the base layer before the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,43 @@ Changelog
 v0.19.1 (unreleased)
 --------------------
 
+- **Type-hint ratchet: the regression package's shared plumbing and its
+  two model classes.** Coverage moves to 1041/1747 (60%), tracked in
+  <#143>. Typed in dependency order -- the base layer before the
+  fitters that build on it, the same sequencing the parametric package
+  used -- so the coming fitter pass starts from typed call boundaries
+  instead of ``Any`` flowing in.
+
+  Eight modules join the ratchet: ``_fit_skeleton`` (the fitting spine
+  every family imports -- ``LogLinearPhi``, ``HazardIdentitiesMixin``,
+  the prepare/assemble pair, both optimiser ladders and
+  ``mirror_distribution``), ``_likelihood`` (the shared censoring- and
+  truncation-aware negative log-likelihood), ``_bounds``,
+  ``tvc_schedule`` (the ``StepSchedule`` machinery), the
+  ``parametric_regression_model`` and
+  ``semi_parametric_regression_model`` classes, and the ``PH``/``AH``
+  factory ``__init__``\ s.
+
+  The conventions carry over from the parametric package:
+  ``Numeric``/``Boxable`` for the distribution-function surface
+  (``HazardIdentitiesMixin`` and ``LogLinearPhi.phi`` are
+  differentiated under autograd), ``npt.ArrayLike`` at the user entry
+  points, and a ``TYPE_CHECKING`` contract block on
+  ``HazardIdentitiesMixin`` declaring the ``Hf``/``hf`` its identities
+  call -- the host class supplies them, and one that forgets still gets
+  the ``AttributeError`` that names it.
+
+  Three annotations followed the code rather than the reverse:
+  ``prepare_regression_fit``'s ``phi_bounds``/``phi_param_map`` really
+  are callables *or* static values (both branches are live);
+  ``_safe_eval`` in the schedule expression interpreter returns
+  ``float | bool`` because comparisons are values in that grammar; and
+  ``_ic_counts`` matches the ``tuple[int, int]`` its mixin supertype
+  declares. No behaviour changed -- annotations are erased at runtime,
+  and the only body edits are local renames where a variable was
+  reused with a second type (the ``segments`` accumulation list, the
+  expression interpreter's comparison operator).
+
 - **The structural duplicates: shared bases extracted where whole class
   bodies were copied.** The body-level sweep's deeper findings, where
   the fix is a base class or driver rather than a moved function.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,8 @@ module = [
     # its LifeModel-contract mismatch (#345) is a runtime-shape question,
     # not an annotation gap.
     'surpyval.univariate.regression.*',
+    'surpyval.univariate.competing_risks',
+    'surpyval.univariate.competing_risks.*',
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,8 @@ module = [
     'surpyval.univariate.regression.*',
     'surpyval.univariate.competing_risks',
     'surpyval.univariate.competing_risks.*',
+    'surpyval.degradation',
+    'surpyval.degradation.*',
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,8 +171,8 @@ module = [
     'surpyval.fit_best',
     'surpyval.utils',
     'surpyval.utils.*',
-    'surpyval.recurrent.tests',
-    'surpyval.recurrent.parametric.counting_process',
+    'surpyval.recurrent',
+    'surpyval.recurrent.*',
     # The whole regression package: plumbing and models first, then the
     # fitters, cox_ph and the heavies. general_log_linear is included --
     # its LifeModel-contract mismatch (#345) is a runtime-shape question,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,6 @@ module = [
     'surpyval.univariate.information_criteria',
     'surpyval.univariate.nonparametric.*',
     'surpyval.recurrent.nonparametric.*',
-    'surpyval.univariate.regression.frailty.*',
     'surpyval.datasets',
     'surpyval.univariate.parametric.distributions.weibull',
     # The discrete distributions, plus the Discretize wrapper.
@@ -176,35 +175,11 @@ module = [
     'surpyval.utils.score',
     'surpyval.recurrent.tests',
     'surpyval.recurrent.parametric.counting_process',
-    'surpyval.univariate.regression.regression_data',
-    # The regression package's shared plumbing and the two model
-    # classes -- typed before the fitters that build on them, so the
-    # fitters' pass starts from typed call boundaries.
-    'surpyval.univariate.regression._fit_skeleton',
-    'surpyval.univariate.regression._likelihood',
-    'surpyval.univariate.regression._bounds',
-    'surpyval.univariate.regression.tvc_schedule',
-    'surpyval.univariate.regression.parametric_regression_model',
-    'surpyval.univariate.regression.semi_parametric_regression_model',
-    'surpyval.univariate.regression.proportional_hazards',
-    'surpyval.univariate.regression.additive_hazards',
-    'surpyval.univariate.regression.tvc_fit',
-    'surpyval.univariate.regression.frailty',
-    # Every accelerated-life module except general_log_linear, whose
-    # phi_param_map and phi_bounds are callables of the covariate
-    # dimension rather than the dict and tuple LifeModel declares. It is
-    # excluded from LIFE_MODELS for the same reason (#345).
-    'surpyval.univariate.regression.accelerated_life',
-    'surpyval.univariate.regression.accelerated_life.accelerated_life',
-    'surpyval.univariate.regression.accelerated_life.dual_exponential',
-    'surpyval.univariate.regression.accelerated_life.dual_power',
-    'surpyval.univariate.regression.accelerated_life.exponential',
-    'surpyval.univariate.regression.accelerated_life.eyring',
-    'surpyval.univariate.regression.accelerated_life.lifemodel',
-    'surpyval.univariate.regression.accelerated_life.linear',
-    'surpyval.univariate.regression.accelerated_life.parameter_substitution',
-    'surpyval.univariate.regression.accelerated_life.power',
-    'surpyval.univariate.regression.accelerated_life.power_exponential',
+    # The whole regression package: plumbing and models first, then the
+    # fitters, cox_ph and the heavies. general_log_linear is included --
+    # its LifeModel-contract mismatch (#345) is a runtime-shape question,
+    # not an annotation gap.
+    'surpyval.univariate.regression.*',
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,10 +169,8 @@ module = [
     'surpyval.univariate.parametric.distributions._single_probability',
     # Already fully annotated; listed so they cannot slip back.
     'surpyval.fit_best',
-    'surpyval.utils.linalg',
-    'surpyval.utils.ipcw',
-    'surpyval.utils.recurrent_utils',
-    'surpyval.utils.score',
+    'surpyval.utils',
+    'surpyval.utils.*',
     'surpyval.recurrent.tests',
     'surpyval.recurrent.parametric.counting_process',
     # The whole regression package: plumbing and models first, then the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,17 @@ module = [
     'surpyval.recurrent.tests',
     'surpyval.recurrent.parametric.counting_process',
     'surpyval.univariate.regression.regression_data',
+    # The regression package's shared plumbing and the two model
+    # classes -- typed before the fitters that build on them, so the
+    # fitters' pass starts from typed call boundaries.
+    'surpyval.univariate.regression._fit_skeleton',
+    'surpyval.univariate.regression._likelihood',
+    'surpyval.univariate.regression._bounds',
+    'surpyval.univariate.regression.tvc_schedule',
+    'surpyval.univariate.regression.parametric_regression_model',
+    'surpyval.univariate.regression.semi_parametric_regression_model',
+    'surpyval.univariate.regression.proportional_hazards',
+    'surpyval.univariate.regression.additive_hazards',
     'surpyval.univariate.regression.tvc_fit',
     'surpyval.univariate.regression.frailty',
     # Every accelerated-life module except general_log_linear, whose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,87 +105,25 @@ skip = ["__init__.py"]
 # signatures. Only autograd's ArrayBox so far -- see the file for why.
 mypy_path = "stubs"
 
-# Modules whose every function is annotated. Listing one here makes an
-# unannotated function in it an error, so the coverage cannot slip back
-# -- a ratchet rather than a target (#143).
-#
-# The package ships py.typed, which tells a user's type checker that
-# these annotations are there to be trusted. Without this setting mypy
-# only checks the annotations that happen to exist, so nothing stopped
-# that promise from being half true.
-#
-# Add a module here once `mypy <module> --disallow-untyped-defs` is
-# clean. Do not add one with a `# type: ignore` to make it pass; the
-# point is the annotations, not the green tick.
+# Every function in the package is annotated (#143), and the package
+# ships py.typed, which tells a user's type checker those annotations
+# are there to be trusted. ``disallow_untyped_defs`` holds that line
+# package-wide: an unannotated function anywhere in ``surpyval`` is an
+# error, so the coverage cannot slip back. This replaced the long
+# per-module ratchet list the coverage was built up under.
+disallow_untyped_defs = true
+
+# The test suite and the alpha (pre-release, no API contract) tree are
+# exercised, not typed; they are exempt from the annotation requirement
+# but still type-checked against the package's annotations.
 [[tool.mypy.overrides]]
 module = [
-    'surpyval.distribution',
-    'surpyval.serialisation',
-    'surpyval.metrics.*',
-    'surpyval.univariate.information_criteria',
-    'surpyval.univariate.nonparametric.*',
-    'surpyval.recurrent.nonparametric.*',
-    'surpyval.datasets',
-    'surpyval.univariate.parametric.distributions.weibull',
-    # The discrete distributions, plus the Discretize wrapper.
-    'surpyval.univariate.parametric.distributions.bernoulli',
-    'surpyval.univariate.parametric.distributions.beta_geometric',
-    'surpyval.univariate.parametric.distributions.binomial',
-    'surpyval.univariate.parametric.distributions.discrete_weibull',
-    'surpyval.univariate.parametric.distributions.discretize',
-    'surpyval.univariate.parametric.distributions.geometric',
-    'surpyval.univariate.parametric.distributions.negative_binomial',
-    'surpyval.univariate.parametric.distributions.poisson',
-    'surpyval.univariate.parametric.distributions.custom_distribution',
-    'surpyval.univariate.parametric.distributions.exact_event_time',
-    'surpyval.univariate.parametric.distributions.normal',
-    'surpyval.univariate.parametric.distributions.lognormal',
-    'surpyval.univariate.parametric.distributions.logistic',
-    'surpyval.univariate.parametric.distributions.rayleigh',
-    'surpyval.univariate.parametric.distributions.beta',
-    'surpyval.univariate.parametric.distributions.beta4',
-    'surpyval.univariate.parametric.distributions.gamma',
-    'surpyval.univariate.parametric.distributions.gumbel',
-    'surpyval.univariate.parametric.distributions.gumbel_lev',
-    'surpyval.univariate.parametric.distributions.loglogistic',
-    'surpyval.univariate.parametric.distributions.exponential',
-    'surpyval.univariate.parametric.distributions.uniform',
-    'surpyval.univariate.parametric.distributions.degenerate',
-    'surpyval.univariate.parametric.distributions.expo_weibull',
-    'surpyval.univariate.parametric.fitters',
-    'surpyval.univariate.parametric.fitters.closed_form',
-    'surpyval.univariate.parametric.fitters.mle',
-    'surpyval.univariate.parametric.fitters.mpp',
-    'surpyval.univariate.parametric.fitters.mom',
-    'surpyval.univariate.parametric.fitters.mps',
-    'surpyval.univariate.parametric.fitters.mse',
-    'surpyval.univariate.parametric.probability_plotting',
-    'surpyval.univariate.parametric.discrete_fitter',
-    'surpyval.univariate.parametric.royston_parmar',
-    'surpyval.univariate.parametric.parametric_fitter',
-    'surpyval.univariate.parametric.parametric',
-    'surpyval.univariate.parametric.mixture_model',
-    'surpyval.univariate.parametric.distributions.fixed_event_probability',
-    'surpyval.univariate.parametric.distributions._single_probability',
-    # Already fully annotated; listed so they cannot slip back.
-    'surpyval.fit_best',
-    'surpyval.utils',
-    'surpyval.utils.*',
-    'surpyval.recurrent',
-    'surpyval.recurrent.*',
-    # The whole regression package: plumbing and models first, then the
-    # fitters, cox_ph and the heavies. general_log_linear is included --
-    # its LifeModel-contract mismatch (#345) is a runtime-shape question,
-    # not an annotation gap.
-    'surpyval.univariate.regression.*',
-    'surpyval.univariate.competing_risks',
-    'surpyval.univariate.competing_risks.*',
-    'surpyval.degradation',
-    'surpyval.degradation.*',
-    'surpyval.multivariate',
-    'surpyval.multivariate.*',
+    'surpyval.tests.*',
+    'surpyval.alpha.*',
+    'conftest',
+    'scripts.*',
 ]
-disallow_untyped_defs = true
+disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,8 @@ module = [
     'surpyval.univariate.competing_risks.*',
     'surpyval.degradation',
     'surpyval.degradation.*',
+    'surpyval.multivariate',
+    'surpyval.multivariate.*',
 ]
 disallow_untyped_defs = true
 

--- a/surpyval/beta/ml/forest/deviance_split.py
+++ b/surpyval/beta/ml/forest/deviance_split.py
@@ -64,7 +64,7 @@ def needs_full_likelihood_split(data: SurpyvalData) -> bool:
     )
 
 
-def _exp_neg_ll_parts(data: SurpyvalData):
+def _exp_neg_ll_parts(data: SurpyvalData) -> tuple:
     """
     Pre-extract the arrays the exponential negative log-likelihood needs,
     so the optimiser's objective is pure vectorised arithmetic.
@@ -86,7 +86,7 @@ def _exp_neg_ll_parts(data: SurpyvalData):
     )
 
 
-def _exp_neg_ll(theta: float, parts) -> float:
+def _exp_neg_ll(theta: float, parts: tuple) -> float:
     """
     Negative log-likelihood of an exponential distribution with rate
     ``lambda = exp(theta)`` under the full data model (all censoring
@@ -221,7 +221,7 @@ def _exp_max_ll(
 _LOG_BETA_BOUNDS = (-3.0, 3.0)
 
 
-def _wei_neg_ll(theta: NDArray, parts) -> float:
+def _wei_neg_ll(theta: NDArray, parts: tuple) -> float:
     """
     Negative log-likelihood of a Weibull distribution with scale
     ``alpha = exp(theta[0])`` and shape ``beta = exp(theta[1])`` under
@@ -247,7 +247,7 @@ def _wei_neg_ll(theta: NDArray, parts) -> float:
     log_alpha, log_beta = float(theta[0]), float(theta[1])
     beta = np.exp(log_beta)
 
-    def z(x):
+    def z(x: NDArray) -> NDArray:
         # (x / alpha) ** beta on the log scale; z(0) = 0
         with np.errstate(all="ignore"):
             return np.where(x > 0, np.exp(beta * (np.log(x) - log_alpha)), 0.0)
@@ -420,14 +420,14 @@ def deviance_split(
             data, box, np.array([log_alpha0, 0.0])
         )
 
-        def child_ll(child_data):
+        def child_ll(child_data: SurpyvalData) -> float:
             return _wei_max_ll(child_data, box, parent_theta)[0]
 
     else:
         bounds = (theta0 - 15.0, theta0 + 15.0)
         parent_ll = _exp_max_ll(data, bounds)
 
-        def child_ll(child_data):
+        def child_ll(child_data: SurpyvalData) -> float:
             return _exp_max_ll(child_data, bounds)
 
     for u in feature_indices_in:

--- a/surpyval/beta/ml/forest/forest.py
+++ b/surpyval/beta/ml/forest/forest.py
@@ -33,7 +33,7 @@ class RandomSurvivalForest(SerialisableMixin):
         n_features_split: int | float | str = "sqrt",
         bootstrap: bool = True,
         kind: str = "weibull",
-    ):
+    ) -> None:
         self.data: SurpyvalData = data
         Z = np.asarray(Z)
         if Z.ndim == 1:
@@ -89,7 +89,7 @@ class RandomSurvivalForest(SerialisableMixin):
         n_features_split: int | float | str = "sqrt",
         bootstrap: bool = True,
         kind: str = "weibull",
-    ):
+    ) -> "RandomSurvivalForest":
         if Z is None:
             raise ValueError("The covariate matrix Z is required")
         data = SurpyvalData(

--- a/surpyval/beta/ml/forest/log_rank_split.py
+++ b/surpyval/beta/ml/forest/log_rank_split.py
@@ -7,7 +7,9 @@ from numpy.typing import NDArray
 from surpyval.utils.surpyval_data import SurpyvalData
 
 
-def _weight_at_or_after(values, weights, grid):
+def _weight_at_or_after(
+    values: NDArray, weights: NDArray, grid: NDArray
+) -> NDArray:
     """Total weight of ``values >= t``, for every ``t`` in ``grid``.
 
     ``grid`` is assumed sorted, as ``to_xrd`` returns it.

--- a/surpyval/beta/ml/forest/node.py
+++ b/surpyval/beta/ml/forest/node.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from functools import cached_property
+from typing import Any
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -46,7 +47,7 @@ class IntermediateNode(Node):
         split_feature_value: float,
         feature_indices_in: NDArray,
         kind: str = "weibull",
-    ):
+    ) -> None:
         # Set split attributes
         self.split_feature_index = split_feature_index
         self.split_feature_value = split_feature_value
@@ -118,11 +119,11 @@ class IntermediateNode(Node):
 
 
 class TerminalNode(Node):
-    def __init__(self, data: SurpyvalData, kind: str = "weibull"):
+    def __init__(self, data: SurpyvalData, kind: str = "weibull") -> None:
         self.data = deepcopy(data)
         self.kind = kind
 
-    def _nonparametric_model(self):
+    def _nonparametric_model(self) -> Any:
         # Nelson-Aalen is a risk-set estimator, so it is only defined for
         # observed / right-censored (optionally left-truncated) data; the
         # Turnbull NPMLE covers the full data model. The tree entry point
@@ -136,7 +137,7 @@ class TerminalNode(Node):
             self.data.x, self.data.c, self.data.n, self.data.t
         )
 
-    def _crude_exponential(self):
+    def _crude_exponential(self) -> Any:
         # Last-resort parametric leaf: the crude event-weight / exposure
         # rate. Always computable when the leaf carries any event
         # information, so a parametric tree stays parametric all the way
@@ -148,7 +149,7 @@ class TerminalNode(Node):
         return Exponential.from_params([float(np.exp(theta0))])
 
     @cached_property
-    def model(self):
+    def model(self) -> Any:
         if self.kind == "non-parametric":
             return self._nonparametric_model()
 

--- a/surpyval/beta/ml/forest/tree.py
+++ b/surpyval/beta/ml/forest/tree.py
@@ -47,7 +47,7 @@ class SurvivalTree(SerialisableMixin):
         min_leaf_failures: int = 2,
         n_features_split: int | float | str = "sqrt",
         kind: str = "weibull",
-    ):
+    ) -> None:
         self.data = data
         self.Z = Z
 
@@ -87,7 +87,7 @@ class SurvivalTree(SerialisableMixin):
         min_leaf_failures: int = 2,
         n_features_split: int | float | str = "sqrt",
         kind: str = "weibull",
-    ):
+    ) -> "SurvivalTree":
         """
         Fit a survival tree from data in the full xcnt(+truncation) data
         model.

--- a/surpyval/degradation/_bounds.py
+++ b/surpyval/degradation/_bounds.py
@@ -31,7 +31,10 @@ Two ways to fix this are provided:
   the first-order approximation is weakest.
 """
 
+from typing import Any
+
 import numpy as np
+import numpy.typing as npt
 from scipy.stats import norm
 
 from surpyval.utils.linalg import bound_signs as _bound_signs
@@ -46,15 +49,20 @@ from surpyval.utils.linalg import (
 # pattern that produced #288) ---------------------------------------------
 
 
-def _logit_bound(p_hat, se, alpha_ci, bound):
+def _logit_bound(
+    p_hat: npt.ArrayLike,
+    se: npt.ArrayLike,
+    alpha_ci: float,
+    bound: str,
+) -> npt.NDArray:
     """Confidence bounds for a probability, taken on the logit scale so they
     stay in ``(0, 1)``. Two-sided puts ``[lower, upper]`` on the last axis."""
-    p_hat = np.clip(np.asarray(p_hat, dtype=float), 1e-15, 1.0 - 1e-15)
+    p_arr = np.clip(np.asarray(p_hat, dtype=float), 1e-15, 1.0 - 1e-15)
     alpha, signs = _bound_signs(alpha_ci, bound)
     z = norm.ppf(1.0 - alpha)
-    logit = np.log(p_hat / (1.0 - p_hat))
+    logit = np.log(p_arr / (1.0 - p_arr))
     with np.errstate(divide="ignore", invalid="ignore"):
-        se_logit = np.asarray(se, dtype=float) / (p_hat * (1.0 - p_hat))
+        se_logit = np.asarray(se, dtype=float) / (p_arr * (1.0 - p_arr))
     lb = logit[..., None] + signs * z * se_logit[..., None]
     cb = 1.0 / (1.0 + np.exp(-lb))
     return cb if bound == "two-sided" else cb[..., 0]
@@ -63,7 +71,9 @@ def _logit_bound(p_hat, se, alpha_ci, bound):
 # -- first stage: per-unit pseudo-failure-time variances ------------------
 
 
-def _inv_path_grad(path_model, threshold, theta):
+def _inv_path_grad(
+    path_model: Any, threshold: float, theta: npt.NDArray
+) -> npt.NDArray:
     """Gradient of ``inv_path(threshold; theta)`` w.r.t. the path parameters,
     by central differences."""
     theta = np.asarray(theta, dtype=float)
@@ -79,7 +89,7 @@ def _inv_path_grad(path_model, threshold, theta):
     return g
 
 
-def pseudo_time_variances(model):
+def pseudo_time_variances(model: Any) -> npt.NDArray:
     """
     Variance of each unit's pseudo failure time from the first stage.
 
@@ -110,7 +120,7 @@ def pseudo_time_variances(model):
 # -- second stage: corrected life-model covariance ------------------------
 
 
-def _life_loglik(model, phi, t):
+def _life_loglik(model: Any, phi: npt.NDArray, t: npt.ArrayLike) -> float:
     """Life-model log-likelihood at parameters ``phi`` and pseudo failure
     times ``t`` (events use the density, censored units the survival)."""
     lm = model.life_model
@@ -124,7 +134,9 @@ def _life_loglik(model, phi, t):
     return float(np.sum(contrib))
 
 
-def life_parameter_covariance(model, method="analytic"):
+def life_parameter_covariance(
+    model: Any, method: str = "analytic"
+) -> npt.NDArray:
     """
     Covariance of the fitted life-model parameters.
 
@@ -184,18 +196,24 @@ def life_parameter_covariance(model, method="analytic"):
 # -- public confidence-bound entry points ---------------------------------
 
 
-def _target(model, x, on):
+def _target(model: Any, x: npt.ArrayLike, on: str) -> Any:
     lm = model.life_model
     gamma = float(getattr(lm, "gamma", 0.0) or 0.0)
     x = np.atleast_1d(np.asarray(x, dtype=float))
 
-    def sf_of(phi):
+    def sf_of(phi: npt.NDArray) -> npt.NDArray:
         return lm.dist.sf(x - gamma, *phi)
 
     return x, sf_of
 
 
-def analytic_cb(model, x, on, alpha_ci, bound):
+def analytic_cb(
+    model: Any,
+    x: npt.ArrayLike,
+    on: str,
+    alpha_ci: float,
+    bound: str,
+) -> npt.NDArray:
     cov = life_parameter_covariance(model, method="analytic")
     phi = np.asarray(model.life_model.params, dtype=float)
     x, sf_of = _target(model, x, on)
@@ -220,7 +238,16 @@ def analytic_cb(model, x, on, alpha_ci, bound):
     return (1.0 - sf_b) if on in ("ff", "F") else -np.log(sf_b)
 
 
-def bootstrap_cb(model, x, on, alpha_ci, bound, n_boot, seed, Z=None):
+def bootstrap_cb(
+    model: Any,
+    x: npt.ArrayLike,
+    on: str,
+    alpha_ci: float,
+    bound: str,
+    n_boot: int,
+    seed: "int | None",
+    Z: "npt.ArrayLike | None" = None,
+) -> npt.NDArray:
     """
     Two-stage bootstrap confidence bounds: resample units with
     replacement and rerun the whole pipeline (per-unit path fit ->
@@ -290,14 +317,14 @@ def bootstrap_cb(model, x, on, alpha_ci, bound, n_boot, seed, Z=None):
             "The degradation bootstrap produced too few successful refits "
             "to form a confidence bound" + detail + "."
         )
-    curves = np.asarray(curves)
+    curves_arr = np.asarray(curves)
     if bound == "two-sided":
-        lo = np.quantile(curves, alpha_ci / 2.0, axis=0)
-        hi = np.quantile(curves, 1.0 - alpha_ci / 2.0, axis=0)
+        lo = np.quantile(curves_arr, alpha_ci / 2.0, axis=0)
+        hi = np.quantile(curves_arr, 1.0 - alpha_ci / 2.0, axis=0)
         return np.stack([lo, hi], axis=-1)
     q = alpha_ci if bound == "lower" else 1.0 - alpha_ci
-    return np.quantile(curves, q, axis=0)
+    return np.quantile(curves_arr, q, axis=0)
 
 
-def _on_method(on):
+def _on_method(on: str) -> str:
     return {"sf": "sf", "R": "sf", "ff": "ff", "F": "ff", "Hf": "Hf"}[on]

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -832,7 +832,9 @@ class DegradationModel(SerialisableMixin):
             rng = np.random.default_rng(random_state)
             u = rng.uniform(size=size)
             return self._reg_qf(u, Z)
-        return self.life_model.random(size)
+        # The life model here is a plain fit (no LFP / zero-inflation),
+        # so ``random`` returns a bare array, never the xcnt tuple.
+        return np.asarray(self.life_model.random(size))
 
     def induced_life(
         self, n_samples: int = 10_000, random_state=None

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -44,7 +44,7 @@ from .path_models import PATH_MODELS, PathModel, get_path_model
 from .population import reml_estimate, reml_estimate_nonlinear
 
 
-def _is_regression_fitter(fitter) -> bool:
+def _is_regression_fitter(fitter: Any) -> bool:
     """True if ``fitter.fit`` takes a covariate matrix ``Z`` (i.e. it is one of
     the regression fitters -- AFT, PH, PO, additive hazards, accelerated
     life)."""
@@ -144,7 +144,9 @@ class InducedFailureDistribution(SerialisableMixin):
         Name of the degradation path model.
     """
 
-    def __init__(self, samples, threshold, path_name):
+    def __init__(
+        self, samples: npt.NDArray, threshold: float, path_name: str
+    ) -> None:
         self.samples = np.asarray(samples, dtype=float)
         self.threshold = float(threshold)
         self.path_name = path_name
@@ -215,12 +217,14 @@ class InducedFailureDistribution(SerialisableMixin):
         """Median failure time."""
         return float(self.qf(0.5))
 
-    def random(self, size: int, random_state=None) -> npt.NDArray:
+    def random(
+        self, size: int, random_state: "int | None" = None
+    ) -> npt.NDArray:
         """Draw failure times by resampling the Monte-Carlo population."""
         rng = np.random.default_rng(random_state)
         return rng.choice(self.samples, size=size)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             "InducedFailureDistribution({} path, threshold={:.6g}, "
             "median={:.6g}, prob_never_fails={:.4g})".format(
@@ -308,7 +312,9 @@ class DegradationModel(SerialisableMixin):
     path_params: npt.NDArray
     pseudo_failure_times: npt.NDArray
     c: npt.NDArray
-    life_model: Parametric
+    #: A plain ``Parametric`` life model, or the regression model
+    #: for an accelerated (covariate) fit.
+    life_model: Any
     measurement_var: float
     path_param_mean: npt.NDArray
     path_param_cov: npt.NDArray
@@ -324,24 +330,24 @@ class DegradationModel(SerialisableMixin):
 
     def __init__(
         self,
-        x,
-        y,
-        i,
-        units,
-        threshold,
-        path_model,
-        path_params,
-        pseudo_failure_times,
-        c,
-        life_model,
-        measurement_var,
-        path_param_mean,
-        path_param_cov,
-        path_param_sample_cov,
-        population_method,
-        path_selection=None,
-        Z=None,
-    ):
+        x: npt.NDArray,
+        y: npt.NDArray,
+        i: npt.NDArray,
+        units: npt.NDArray,
+        threshold: float,
+        path_model: Any,
+        path_params: npt.NDArray,
+        pseudo_failure_times: npt.NDArray,
+        c: npt.NDArray,
+        life_model: Any,
+        measurement_var: float,
+        path_param_mean: npt.NDArray,
+        path_param_cov: npt.NDArray,
+        path_param_sample_cov: npt.NDArray,
+        population_method: str,
+        path_selection: "dict | None" = None,
+        Z: "npt.NDArray | None" = None,
+    ) -> None:
         self.x = x
         self.y = y
         self.i = i
@@ -364,7 +370,7 @@ class DegradationModel(SerialisableMixin):
     # -- serialisation -----------------------------------------------------
 
     @staticmethod
-    def _life_model_to_dict(life_model) -> dict:
+    def _life_model_to_dict(life_model: Any) -> dict:
         out = life_model.to_dict()
         out["_life_class"] = (
             "ParametricRegressionModel"
@@ -374,7 +380,7 @@ class DegradationModel(SerialisableMixin):
         return out
 
     @staticmethod
-    def _life_model_from_dict(life_dict: dict):
+    def _life_model_from_dict(life_dict: dict) -> Any:
         life_dict = dict(life_dict)
         life_class = life_dict.pop("_life_class")
         if life_class == "ParametricRegressionModel":
@@ -490,7 +496,7 @@ class DegradationModel(SerialisableMixin):
         """The life model viewed as a regression model (accelerated only)."""
         return cast(ParametricRegressionModel, self.life_model)
 
-    def _predict_Z(self, Z):
+    def _predict_Z(self, Z: Any) -> Any:
         """Validate the covariate argument for the prediction methods: an
         accelerated model needs a stress vector ``Z``; a plain model rejects
         one."""
@@ -508,7 +514,7 @@ class DegradationModel(SerialisableMixin):
             )
         return None
 
-    def path(self, x: npt.ArrayLike, unit) -> npt.NDArray:
+    def path(self, x: npt.ArrayLike, unit: Any) -> npt.NDArray:
         """Evaluate the fitted degradation path of ``unit`` at ``x``."""
         idx = self._unit_index[unit]
         return self.path_model.path(x, *self.path_params[idx])
@@ -576,7 +582,7 @@ class DegradationModel(SerialisableMixin):
         y: npt.ArrayLike,
         alpha_ci: float = 0.05,
         n_samples: int = 10_000,
-        random_state=None,
+        random_state: "int | None" = None,
     ) -> RULPrediction:
         """
         Bayesian remaining-useful-life prediction for a new unit.
@@ -758,7 +764,7 @@ class DegradationModel(SerialisableMixin):
             )
         return x, y
 
-    def _life_fn(self, name: str, x: npt.ArrayLike, Z) -> npt.NDArray:
+    def _life_fn(self, name: str, x: npt.ArrayLike, Z: Any) -> npt.NDArray:
         # One dispatcher for the five distribution functions: the
         # accelerated model evaluates its regression at stress ``Z``, the
         # plain model evaluates its fitted life distribution. The named
@@ -768,7 +774,7 @@ class DegradationModel(SerialisableMixin):
             return getattr(self._reg, name)(x, Z)
         return getattr(self.life_model, name)(x)
 
-    def sf(self, x: npt.ArrayLike, Z=None) -> npt.NDArray:
+    def sf(self, x: npt.ArrayLike, Z: Any = None) -> npt.NDArray:
         """
         Survival function of the fitted life model.
 
@@ -777,23 +783,23 @@ class DegradationModel(SerialisableMixin):
         """
         return self._life_fn("sf", x, Z)
 
-    def ff(self, x: npt.ArrayLike, Z=None) -> npt.NDArray:
+    def ff(self, x: npt.ArrayLike, Z: Any = None) -> npt.NDArray:
         """CDF of the fitted life model (pass ``Z`` for accelerated models)."""
         return self._life_fn("ff", x, Z)
 
-    def df(self, x: npt.ArrayLike, Z=None) -> npt.NDArray:
+    def df(self, x: npt.ArrayLike, Z: Any = None) -> npt.NDArray:
         """Density of the fitted life model (``Z`` for accelerated models)."""
         return self._life_fn("df", x, Z)
 
-    def hf(self, x: npt.ArrayLike, Z=None) -> npt.NDArray:
+    def hf(self, x: npt.ArrayLike, Z: Any = None) -> npt.NDArray:
         """Hazard rate of the fitted life model (``Z`` for accelerated)."""
         return self._life_fn("hf", x, Z)
 
-    def Hf(self, x: npt.ArrayLike, Z=None) -> npt.NDArray:
+    def Hf(self, x: npt.ArrayLike, Z: Any = None) -> npt.NDArray:
         """Cumulative hazard of the life model (``Z`` for accelerated)."""
         return self._life_fn("Hf", x, Z)
 
-    def qf(self, p: npt.ArrayLike, Z=None) -> npt.NDArray:
+    def qf(self, p: npt.ArrayLike, Z: Any = None) -> npt.NDArray:
         """
         Quantile function of the fitted life model.
 
@@ -806,7 +812,7 @@ class DegradationModel(SerialisableMixin):
             return self._reg_qf(p, Z)
         return self.life_model.qf(p)
 
-    def mean(self, Z=None) -> float:
+    def mean(self, Z: Any = None) -> float:
         """
         Mean of the fitted life model.
 
@@ -819,7 +825,12 @@ class DegradationModel(SerialisableMixin):
             return self._reg_mean(Z)
         return self.life_model.mean()
 
-    def random(self, size: int, Z=None, random_state=None) -> npt.NDArray:
+    def random(
+        self,
+        size: int,
+        Z: Any = None,
+        random_state: "int | None" = None,
+    ) -> npt.NDArray:
         """
         Random pseudo failure times from the fitted life model.
 
@@ -837,7 +848,7 @@ class DegradationModel(SerialisableMixin):
         return np.asarray(self.life_model.random(size))
 
     def induced_life(
-        self, n_samples: int = 10_000, random_state=None
+        self, n_samples: int = 10_000, random_state: "int | None" = None
     ) -> InducedFailureDistribution:
         """
         The population failure-time distribution induced by the path model
@@ -893,7 +904,7 @@ class DegradationModel(SerialisableMixin):
             t, self.threshold, self.path_model.name
         )
 
-    def _reg_qf(self, p: npt.ArrayLike, Z) -> npt.NDArray:
+    def _reg_qf(self, p: npt.ArrayLike, Z: Any) -> npt.NDArray:
         """
         Quantile function of an accelerated life model by bisection.
 
@@ -909,7 +920,7 @@ class DegradationModel(SerialisableMixin):
         if not (np.isfinite(scale) and scale > 0):
             scale = 1.0
 
-        def target_sf(t):
+        def target_sf(t: float) -> float:
             return float(self._reg.sf(np.array([t]), Z).ravel()[0])
 
         out = np.empty_like(p_arr)
@@ -942,7 +953,7 @@ class DegradationModel(SerialisableMixin):
             out[k] = 0.5 * (lo + hi)
         return out
 
-    def _reg_mean(self, Z) -> float:
+    def _reg_mean(self, Z: Any) -> float:
         """
         Mean life of an accelerated model at stress ``Z``.
 
@@ -985,8 +996,8 @@ class DegradationModel(SerialisableMixin):
         bound: str = "two-sided",
         method: str = "analytic",
         n_boot: int = 200,
-        seed=None,
-        Z=None,
+        seed: "int | None" = None,
+        Z: Any = None,
     ) -> npt.NDArray:
         r"""
         Confidence bounds on the reliability of the fitted life model that
@@ -1059,7 +1070,7 @@ class DegradationModel(SerialisableMixin):
             return bootstrap_cb(self, x, on, alpha_ci, bound, n_boot, seed)
         raise ValueError("`method` must be 'analytic' or 'bootstrap'")
 
-    def plot(self, ax=None):
+    def plot(self, ax: Any = None) -> Any:
         """
         Plot the degradation data, the fitted per-unit paths (extended
         to each unit's pseudo failure time), and the failure threshold.
@@ -1103,7 +1114,7 @@ class DegradationModel(SerialisableMixin):
         ax.legend()
         return ax
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.is_accelerated:
             names = self.life_model.parameter_names()
             dist_name = self.life_model.distribution.name
@@ -1187,7 +1198,7 @@ class DegradationAnalysis_:
         i: npt.ArrayLike,
         threshold: float,
         path: "str | PathModel" = "linear",
-        distribution=Weibull,
+        distribution: Any = Weibull,
         how: str = "MLE",
         population_method: str = "moments",
         Z: npt.ArrayLike | None = None,
@@ -1443,7 +1454,10 @@ class DegradationAnalysis_:
 
     @staticmethod
     def _select_path_model(
-        x_arr, y_arr, i_arr, units
+        x_arr: npt.NDArray,
+        y_arr: npt.NDArray,
+        i_arr: npt.NDArray,
+        units: npt.NDArray,
     ) -> "tuple[PathModel, dict[str, float]]":
         """
         Select the registered path model with the smallest AICc over
@@ -1510,7 +1524,7 @@ class DegradationAnalysis_:
         y: str = "y",
         i: str = "i",
         Z_cols: "str | list[str] | None" = None,
-        **fit_kwargs,
+        **fit_kwargs: Any,
     ) -> DegradationModel:
         """
         Fit a degradation analysis model from a DataFrame.

--- a/surpyval/degradation/destructive.py
+++ b/surpyval/degradation/destructive.py
@@ -40,7 +40,10 @@ moves), the standard destructive-degradation / degradation-distribution model
 (Meeker & Escobar).
 """
 
+from typing import Any
+
 import numpy as np
+import numpy.typing as npt
 from scipy.optimize import minimize
 
 from surpyval.serialisation import stamp_schema
@@ -63,7 +66,7 @@ _LOG_RESPONSE = {"LogNormal", "LogLogistic"}
 _DIST_BY_NAME = {"Normal": Normal, "LogNormal": LogNormal}
 
 
-def _resolve_distribution(distribution):
+def _resolve_distribution(distribution: Any) -> Any:
     if isinstance(distribution, str):
         if distribution not in _DIST_BY_NAME:
             raise ValueError(
@@ -87,16 +90,16 @@ class DestructiveDegradationModel:
 
     def __init__(
         self,
-        distribution,
-        transform,
-        direction,
-        beta,
-        sigma,
-        threshold,
-        data,
-        neg_ll,
-        transform_scores=None,
-    ):
+        distribution: Any,
+        transform: str,
+        direction: str,
+        beta: npt.NDArray,
+        sigma: float,
+        threshold: float,
+        data: "dict | None",
+        neg_ll: float,
+        transform_scores: "dict | None" = None,
+    ) -> None:
         self.distribution = distribution
         self.transform = transform  # name
         self._phi = _TRANSFORMS[transform][0]
@@ -111,11 +114,13 @@ class DestructiveDegradationModel:
 
     # -- degradation distribution over time -------------------------------
 
-    def _loc(self, t):
+    def _loc(self, t: npt.ArrayLike) -> npt.NDArray:
         t = np.atleast_1d(np.asarray(t, dtype=float))
         return self.beta[0] + self.beta[1] * self._phi(t)
 
-    def degradation_quantile(self, q, t):
+    def degradation_quantile(
+        self, q: npt.ArrayLike, t: npt.ArrayLike
+    ) -> npt.NDArray:
         """
         The ``q``-quantile of the destructive measurement at time ``t`` (the
         fitted degradation distribution ``dist(loc(t), sigma)``).
@@ -124,13 +129,13 @@ class DestructiveDegradationModel:
         out = np.asarray(self.distribution.qf(q, loc, self.sigma), dtype=float)
         return out[0] if np.ndim(t) == 0 else out
 
-    def median_degradation(self, t):
+    def median_degradation(self, t: npt.ArrayLike) -> npt.NDArray:
         """Median destructive measurement at time ``t``."""
         return self.degradation_quantile(0.5, t)
 
     # -- induced lifetime distribution at the threshold -------------------
 
-    def ff(self, t):
+    def ff(self, t: npt.ArrayLike) -> npt.NDArray:
         """Failure (CDF) of the lifetime induced by crossing the threshold."""
         loc = self._loc(t)
         thr = self.threshold
@@ -145,15 +150,15 @@ class DestructiveDegradationModel:
             )
         return out[0] if np.ndim(t) == 0 else out
 
-    def sf(self, t):
+    def sf(self, t: npt.ArrayLike) -> npt.NDArray:
         """Reliability of the induced lifetime distribution."""
         return 1.0 - self.ff(t)
 
-    def Hf(self, t):
+    def Hf(self, t: npt.ArrayLike) -> npt.NDArray:
         """Cumulative hazard of the induced lifetime distribution."""
         return -np.log(np.maximum(self.sf(t), np.finfo(float).tiny))
 
-    def df(self, t):
+    def df(self, t: npt.ArrayLike) -> npt.NDArray:
         """
         Density of the induced lifetime distribution (finite-difference of the
         CDF; the closed form depends on the time transform).
@@ -168,13 +173,13 @@ class DestructiveDegradationModel:
 
     def cb(
         self,
-        t,
-        on="sf",
-        alpha_ci=0.05,
-        bound="two-sided",
-        n_boot=200,
-        seed=None,
-    ):
+        t: npt.ArrayLike,
+        on: str = "sf",
+        alpha_ci: float = 0.05,
+        bound: str = "two-sided",
+        n_boot: int = 200,
+        seed: "int | None" = None,
+    ) -> npt.NDArray:
         """
         Bootstrap confidence bounds on the induced lifetime function ``on``.
 
@@ -202,6 +207,11 @@ class DestructiveDegradationModel:
             raise ValueError("`bound` must be 'two-sided', 'lower' or 'upper'")
         t = np.atleast_1d(np.asarray(t, dtype=float))
         rng = np.random.default_rng(seed)
+        if self.data is None:
+            raise ValueError(
+                "Bootstrap bounds need the fit data, which this "
+                "deserialised model does not carry."
+            )
         x, y, c = self.data["x"], self.data["y"], self.data["c"]
         n = x.shape[0]
 
@@ -223,19 +233,19 @@ class DestructiveDegradationModel:
             draws.append(getattr(m, on)(t))
         if not draws:
             raise RuntimeError("every bootstrap resample failed to fit")
-        draws = np.vstack(draws)
+        draws_arr = np.vstack(draws)
 
         if bound == "lower":
-            return np.quantile(draws, alpha_ci, axis=0)
+            return np.quantile(draws_arr, alpha_ci, axis=0)
         if bound == "upper":
-            return np.quantile(draws, 1.0 - alpha_ci, axis=0)
-        lo = np.quantile(draws, alpha_ci / 2.0, axis=0)
-        hi = np.quantile(draws, 1.0 - alpha_ci / 2.0, axis=0)
+            return np.quantile(draws_arr, 1.0 - alpha_ci, axis=0)
+        lo = np.quantile(draws_arr, alpha_ci / 2.0, axis=0)
+        hi = np.quantile(draws_arr, 1.0 - alpha_ci / 2.0, axis=0)
         return np.stack([lo, hi], axis=-1)
 
     # -- serialisation ----------------------------------------------------
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         """Serialise to a plain JSON-safe dict."""
         return stamp_schema(
             {
@@ -250,7 +260,7 @@ class DestructiveDegradationModel:
         )
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d: dict) -> "DestructiveDegradationModel":
         """Rebuild a model from :meth:`to_dict`."""
         if d.get("model") != "DestructiveDegradationModel":
             got = d.get("model")
@@ -270,7 +280,7 @@ class DestructiveDegradationModel:
             neg_ll=np.nan,
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             "Destructive Degradation Model"
             "\n============================="
@@ -298,7 +308,14 @@ class DestructiveDegradation_:
     unit). Use the module-level singleton :data:`DestructiveDegradation`.
     """
 
-    def _neg_ll(self, dist, phi_t, y, c, params):
+    def _neg_ll(
+        self,
+        dist: Any,
+        phi_t: npt.NDArray,
+        y: npt.NDArray,
+        c: npt.NDArray,
+        params: npt.NDArray,
+    ) -> float:
         beta0, beta1, log_sigma = params
         sigma = np.exp(log_sigma)
         loc = beta0 + beta1 * phi_t
@@ -314,7 +331,14 @@ class DestructiveDegradation_:
             ll = ll + dist.log_ff(y[lc], loc[lc], sigma).sum()
         return -ll
 
-    def _fit_one(self, dist, transform, x, y, c):
+    def _fit_one(
+        self,
+        dist: Any,
+        transform: str,
+        x: npt.NDArray,
+        y: npt.NDArray,
+        c: npt.NDArray,
+    ) -> tuple:
         phi = _TRANSFORMS[transform][0]
         phi_t = phi(x)
         # OLS initial values (on the log response for positive-support dists).
@@ -331,7 +355,7 @@ class DestructiveDegradation_:
 
         with np.errstate(all="ignore"):
 
-            def fun(p):
+            def fun(p: npt.NDArray) -> float:
                 return self._neg_ll(dist, phi_t, y, c, p)
 
             res = minimize(fun, init, method="Nelder-Mead")
@@ -344,14 +368,14 @@ class DestructiveDegradation_:
 
     def fit(
         self,
-        x,
-        y,
-        threshold,
-        c=None,
-        distribution=LogNormal,
-        transform="linear",
-        direction="auto",
-    ):
+        x: npt.ArrayLike,
+        y: npt.ArrayLike,
+        threshold: float,
+        c: "npt.ArrayLike | None" = None,
+        distribution: Any = LogNormal,
+        transform: str = "linear",
+        direction: str = "auto",
+    ) -> "DestructiveDegradationModel":
         r"""
         Fit a destructive degradation model.
 
@@ -432,7 +456,7 @@ class DestructiveDegradation_:
                 fits[name] = (beta, sigma, nll)
             if not fits:
                 raise RuntimeError("no time transform could be fit")
-            best = min(scores, key=scores.get)
+            best = min(scores, key=lambda k: scores[k])
             beta, sigma, nll = fits[best]
             transform = best
             transform_scores = scores

--- a/surpyval/degradation/path_models.py
+++ b/surpyval/degradation/path_models.py
@@ -28,7 +28,7 @@ import numpy.typing as npt
 from scipy.optimize import curve_fit
 
 
-def _ols(z, y):
+def _ols(z: npt.NDArray, y: npt.NDArray) -> tuple[float, float]:
     """Closed-form least squares fit of ``y = intercept + slope * z``."""
     A = np.column_stack([np.ones_like(z), z])
     (intercept, slope), *_ = np.linalg.lstsq(A, y, rcond=None)
@@ -96,7 +96,9 @@ class PathModel(ABC):
     def check_data(self, x: npt.NDArray, y: npt.NDArray) -> None:
         """Raise ``ValueError`` if the data is outside the model domain."""
 
-    def _initial_guess(self, x, y):
+    def _initial_guess(
+        self, x: npt.NDArray, y: npt.NDArray
+    ) -> "npt.ArrayLike | list":
         """One starting parameter vector, or a list of candidates."""
         raise NotImplementedError
 
@@ -127,7 +129,7 @@ class PathModel(ABC):
             )
         return best_params
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "{} Degradation Path Model".format(self.name)
 
 
@@ -138,21 +140,21 @@ class LinearPath_(PathModel):
     param_names = ["a", "b"]
     linear_in_parameters = True
 
-    def path(self, x, *params):
+    def path(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         return a + b * np.asarray(x, dtype=float)
 
-    def inv_path(self, y, *params):
+    def inv_path(self, y: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         y = np.asarray(y, dtype=float)
         with np.errstate(divide="ignore", invalid="ignore"):
             return (y - a) / b
 
-    def jacobian(self, x, *params):
+    def jacobian(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         x = np.asarray(x, dtype=float)
         return np.column_stack([np.ones_like(x), x])
 
-    def fit(self, x, y):
+    def fit(self, x: npt.ArrayLike, y: npt.ArrayLike) -> npt.NDArray:
         x = np.asarray(x, dtype=float)
         y = np.asarray(y, dtype=float)
         self.check_data(x, y)
@@ -165,30 +167,32 @@ class ExponentialPath_(PathModel):
     name = "Exponential"
     param_names = ["a", "b"]
 
-    def path(self, x, *params):
+    def path(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         return a * np.exp(b * np.asarray(x, dtype=float))
 
-    def inv_path(self, y, *params):
+    def inv_path(self, y: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         y = np.asarray(y, dtype=float)
         with np.errstate(divide="ignore", invalid="ignore"):
             return np.log(y / a) / b
 
-    def jacobian(self, x, *params):
+    def jacobian(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         x = np.asarray(x, dtype=float)
         e = np.exp(b * x)
         return np.column_stack([e, a * x * e])
 
-    def check_data(self, x, y):
+    def check_data(self, x: npt.NDArray, y: npt.NDArray) -> None:
         if (y <= 0).any():
             raise ValueError(
                 "The exponential path model requires strictly positive "
                 "degradation measurements"
             )
 
-    def _initial_guess(self, x, y):
+    def _initial_guess(
+        self, x: npt.NDArray, y: npt.NDArray
+    ) -> "npt.ArrayLike | list":
         intercept, slope = _ols(x, np.log(y))
         return np.exp(intercept), slope
 
@@ -199,24 +203,24 @@ class PowerPath_(PathModel):
     name = "Power"
     param_names = ["a", "b"]
 
-    def path(self, x, *params):
+    def path(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         with np.errstate(divide="ignore", invalid="ignore"):
             return a * np.power(np.asarray(x, dtype=float), b)
 
-    def inv_path(self, y, *params):
+    def inv_path(self, y: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         y = np.asarray(y, dtype=float)
         with np.errstate(divide="ignore", invalid="ignore"):
             return np.power(y / a, 1.0 / b)
 
-    def jacobian(self, x, *params):
+    def jacobian(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         x = np.asarray(x, dtype=float)
         xb = np.power(x, b)
         return np.column_stack([xb, a * xb * np.log(x)])
 
-    def check_data(self, x, y):
+    def check_data(self, x: npt.NDArray, y: npt.NDArray) -> None:
         if (x <= 0).any():
             raise ValueError(
                 "The power path model requires strictly positive times"
@@ -227,7 +231,9 @@ class PowerPath_(PathModel):
                 "degradation measurements"
             )
 
-    def _initial_guess(self, x, y):
+    def _initial_guess(
+        self, x: npt.NDArray, y: npt.NDArray
+    ) -> "npt.ArrayLike | list":
         intercept, slope = _ols(np.log(x), np.log(y))
         return np.exp(intercept), slope
 
@@ -239,28 +245,28 @@ class LogarithmicPath_(PathModel):
     param_names = ["a", "b"]
     linear_in_parameters = True
 
-    def path(self, x, *params):
+    def path(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         with np.errstate(divide="ignore", invalid="ignore"):
             return a + b * np.log(np.asarray(x, dtype=float))
 
-    def inv_path(self, y, *params):
+    def inv_path(self, y: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         y = np.asarray(y, dtype=float)
         with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
             return np.exp((y - a) / b)
 
-    def jacobian(self, x, *params):
+    def jacobian(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         x = np.asarray(x, dtype=float)
         return np.column_stack([np.ones_like(x), np.log(x)])
 
-    def check_data(self, x, y):
+    def check_data(self, x: npt.NDArray, y: npt.NDArray) -> None:
         if (x <= 0).any():
             raise ValueError(
                 "The logarithmic path model requires strictly positive times"
             )
 
-    def fit(self, x, y):
+    def fit(self, x: npt.ArrayLike, y: npt.ArrayLike) -> npt.NDArray:
         x = np.asarray(x, dtype=float)
         y = np.asarray(y, dtype=float)
         self.check_data(x, y)
@@ -274,28 +280,28 @@ class LloydLipowPath_(PathModel):
     param_names = ["a", "b"]
     linear_in_parameters = True
 
-    def path(self, x, *params):
+    def path(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         with np.errstate(divide="ignore", invalid="ignore"):
             return a - b / np.asarray(x, dtype=float)
 
-    def inv_path(self, y, *params):
+    def inv_path(self, y: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         y = np.asarray(y, dtype=float)
         with np.errstate(divide="ignore", invalid="ignore"):
             return b / (a - y)
 
-    def jacobian(self, x, *params):
+    def jacobian(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         x = np.asarray(x, dtype=float)
         return np.column_stack([np.ones_like(x), -1.0 / x])
 
-    def check_data(self, x, y):
+    def check_data(self, x: npt.NDArray, y: npt.NDArray) -> None:
         if (x <= 0).any():
             raise ValueError(
                 "The Lloyd-Lipow path model requires strictly positive times"
             )
 
-    def fit(self, x, y):
+    def fit(self, x: npt.ArrayLike, y: npt.ArrayLike) -> npt.NDArray:
         x = np.asarray(x, dtype=float)
         y = np.asarray(y, dtype=float)
         self.check_data(x, y)
@@ -310,12 +316,12 @@ class QuadraticPath_(PathModel):
     param_names = ["a", "b", "c"]
     linear_in_parameters = True
 
-    def path(self, x, *params):
+    def path(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b, c = params
         x = np.asarray(x, dtype=float)
         return a + b * x + c * x**2
 
-    def inv_path(self, y, *params):
+    def inv_path(self, y: npt.ArrayLike, *params: float) -> npt.NDArray:
         """First positive time at which the parabola reaches ``y``."""
         a, b, c = params
         y = np.asarray(y, dtype=float)
@@ -337,11 +343,11 @@ class QuadraticPath_(PathModel):
             first = np.where(np.isfinite(first), first, np.nan)
             return np.where(c == 0, linear_root, first)
 
-    def jacobian(self, x, *params):
+    def jacobian(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         x = np.asarray(x, dtype=float)
         return np.column_stack([np.ones_like(x), x, x**2])
 
-    def fit(self, x, y):
+    def fit(self, x: npt.ArrayLike, y: npt.ArrayLike) -> npt.NDArray:
         x = np.asarray(x, dtype=float)
         y = np.asarray(y, dtype=float)
         self.check_data(x, y)
@@ -359,19 +365,19 @@ class GompertzPath_(PathModel):
     name = "Gompertz"
     param_names = ["a", "b", "c"]
 
-    def path(self, x, *params):
+    def path(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b, c = params
         x = np.asarray(x, dtype=float)
         with np.errstate(over="ignore"):
             return a * np.exp(-b * np.exp(-c * x))
 
-    def inv_path(self, y, *params):
+    def inv_path(self, y: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b, c = params
         y = np.asarray(y, dtype=float)
         with np.errstate(divide="ignore", invalid="ignore"):
             return -np.log(-np.log(y / a) / b) / c
 
-    def jacobian(self, x, *params):
+    def jacobian(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b, c = params
         x = np.asarray(x, dtype=float)
         inner = np.exp(-c * x)
@@ -380,14 +386,16 @@ class GompertzPath_(PathModel):
             [outer, -a * inner * outer, a * b * x * inner * outer]
         )
 
-    def check_data(self, x, y):
+    def check_data(self, x: npt.NDArray, y: npt.NDArray) -> None:
         if (y <= 0).any():
             raise ValueError(
                 "The Gompertz path model requires strictly positive "
                 "degradation measurements"
             )
 
-    def _initial_guess(self, x, y):
+    def _initial_guess(
+        self, x: npt.NDArray, y: npt.NDArray
+    ) -> "npt.ArrayLike | list":
         # slightly above the largest measurement as the asymptote, then
         # -ln(y/a) decays exponentially: linearise on its logarithm
         a0 = 1.05 * y.max()
@@ -406,25 +414,27 @@ class OffsetExponentialPath_(PathModel):
     name = "Offset Exponential"
     param_names = ["a", "b", "c"]
 
-    def path(self, x, *params):
+    def path(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b, c = params
         x = np.asarray(x, dtype=float)
         with np.errstate(over="ignore"):
             return a + b * np.exp(c * x)
 
-    def inv_path(self, y, *params):
+    def inv_path(self, y: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b, c = params
         y = np.asarray(y, dtype=float)
         with np.errstate(divide="ignore", invalid="ignore"):
             return np.log((y - a) / b) / c
 
-    def jacobian(self, x, *params):
+    def jacobian(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b, c = params
         x = np.asarray(x, dtype=float)
         e = np.exp(c * x)
         return np.column_stack([np.ones_like(x), e, b * x * e])
 
-    def _initial_guess(self, x, y):
+    def _initial_guess(
+        self, x: npt.NDArray, y: npt.NDArray
+    ) -> "npt.ArrayLike | list":
         # for an offset outside the observed range, y - a0 has one
         # sign, so its magnitude linearises on a log scale; try an
         # offset on each side and keep the better fit
@@ -450,25 +460,25 @@ class MichaelisMentenPath_(PathModel):
     name = "Michaelis-Menten"
     param_names = ["a", "b"]
 
-    def path(self, x, *params):
+    def path(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         x = np.asarray(x, dtype=float)
         with np.errstate(divide="ignore", invalid="ignore"):
             return a * x / (b + x)
 
-    def inv_path(self, y, *params):
+    def inv_path(self, y: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         y = np.asarray(y, dtype=float)
         with np.errstate(divide="ignore", invalid="ignore"):
             return b * y / (a - y)
 
-    def jacobian(self, x, *params):
+    def jacobian(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
         a, b = params
         x = np.asarray(x, dtype=float)
         denominator = b + x
         return np.column_stack([x / denominator, -a * x / denominator**2])
 
-    def check_data(self, x, y):
+    def check_data(self, x: npt.NDArray, y: npt.NDArray) -> None:
         if (x <= 0).any():
             raise ValueError(
                 "The Michaelis-Menten path model requires strictly "
@@ -480,7 +490,9 @@ class MichaelisMentenPath_(PathModel):
                 "positive degradation measurements"
             )
 
-    def _initial_guess(self, x, y):
+    def _initial_guess(
+        self, x: npt.NDArray, y: npt.NDArray
+    ) -> "npt.ArrayLike | list":
         # Lineweaver-Burk linearisation: 1/y = 1/a + (b/a) / x
         intercept, slope = _ols(1.0 / x, 1.0 / y)
         if intercept > 0:

--- a/surpyval/degradation/population.py
+++ b/surpyval/degradation/population.py
@@ -42,6 +42,8 @@ reduces exactly to the linear REML in one pass (``w_i = y_i`` and the
 modes drop out), so the two routines agree.
 """
 
+from typing import Any
+
 import numpy as np
 import numpy.typing as npt
 from scipy.linalg import cho_factor, cho_solve
@@ -80,7 +82,12 @@ def _z_from_init(
     return z
 
 
-def _reml_pieces(z, y_list, x_mat_list, p):
+def _reml_pieces(
+    z: npt.NDArray,
+    y_list: list,
+    x_mat_list: list,
+    p: int,
+) -> tuple:
     """
     Evaluate the model at ``z``.
 
@@ -143,7 +150,7 @@ def reml_estimate(
     """
     p = x_mat_list[0].shape[1]
 
-    def objective(z):
+    def objective(z: npt.NDArray) -> float:
         try:
             return _reml_pieces(z, y_list, x_mat_list, p)[0]
         except np.linalg.LinAlgError:
@@ -175,7 +182,7 @@ def _prior_precision(cov: npt.NDArray, sigma2: float) -> npt.NDArray:
 
 
 def _conditional_mode(
-    path_model,
+    path_model: Any,
     x: npt.NDArray,
     y: npt.NDArray,
     mu: npt.NDArray,
@@ -194,7 +201,7 @@ def _conditional_mode(
     """
     theta = np.array(theta0, dtype=float)
 
-    def penalised(t):
+    def penalised(t: npt.NDArray) -> float:
         resid = y - path_model.path(x, *t)
         delta = t - mu
         return (resid @ resid) / sigma2 + delta @ prior_precision @ delta
@@ -233,7 +240,7 @@ def _conditional_mode(
 def reml_estimate_nonlinear(
     y_list: "list[npt.NDArray]",
     x_list: "list[npt.NDArray]",
-    path_model,
+    path_model: Any,
     mean_init: npt.NDArray,
     cov_init: npt.NDArray,
     sigma2_init: float,

--- a/surpyval/degradation/process_models.py
+++ b/surpyval/degradation/process_models.py
@@ -21,7 +21,10 @@ degradation:
   distribution comes from the (regularised) incomplete gamma function.
 """
 
+from typing import TYPE_CHECKING
+
 import numpy as np
+import numpy.typing as npt
 from scipy.integrate import quad
 from scipy.optimize import brentq, minimize_scalar
 from scipy.special import gammaincc, gammaln
@@ -38,7 +41,9 @@ __all__ = [
 ]
 
 
-def _increments(x, y, i):
+def _increments(
+    x: npt.ArrayLike, y: npt.ArrayLike, i: npt.ArrayLike
+) -> tuple[npt.NDArray, npt.NDArray]:
     """
     Validate degradation data and return the pooled per-unit increments.
 
@@ -99,13 +104,19 @@ class ProcessRUL:
         current degradation is at or beyond it).
     """
 
-    def __init__(self, rul, rul_interval, prob_already_failed, alpha_ci):
+    def __init__(
+        self,
+        rul: float,
+        rul_interval: tuple,
+        prob_already_failed: float,
+        alpha_ci: float,
+    ) -> None:
         self.rul = rul
         self.rul_interval = rul_interval
         self.prob_already_failed = prob_already_failed
         self.alpha_ci = alpha_ci
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         lo, hi = self.rul_interval
         return (
             "ProcessRUL(rul={:.4g}, interval=({:.4g}, {:.4g}), "
@@ -149,15 +160,19 @@ class FirstPassageProcessModel(SerialisableMixin):
     param_names: list
     threshold: float
 
-    def __init__(self, *params_then_threshold):
+    if TYPE_CHECKING:
+        # The density is each subclass's own (closed form vs numeric).
+        def df(self, t: npt.ArrayLike) -> "npt.NDArray | float": ...
+
+    def __init__(self, *params_then_threshold: float) -> None:
         # Subclasses define their own named-parameter __init__; this
         # signature exists so ``from_dict`` type-checks against the base.
         raise NotImplementedError
 
-    def _ff_distance(self, t, distance):
+    def _ff_distance(self, t: npt.ArrayLike, distance: float) -> npt.NDArray:
         raise NotImplementedError
 
-    def _quantile_hi0(self, distance):
+    def _quantile_hi0(self, distance: float) -> float:
         """Starting upper bracket for the quantile search."""
         raise NotImplementedError
 
@@ -183,33 +198,33 @@ class FirstPassageProcessModel(SerialisableMixin):
             model_dict["threshold"],
         )
 
-    def ff(self, t):
+    def ff(self, t: npt.ArrayLike) -> "npt.NDArray | float":
         """Failure (CDF) of the first-passage time to the threshold."""
         scalar = np.isscalar(t)
         res = self._ff_distance(np.atleast_1d(t), self.threshold)
         return float(res[0]) if scalar else res
 
-    def sf(self, t):
+    def sf(self, t: npt.ArrayLike) -> "npt.NDArray | float":
         """Survival function of the first-passage time."""
         scalar = np.isscalar(t)
         res = 1.0 - self._ff_distance(np.atleast_1d(t), self.threshold)
         return float(res[0]) if scalar else res
 
-    def hf(self, t):
+    def hf(self, t: npt.ArrayLike) -> "npt.NDArray | float":
         """Hazard function of the first-passage time."""
         return self.df(t) / self.sf(t)
 
-    def Hf(self, t):
+    def Hf(self, t: npt.ArrayLike) -> "npt.NDArray | float":
         """Cumulative hazard of the first-passage time."""
         return -np.log(self.sf(t))
 
-    def qf(self, p):
+    def qf(self, p: npt.ArrayLike) -> "npt.NDArray | float":
         """Quantile (inverse CDF) of the first-passage time."""
         p = np.atleast_1d(np.asarray(p, dtype=float))
         out = np.array([self._quantile(pi, self.threshold) for pi in p])
         return float(out[0]) if out.shape == (1,) else out
 
-    def _quantile(self, p, distance):
+    def _quantile(self, p: float, distance: float) -> float:
         if not (0.0 < p < 1.0):
             return 0.0 if p <= 0.0 else np.inf
         # bracket from the subclass's starting scale and expand until it
@@ -225,7 +240,9 @@ class FirstPassageProcessModel(SerialisableMixin):
             hi,
         )
 
-    def predict_rul(self, current_degradation, alpha_ci=0.05):
+    def predict_rul(
+        self, current_degradation: float, alpha_ci: float = 0.05
+    ) -> ProcessRUL:
         """
         Remaining useful life given the current degradation level.
 
@@ -279,20 +296,20 @@ class WienerProcessModel(FirstPassageProcessModel):
     _human_name = "Wiener-process"
     param_names = ["mu", "sigma"]
 
-    def __init__(self, mu, sigma, threshold):
+    def __init__(self, mu: float, sigma: float, threshold: float) -> None:
         self.mu = float(mu)
         self.sigma = float(sigma)
         self.threshold = float(threshold)
         self.params = np.array([self.mu, self.sigma])
 
-    def _ig(self, distance):
+    def _ig(self, distance: float) -> tuple[float, float]:
         # Inverse-Gaussian (mean nu, shape lam) parameters for first passage
         # over ``distance`` at drift mu / diffusion sigma.
         nu = distance / self.mu
         lam = distance**2 / self.sigma**2
         return nu, lam
 
-    def _ff_distance(self, t, distance):
+    def _ff_distance(self, t: npt.ArrayLike, distance: float) -> npt.NDArray:
         # Inverse-Gaussian first-passage CDF over ``distance``.
         t = np.asarray(t, dtype=float)
         nu, lam = self._ig(distance)
@@ -306,7 +323,7 @@ class WienerProcessModel(FirstPassageProcessModel):
         out[pos] = cdf
         return out
 
-    def df(self, t):
+    def df(self, t: npt.ArrayLike) -> "npt.NDArray | float":
         """Density of the first-passage (Inverse-Gaussian) time."""
         scalar = np.isscalar(t)
         t = np.atleast_1d(np.asarray(t, dtype=float))
@@ -319,21 +336,23 @@ class WienerProcessModel(FirstPassageProcessModel):
         )
         return float(out[0]) if scalar else out
 
-    def mean(self):
+    def mean(self) -> float:
         """Mean time to failure (``threshold / mu``)."""
         return self.threshold / self.mu
 
-    def _quantile_hi0(self, distance):
+    def _quantile_hi0(self, distance: float) -> float:
         # bracket around the first-passage mean
         return distance / self.mu
 
-    def random(self, size, random_state=None):
+    def random(
+        self, size: int, random_state: "int | None" = None
+    ) -> npt.NDArray:
         """Draw first-passage (failure) times from the fitted model."""
         rng = np.random.default_rng(random_state)
         nu, lam = self._ig(self.threshold)
         return rng.wald(nu, lam, size=size)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             "Wiener Process Degradation Model\n"
             "================================\n"
@@ -351,7 +370,13 @@ class WienerProcess:
     :class:`WienerProcessModel`)."""
 
     @classmethod
-    def fit(cls, x, y, i, threshold):
+    def fit(
+        cls,
+        x: npt.ArrayLike,
+        y: npt.ArrayLike,
+        i: npt.ArrayLike,
+        threshold: float,
+    ) -> "WienerProcessModel":
         """
         Fit a Wiener-process degradation model by maximum likelihood.
 
@@ -416,13 +441,13 @@ class GammaProcessModel(FirstPassageProcessModel):
     _human_name = "gamma-process"
     param_names = ["alpha", "beta"]
 
-    def __init__(self, alpha, beta, threshold):
+    def __init__(self, alpha: float, beta: float, threshold: float) -> None:
         self.alpha = float(alpha)
         self.beta = float(beta)
         self.threshold = float(threshold)
         self.params = np.array([self.alpha, self.beta])
 
-    def _ff_distance(self, t, distance):
+    def _ff_distance(self, t: npt.ArrayLike, distance: float) -> npt.NDArray:
         # P(T <= t) = P(W(t) >= distance) with W(t) ~ Gamma(alpha t, beta).
         t = np.asarray(t, dtype=float)
         out = np.zeros_like(t, dtype=float)
@@ -430,7 +455,7 @@ class GammaProcessModel(FirstPassageProcessModel):
         out[pos] = gammaincc(self.alpha * t[pos], self.beta * distance)
         return out
 
-    def df(self, t):
+    def df(self, t: npt.ArrayLike) -> "npt.NDArray | float":
         """Density of the first-passage time (numeric derivative of ``ff``)."""
         scalar = np.isscalar(t)
         t = np.atleast_1d(np.asarray(t, dtype=float))
@@ -445,7 +470,7 @@ class GammaProcessModel(FirstPassageProcessModel):
         out = np.clip(out, 0.0, None)
         return float(out[0]) if scalar else out
 
-    def mean(self):
+    def mean(self) -> float:
         """Mean time to failure, ``integral of the survival function``."""
         val, _ = quad(
             lambda t: self._sf_distance_scalar(t, self.threshold),
@@ -455,23 +480,25 @@ class GammaProcessModel(FirstPassageProcessModel):
         )
         return val
 
-    def _sf_distance_scalar(self, t, distance):
+    def _sf_distance_scalar(self, t: float, distance: float) -> float:
         if t <= 0:
             return 1.0
         return 1.0 - gammaincc(self.alpha * t, self.beta * distance)
 
-    def _quantile_hi0(self, distance):
+    def _quantile_hi0(self, distance: float) -> float:
         # rough starting scale from the mean increment rate
         rate = self.alpha / self.beta  # mean degradation per unit time
         return max(distance / rate, 1.0)
 
-    def random(self, size, random_state=None):
+    def random(
+        self, size: int, random_state: "int | None" = None
+    ) -> npt.NDArray:
         """Draw first-passage (failure) times via inverse-CDF sampling."""
         rng = np.random.default_rng(random_state)
         u = rng.uniform(size=size)
         return np.array([self._quantile(ui, self.threshold) for ui in u])
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             "Gamma Process Degradation Model\n"
             "===============================\n"
@@ -489,7 +516,13 @@ class GammaProcess:
     :class:`GammaProcessModel`)."""
 
     @classmethod
-    def fit(cls, x, y, i, threshold):
+    def fit(
+        cls,
+        x: npt.ArrayLike,
+        y: npt.ArrayLike,
+        i: npt.ArrayLike,
+        threshold: float,
+    ) -> "GammaProcessModel":
         """
         Fit a Gamma-process degradation model by maximum likelihood.
 
@@ -526,7 +559,7 @@ class GammaProcess:
         sum_dy = dy.sum()
         log_dy = np.log(dy)
 
-        def neg_ll(alpha):
+        def neg_ll(alpha: float) -> float:
             # Profile out beta: d/dbeta -> beta = alpha * sum_dt / sum_dy.
             beta = alpha * sum_dt / sum_dy
             k = alpha * dt

--- a/surpyval/multivariate/parametric/copula/archimedean.py
+++ b/surpyval/multivariate/parametric/copula/archimedean.py
@@ -6,7 +6,10 @@ Clayton additionally supplies closed forms for speed. Each family converts
 an empirical Kendall's tau into a starting parameter for the optimiser.
 """
 
+from typing import Any
+
 import numpy as onp
+import numpy.typing as npt
 from scipy.optimize import brentq
 
 from surpyval import np
@@ -20,44 +23,48 @@ class IndependenceCopula(Copula):
     bounds = ()
     param_names = ()
 
-    def cdf(self, u, v, *params):
+    def cdf(self, u: Any, v: Any, *params: Any) -> Any:
         return u * v
 
-    def du(self, u, v, *params):
+    def du(self, u: Any, v: Any, *params: Any) -> Any:
         return np.asarray(v) * np.ones_like(np.asarray(u))
 
-    def dv(self, u, v, *params):
+    def dv(self, u: Any, v: Any, *params: Any) -> Any:
         return np.asarray(u) * np.ones_like(np.asarray(v))
 
-    def pdf(self, u, v, *params):
+    def pdf(self, u: Any, v: Any, *params: Any) -> Any:
         return np.ones_like(np.asarray(u) * np.asarray(v))
 
-    def kendall_tau(self, *params):
+    def kendall_tau(self, *params: float) -> float:
         return 0.0
 
-    def spearman_rho(self, *params):
+    def spearman_rho(self, *params: float) -> float:
         return 0.0
 
     def fit(
         self,
-        x,
-        c=None,
-        n=None,
-        t=None,
-        margins=None,
-        how="IFM",
-        xl=None,
-        xr=None,
-    ):
+        x: npt.ArrayLike,
+        c: "npt.ArrayLike | None" = None,
+        n: "npt.ArrayLike | None" = None,
+        t: "npt.ArrayLike | None" = None,
+        margins: Any = None,
+        how: str = "IFM",
+        xl: "npt.ArrayLike | None" = None,
+        xr: "npt.ArrayLike | None" = None,
+    ) -> Any:
         # No parameter to estimate; only the margins are fitted.
         return super().fit(
             x, c=c, n=n, t=t, margins=margins, how="IFM", xl=xl, xr=xr
         )
 
-    def _fit_theta(self, margin_models, data):
+    def _fit_theta(  # type: ignore[override]
+        self, margin_models: list, data: Any
+    ) -> npt.NDArray:
         return onp.asarray([], dtype=float)
 
-    def _fit_joint(self, margins, margin_models, data):
+    def _fit_joint(
+        self, margins: Any, margin_models: list, data: Any
+    ) -> tuple:
         return onp.asarray([], dtype=float), margin_models
 
 
@@ -68,17 +75,21 @@ class ClaytonCopula(Copula):
     bounds = ((0, None),)
     param_names = ("theta",)
 
-    def cdf(self, u, v, theta):
+    # Named single parameter narrows the variadic base contract.
+    def cdf(self, u: Any, v: Any, theta: Any) -> Any:  # type: ignore[override]
         return (u ** (-theta) + v ** (-theta) - 1.0) ** (-1.0 / theta)
 
-    def du(self, u, v, theta):
+    # Named single parameter narrows the variadic base contract.
+    def du(self, u: Any, v: Any, theta: Any) -> Any:  # type: ignore[override]
         base = u ** (-theta) + v ** (-theta) - 1.0
         return u ** (-theta - 1.0) * base ** (-1.0 / theta - 1.0)
 
-    def dv(self, u, v, theta):
+    # Named single parameter narrows the variadic base contract.
+    def dv(self, u: Any, v: Any, theta: Any) -> Any:  # type: ignore[override]
         return self.du(v, u, theta)
 
-    def pdf(self, u, v, theta):
+    # Named single parameter narrows the variadic base contract.
+    def pdf(self, u: Any, v: Any, theta: Any) -> Any:  # type: ignore[override]
         base = u ** (-theta) + v ** (-theta) - 1.0
         return (
             (1.0 + theta)
@@ -86,13 +97,13 @@ class ClaytonCopula(Copula):
             * base ** (-1.0 / theta - 2.0)
         )
 
-    def kendall_tau(self, theta):
+    def kendall_tau(self, theta: float) -> float:  # type: ignore[override]
         return theta / (theta + 2.0)
 
-    def tail_dependence(self, theta):
+    def tail_dependence(self, theta: float) -> tuple:  # type: ignore[override]
         return (2.0 ** (-1.0 / theta), 0.0)
 
-    def _init_theta(self, dims):
+    def _init_theta(self, dims: list) -> npt.NDArray:
         tau = onp.clip(self._emp_tau(dims), 1e-3, 0.95)
         return onp.asarray([max(2.0 * tau / (1.0 - tau), 1e-2)])
 
@@ -104,18 +115,19 @@ class GumbelCopula(Copula):
     bounds = ((1, None),)
     param_names = ("theta",)
 
-    def cdf(self, u, v, theta):
+    # Named single parameter narrows the variadic base contract.
+    def cdf(self, u: Any, v: Any, theta: Any) -> Any:  # type: ignore[override]
         lu = (-np.log(u)) ** theta
         lv = (-np.log(v)) ** theta
         return np.exp(-((lu + lv) ** (1.0 / theta)))
 
-    def kendall_tau(self, theta):
+    def kendall_tau(self, theta: float) -> float:  # type: ignore[override]
         return 1.0 - 1.0 / theta
 
-    def tail_dependence(self, theta):
+    def tail_dependence(self, theta: float) -> tuple:  # type: ignore[override]
         return (0.0, 2.0 - 2.0 ** (1.0 / theta))
 
-    def _init_theta(self, dims):
+    def _init_theta(self, dims: list) -> npt.NDArray:
         tau = onp.clip(self._emp_tau(dims), 1e-3, 0.95)
         return onp.asarray([max(1.0 / (1.0 - tau), 1.0 + 1e-2)])
 
@@ -127,23 +139,24 @@ class FrankCopula(Copula):
     bounds = ((None, None),)
     param_names = ("theta",)
 
-    def cdf(self, u, v, theta):
+    # Named single parameter narrows the variadic base contract.
+    def cdf(self, u: Any, v: Any, theta: Any) -> Any:  # type: ignore[override]
         # Guard the removable singularity at theta -> 0 (independence).
         theta = np.where(np.abs(theta) < 1e-8, 1e-8, theta)
         num = (np.exp(-theta * u) - 1.0) * (np.exp(-theta * v) - 1.0)
         return -1.0 / theta * np.log(1.0 + num / (np.exp(-theta) - 1.0))
 
-    def kendall_tau(self, theta):
+    def kendall_tau(self, theta: float) -> float:  # type: ignore[override]
         if abs(theta) < 1e-8:
             return 0.0
         return 1.0 - 4.0 / theta * (1.0 - _debye1(theta))
 
-    def _init_theta(self, dims):
+    def _init_theta(self, dims: list) -> npt.NDArray:
         tau = onp.clip(self._emp_tau(dims), -0.95, 0.95)
         if abs(tau) < 1e-3:
             return onp.asarray([1e-2])
 
-        def gap(theta):
+        def gap(theta: float) -> float:
             return self.kendall_tau(theta) - tau
 
         try:
@@ -155,7 +168,7 @@ class FrankCopula(Copula):
         return onp.asarray([theta])
 
 
-def _debye1(theta):
+def _debye1(theta: float) -> float:
     """First Debye function ``D_1(t) = (1/t) int_0^t s/(e^s-1) ds``."""
     from scipy.integrate import quad
 

--- a/surpyval/multivariate/parametric/copula/copula.py
+++ b/surpyval/multivariate/parametric/copula/copula.py
@@ -18,7 +18,10 @@ each right/left/interval-censored dimension contributes a difference of
 bookkeeping uniform across all 16 bivariate censoring combinations.
 """
 
+from typing import Any
+
 import numpy as onp
+import numpy.typing as npt
 from autograd import elementwise_grad
 from scipy.optimize import minimize
 
@@ -46,43 +49,43 @@ class Copula:
     param_names: tuple = ("theta",)
 
     # -- the four copula primitives ---------------------------------------
-    def cdf(self, u, v, *params):
+    def cdf(self, u: Any, v: Any, *params: Any) -> Any:
         raise NotImplementedError
 
-    def du(self, u, v, *params):
+    def du(self, u: Any, v: Any, *params: Any) -> Any:
         """``dC/du`` -- the h-function. autograd default; override if known."""
         return elementwise_grad(lambda a: self.cdf(a, v, *params))(
             onp.asarray(u, dtype=float)
         )
 
-    def dv(self, u, v, *params):
+    def dv(self, u: Any, v: Any, *params: Any) -> Any:
         """``dC/dv``. autograd default; override if known."""
         return elementwise_grad(lambda b: self.cdf(u, b, *params))(
             onp.asarray(v, dtype=float)
         )
 
-    def pdf(self, u, v, *params):
+    def pdf(self, u: Any, v: Any, *params: Any) -> Any:
         """``d2C/du dv`` -- the copula density. autograd default."""
         return elementwise_grad(lambda b: self.du(u, b, *params))(
             onp.asarray(v, dtype=float)
         )
 
     # -- dependence measures (closed-form overrides preferred) ------------
-    def kendall_tau(self, *params):
+    def kendall_tau(self, *params: float) -> float:
         """Kendall's tau. Default: empirical estimate from a large sample."""
         from scipy.stats import kendalltau
 
         u, v = self.sample_uv(50_000, params, random_state=0)
         return float(kendalltau(u, v).statistic)
 
-    def spearman_rho(self, *params):
+    def spearman_rho(self, *params: float) -> float:
         """Spearman's rho. Default: empirical estimate from a large sample."""
         from scipy.stats import spearmanr
 
         u, v = self.sample_uv(50_000, params, random_state=0)
         return float(spearmanr(u, v).statistic)
 
-    def tail_dependence(self, *params):
+    def tail_dependence(self, *params: float) -> tuple:
         """Lower/upper tail-dependence coefficients ``(lambda_L, lambda_U)``.
 
         Default ``(0.0, 0.0)`` (no tail dependence); families override.
@@ -90,7 +93,12 @@ class Copula:
         return (0.0, 0.0)
 
     # -- sampling ---------------------------------------------------------
-    def sample_uv(self, size, params, random_state=None):
+    def sample_uv(
+        self,
+        size: int,
+        params: Any,
+        random_state: "int | None" = None,
+    ) -> tuple[npt.NDArray, npt.NDArray]:
         """Draw ``(u, v)`` pairs by conditional inversion of the h-function.
 
         ``u`` is uniform; given ``u`` and a uniform ``w``, ``v`` solves
@@ -103,7 +111,13 @@ class Copula:
         v = self._invert_du(u, w, params)
         return u, v
 
-    def _invert_du(self, u, w, params, iters=60):
+    def _invert_du(
+        self,
+        u: npt.NDArray,
+        w: npt.NDArray,
+        params: Any,
+        iters: int = 60,
+    ) -> npt.NDArray:
         lo = onp.full_like(onp.asarray(u, dtype=float), _EPS)
         hi = onp.full_like(lo, 1 - _EPS)
         for _ in range(iters):
@@ -114,7 +128,14 @@ class Copula:
         return 0.5 * (lo + hi)
 
     # -- likelihood primitives -------------------------------------------
-    def _eval(self, u, v, diff_u, diff_v, params):
+    def _eval(
+        self,
+        u: Any,
+        v: Any,
+        diff_u: bool,
+        diff_v: bool,
+        params: Any,
+    ) -> Any:
         u = np.clip(u, _EPS, 1 - _EPS)
         v = np.clip(v, _EPS, 1 - _EPS)
         if diff_u and diff_v:
@@ -126,7 +147,7 @@ class Copula:
         return self.cdf(u, v, *params)
 
     @staticmethod
-    def _op_terms(code, upoint, ulo, uhi):
+    def _op_terms(code: int, upoint: Any, ulo: Any, uhi: Any) -> list:
         """Per-dimension operator: list of ``(coef, u_value, differentiate)``.
 
         Applying the tensor product of the two dimensions' operators to ``C``
@@ -142,7 +163,7 @@ class Copula:
         # interval censored -> C(.,uhi) - C(.,ulo)
         return [(1.0, uhi, False), (-1.0, ulo, False)]
 
-    def _pair_loglik(self, params, d0, d1):
+    def _pair_loglik(self, params: Any, d0: Any, d1: Any) -> Any:
         """Per-row log-likelihood for two prepared dimensions ``d0, d1``."""
         c0, c1 = d0["c"], d1["c"]
         N = len(c0)
@@ -176,7 +197,7 @@ class Copula:
             ll = ll - self._trunc_logmass(params, d0, d1)
         return ll
 
-    def _trunc_logmass(self, params, d0, d1):
+    def _trunc_logmass(self, params: Any, d0: Any, d1: Any) -> Any:
         """Log copula mass over the per-row truncation rectangle."""
         ul0, ur0 = d0["ul"], d0["ur"]
         ul1, ur1 = d1["ul"], d1["ur"]
@@ -189,7 +210,16 @@ class Copula:
         return onp.log(onp.clip(mass, _TINY, None))
 
     # -- fitting ----------------------------------------------------------
-    def _prepare_dim(self, margin, x, c, xl, xr, tl, tr):
+    def _prepare_dim(
+        self,
+        margin: Any,
+        x: Any,
+        c: Any,
+        xl: Any,
+        xr: Any,
+        tl: Any,
+        tr: Any,
+    ) -> dict:
         """Transform one dimension's data into copula (u-space) arrays."""
         u = onp.clip(onp.asarray(margin.ff(x), dtype=float), _EPS, 1 - _EPS)
         ulo = onp.clip(onp.asarray(margin.ff(xl), dtype=float), _EPS, 1 - _EPS)
@@ -210,21 +240,21 @@ class Copula:
             "has_trunc": has_trunc,
         }
 
-    def neg_ll(self, params, dims, weights):
+    def neg_ll(self, params: Any, dims: list, weights: npt.NDArray) -> float:
         ll = self._pair_loglik(params, dims[0], dims[1])
         return -float(onp.sum(weights * ll))
 
     def fit(
         self,
-        x,
-        c=None,
-        n=None,
-        t=None,
-        margins=None,
-        how="IFM",
-        xl=None,
-        xr=None,
-    ):
+        x: npt.ArrayLike,
+        c: "npt.ArrayLike | None" = None,
+        n: "npt.ArrayLike | None" = None,
+        t: "npt.ArrayLike | None" = None,
+        margins: Any = None,
+        how: str = "IFM",
+        xl: "npt.ArrayLike | None" = None,
+        xr: "npt.ArrayLike | None" = None,
+    ) -> Any:
         """Fit the copula and its margins to multivariate survival data.
 
         Parameters
@@ -267,7 +297,7 @@ class Copula:
 
         return CopulaModel(self, theta, margin_models, data=data, how=how)
 
-    def from_params(self, params, margins):
+    def from_params(self, params: Any, margins: Any) -> Any:
         """Build a :class:`CopulaModel` from a known parameter and margins."""
         from surpyval.multivariate.parametric.copula.copula_model import (
             CopulaModel,
@@ -276,7 +306,7 @@ class Copula:
         params = onp.atleast_1d(onp.asarray(params, dtype=float))
         return CopulaModel(self, params, list(margins), data=None, how="given")
 
-    def _fit_margins(self, margins, data):
+    def _fit_margins(self, margins: Any, data: Any) -> list:
         models = []
         for d, margin in enumerate(margins):
             if not hasattr(margin, "fit"):
@@ -297,7 +327,7 @@ class Copula:
                 models.append(margin.fit(x=xd, c=cd))
         return models
 
-    def _bounds_transforms(self):
+    def _bounds_transforms(self) -> tuple:
         from surpyval.univariate.parametric.fitters import bounds_convert
 
         param_map = {n: i for i, n in enumerate(self.param_names)}
@@ -306,14 +336,14 @@ class Copula:
         )
         return to_unbounded, to_bounded
 
-    def _fit_theta(self, margin_models, data):
+    def _fit_theta(self, margin_models: list, data: Any) -> npt.NDArray:
         dims = [
             self._prepare_dim(margin_models[d], *data.dimension(d))
             for d in range(data.D)
         ]
         to_unbounded, to_bounded = self._bounds_transforms()
 
-        def obj(phi):
+        def obj(phi: npt.NDArray) -> float:
             params = to_bounded(phi)
             return self.neg_ll(params, dims, data.n)
 
@@ -321,7 +351,9 @@ class Copula:
         res = minimize(obj, init, method="Nelder-Mead")
         return onp.asarray(to_bounded(res.x), dtype=float)
 
-    def _fit_joint(self, margins, margin_models, data):
+    def _fit_joint(
+        self, margins: Any, margin_models: list, data: Any
+    ) -> tuple:
         # Start from the IFM solution, then refine copula + margin params
         # jointly. Margins are re-evaluated from their parameter vectors at
         # each step via ``from_params``.
@@ -330,7 +362,7 @@ class Copula:
         splits = onp.cumsum([len(m.params) for m in margin_models])[:-1]
         to_unbounded, to_bounded = self._bounds_transforms()
 
-        def unpack(phi):
+        def unpack(phi: npt.NDArray) -> tuple:
             theta = to_bounded(phi[: len(self.param_names)])
             rest = phi[len(self.param_names) :]
             parts = onp.split(rest, splits)
@@ -339,7 +371,7 @@ class Copula:
             ]
             return theta, models
 
-        def obj(phi):
+        def obj(phi: npt.NDArray) -> float:
             theta, models = unpack(phi)
             dims = [
                 self._prepare_dim(models[d], *data.dimension(d))
@@ -359,12 +391,12 @@ class Copula:
         theta, models = unpack(res.x)
         return onp.asarray(theta, dtype=float), models
 
-    def _init_theta(self, dims):
+    def _init_theta(self, dims: list) -> npt.NDArray:
         """Initial parameter guess. Override per family for robustness."""
         return onp.asarray([1.0])
 
     @staticmethod
-    def _emp_tau(dims):
+    def _emp_tau(dims: list) -> float:
         """Empirical Kendall's tau over rows where both dims are observed."""
         from scipy.stats import kendalltau
 

--- a/surpyval/multivariate/parametric/copula/copula_model.py
+++ b/surpyval/multivariate/parametric/copula/copula_model.py
@@ -1,6 +1,9 @@
 """The fitted joint model from ``Copula.fit`` / ``Copula.from_params``."""
 
+from typing import Any
+
 import numpy as onp
+import numpy.typing as npt
 
 from surpyval.distribution import MultivariateDistribution
 from surpyval.serialisation import SerialisableMixin, stamp_schema
@@ -21,7 +24,14 @@ class CopulaModel(SerialisableMixin, MultivariateDistribution):
         The fitted margin models (each exposes ``ff``/``df``/``qf``).
     """
 
-    def __init__(self, copula, params, margins, data=None, how="given"):
+    def __init__(
+        self,
+        copula: Any,
+        params: npt.ArrayLike,
+        margins: Any,
+        data: Any = None,
+        how: str = "given",
+    ) -> None:
         self.copula = copula
         self.params = onp.atleast_1d(onp.asarray(params, dtype=float))
         self.margins = list(margins)
@@ -29,7 +39,9 @@ class CopulaModel(SerialisableMixin, MultivariateDistribution):
         self.method = how
 
     # -- internal ---------------------------------------------------------
-    def _uv(self, x):
+    def _uv(
+        self, x: npt.ArrayLike
+    ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
         x = onp.atleast_2d(onp.asarray(x, dtype=float))
         if x.shape[1] != 2:
             raise ValueError("x must have two columns (one per dimension)")
@@ -38,18 +50,18 @@ class CopulaModel(SerialisableMixin, MultivariateDistribution):
         return x, u, v
 
     # -- joint survival interface ----------------------------------------
-    def cdf(self, x):
+    def cdf(self, x: npt.ArrayLike) -> npt.NDArray:
         """Joint CDF ``P(X_1 <= x_1, X_2 <= x_2)``."""
         _, u, v = self._uv(x)
         return onp.asarray(self.copula.cdf(u, v, *self.params))
 
-    def sf(self, x):
+    def sf(self, x: npt.ArrayLike) -> npt.NDArray:
         """Joint survival ``P(X_1 > x_1, X_2 > x_2)``."""
         _, u, v = self._uv(x)
         c = onp.asarray(self.copula.cdf(u, v, *self.params))
         return 1.0 - u - v + c
 
-    def pdf(self, x):
+    def pdf(self, x: npt.ArrayLike) -> npt.NDArray:
         """Joint density ``c(F_1, F_2) f_1 f_2``."""
         x, u, v = self._uv(x)
         c = onp.asarray(self.copula.pdf(u, v, *self.params))
@@ -57,11 +69,13 @@ class CopulaModel(SerialisableMixin, MultivariateDistribution):
         f2 = onp.asarray(self.margins[1].df(x[:, 1]))
         return c * f1 * f2
 
-    def ff(self, x):
+    def ff(self, x: npt.ArrayLike) -> npt.NDArray:
         """Alias of :meth:`cdf` for consistency with surpyval naming."""
         return self.cdf(x)
 
-    def conditional_cdf(self, x, given_dim=0):
+    def conditional_cdf(
+        self, x: npt.ArrayLike, given_dim: int = 0
+    ) -> npt.NDArray:
         """``P(X_other <= x_other | X_d = x_d)`` -- the copula h-function."""
         x, u, v = self._uv(x)
         if given_dim == 0:
@@ -69,7 +83,11 @@ class CopulaModel(SerialisableMixin, MultivariateDistribution):
         return onp.asarray(self.copula.dv(u, v, *self.params))
 
     # -- sampling ---------------------------------------------------------
-    def random(self, size, random_state=None):
+    def random(
+        self,
+        size: "int | tuple[int, ...]",
+        random_state: "int | None" = None,
+    ) -> npt.NDArray:
         """Draw correlated samples; returns an array of shape ``(size, 2)``."""
         u, v = self.copula.sample_uv(size, self.params, random_state)
         x1 = onp.asarray(self.margins[0].qf(u))
@@ -77,17 +95,17 @@ class CopulaModel(SerialisableMixin, MultivariateDistribution):
         return onp.column_stack([x1, x2])
 
     # -- dependence summaries --------------------------------------------
-    def kendall_tau(self):
+    def kendall_tau(self) -> float:
         return self.copula.kendall_tau(*self.params)
 
-    def spearman_rho(self):
+    def spearman_rho(self) -> float:
         return self.copula.spearman_rho(*self.params)
 
-    def tail_dependence(self):
+    def tail_dependence(self) -> tuple:
         return self.copula.tail_dependence(*self.params)
 
     # -- serialisation ----------------------------------------------------
-    def to_dict(self):
+    def to_dict(self) -> dict:
         margins = []
         for m in self.margins:
             margins.append(m.to_dict() if hasattr(m, "to_dict") else None)
@@ -102,7 +120,7 @@ class CopulaModel(SerialisableMixin, MultivariateDistribution):
         )
 
     @classmethod
-    def from_dict(cls, model_dict):
+    def from_dict(cls, model_dict: dict) -> "CopulaModel":
         import surpyval
 
         from .archimedean import Clayton, Frank, Gumbel, Independence
@@ -134,7 +152,7 @@ class CopulaModel(SerialisableMixin, MultivariateDistribution):
             how=model_dict.get("how", "given"),
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         param_str = ", ".join(
             f"{n}={p:.4g}"
             for n, p in zip(self.copula.param_names, self.params)

--- a/surpyval/multivariate/parametric/copula/elliptical.py
+++ b/surpyval/multivariate/parametric/copula/elliptical.py
@@ -6,7 +6,10 @@ The Gaussian copula's CDF is the bivariate-normal CDF, which has no
 optimised on a ``tanh`` reparameterisation so the optimiser stays in range.
 """
 
+from typing import Any
+
 import numpy as onp
+import numpy.typing as npt
 from scipy.special import ndtr, ndtri
 from scipy.stats import multivariate_normal
 
@@ -23,10 +26,11 @@ class GaussianCopula(Copula):
     param_names = ("rho",)
 
     @staticmethod
-    def _clip_rho(rho):
+    def _clip_rho(rho: float) -> float:
         return float(onp.clip(rho, -_RHO_MAX, _RHO_MAX))
 
-    def cdf(self, u, v, rho):
+    # Named single parameter narrows the variadic base contract.
+    def cdf(self, u: Any, v: Any, rho: Any) -> Any:  # type: ignore[override]
         rho = self._clip_rho(rho)
         a = ndtri(onp.clip(onp.asarray(u, dtype=float), 1e-12, 1 - 1e-12))
         b = ndtri(onp.clip(onp.asarray(v, dtype=float), 1e-12, 1 - 1e-12))
@@ -35,16 +39,19 @@ class GaussianCopula(Copula):
         out = multivariate_normal.cdf(pts, mean=[0.0, 0.0], cov=cov)
         return onp.asarray(out).reshape(onp.asarray(a).shape)
 
-    def du(self, u, v, rho):
+    # Named single parameter narrows the variadic base contract.
+    def du(self, u: Any, v: Any, rho: Any) -> Any:  # type: ignore[override]
         rho = self._clip_rho(rho)
         a = ndtri(onp.clip(onp.asarray(u, dtype=float), 1e-12, 1 - 1e-12))
         b = ndtri(onp.clip(onp.asarray(v, dtype=float), 1e-12, 1 - 1e-12))
         return ndtr((b - rho * a) / onp.sqrt(1.0 - rho**2))
 
-    def dv(self, u, v, rho):
+    # Named single parameter narrows the variadic base contract.
+    def dv(self, u: Any, v: Any, rho: Any) -> Any:  # type: ignore[override]
         return self.du(v, u, rho)
 
-    def pdf(self, u, v, rho):
+    # Named single parameter narrows the variadic base contract.
+    def pdf(self, u: Any, v: Any, rho: Any) -> Any:  # type: ignore[override]
         rho = self._clip_rho(rho)
         a = ndtri(onp.clip(onp.asarray(u, dtype=float), 1e-12, 1 - 1e-12))
         b = ndtri(onp.clip(onp.asarray(v, dtype=float), 1e-12, 1 - 1e-12))
@@ -52,13 +59,18 @@ class GaussianCopula(Copula):
         quad = (rho**2 * (a**2 + b**2) - 2.0 * rho * a * b) / (2.0 * denom)
         return onp.exp(-quad) / onp.sqrt(denom)
 
-    def kendall_tau(self, rho):
+    def kendall_tau(self, rho: float) -> float:  # type: ignore[override]
         return 2.0 / onp.pi * onp.arcsin(self._clip_rho(rho))
 
-    def spearman_rho(self, rho):
+    def spearman_rho(self, rho: float) -> float:  # type: ignore[override]
         return 6.0 / onp.pi * onp.arcsin(self._clip_rho(rho) / 2.0)
 
-    def sample_uv(self, size, params, random_state=None):
+    def sample_uv(
+        self,
+        size: int,
+        params: Any,
+        random_state: "int | None" = None,
+    ) -> tuple[npt.NDArray, npt.NDArray]:
         rho = self._clip_rho(params[0])
         rng = onp.random.default_rng(random_state)
         z1 = rng.standard_normal(size)
@@ -66,17 +78,17 @@ class GaussianCopula(Copula):
         z2 = rho * z1 + onp.sqrt(1.0 - rho**2) * z2
         return ndtr(z1), ndtr(z2)
 
-    def _bounds_transforms(self):
+    def _bounds_transforms(self) -> tuple:
         # tanh keeps rho strictly inside (-1, 1) during optimisation.
-        def to_unbounded(params):
+        def to_unbounded(params: npt.NDArray) -> npt.NDArray:
             return onp.arctanh(onp.clip(params, -_RHO_MAX, _RHO_MAX))
 
-        def to_bounded(phi):
+        def to_bounded(phi: npt.NDArray) -> npt.NDArray:
             return onp.tanh(onp.asarray(phi, dtype=float))
 
         return to_unbounded, to_bounded
 
-    def _init_theta(self, dims):
+    def _init_theta(self, dims: list) -> npt.NDArray:
         return onp.asarray([onp.sin(onp.pi / 2.0 * self._emp_tau(dims))])
 
 

--- a/surpyval/multivariate/parametric/data.py
+++ b/surpyval/multivariate/parametric/data.py
@@ -15,6 +15,7 @@ truncation window ``t`` apply to the whole row.
 """
 
 import numpy as np
+import numpy.typing as npt
 
 
 class MultivariateSurpyvalData:
@@ -37,7 +38,15 @@ class MultivariateSurpyvalData:
         Interval-censoring bounds, required where ``c == 2``.
     """
 
-    def __init__(self, x, c=None, n=None, t=None, xl=None, xr=None):
+    def __init__(
+        self,
+        x: npt.ArrayLike,
+        c: "npt.ArrayLike | None" = None,
+        n: "npt.ArrayLike | None" = None,
+        t: "npt.ArrayLike | None" = None,
+        xl: "npt.ArrayLike | None" = None,
+        xr: "npt.ArrayLike | None" = None,
+    ) -> None:
         x = self._as_2d(x)
         N, D = x.shape
 
@@ -87,7 +96,7 @@ class MultivariateSurpyvalData:
         self.D = D
 
     @staticmethod
-    def _as_2d(x):
+    def _as_2d(x: npt.ArrayLike) -> npt.NDArray:
         # A list/tuple is read as a sequence of per-dimension (column)
         # vectors; an ndarray is taken as already row-by-dimension.
         if isinstance(x, (list, tuple)):
@@ -98,7 +107,7 @@ class MultivariateSurpyvalData:
                 x = x.reshape(-1, 1)
         return x
 
-    def dimension(self, d):
+    def dimension(self, d: int) -> tuple:
         """Return ``(x, c, xl, xr, tl, tr)`` arrays for series ``d``."""
         return (
             self.x[:, d],

--- a/surpyval/recurrent/competing_risks/nonparametric/cause_specific_mcf.py
+++ b/surpyval/recurrent/competing_risks/nonparametric/cause_specific_mcf.py
@@ -12,7 +12,11 @@ See ``surpyval.univariate.competing_risks`` for the univariate
 (time-to-first-event) competing-risks models.
 """
 
+from typing import Any
+
+import numpy as np
 from matplotlib import pyplot as plt
+from numpy.typing import ArrayLike
 
 from surpyval.recurrent.nonparametric.mcf import NonParametricCounting
 from surpyval.serialisation import SerialisableMixin, stamp_schema, to_native
@@ -22,10 +26,14 @@ from surpyval.utils.recurrent_utils import (
 )
 
 
-def _counting_model_from_xrd(x, r, d):
+def _counting_model_from_xrd(
+    x: np.ndarray, r: np.ndarray, d: np.ndarray
+) -> Any:
     """Single-cause ``NonParametricCounting`` from an ``(x, r, d)``
     triple; delegates to the one shared estimator."""
-    return type(NonParametricCounting).from_xrd(x, r, d)
+    # ``from_xrd`` is a classmethod, so calling it through the
+    # singleton instance binds the class exactly as ``type(...)`` did.
+    return NonParametricCounting.from_xrd(x, r, d)
 
 
 class CauseSpecificMCF(SerialisableMixin):
@@ -38,12 +46,20 @@ class CauseSpecificMCF(SerialisableMixin):
     ``self.models[cause]`` or use the convenience methods below.
     """
 
-    def __repr__(self):
+    # Populated by the fit classmethods; declared for the type checker.
+    df: Any
+    data: Any
+    event_types: list
+    models: dict
+    x: "np.ndarray"
+    r: "np.ndarray"
+
+    def __repr__(self) -> str:
         return "Cause-specific MCF with causes: {}".format(self.event_types)
 
     # -- serialisation -----------------------------------------------------
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         """
         Serialise this fitted cause-specific MCF to a plain, JSON-serialisable
         dict: the list of event types and each cause's per-cause MCF estimate.
@@ -63,7 +79,7 @@ class CauseSpecificMCF(SerialisableMixin):
         )
 
     @classmethod
-    def from_dict(cls, model_dict):
+    def from_dict(cls, model_dict: dict) -> "CauseSpecificMCF":
         """
         Rebuild a cause-specific MCF from a :meth:`to_dict` dictionary.
 
@@ -83,15 +99,22 @@ class CauseSpecificMCF(SerialisableMixin):
         }
         return out
 
-    def mcf(self, x, cause, interp="step"):
+    def mcf(
+        self, x: ArrayLike, cause: Any, interp: str = "step"
+    ) -> np.ndarray:
         """Cause-specific MCF evaluated at ``x`` for the given ``cause``."""
         return self.models[cause].mcf(x, interp=interp)
 
-    def mcf_cb(self, x, cause, **kwargs):
+    def mcf_cb(self, x: ArrayLike, cause: Any, **kwargs: Any) -> Any:
         """Confidence bounds on the cause-specific MCF for ``cause``."""
         return self.models[cause].mcf_cb(x, **kwargs)
 
-    def plot(self, confidence=0.95, plot_bounds=True, ax=None):
+    def plot(
+        self,
+        confidence: float = 0.95,
+        plot_bounds: bool = True,
+        ax: Any = None,
+    ) -> Any:
         """Overlay the MCF of every cause on a single axis."""
         if ax is None:
             ax = plt.gcf().gca()
@@ -102,7 +125,7 @@ class CauseSpecificMCF(SerialisableMixin):
         return ax
 
     @classmethod
-    def fit_from_recurrent_data(cls, data):
+    def fit_from_recurrent_data(cls, data: Any) -> "CauseSpecificMCF":
         if data.e is None:
             raise ValueError(
                 "RecurrentEventData has no event-type marks; pass `e` to "
@@ -120,7 +143,16 @@ class CauseSpecificMCF(SerialisableMixin):
         return out
 
     @classmethod
-    def fit(cls, x, i=None, c=None, n=None, e=None, tl=None, tr=None):
+    def fit(
+        cls,
+        x: ArrayLike,
+        i: "ArrayLike | None" = None,
+        c: "ArrayLike | None" = None,
+        n: "ArrayLike | None" = None,
+        e: "ArrayLike | None" = None,
+        tl: "ArrayLike | None" = None,
+        tr: "ArrayLike | None" = None,
+    ) -> "CauseSpecificMCF":
         """
         Fit a cause-specific MCF.
 
@@ -160,15 +192,15 @@ class CauseSpecificMCF(SerialisableMixin):
     @classmethod
     def fit_from_df(
         cls,
-        df,
-        x_col,
-        e_col,
-        i_col=None,
-        c_col=None,
-        n_col=None,
-        tl_col=None,
-        tr_col=None,
-    ):
+        df: Any,
+        x_col: str,
+        e_col: str,
+        i_col: "str | None" = None,
+        c_col: "str | None" = None,
+        n_col: "str | None" = None,
+        tl_col: "str | None" = None,
+        tr_col: "str | None" = None,
+    ) -> "CauseSpecificMCF":
         """
         Fit a cause-specific MCF from a :class:`pandas.DataFrame`, naming the
         columns to read.
@@ -196,7 +228,7 @@ class CauseSpecificMCF(SerialisableMixin):
         CauseSpecificMCF
         """
 
-        def col(name):
+        def col(name: "str | None") -> Any:
             return None if name is None else df[name].to_numpy()
 
         model = cls.fit(

--- a/surpyval/recurrent/competing_risks/parametric/cause_specific_nhpp.py
+++ b/surpyval/recurrent/competing_risks/parametric/cause_specific_nhpp.py
@@ -19,7 +19,11 @@ reuses the whole intensity-fitting, inference and diagnostic machinery
 unchanged.
 """
 
+from typing import Any
+
+import numpy as np
 from matplotlib import pyplot as plt
+from numpy.typing import ArrayLike
 
 from surpyval.recurrent.parametric.crow_amsaa import CrowAMSAA
 from surpyval.recurrent.parametric.parametric_recurrence import (
@@ -43,14 +47,22 @@ class CauseSpecificNHPP(SerialisableMixin):
     diagnostic behaviour -- or use the convenience methods below.
     """
 
-    def __repr__(self):
+    # Populated by the fit classmethods; declared for the type checker.
+    df: Any
+    data: Any
+    event_types: list
+    models: dict
+    dist: Any
+    how: str
+
+    def __repr__(self) -> str:
         return "Cause-specific {} with causes: {}".format(
             self.dist.name, self.event_types
         )
 
     # -- serialisation -----------------------------------------------------
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         """
         Serialise this fitted cause-specific NHPP to a plain,
         JSON-serialisable dict: the shared intensity model's name, the list of
@@ -72,7 +84,7 @@ class CauseSpecificNHPP(SerialisableMixin):
         )
 
     @classmethod
-    def from_dict(cls, model_dict):
+    def from_dict(cls, model_dict: dict) -> "CauseSpecificNHPP":
         """
         Rebuild a cause-specific NHPP from a :meth:`to_dict` dictionary.
 
@@ -97,7 +109,7 @@ class CauseSpecificNHPP(SerialisableMixin):
     # --- per-item observation windows ------------------------------------
 
     @staticmethod
-    def _item_window(data, item):
+    def _item_window(data: Any, item: Any) -> tuple:
         """The ``(entry, end)`` observation window of a single item.
 
         Entry is the item's left-truncation bound (delayed entry). The end is
@@ -120,8 +132,12 @@ class CauseSpecificNHPP(SerialisableMixin):
 
     @classmethod
     def fit_from_recurrent_data(
-        cls, data, dist=CrowAMSAA, how="MLE", init=None
-    ):
+        cls,
+        data: Any,
+        dist: Any = CrowAMSAA,
+        how: str = "MLE",
+        init: "ArrayLike | None" = None,
+    ) -> "CauseSpecificNHPP":
         """
         Fit the cause-specific intensity model from prepared
         :class:`RecurrentEventData` carrying event-type marks ``e``.
@@ -198,17 +214,17 @@ class CauseSpecificNHPP(SerialisableMixin):
     @classmethod
     def fit(
         cls,
-        x,
-        i=None,
-        c=None,
-        n=None,
-        e=None,
-        tl=None,
-        tr=None,
-        dist=CrowAMSAA,
-        how="MLE",
-        init=None,
-    ):
+        x: ArrayLike,
+        i: "ArrayLike | None" = None,
+        c: "ArrayLike | None" = None,
+        n: "ArrayLike | None" = None,
+        e: "ArrayLike | None" = None,
+        tl: "ArrayLike | None" = None,
+        tr: "ArrayLike | None" = None,
+        dist: Any = CrowAMSAA,
+        how: str = "MLE",
+        init: "ArrayLike | None" = None,
+    ) -> "CauseSpecificNHPP":
         """
         Fit a cause-specific intensity model.
 
@@ -250,24 +266,24 @@ class CauseSpecificNHPP(SerialisableMixin):
     @classmethod
     def fit_from_df(
         cls,
-        df,
-        x_col,
-        e_col,
-        i_col=None,
-        c_col=None,
-        n_col=None,
-        tl_col=None,
-        tr_col=None,
-        dist=CrowAMSAA,
-        how="MLE",
-        init=None,
-    ):
+        df: Any,
+        x_col: str,
+        e_col: str,
+        i_col: "str | None" = None,
+        c_col: "str | None" = None,
+        n_col: "str | None" = None,
+        tl_col: "str | None" = None,
+        tr_col: "str | None" = None,
+        dist: Any = CrowAMSAA,
+        how: str = "MLE",
+        init: "ArrayLike | None" = None,
+    ) -> "CauseSpecificNHPP":
         """
         Fit a cause-specific intensity model from a :class:`pandas.DataFrame`,
         naming the columns to read. See :meth:`fit` for the meaning of each.
         """
 
-        def col(name):
+        def col(name: "str | None") -> Any:
             return None if name is None else df[name].to_numpy()
 
         model = cls.fit(
@@ -287,7 +303,7 @@ class CauseSpecificNHPP(SerialisableMixin):
 
     # --- evaluation ------------------------------------------------------
 
-    def _check_cause(self, cause):
+    def _check_cause(self, cause: Any) -> None:
         if cause not in self.models:
             raise ValueError(
                 "Unrecognised cause {!r}; known causes are {}".format(
@@ -295,36 +311,35 @@ class CauseSpecificNHPP(SerialisableMixin):
                 )
             )
 
-    def cif(self, x, cause):
+    def cif(self, x: ArrayLike, cause: Any) -> np.ndarray:
         """Cause-specific cumulative intensity (expected ``cause`` count)."""
         self._check_cause(cause)
         return self.models[cause].cif(x)
 
-    def iif(self, x, cause):
+    def iif(self, x: ArrayLike, cause: Any) -> np.ndarray:
         """Cause-specific instantaneous intensity for ``cause``."""
         self._check_cause(cause)
         return self.models[cause].iif(x)
 
-    def mcf(self, x, cause):
+    def mcf(self, x: ArrayLike, cause: Any) -> np.ndarray:
         """Cause-specific mean cumulative function (alias of :meth:`cif`)."""
         return self.cif(x, cause)
 
-    def total_cif(self, x):
+    def total_cif(self, x: ArrayLike) -> np.ndarray:
         """
         Total cumulative intensity across all causes -- the expected number of
         events of any type, which (the causes being independent thinnings of
         the overall process) is the sum of the cause-specific intensities.
         """
-        total = None
+        total: "np.ndarray | None" = None
         for cause in self.event_types:
             contribution = self.models[cause].cif(x)
             total = contribution if total is None else total + contribution
+        assert total is not None  # event_types is never empty on a fit model
         return total
 
-    def plot(self, ax=None):
+    def plot(self, ax: Any = None) -> Any:
         """Overlay the fitted cause-specific CIFs on a single axis."""
-        import numpy as np
-
         if ax is None:
             ax = plt.gcf().gca()
         x_plot = np.linspace(0, float(self.data.x.max()), 200)

--- a/surpyval/recurrent/diagnostics.py
+++ b/surpyval/recurrent/diagnostics.py
@@ -22,11 +22,13 @@ and are exposed as methods on ``ParametricRecurrenceModel``.
 """
 
 import warnings
+from typing import Any, Callable
 
 import numpy as np
+from numpy.typing import ArrayLike
 
 
-def _validate_diagnostic_data(data, what):
+def _validate_diagnostic_data(data: Any, what: str) -> None:
     """
     The diagnostics need exact event times: interval-censored (2D ``x`` or
     ``c == 2``) and left-censored (``c == -1``) observations cannot be
@@ -44,7 +46,7 @@ def _validate_diagnostic_data(data, what):
         )
 
 
-def _per_item_windows(data):
+def _per_item_windows(data: Any) -> list:
     """
     Group the data by item and resolve each item's observation window.
 
@@ -79,7 +81,7 @@ def _per_item_windows(data):
     return items
 
 
-def _as_item_cif(cif):
+def _as_item_cif(cif: Any) -> Callable:
     """
     Normalise the ``cif`` argument of the diagnostics into a factory that
     maps an item identifier to that item's CIF callable. A plain callable
@@ -92,7 +94,7 @@ def _as_item_cif(cif):
     return lambda item: cif[item]
 
 
-def cumulative_hazard_residuals(data, cif):
+def cumulative_hazard_residuals(data: Any, cif: Any) -> np.ndarray:
     """
     Rescaled interarrival times ``cif(t_k) - cif(t_{k-1})`` for every
     observed event (with ``t_0`` each item's entry time), pooled across
@@ -116,7 +118,7 @@ def cumulative_hazard_residuals(data, cif):
     return np.concatenate(residuals)
 
 
-def martingale_residuals(data, cif):
+def martingale_residuals(data: Any, cif: Any) -> np.ndarray:
     """
     Per-item martingale residuals: the observed event count minus the
     expected count ``cif(close) - cif(entry)`` over the item's observation
@@ -158,14 +160,21 @@ class GoodnessOfFitResult:
         The number of systems (items) in the data.
     """
 
-    def __init__(self, statistic, p_value, n_boot, n_events, n_systems):
+    def __init__(
+        self,
+        statistic: float,
+        p_value: float,
+        n_boot: int,
+        n_events: int,
+        n_systems: int,
+    ) -> None:
         self.statistic = statistic
         self.p_value = p_value
         self.n_boot = n_boot
         self.n_events = n_events
         self.n_systems = n_systems
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         title = "Cramer-von Mises Goodness-of-Fit Test"
         return "\n".join(
             [
@@ -180,7 +189,7 @@ class GoodnessOfFitResult:
         )
 
 
-def _conditional_uniforms(data, cif):
+def _conditional_uniforms(data: Any, cif: Any) -> tuple[np.ndarray, int]:
     """
     The conditionally-uniform transforms behind the Cramer-von Mises
     statistic, pooled across items. For a time-truncated item every event
@@ -212,7 +221,9 @@ def _conditional_uniforms(data, cif):
     return np.concatenate(u), n_systems
 
 
-def trend_test(data, test="laplace", alternative="two-sided"):
+def trend_test(
+    data: Any, test: str = "laplace", alternative: str = "two-sided"
+) -> Any:
     """
     Trend test for recurrent-event data: the null hypothesis is that the
     events follow a *homogeneous* Poisson process (no trend), so it checks
@@ -249,7 +260,7 @@ def trend_test(data, test="laplace", alternative="two-sided"):
     return tests[test](x, i=i, T=T, alternative=alternative)
 
 
-def cvm_statistic(u):
+def cvm_statistic(u: ArrayLike) -> float:
     """
     The Cramer-von Mises statistic ``1/(12M) + sum_j (u_(j) -
     (2j - 1)/(2M))^2`` of a sample ``u`` against the standard uniform.
@@ -260,7 +271,9 @@ def cvm_statistic(u):
     return float(1.0 / (12.0 * m) + np.sum((u - (2 * j - 1) / (2 * m)) ** 2))
 
 
-def _renewal_conditional_uniforms(data, increments):
+def _renewal_conditional_uniforms(
+    data: Any, increments: np.ndarray
+) -> tuple[np.ndarray, int]:
     """
     The conditionally-uniform transforms behind the Cramer-von Mises statistic
     for a renewal / virtual-age process, which has no marginal cumulative
@@ -298,8 +311,13 @@ def _renewal_conditional_uniforms(data, increments):
 
 
 def _cvm_pvalue(
-    data, payload, simulate_refit, n_boot, seed, uniforms=_conditional_uniforms
-):
+    data: Any,
+    payload: Any,
+    simulate_refit: Callable,
+    n_boot: int,
+    seed: "int | None",
+    uniforms: Callable = _conditional_uniforms,
+) -> "GoodnessOfFitResult":
     """
     Shared Cramer-von Mises core: the observed statistic comes from the
     conditionally-uniform transforms of ``data`` under ``payload`` (computed
@@ -316,7 +334,7 @@ def _cvm_pvalue(
     observed = cvm_statistic(u)
 
     rng = np.random.default_rng(seed)
-    statistics = []
+    statistics: list = []
     failures = 0
     while len(statistics) < n_boot and failures < 2 * n_boot:
         try:
@@ -342,20 +360,27 @@ def _cvm_pvalue(
             "dropped.".format(failures)
         )
 
-    statistics = np.asarray(statistics)
+    stats_arr = np.asarray(statistics)
     p_value = float(
-        (1.0 + np.sum(statistics >= observed)) / (statistics.size + 1.0)
+        (1.0 + np.sum(stats_arr >= observed)) / (stats_arr.size + 1.0)
     )
     return GoodnessOfFitResult(
         statistic=observed,
         p_value=p_value,
-        n_boot=int(statistics.size),
+        n_boot=int(stats_arr.size),
         n_events=int(u.size),
         n_systems=n_systems,
     )
 
 
-def _simulate_window(rng, entry, close, span, e0, inv_cif):
+def _simulate_window(
+    rng: Any,
+    entry: float,
+    close: float,
+    span: float,
+    e0: float,
+    inv_cif: Callable,
+) -> tuple[np.ndarray, float]:
     """
     Simulate one item's window from the fitted intensity: the event count over
     ``[entry, close]`` is Poisson with mean ``span`` and the times are the
@@ -367,7 +392,9 @@ def _simulate_window(rng, entry, close, span, e0, inv_cif):
     return times, close
 
 
-def cramer_von_mises(model, n_boot=200, seed=None):
+def cramer_von_mises(
+    model: Any, n_boot: int = 200, seed: "int | None" = None
+) -> "GoodnessOfFitResult":
     """
     Cramer-von Mises goodness-of-fit test of a fitted parametric recurrent
     model; see :meth:`ParametricRecurrenceModel.cramer_von_mises` for the
@@ -390,7 +417,7 @@ def cramer_von_mises(model, n_boot=200, seed=None):
         )
     windows = _per_item_windows(data)
 
-    def simulate_refit(rng):
+    def simulate_refit(rng: Any) -> tuple:
         x_b, i_b, c_b, tl_b = [], [], [], []
         for item_id, (_, _, entry, close, _) in enumerate(windows):
             span = float(model.cif(close) - model.cif(entry))
@@ -417,7 +444,9 @@ def cramer_von_mises(model, n_boot=200, seed=None):
     return _cvm_pvalue(data, model.cif, simulate_refit, n_boot, seed)
 
 
-def cramer_von_mises_regression(model, n_boot=200, seed=None):
+def cramer_von_mises_regression(
+    model: Any, n_boot: int = 200, seed: "int | None" = None
+) -> "GoodnessOfFitResult":
     """
     Cramer-von Mises goodness-of-fit test of a fitted proportional-intensity
     regression model; see
@@ -441,7 +470,7 @@ def cramer_von_mises_regression(model, n_boot=200, seed=None):
     item_cif = model._item_cif_map()
     windows = _per_item_windows(data)
 
-    def simulate_refit(rng):
+    def simulate_refit(rng: Any) -> tuple:
         x_b, i_b, c_b, tl_b, Z_b = [], [], [], [], []
         for item_id, (item, _, entry, close, _) in enumerate(windows):
             Z_item = Z_by_item[item]
@@ -487,7 +516,9 @@ def cramer_von_mises_regression(model, n_boot=200, seed=None):
     return _cvm_pvalue(data, item_cif, simulate_refit, n_boot, seed)
 
 
-def cramer_von_mises_renewal(model, n_boot=200, seed=None):
+def cramer_von_mises_renewal(
+    model: Any, n_boot: int = 200, seed: "int | None" = None
+) -> "GoodnessOfFitResult":
     """
     Cramer-von Mises goodness-of-fit test of a fitted renewal / virtual-age
     imperfect-repair model; see :meth:`RenewalModel.cramer_von_mises` for the
@@ -514,7 +545,7 @@ def cramer_von_mises_renewal(model, n_boot=200, seed=None):
         int((data.c[data.i == item] == 0).sum()) for item in np.unique(data.i)
     ]
 
-    def simulate_refit(rng):
+    def simulate_refit(rng: Any) -> tuple:
         x_b, i_b = [], []
         new_id = 0
         for count in counts:

--- a/surpyval/recurrent/inference.py
+++ b/surpyval/recurrent/inference.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Any, Callable
 
 import numpy as np
 
@@ -35,14 +36,21 @@ class LikelihoodInferenceMixin:
     returned as NaN with a warning.
     """
 
-    def _check_fitted(self):
+    # Supplied by the fitting routine (see the class docstring); declared
+    # here so the checker knows their types on the host class.
+    _neg_ll: Callable
+    _mle: np.ndarray
+    _n_obs: int
+    _fitter: Any
+
+    def _check_fitted(self) -> None:
         if not hasattr(self, "_neg_ll"):
             raise ValueError(
                 "Inference is only available for models fitted from data; "
                 "fit_from_parameters does not compute a likelihood."
             )
 
-    def _parameter_names(self):
+    def _parameter_names(self) -> list:
         """
         Names of the entries of ``_mle``, in order. Subclasses override this to
         label their parameters (e.g. the renewal models prepend the restoration
@@ -51,28 +59,28 @@ class LikelihoodInferenceMixin:
         raise NotImplementedError
 
     @property
-    def parameter_names(self):
+    def parameter_names(self) -> list:
         self._check_fitted()
         return list(self._parameter_names())
 
     @property
-    def log_likelihood(self):
+    def log_likelihood(self) -> float:
         self._check_fitted()
         return -float(self._neg_ll(self._mle))
 
     @property
-    def aic(self):
+    def aic(self) -> float:
         self._check_fitted()
         k = self._mle.size
         return 2.0 * k - 2.0 * self.log_likelihood
 
     @property
-    def bic(self):
+    def bic(self) -> float:
         self._check_fitted()
         k = self._mle.size
         return k * np.log(self._n_obs) - 2.0 * self.log_likelihood
 
-    def covariance(self):
+    def covariance(self) -> np.ndarray:
         """
         Approximate parameter covariance matrix, ordered to match
         :attr:`parameter_names`. Computed as the inverse of the numerical
@@ -93,7 +101,7 @@ class LikelihoodInferenceMixin:
             warnings.warn("Hessian is singular; covariance is unavailable.")
             return np.full((n, n), np.nan)
 
-    def standard_errors(self):
+    def standard_errors(self) -> np.ndarray:
         """
         Standard errors of the fitted parameters (the square roots of the
         diagonal of :meth:`covariance`), ordered to match
@@ -110,7 +118,7 @@ class LikelihoodInferenceMixin:
             )
         return se
 
-    def _parameter_bounds(self):
+    def _parameter_bounds(self) -> list:
         """
         Natural-space ``(lower, upper)`` bounds for each entry of ``_mle``,
         ordered to match :attr:`parameter_names`. Subclasses override this so
@@ -119,7 +127,12 @@ class LikelihoodInferenceMixin:
         """
         return [(None, None)] * self._mle.size
 
-    def param_cb(self, name, alpha_ci=0.05, bound="two-sided"):
+    def param_cb(
+        self,
+        name: str,
+        alpha_ci: float = 0.05,
+        bound: str = "two-sided",
+    ) -> np.ndarray:
         """
         Confidence bound(s) on a fitted parameter, mirroring the univariate
         ``Parametric.param_cb`` API.

--- a/surpyval/recurrent/nonparametric/mcf.py
+++ b/surpyval/recurrent/nonparametric/mcf.py
@@ -28,7 +28,8 @@ class NonParametricCounting(SerialisableMixin):
     r: npt.NDArray
     d: npt.NDArray
     mcf_hat: npt.NDArray
-    var: npt.NDArray
+    #: ``None`` on simulated models, which carry no variance.
+    var: "npt.NDArray | None"
     data: RecurrentEventData
 
     # -- serialisation -----------------------------------------------------
@@ -139,6 +140,11 @@ class NonParametricCounting(SerialisableMixin):
             # parametric cif_cb (#285).
             stat = np.array([1, -1]).reshape(2, 1) * stat
 
+        if self.var is None:
+            raise ValueError(
+                "This model carries no variance (a simulated MCF), so "
+                "confidence bounds are unavailable."
+            )
         if bound_type == "exp":
             # Exponential Greenwood confidence
             mcf_cb = self.mcf_hat * np.exp(

--- a/surpyval/recurrent/parametric/counting_process.py
+++ b/surpyval/recurrent/parametric/counting_process.py
@@ -1,6 +1,14 @@
 from abc import ABC, abstractmethod
 
-from numpy.typing import ArrayLike
+import numpy.typing as npt
+from autograd.numpy.numpy_boxes import ArrayBox
+
+# The NHPP likelihoods differentiate these functions with autograd, so a
+# parameter (and hence any value computed from one) may be a plain array,
+# a float, or an autograd ArrayBox -- the same union the univariate
+# distributions use. ``ArrayLike`` would be a trap here: it admits str
+# and bytes, so the concrete models' arithmetic would not type check.
+Boxable = npt.NDArray | float | ArrayBox
 
 
 class CountingProcess(ABC):
@@ -24,18 +32,21 @@ class CountingProcess(ABC):
     process.
     """
 
+    #: Names of the model's parameters (see the class docstring).
+    param_names: list
+
     @abstractmethod
-    def iif(self, x: ArrayLike, *params: ArrayLike) -> ArrayLike:
+    def iif(self, x: Boxable, *params: Boxable) -> Boxable:
         """Instantaneous intensity function (event rate) at ``x``."""
         ...
 
     @abstractmethod
-    def cif(self, x: ArrayLike, *params: ArrayLike) -> ArrayLike:
+    def cif(self, x: Boxable, *params: Boxable) -> Boxable:
         """Cumulative intensity (expected event count) by ``x``."""
         ...
 
     @abstractmethod
-    def log_iif(self, x: ArrayLike, *params: ArrayLike) -> ArrayLike:
+    def log_iif(self, x: Boxable, *params: Boxable) -> Boxable:
         """Natural logarithm of the instantaneous intensity at ``x``."""
         ...
 
@@ -66,11 +77,11 @@ class IntensityModel(CountingProcess):
     """
 
     @abstractmethod
-    def inv_cif(self, N: ArrayLike, *params: ArrayLike) -> ArrayLike:
+    def inv_cif(self, N: Boxable, *params: Boxable) -> Boxable:
         """Time by which ``N`` events are expected; the inverse of ``cif``."""
         ...
 
     @abstractmethod
-    def parameter_initialiser(self, x: ArrayLike) -> ArrayLike:
+    def parameter_initialiser(self, x: npt.ArrayLike) -> npt.NDArray:
         """Starting parameter vector for the optimiser given event times."""
         ...

--- a/surpyval/recurrent/parametric/cox_lewis.py
+++ b/surpyval/recurrent/parametric/cox_lewis.py
@@ -1,5 +1,7 @@
 import numpy as np
+import numpy.typing as npt
 
+from surpyval.recurrent.parametric.counting_process import Boxable
 from surpyval.utils.fitter import singleton_fitter
 
 from .nhpp_fitter import NHPPFitter
@@ -42,7 +44,7 @@ class CoxLewis(NHPPFitter):
            3.00754742])
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.name = "Cox-Lewis"
         self.param_names = ["alpha", "beta"]
         # alpha is the *log*-intensity intercept and is legitimately
@@ -52,27 +54,27 @@ class CoxLewis(NHPPFitter):
         self.bounds = ((None, None), (None, None))
         self.support = (0.0, np.inf)
 
-    def parameter_initialiser(self, x):
+    def parameter_initialiser(self, x: npt.ArrayLike) -> npt.NDArray:
         return np.array([1.0, 1.0])
 
-    def cif(self, x, *params):
+    def cif(self, x: Boxable, *params: Boxable) -> Boxable:
         # The Cox-Lewis intensity is log-linear, so its cumulative intensity
         # is the integral of ``exp(alpha + beta * x)`` from 0 to ``x``.
         alpha = params[0]
         beta = params[1]
         return np.exp(alpha) / beta * (np.exp(beta * x) - 1.0)
 
-    def iif(self, x, *params):
+    def iif(self, x: Boxable, *params: Boxable) -> Boxable:
         alpha = params[0]
         beta = params[1]
         return np.exp(alpha + beta * x)
 
-    def log_iif(self, x, *params):
+    def log_iif(self, x: Boxable, *params: Boxable) -> Boxable:
         alpha = params[0]
         beta = params[1]
         return alpha + beta * x
 
-    def inv_cif(self, N, *params):
+    def inv_cif(self, N: Boxable, *params: Boxable) -> Boxable:
         alpha = params[0]
         beta = params[1]
         # For an improving system (beta < 0) the cumulative intensity is

--- a/surpyval/recurrent/parametric/crow_amsaa.py
+++ b/surpyval/recurrent/parametric/crow_amsaa.py
@@ -1,5 +1,7 @@
 import numpy as np
+import numpy.typing as npt
 
+from surpyval.recurrent.parametric.counting_process import Boxable
 from surpyval.utils.fitter import singleton_fitter
 
 from .nhpp_fitter import NHPPFitter
@@ -42,31 +44,31 @@ class CrowAMSAA(NHPPFitter):
            2714.78099355, 3071.15581638])
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.name = "Crow-AMSAA"
         self.param_names = ["alpha", "beta"]
         self.bounds = ((0, None), (None, None))
         self.support = (0.0, np.inf)
 
-    def parameter_initialiser(self, x):
+    def parameter_initialiser(self, x: npt.ArrayLike) -> npt.NDArray:
         return np.array([1.0, 1.0])
 
-    def cif(self, x, *params):
+    def cif(self, x: Boxable, *params: Boxable) -> Boxable:
         alpha = params[0]
         beta = params[1]
         return (x / alpha) ** beta
 
-    def iif(self, x, *params):
+    def iif(self, x: Boxable, *params: Boxable) -> Boxable:
         alpha = params[0]
         beta = params[1]
         return (beta / alpha**beta) * (x ** (beta - 1))
 
-    def log_iif(self, x, *params):
+    def log_iif(self, x: Boxable, *params: Boxable) -> Boxable:
         alpha = params[0]
         beta = params[1]
         return np.log(beta) - beta * np.log(alpha) + (beta - 1) * np.log(x)
 
-    def inv_cif(self, N, *params):
+    def inv_cif(self, N: Boxable, *params: Boxable) -> Boxable:
         alpha = params[0]
         beta = params[1]
         return alpha * (N ** (1.0 / beta))

--- a/surpyval/recurrent/parametric/duane.py
+++ b/surpyval/recurrent/parametric/duane.py
@@ -1,5 +1,7 @@
 import numpy as np
+import numpy.typing as npt
 
+from surpyval.recurrent.parametric.counting_process import Boxable
 from surpyval.utils.fitter import singleton_fitter
 
 from .nhpp_fitter import NHPPFitter
@@ -42,25 +44,25 @@ class Duane(NHPPFitter):
            2714.87871658, 3071.25832646])
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.name = "Duane"
         self.param_names = ["alpha", "b"]
         self.bounds = ((0, None), (0, None))
         self.support = (0.0, np.inf)
 
-    def parameter_initialiser(self, x):
+    def parameter_initialiser(self, x: npt.ArrayLike) -> npt.NDArray:
         return np.array([1.0, 1.0])
 
-    def cif(self, x, *params):
+    def cif(self, x: Boxable, *params: Boxable) -> Boxable:
         return params[1] * x ** params[0]
 
-    def iif(self, x, *params):
+    def iif(self, x: Boxable, *params: Boxable) -> Boxable:
         return params[0] * params[1] * x ** (params[0] - 1.0)
 
-    def log_iif(self, x, *params):
+    def log_iif(self, x: Boxable, *params: Boxable) -> Boxable:
         return (
             np.log(params[0]) + np.log(params[1]) + (params[0] - 1) * np.log(x)
         )
 
-    def inv_cif(self, N, *params):
+    def inv_cif(self, N: Boxable, *params: Boxable) -> Boxable:
         return (N / params[1]) ** (1.0 / params[0])

--- a/surpyval/recurrent/parametric/hpp.py
+++ b/surpyval/recurrent/parametric/hpp.py
@@ -1,14 +1,21 @@
+from typing import Any, Callable
+
 import numpy as np
 from autograd import hessian, jacobian
 from autograd import numpy as anp
+from numpy.typing import ArrayLike
 from scipy.optimize import root
 from scipy.special import gammaln
 
-from surpyval.recurrent.parametric.counting_process import CountingProcess
+from surpyval.recurrent.parametric.counting_process import (
+    Boxable,
+    CountingProcess,
+)
 from surpyval.recurrent.parametric.parametric_recurrence import (
     ParametricRecurrenceModel,
 )
 from surpyval.utils.fitter import singleton_fitter
+from surpyval.utils.recurrent_event_data import RecurrentEventData
 from surpyval.utils.recurrent_utils import handle_xicn
 
 
@@ -47,13 +54,18 @@ class HPP(CountingProcess):
            2169.4775629 , 2603.37307548])
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.param_names = ["lambda"]
         self.bounds = ((0, None),)
         self.support = (0.0, np.inf)
         self.name = "Homogeneous Poisson Process"
 
-    def iif(self, x, rate):
+    # The base contract is variadic (*params); HPP's one parameter
+    # is named for clarity, which the checker flags as a narrower
+    # override. The runtime call sites all pass positionally.
+    def iif(  # type: ignore[override]
+        self, x: Boxable, rate: Boxable
+    ) -> Boxable:
         """
         Instantaneous intensity function (IIF) or the failure rate of the
         HPP model.
@@ -72,7 +84,12 @@ class HPP(CountingProcess):
         """
         return np.ones_like(x) * rate
 
-    def log_iif(self, x, rate):
+    # The base contract is variadic (*params); HPP's one parameter
+    # is named for clarity, which the checker flags as a narrower
+    # override. The runtime call sites all pass positionally.
+    def log_iif(  # type: ignore[override]
+        self, x: Boxable, rate: Boxable
+    ) -> Boxable:
         """
         Natural logarithm of the instantaneous intensity function (IIF) of
         the HPP model.
@@ -91,7 +108,12 @@ class HPP(CountingProcess):
         """
         return np.log(rate) * np.ones_like(x)
 
-    def cif(self, x, rate):
+    # The base contract is variadic (*params); HPP's one parameter
+    # is named for clarity, which the checker flags as a narrower
+    # override. The runtime call sites all pass positionally.
+    def cif(  # type: ignore[override]
+        self, x: Boxable, rate: Boxable
+    ) -> Boxable:
         """
         Cumulative intensity function (CIF) of the HPP model.
 
@@ -109,7 +131,7 @@ class HPP(CountingProcess):
         """
         return rate * np.array(x)
 
-    def inv_cif(self, cif, rate):
+    def inv_cif(self, cif: Boxable, rate: Boxable) -> Boxable:
         """
         Inverse of the cumulative intensity function (CIF) of the HPP model.
 
@@ -127,7 +149,7 @@ class HPP(CountingProcess):
         """
         return np.array(cif) / rate
 
-    def create_negll_func(self, data):
+    def create_negll_func(self, data: RecurrentEventData) -> Callable:
         x, c, n = data.x, data.c, data.n
         x_prev = data.get_previous_x()
 
@@ -161,7 +183,7 @@ class HPP(CountingProcess):
             len_observed = len(x_o)
             observed_time = (x_prev_o - x_o).sum()
         else:
-            len_observed = 0.0
+            len_observed = 0
             observed_time = 0.0
 
         if has_left_censoring:
@@ -197,6 +219,8 @@ class HPP(CountingProcess):
         right_truncation_time = (x_close_last - x_close_tr).sum()
 
         if has_interval_censoring:
+            # interval data implies 2-D x, so the right column exists
+            assert x_r is not None
             interval_mask = c == 2
             x_i_l = x_l[interval_mask]
             x_i_r = x_r[interval_mask]
@@ -217,7 +241,7 @@ class HPP(CountingProcess):
             n_log_x_interval_sum = 0.0
             n_i_factorial_sum = 0.0
 
-        def negll_func(log_rate):
+        def negll_func(log_rate: np.ndarray) -> float:
             rate = anp.exp(log_rate)
             ll = len_observed * log_rate + rate * observed_time
             ll += rate * right_censored_time
@@ -239,7 +263,9 @@ class HPP(CountingProcess):
 
         return negll_func
 
-    def fit_from_recurrent_data(self, data, init=None):
+    def fit_from_recurrent_data(
+        self, data: RecurrentEventData, init: "ArrayLike | None" = None
+    ) -> Any:
         """
         Fits the HPP model to recurrent data and returns the fitted model.
 
@@ -288,16 +314,16 @@ class HPP(CountingProcess):
 
     def fit(
         self,
-        x,
-        i=None,
-        c=None,
-        n=None,
-        t=None,
-        tl=None,
-        tr=None,
-        init=None,
-        windows=None,
-    ):
+        x: ArrayLike,
+        i: "ArrayLike | None" = None,
+        c: "ArrayLike | None" = None,
+        n: "ArrayLike | None" = None,
+        t: "ArrayLike | None" = None,
+        tl: "ArrayLike | None" = None,
+        tr: "ArrayLike | None" = None,
+        init: "ArrayLike | None" = None,
+        windows: "dict | None" = None,
+    ) -> Any:
         """
         Fits the HPP model to the provided data and returns the fitted model.
 

--- a/surpyval/recurrent/parametric/nhpp_fitter.py
+++ b/surpyval/recurrent/parametric/nhpp_fitter.py
@@ -1,4 +1,7 @@
+from typing import Callable
+
 from autograd import numpy as np
+from numpy.typing import ArrayLike
 from scipy.optimize import minimize
 from scipy.special import gammaln
 
@@ -6,11 +9,15 @@ from surpyval.recurrent.parametric.counting_process import IntensityModel
 from surpyval.recurrent.parametric.parametric_recurrence import (
     ParametricRecurrenceModel,
 )
+from surpyval.utils.recurrent_event_data import RecurrentEventData
 from surpyval.utils.recurrent_utils import handle_xicn
 
 
 class NHPPFitter(IntensityModel):
-    def create_negll_func(self, data):
+    #: Natural-space parameter bounds, set by each concrete intensity model.
+    bounds: tuple
+
+    def create_negll_func(self, data: RecurrentEventData) -> Callable:
         s = data.split_for_nhpp_likelihood()
         x_o, x_o_prev = s["x_o"], s["x_o_prev"]
         x_right, x_right_prev = s["x_right"], s["x_right_prev"]
@@ -23,18 +30,18 @@ class NHPPFitter(IntensityModel):
         # will not encounter any invalid values since taking the log of 0
         # will not occur.
 
-        def negll_func(params):
+        def negll_func(params: np.ndarray) -> float:
             # ll of directly observed
-            ll = (
+            ll = np.sum(
                 self.log_iif(x_o, *params)
                 + self.cif(x_o_prev, *params)
                 - self.cif(x_o, *params)
-            ).sum()
+            )
 
             # ll of right censored
-            ll += (
+            ll += np.sum(
                 self.cif(x_right_prev, *params) - self.cif(x_right, *params)
-            ).sum()
+            )
 
             # ll of left censored
             left_delta_cif = self.cif(x_left, *params)
@@ -58,15 +65,20 @@ class NHPPFitter(IntensityModel):
             # extend the integral from each item's last in-window time to its
             # right-truncation time tr (zero when tr is infinite or already
             # coincides with a right-censoring row)
-            ll += (
+            ll += np.sum(
                 self.cif(x_close_last, *params) - self.cif(x_close_tr, *params)
-            ).sum()
+            )
 
             return -ll
 
         return negll_func
 
-    def fit_from_recurrent_data(self, data, how="MLE", init=None):
+    def fit_from_recurrent_data(
+        self,
+        data: RecurrentEventData,
+        how: str = "MLE",
+        init: "ArrayLike | None" = None,
+    ) -> ParametricRecurrenceModel:
         """
         Fit the NHPP model from recurrent data using either Maximum Likelihood
         Estimation (MLE) or Mean Square Error (MSE) methods.
@@ -98,7 +110,7 @@ class NHPPFitter(IntensityModel):
         x_unqiue, r, d = data.to_xrd()
         mcf_hat = np.cumsum(d / r)
 
-        def fun(params):
+        def fun(params: np.ndarray) -> float:
             return np.sum((self.cif(x_unqiue, *params) - mcf_hat) ** 2)
 
         res = minimize(fun, param_init, bounds=self.bounds)
@@ -137,17 +149,17 @@ class NHPPFitter(IntensityModel):
 
     def fit(
         self,
-        x,
-        i=None,
-        c=None,
-        n=None,
-        t=None,
-        tl=None,
-        tr=None,
-        how="MLE",
-        init=None,
-        windows=None,
-    ):
+        x: ArrayLike,
+        i: "ArrayLike | None" = None,
+        c: "ArrayLike | None" = None,
+        n: "ArrayLike | None" = None,
+        t: "ArrayLike | None" = None,
+        tl: "ArrayLike | None" = None,
+        tr: "ArrayLike | None" = None,
+        how: str = "MLE",
+        init: "ArrayLike | None" = None,
+        windows: "dict | None" = None,
+    ) -> ParametricRecurrenceModel:
         """
         Fit the NHPP model from the provided data. This function prepares the
         data to ensure that it is in the correct format for the fitting.
@@ -206,7 +218,7 @@ class NHPPFitter(IntensityModel):
         )
         return self.fit_from_recurrent_data(data, how, init)
 
-    def from_params(self, params):
+    def from_params(self, params: ArrayLike) -> ParametricRecurrenceModel:
         """
         Create a model instance directly from parameters without fitting.
 
@@ -224,7 +236,7 @@ class NHPPFitter(IntensityModel):
             the provided parameters.
         """
         model = ParametricRecurrenceModel()
-        model.params = params
+        model.params = np.asarray(params)
         model.dist = self
         model.how = "from_params"
         return model

--- a/surpyval/recurrent/parametric/parametric_recurrence.py
+++ b/surpyval/recurrent/parametric/parametric_recurrence.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 import numpy as np
 from matplotlib import pyplot as plt
+from numpy.typing import ArrayLike
 
 from surpyval.recurrent import diagnostics
 from surpyval.recurrent.inference import LikelihoodInferenceMixin
@@ -34,9 +37,21 @@ class ParametricRecurrenceModel(
     >>> model = HPP.fit(x)
     """
 
+    # Populated by the fitters; declared for the type checker.
+    dist: Any
+    params: "np.ndarray"
+    param_names: list
+    bounds: tuple
+    support: tuple
+    name: str
+    data: Any
+    mcf_hat: "np.ndarray"
+    how: str
+    res: Any
+
     # -- serialisation -----------------------------------------------------
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         """
         Serialise this fitted recurrence model to a plain, JSON-serialisable
         dict.
@@ -61,7 +76,7 @@ class ParametricRecurrenceModel(
         )
 
     @classmethod
-    def from_dict(cls, model_dict):
+    def from_dict(cls, model_dict: dict) -> "ParametricRecurrenceModel":
         """
         Rebuild a recurrence model from a :meth:`to_dict` dictionary.
 
@@ -80,13 +95,13 @@ class ParametricRecurrenceModel(
         out.how = model_dict.get("how", "from_params")
         return out
 
-    def _parameter_names(self):
+    def _parameter_names(self) -> list:
         return list(self.dist.param_names)
 
-    def _parameter_bounds(self):
+    def _parameter_bounds(self) -> list:
         return list(self.dist.bounds)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         param_string = "\n".join(
             [
                 "{:>10}".format(name) + ": " + str(p)
@@ -106,7 +121,7 @@ class ParametricRecurrenceModel(
     # CoxLewis post-processing from RecurrenceSimulationMixin; this model is
     # unconditional, so it needs no extra cif args (_cif_args defaults to ()).
 
-    def cif(self, x):
+    def cif(self, x: ArrayLike) -> np.ndarray:
         """
         Compute the cumulative incidence function (CIF) based on the fitted
         model. No need to pass parameters as it uses the parameters of the
@@ -127,7 +142,9 @@ class ParametricRecurrenceModel(
         x = np.array(x)
         return self.dist.cif(x, *self.params)
 
-    def mcf(self, x):
+    # Narrows the mixin mcf (no simulation arguments): the fitted
+    # model evaluates its own CIF directly.
+    def mcf(self, x: ArrayLike) -> np.ndarray:  # type: ignore[override]
         """
         The mean cumulative function (MCF). For these counting processes the
         MCF equals the cumulative intensity, so this is a closed-form alias for
@@ -147,7 +164,7 @@ class ParametricRecurrenceModel(
         """
         return self.cif(x)
 
-    def iif(self, x):
+    def iif(self, x: ArrayLike) -> np.ndarray:
         """
         Compute the intensity function based on the fitted model. No need to
         pass parameters as it uses the parameters of the fitted model.
@@ -167,7 +184,7 @@ class ParametricRecurrenceModel(
         x = np.array(x)
         return self.dist.iif(x, *self.params)
 
-    def inv_cif(self, x):
+    def inv_cif(self, x: ArrayLike) -> np.ndarray:
         x = np.array(x)
         if hasattr(self.dist, "inv_cif"):
             return self.dist.inv_cif(x, *self.params)
@@ -176,14 +193,14 @@ class ParametricRecurrenceModel(
                 "Inverse cif undefined for {}".format(self.dist.name)
             )
 
-    def _check_has_data(self, what):
+    def _check_has_data(self, what: str) -> None:
         if not hasattr(self, "data"):
             raise ValueError(
                 "{} requires a model fitted from data; fit_from_parameters "
                 "models carry no data.".format(what)
             )
 
-    def residuals(self, kind="cumulative_hazard"):
+    def residuals(self, kind: str = "cumulative_hazard") -> np.ndarray:
         """
         Residual diagnostics for the fitted model, from the time-rescaling
         theorem.
@@ -221,7 +238,9 @@ class ParametricRecurrenceModel(
             "got {!r}".format(kind)
         )
 
-    def trend_test(self, test="laplace", alternative="two-sided"):
+    def trend_test(
+        self, test: str = "laplace", alternative: str = "two-sided"
+    ) -> Any:
         """
         Run a trend test on the data this model was fitted to.
 
@@ -251,7 +270,9 @@ class ParametricRecurrenceModel(
             self.data, test=test, alternative=alternative
         )
 
-    def cramer_von_mises(self, n_boot=200, seed=None):
+    def cramer_von_mises(
+        self, n_boot: int = 200, seed: "int | None" = None
+    ) -> Any:
         """
         Cramer-von Mises goodness-of-fit test of the fitted intensity.
 
@@ -286,7 +307,12 @@ class ParametricRecurrenceModel(
         self._check_has_data("cramer_von_mises")
         return diagnostics.cramer_von_mises(self, n_boot=n_boot, seed=seed)
 
-    def cif_cb(self, x, alpha_ci=0.05, bound="two-sided"):
+    def cif_cb(
+        self,
+        x: ArrayLike,
+        alpha_ci: float = 0.05,
+        bound: str = "two-sided",
+    ) -> np.ndarray:
         """
         Confidence bounds on the fitted CIF at ``x``, from the delta method.
 
@@ -323,7 +349,13 @@ class ParametricRecurrenceModel(
         )
         return log_transformed_cb(self.cif(x), se, alpha_ci, bound)
 
-    def plot(self, ax=None, plot_bounds=True, confidence=0.95):
+    # Narrows the mixin plot (bounds options) -- same known divergence.
+    def plot(  # type: ignore[override]
+        self,
+        ax: Any = None,
+        plot_bounds: bool = True,
+        confidence: float = 0.95,
+    ) -> Any:
         """
         Plot the fitted CIF over the nonparametric MCF of the data used to
         fit it, with a delta-method confidence band around the fitted curve

--- a/surpyval/recurrent/regression/hpp_proportional_intensity.py
+++ b/surpyval/recurrent/regression/hpp_proportional_intensity.py
@@ -1,4 +1,7 @@
+from typing import Any, Callable
+
 import numpy as np
+from numpy.typing import ArrayLike
 from scipy.optimize import minimize
 from scipy.special import gammaln
 
@@ -58,16 +61,16 @@ class ProportionalIntensityHPP:
     # ``ProportionalIntensityModel``'s repr via ``dist.name``.
     name = "Constant"
 
-    def iif(self, x, rate):
+    def iif(self, x: ArrayLike, rate: ArrayLike) -> ArrayLike:
         return np.ones_like(np.asarray(x, dtype=float)) * rate
 
-    def cif(self, x, rate):
+    def cif(self, x: ArrayLike, rate: ArrayLike) -> ArrayLike:
         return rate * np.asarray(x, dtype=float)
 
-    def inv_cif(self, cif, rate):
+    def inv_cif(self, cif: ArrayLike, rate: ArrayLike) -> ArrayLike:
         return np.asarray(cif, dtype=float) / rate
 
-    def create_negll_func(self, data):
+    def create_negll_func(self, data: Any) -> Callable:
         x, c, n = data.x, data.c, data.n
         Z = data.Z
         x_prev = data.get_previous_x()
@@ -107,7 +110,7 @@ class ProportionalIntensityHPP:
             Z_o = Z[c == 0]
         else:
             x_o = 0.0
-            len_observed = 0.0
+            len_observed = 0
             Z_o = np.zeros((1, Z.shape[1]))
 
         if has_right_censoring:
@@ -138,6 +141,8 @@ class ProportionalIntensityHPP:
             Z_left = np.zeros((1, Z.shape[1]))
 
         if has_interval_censoring:
+            # interval data implies 2-D x, so the right column exists
+            assert x_r is not None
             x_i_l = x_l[c == 2]
             x_i_r = x_r[c == 2]
             delta_xi = x_i_r - x_i_l
@@ -164,7 +169,7 @@ class ProportionalIntensityHPP:
         x_close = x_close_last - x_close_tr
         Z_close = Z[close_idx]
 
-        def negll_func(params):
+        def negll_func(params: np.ndarray) -> float:
             log_rate = params[0]
             rate = np.exp(log_rate)
             beta_coeffs = params[1:]
@@ -205,8 +210,17 @@ class ProportionalIntensityHPP:
         return negll_func
 
     def fit(
-        self, x, Z, i=None, c=None, n=None, t=None, tl=None, tr=None, init=None
-    ):
+        self,
+        x: ArrayLike,
+        Z: ArrayLike,
+        i: "ArrayLike | None" = None,
+        c: "ArrayLike | None" = None,
+        n: "ArrayLike | None" = None,
+        t: "ArrayLike | None" = None,
+        tl: "ArrayLike | None" = None,
+        tr: "ArrayLike | None" = None,
+        init: "ArrayLike | None" = None,
+    ) -> Any:
         """
         Fit the model using the provided data and initial parameters (if given)
 
@@ -245,7 +259,12 @@ class ProportionalIntensityHPP:
         data = handle_xicn(x, i, c, n, t=t, tl=tl, tr=tr, Z=Z)
         return self.fit_from_recurrent_data(data, init=init)
 
-    def fit_from_recurrent_data(self, data, dist=None, init=None):
+    def fit_from_recurrent_data(
+        self,
+        data: Any,
+        dist: Any = None,
+        init: "ArrayLike | None" = None,
+    ) -> Any:
         """
         Fit from a prepared ``RecurrentEventData``. ``dist`` is accepted for a
         uniform interface with the NHPP fitter but is ignored: the homogeneous

--- a/surpyval/recurrent/regression/nhpp_proportional_intensity.py
+++ b/surpyval/recurrent/regression/nhpp_proportional_intensity.py
@@ -1,4 +1,7 @@
+from typing import Any, Callable
+
 import numpy as np
+from numpy.typing import ArrayLike
 from scipy.optimize import minimize
 from scipy.special import gammaln
 
@@ -63,7 +66,7 @@ class ProportionalIntensityNHPP:
     <BLANKLINE>
     """
 
-    def create_negll_func(self, data, dist):
+    def create_negll_func(self, data: Any, dist: Any) -> Callable:
         Z = data.Z
         s = data.split_for_nhpp_likelihood()
         x_o, x_o_prev = s["x_o"], s["x_o_prev"]
@@ -94,7 +97,7 @@ class ProportionalIntensityNHPP:
         # will not encounter any invalid values since taking the log of 0
         # will not occur.
 
-        def negll_func(params):
+        def negll_func(params: np.ndarray) -> float:
             dist_params = params[: len(dist.param_names)]
             beta_coeffs = params[len(dist.param_names) :]
             # ll of directly observed
@@ -151,7 +154,12 @@ class ProportionalIntensityNHPP:
 
         return negll_func
 
-    def fit_from_recurrent_data(self, data, dist, init=None):
+    def fit_from_recurrent_data(
+        self,
+        data: Any,
+        dist: Any,
+        init: "ArrayLike | None" = None,
+    ) -> Any:
         if not isinstance(dist, CountingProcess):
             raise TypeError(
                 "`dist` must be a CountingProcess instance "
@@ -208,17 +216,17 @@ class ProportionalIntensityNHPP:
 
     def fit(
         self,
-        x,
-        Z,
-        i=None,
-        c=None,
-        n=None,
-        t=None,
-        tl=None,
-        tr=None,
-        dist=Duane,
-        init=None,
-    ):
+        x: ArrayLike,
+        Z: ArrayLike,
+        i: "ArrayLike | None" = None,
+        c: "ArrayLike | None" = None,
+        n: "ArrayLike | None" = None,
+        t: "ArrayLike | None" = None,
+        tl: "ArrayLike | None" = None,
+        tr: "ArrayLike | None" = None,
+        dist: Any = Duane,
+        init: "ArrayLike | None" = None,
+    ) -> Any:
         """
         Fit the model using the provided data and initial parameters.
 

--- a/surpyval/recurrent/regression/proportional_intensity.py
+++ b/surpyval/recurrent/regression/proportional_intensity.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 import numpy as np
 from matplotlib import pyplot as plt
+from numpy.typing import ArrayLike
 
 from surpyval.recurrent import diagnostics
 from surpyval.recurrent.inference import LikelihoodInferenceMixin
@@ -40,7 +43,22 @@ class ProportionalIntensityModel(
     array([8.84210972e-07, 2.79074784e-05, 2.10220821e-04])
     """
 
-    def __repr__(self):
+    # Populated by the fitters; declared for the type checker.
+    kind: str
+    parameterization: str
+    support: tuple
+    _fitter_dist: Any
+    dist: Any
+    params: "np.ndarray"
+    coeffs: "np.ndarray"
+    param_names: list
+    bounds: tuple
+    name: str
+    data: Any
+    how: str
+    res: Any
+
+    def __repr__(self) -> str:
         out = (
             "Proportional Intensity Recurrence Model"
             + "\n======================================="
@@ -62,7 +80,7 @@ class ProportionalIntensityModel(
 
     # -- serialisation -----------------------------------------------------
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         """
         Serialise this fitted proportional-intensity model to a plain,
         JSON-serialisable dict.
@@ -90,7 +108,7 @@ class ProportionalIntensityModel(
         )
 
     @classmethod
-    def from_dict(cls, model_dict):
+    def from_dict(cls, model_dict: dict) -> "ProportionalIntensityModel":
         """
         Rebuild a proportional-intensity model from a :meth:`to_dict`
         dictionary.
@@ -121,7 +139,7 @@ class ProportionalIntensityModel(
         out.coeffs = np.array(model_dict["coeffs"], dtype=float)
         return out
 
-    def cif(self, x, Z):
+    def cif(self, x: ArrayLike, Z: ArrayLike) -> np.ndarray:
         """
         Compute the cumulative incidence function of the model with the
         parameters found by the fit method.
@@ -138,7 +156,7 @@ class ProportionalIntensityModel(
         """
         return self.dist.cif(x, *self.params) * np.exp(Z @ self.coeffs)
 
-    def iif(self, x, Z):
+    def iif(self, x: ArrayLike, Z: ArrayLike) -> np.ndarray:
         """
         Compute the instantaneous incidence function of the model with the
         parameters found by the fit method.
@@ -155,7 +173,7 @@ class ProportionalIntensityModel(
         """
         return self.dist.iif(x, *self.params) * np.exp(Z @ self.coeffs)
 
-    def inv_cif(self, x, Z):
+    def inv_cif(self, x: ArrayLike, Z: ArrayLike) -> np.ndarray:
         if hasattr(self.dist, "inv_cif"):
             return self.dist.inv_cif(x / np.exp(self.coeffs @ Z), *self.params)
         else:
@@ -163,7 +181,7 @@ class ProportionalIntensityModel(
                 "Inverse cif undefined for {}".format(self.dist.name)
             )
 
-    def _item_cif_map(self):
+    def _item_cif_map(self) -> dict:
         # Each item's cumulative intensity is the baseline scaled by its own
         # ``exp(Z'beta)`` factor. The covariates are per item (static), so the
         # item's Z is taken from its first row. Returns ``{item: cif(x)}`` for
@@ -177,7 +195,7 @@ class ProportionalIntensityModel(
             )
         return cif_map
 
-    def residuals(self, kind="cumulative_hazard"):
+    def residuals(self, kind: str = "cumulative_hazard") -> np.ndarray:
         """
         Residual diagnostics for the fitted model, from the time-rescaling
         theorem applied per item (each item's intensity is the baseline
@@ -214,7 +232,9 @@ class ProportionalIntensityModel(
             "got {!r}".format(kind)
         )
 
-    def trend_test(self, test="laplace", alternative="two-sided"):
+    def trend_test(
+        self, test: str = "laplace", alternative: str = "two-sided"
+    ) -> Any:
         """
         Run a trend test on the data this model was fitted to. The null
         hypothesis is a *homogeneous* Poisson process (no trend); the
@@ -240,7 +260,9 @@ class ProportionalIntensityModel(
             self.data, test=test, alternative=alternative
         )
 
-    def cramer_von_mises(self, n_boot=200, seed=None):
+    def cramer_von_mises(
+        self, n_boot: int = 200, seed: "int | None" = None
+    ) -> Any:
         """
         Cramer-von Mises goodness-of-fit test of the fitted proportional-
         intensity model.
@@ -273,7 +295,13 @@ class ProportionalIntensityModel(
             self, n_boot=n_boot, seed=seed
         )
 
-    def cif_cb(self, x, Z, alpha_ci=0.05, bound="two-sided"):
+    def cif_cb(
+        self,
+        x: ArrayLike,
+        Z: ArrayLike,
+        alpha_ci: float = 0.05,
+        bound: str = "two-sided",
+    ) -> np.ndarray:
         """
         Confidence bounds on the fitted CIF at ``x`` for covariates ``Z``,
         from the delta method.
@@ -308,7 +336,7 @@ class ProportionalIntensityModel(
         Z = np.asarray(Z, dtype=float)
         n_dist_params = len(self.params)
 
-        def cif_at(theta):
+        def cif_at(theta: np.ndarray) -> np.ndarray:
             return self.dist.cif(x, *theta[:n_dist_params]) * np.exp(
                 Z @ theta[n_dist_params:]
             )
@@ -316,7 +344,13 @@ class ProportionalIntensityModel(
         se = delta_method_se(cif_at, self._mle, self.covariance())
         return log_transformed_cb(self.cif(x, Z), se, alpha_ci, bound)
 
-    def plot(self, ax=None, plot_bounds=True, confidence=0.95):
+    # Extends the mixin plot with covariates -- same known divergence.
+    def plot(  # type: ignore[override]
+        self,
+        ax: Any = None,
+        plot_bounds: bool = True,
+        confidence: float = 0.95,
+    ) -> Any:
         """
         PLots the CIF of the model against the data used to fit it.
 
@@ -366,7 +400,7 @@ class ProportionalIntensityModel(
             )
         return ax
 
-    def _parameter_names(self):
+    def _parameter_names(self) -> list:
         # The base-rate (intensity) parameters lead ``_mle``, followed by the
         # covariate coefficients.
         return [
@@ -374,21 +408,29 @@ class ProportionalIntensityModel(
             *["beta_{}".format(i) for i in range(len(self.coeffs))],
         ]
 
-    def _parameter_bounds(self):
+    def _parameter_bounds(self) -> list:
         # The base-rate bounds come from the intensity model (PI-HPP stores
         # them on the fitted model directly; PI-NHPP's live on ``dist``); the
         # covariate coefficients are unbounded.
         dist_bounds = getattr(self, "bounds", None) or self.dist.bounds
         return [*dist_bounds, *[(None, None)] * len(self.coeffs)]
 
-    def _cif_args(self):
+    def _cif_args(self) -> tuple:
         # The shared inverse-CIF sampler threads these into cif/inv_cif; the
         # covariate vector for the run is stashed on ``_sim_Z`` by the public
         # simulation entry points below. (CoxLewis post-processing is handled
         # by the shared mixin.)
         return (self._sim_Z,)
 
-    def count_terminated_simulation(self, events, Z, items=1, seed=None):
+    # Extends the mixin signature with the covariate vector ``Z``
+    # -- a known signature divergence in the simulation API.
+    def count_terminated_simulation(  # type: ignore[override]
+        self,
+        events: int,
+        Z: ArrayLike,
+        items: int = 1,
+        seed: "int | None" = None,
+    ) -> Any:
         """
         Simulate count-terminated recurrence data based on the fitted model.
 
@@ -415,9 +457,17 @@ class ProportionalIntensityModel(
             events, items=items, seed=seed
         )
 
-    def time_terminated_simulation(
-        self, T, Z, items=1, tol=1e-8, max_events=10_000, seed=None
-    ):
+    # Extends the mixin signature with the covariate vector ``Z``
+    # -- a known signature divergence in the simulation API.
+    def time_terminated_simulation(  # type: ignore[override]
+        self,
+        T: float,
+        Z: ArrayLike,
+        items: int = 1,
+        tol: float = 1e-8,
+        max_events: int = 10_000,
+        seed: "int | None" = None,
+    ) -> Any:
         """
         Simulate time-terminated recurrence data based on the fitted model.
 
@@ -457,7 +507,15 @@ class ProportionalIntensityModel(
             T, items=items, tol=tol, max_events=max_events, seed=seed
         )
 
-    def count_terminated_simulation_data(self, events, Z, items=1, seed=None):
+    # Extends the mixin signature with the covariate vector ``Z``
+    # -- a known signature divergence in the simulation API.
+    def count_terminated_simulation_data(  # type: ignore[override]
+        self,
+        events: int,
+        Z: ArrayLike,
+        items: int = 1,
+        seed: "int | None" = None,
+    ) -> Any:
         """
         Simulate count-terminated recurrence data and return the raw events.
         Like :meth:`count_terminated_simulation` but yields the simulated
@@ -468,9 +526,17 @@ class ProportionalIntensityModel(
             events, items=items, seed=seed
         )
 
-    def time_terminated_simulation_data(
-        self, T, Z, items=1, tol=1e-8, max_events=10_000, seed=None
-    ):
+    # Extends the mixin signature with the covariate vector ``Z``
+    # -- a known signature divergence in the simulation API.
+    def time_terminated_simulation_data(  # type: ignore[override]
+        self,
+        T: float,
+        Z: ArrayLike,
+        items: int = 1,
+        tol: float = 1e-8,
+        max_events: int = 10_000,
+        seed: "int | None" = None,
+    ) -> Any:
         """
         Simulate time-terminated recurrence data and return the raw events.
         Like :meth:`time_terminated_simulation` but yields the simulated
@@ -481,7 +547,15 @@ class ProportionalIntensityModel(
             T, items=items, tol=tol, max_events=max_events, seed=seed
         )
 
-    def mcf(self, x, Z, items=1000, seed=None):
+    # Extends the mixin signature with the covariate vector ``Z``
+    # -- a known signature divergence in the simulation API.
+    def mcf(  # type: ignore[override]
+        self,
+        x: ArrayLike,
+        Z: ArrayLike,
+        items: int = 1000,
+        seed: "int | None" = None,
+    ) -> Any:
         """
         Estimate the mean cumulative function at ``x`` for covariates ``Z`` by
         simulating ``items`` time-terminated sequences out to ``max(x)``.

--- a/surpyval/recurrent/renewal/ara.py
+++ b/surpyval/recurrent/renewal/ara.py
@@ -1,4 +1,7 @@
+from typing import Any, Callable
+
 import numpy as np
+from numpy.typing import ArrayLike
 
 from surpyval import Weibull
 from surpyval.recurrent.renewal.fit_mixin import RenewalFitMixin
@@ -13,7 +16,9 @@ from surpyval.utils.recurrent_utils import (
 )
 
 
-def ara_virtual_ages(arrival_times, rho, m):
+def ara_virtual_ages(
+    arrival_times: np.ndarray, rho: float, m: "int | float"
+) -> np.ndarray:
     """
     Effective (virtual) age at the start of each interarrival for the
     Arithmetic Reduction of Age model with memory ``m`` (Doyen & Gaudoin,
@@ -83,13 +88,13 @@ class ARA(RenewalFitMixin):
     """
 
     @staticmethod
-    def _build_sampler(model):
+    def _build_sampler(model: Any) -> Callable:
         rho = model.rho
         m = model.m
-        arrivals = []
+        arrivals: list = []
         running = 0.0
 
-        def sample(ui):
+        def sample(ui: float) -> float:
             nonlocal running
             if not arrivals:
                 v = 0.0
@@ -107,7 +112,9 @@ class ARA(RenewalFitMixin):
 
         return sample
 
-    def _make_model(self, underlying_model, rho, m):
+    def _make_model(
+        self, underlying_model: Any, rho: float, m: "int | float"
+    ) -> "RenewalModel":
         out = RenewalModel(
             underlying_model,
             rho,
@@ -120,7 +127,7 @@ class ARA(RenewalFitMixin):
         out.m = m
         return out
 
-    def _rescaled_increments(self, model, data):
+    def _rescaled_increments(self, model: Any, data: Any) -> np.ndarray:
         """
         Per-interval cumulative-hazard increments ``H(v_k + x_k) - H(v_k)``
         (the time-rescaling residuals) for a fitted ARA model, with ``v_k`` the
@@ -139,20 +146,22 @@ class ARA(RenewalFitMixin):
             model.model.Hf(x_new) - model.model.Hf(virtual_ages), dtype=float
         )
 
-    def _refit(self, model, data):
+    def _refit(self, model: Any, data: Any) -> Any:
         """Refit this model family on ``data`` with the same lifetime
         distribution and memory; used by the Cramer-von Mises bootstrap."""
         return self.fit_from_recurrent_data(
             data, dist=model.model.dist, m=model.m
         )
 
-    def create_negll_func(self, data, dist, m):
+    def create_negll_func(
+        self, data: Any, dist: Any, m: "int | float"
+    ) -> Callable:
         _, idx = np.unique(data.i, return_index=True)
         arrival_by_item = np.split(data.x, idx)[1:]
         interarrival = data.get_interarrival_times()
         c = data.c
 
-        def negll_func(params):
+        def negll_func(params: np.ndarray) -> float:
             rho = params[0]
             dist_params = params[1:]
 
@@ -175,7 +184,13 @@ class ARA(RenewalFitMixin):
 
         return negll_func
 
-    def fit_from_recurrent_data(self, data, dist=Weibull, m=1, init=None):
+    def fit_from_recurrent_data(
+        self,
+        data: Any,
+        dist: Any = Weibull,
+        m: "int | float" = 1,
+        init: "ArrayLike | None" = None,
+    ) -> "RenewalModel":
         """
         Fit the ARA model from recurrent data.
 
@@ -225,7 +240,16 @@ class ARA(RenewalFitMixin):
         )
         return out
 
-    def fit(self, x, i=None, c=None, n=None, dist=Weibull, m=1, init=None):
+    def fit(
+        self,
+        x: ArrayLike,
+        i: "ArrayLike | None" = None,
+        c: "ArrayLike | None" = None,
+        n: "ArrayLike | None" = None,
+        dist: Any = Weibull,
+        m: "int | float" = 1,
+        init: "ArrayLike | None" = None,
+    ) -> "RenewalModel":
         """
         Fit the ARA model.
 
@@ -257,7 +281,13 @@ class ARA(RenewalFitMixin):
         data = handle_xicn(x, i, c, n)
         return self.fit_from_recurrent_data(data, dist, m, init=init)
 
-    def fit_from_parameters(self, params, rho, m=1, dist=Weibull):
+    def fit_from_parameters(
+        self,
+        params: ArrayLike,
+        rho: float,
+        m: "int | float" = 1,
+        dist: Any = Weibull,
+    ) -> "RenewalModel":
         """
         Build an ARA model from given parameters.
 

--- a/surpyval/recurrent/renewal/ari.py
+++ b/surpyval/recurrent/renewal/ari.py
@@ -1,7 +1,13 @@
+from typing import TYPE_CHECKING, Any, Callable
+
 import numpy as np
+from numpy.typing import ArrayLike
 from scipy.optimize import brentq
 
 from surpyval.recurrent.parametric.crow_amsaa import CrowAMSAA
+
+if TYPE_CHECKING:
+    from surpyval.recurrent.renewal.renewal_model import RenewalModel
 from surpyval.recurrent.renewal.fit_mixin import RenewalFitMixin
 from surpyval.utils.fitter import singleton_fitter
 from surpyval.utils.recurrent_utils import (
@@ -13,7 +19,9 @@ from surpyval.utils.recurrent_utils import (
 )
 
 
-def ari_reduction(failure_intensities, rho, m):
+def ari_reduction(
+    failure_intensities: np.ndarray, rho: float, m: "int | float"
+) -> "np.ndarray | float":
     """
     Intensity reduction ``R_n`` in force just after the most recent failure for
     the Arithmetic Reduction of Intensity model with memory ``m`` (Doyen &
@@ -37,7 +45,12 @@ def ari_reduction(failure_intensities, rho, m):
     return rho * np.sum(weights * recent)
 
 
-def _reduction_sequence(failure_intensities, position, rho, m):
+def _reduction_sequence(
+    failure_intensities: np.ndarray,
+    position: int,
+    rho: float,
+    m: "int | float",
+) -> np.ndarray:
     """``R_n`` after every failure at once, for failures from many items.
 
     ``failure_intensities`` holds ``lambda_0`` at each *observed* failure
@@ -68,7 +81,7 @@ def _reduction_sequence(failure_intensities, position, rho, m):
     return rho * total
 
 
-def _event_layout(data):
+def _event_layout(data: Any) -> tuple:
     """Per-row bookkeeping shared by the likelihood and the residuals.
 
     ``prev`` is the previous event time, restarting at 0 for each item.
@@ -142,7 +155,7 @@ class ARI(RenewalFitMixin):
     """
 
     @staticmethod
-    def _build_sampler(model):
+    def _build_sampler(model: Any) -> Callable:
         dist = model.model.dist
         dp = model.model.params
         rho = model.rho
@@ -151,12 +164,12 @@ class ARI(RenewalFitMixin):
         running = [0.0]
         reduction = [0.0]
 
-        def sample(ui):
+        def sample(ui: float) -> float:
             t0 = running[0]
             red = reduction[0]
             energy = -np.log(ui)
 
-            def g(x):
+            def g(x: float) -> float:
                 delta = dist.cif(t0 + x, *dp) - dist.cif(t0, *dp)
                 return delta - red * x - energy
 
@@ -169,15 +182,23 @@ class ARI(RenewalFitMixin):
 
             running[0] = t0 + xi
             history_iif.append(dist.iif(running[0], *dp))
-            reduction[0] = ari_reduction(history_iif, rho, m)
+            reduction[0] = float(
+                ari_reduction(np.asarray(history_iif), rho, m)
+            )
             return xi
 
         return sample
 
-    def _make_model(self, baseline_dist, dist_params, rho, m):
+    def _make_model(
+        self,
+        baseline_dist: Any,
+        dist_params: ArrayLike,
+        rho: float,
+        m: "int | float",
+    ) -> "RenewalModel":
         from surpyval.recurrent.renewal.renewal_model import RenewalModel
 
-        model = baseline_dist.from_params(list(dist_params))
+        model = baseline_dist.from_params(np.asarray(dist_params).tolist())
         out = RenewalModel(
             model,
             rho,
@@ -191,7 +212,7 @@ class ARI(RenewalFitMixin):
         out.m = m
         return out
 
-    def _rescaled_increments(self, model, data):
+    def _rescaled_increments(self, model: Any, data: Any) -> np.ndarray:
         """
         Per-interval compensator increments (time-rescaling residuals) for a
         fitted ARI model: the integral of the reduced intensity over each
@@ -212,20 +233,22 @@ class ARI(RenewalFitMixin):
         delta_cif = np.asarray(dist.cif(x) - dist.cif(prev), dtype=float)
         return delta_cif - active * (x - prev)
 
-    def _refit(self, model, data):
+    def _refit(self, model: Any, data: Any) -> Any:
         """Refit this model family on ``data`` with the same baseline
         intensity and memory; used by the Cramer-von Mises bootstrap."""
         return self.fit_from_recurrent_data(
             data, dist=model.model.dist, m=model.m
         )
 
-    def create_negll_func(self, data, dist, m):
+    def create_negll_func(
+        self, data: Any, dist: Any, m: "int | float"
+    ) -> Callable:
         x = np.asarray(data.x, dtype=float)
         prev, observed, failure_pos, in_force = _event_layout(data)
         gap = x - prev
         x_failures = x[observed]
 
-        def negll_func(params):
+        def negll_func(params: np.ndarray) -> float:
             rho = params[0]
             dist_params = params[1:]
 
@@ -253,7 +276,13 @@ class ARI(RenewalFitMixin):
 
         return negll_func
 
-    def fit_from_recurrent_data(self, data, dist=CrowAMSAA, m=1, init=None):
+    def fit_from_recurrent_data(
+        self,
+        data: Any,
+        dist: Any = CrowAMSAA,
+        m: "int | float" = 1,
+        init: "ArrayLike | None" = None,
+    ) -> "RenewalModel":
         """
         Fit the ARI model from recurrent data.
 
@@ -311,7 +340,7 @@ class ARI(RenewalFitMixin):
         return out
 
     @staticmethod
-    def _initial_baseline_params(data, dist):
+    def _initial_baseline_params(data: Any, dist: Any) -> np.ndarray:
         """
         Initial parameters for the baseline intensity model: the plain NHPP fit
         of that baseline if it succeeds, otherwise its own parameter
@@ -328,7 +357,16 @@ class ARI(RenewalFitMixin):
             base_params = np.asarray(dist.parameter_initialiser(data.x))
         return base_params
 
-    def fit(self, x, i=None, c=None, n=None, dist=CrowAMSAA, m=1, init=None):
+    def fit(
+        self,
+        x: ArrayLike,
+        i: "ArrayLike | None" = None,
+        c: "ArrayLike | None" = None,
+        n: "ArrayLike | None" = None,
+        dist: Any = CrowAMSAA,
+        m: "int | float" = 1,
+        init: "ArrayLike | None" = None,
+    ) -> "RenewalModel":
         """
         Fit the ARI model.
 
@@ -360,7 +398,13 @@ class ARI(RenewalFitMixin):
         data = handle_xicn(x, i, c, n)
         return self.fit_from_recurrent_data(data, dist, m, init=init)
 
-    def fit_from_parameters(self, dist_params, rho, m=1, dist=CrowAMSAA):
+    def fit_from_parameters(
+        self,
+        dist_params: ArrayLike,
+        rho: float,
+        m: "int | float" = 1,
+        dist: Any = CrowAMSAA,
+    ) -> "RenewalModel":
         """
         Build an ARI model from given parameters.
 

--- a/surpyval/recurrent/renewal/fit_mixin.py
+++ b/surpyval/recurrent/renewal/fit_mixin.py
@@ -1,4 +1,7 @@
+from typing import Any, Callable
+
 import numpy as np
+from numpy.typing import ArrayLike
 from scipy.optimize import minimize
 
 from surpyval.univariate.parametric.fitters import bounds_convert
@@ -23,7 +26,7 @@ class RenewalFitMixin:
     """
 
     @staticmethod
-    def _initial_dist_params(data, dist):
+    def _initial_dist_params(data: Any, dist: Any) -> np.ndarray:
         """
         Initial parameters for the underlying lifetime distribution, fitted to
         the times-to-first-event when there are enough of them (these are
@@ -47,7 +50,9 @@ class RenewalFitMixin:
         return dist_params
 
     @staticmethod
-    def _bounds_transform(data_x, bounds, param_names):
+    def _bounds_transform(
+        data_x: np.ndarray, bounds: list, param_names: list
+    ) -> tuple[Callable, Callable]:
         """
         Build the (bounded -> unbounded) parameter transforms used by the
         fitters that optimise in an unconstrained space. ``bounds`` are the
@@ -61,7 +66,11 @@ class RenewalFitMixin:
         return transform, inv_trans
 
     @staticmethod
-    def _multistart(fit_once, inits, user_init):
+    def _multistart(
+        fit_once: Callable,
+        inits: "list | None",
+        user_init: "ArrayLike | None",
+    ) -> Any:
         """
         Drive the multi-start fit. ``fit_once(x0) -> OptimizeResult`` runs the
         optimiser from a single natural-space start ``x0``. With no user
@@ -71,6 +80,7 @@ class RenewalFitMixin:
         Raises ``ValueError`` with the shared messages when nothing converges.
         """
         if user_init is None:
+            assert inits is not None
             results = [res for res in map(fit_once, inits) if res.success]
             if not results:
                 raise ValueError(
@@ -89,15 +99,15 @@ class RenewalFitMixin:
 
     def _fit_restoration_ml(
         self,
-        data,
-        neg_ll,
-        restoration_bounds,
-        restoration_name,
-        dist,
-        restoration_inits,
-        dist_init_params,
-        init,
-    ):
+        data: Any,
+        neg_ll: Callable,
+        restoration_bounds: tuple,
+        restoration_name: str,
+        dist: Any,
+        restoration_inits: tuple,
+        dist_init_params: "np.ndarray | None",
+        init: "ArrayLike | None",
+    ) -> tuple[Any, np.ndarray]:
         """
         The transform-space fitting spine shared by ``ARA``, ``ARI`` and
         ``GeneralizedRenewal``: multi-start Nelder-Mead on the negative
@@ -117,7 +127,7 @@ class RenewalFitMixin:
             [restoration_name, *dist.param_names],
         )
 
-        def fit_once(x0):
+        def fit_once(x0: np.ndarray) -> Any:
             return minimize(
                 lambda p: neg_ll(inv_trans(p)),
                 transform(np.asarray(x0, dtype=float)),
@@ -125,13 +135,24 @@ class RenewalFitMixin:
             )
 
         if init is None:
+            # The caller supplies initial distribution parameters whenever
+            # it does not supply a full ``init``.
+            assert dist_init_params is not None
             inits = [[r0, *dist_init_params] for r0 in restoration_inits]
         else:
             inits = None
         res = self._multistart(fit_once, inits, init)
         return res, inv_trans(res.x)
 
-    def _attach_inference(self, model, neg_ll, mle, n_obs, res, data):
+    def _attach_inference(
+        self,
+        model: Any,
+        neg_ll: Callable,
+        mle: ArrayLike,
+        n_obs: int,
+        res: Any,
+        data: Any,
+    ) -> Any:
         """
         Store the fit artefacts and the attributes
         :class:`LikelihoodInferenceMixin` needs: ``_neg_ll`` (the negative

--- a/surpyval/recurrent/renewal/generalized_one_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_one_renewal.py
@@ -1,4 +1,7 @@
+from typing import Any, Callable
+
 import numpy as np
+from numpy.typing import ArrayLike
 from scipy.optimize import minimize
 
 from surpyval import Weibull
@@ -73,12 +76,12 @@ class GeneralizedOneRenewal(RenewalFitMixin):
     """
 
     @staticmethod
-    def _build_sampler(model):
+    def _build_sampler(model: Any) -> Callable:
         base_params = model.model.params
         q = model.q
         j = 0
 
-        def sample(ui):
+        def sample(ui: float) -> float:
             nonlocal j
             # The jth interarrival is the base lifetime scaled by (1 + q) ** j,
             # so its quantiles are the base quantiles multiplied by the same
@@ -89,7 +92,7 @@ class GeneralizedOneRenewal(RenewalFitMixin):
 
         return sample
 
-    def _make_model(self, underlying_model, q):
+    def _make_model(self, underlying_model: Any, q: float) -> "RenewalModel":
         return RenewalModel(
             underlying_model,
             q,
@@ -100,7 +103,7 @@ class GeneralizedOneRenewal(RenewalFitMixin):
             restoration_bounds=(-1, None),
         )
 
-    def _rescaled_increments(self, model, data):
+    def _rescaled_increments(self, model: Any, data: Any) -> np.ndarray:
         """
         Per-interval cumulative-hazard increments (time-rescaling residuals)
         for a fitted G1 renewal model. The ``j``-th interarrival of an item is
@@ -119,13 +122,20 @@ class GeneralizedOneRenewal(RenewalFitMixin):
         )
         return np.asarray(model.model.Hf(scaled), dtype=float)
 
-    def _refit(self, model, data):
+    def _refit(self, model: Any, data: Any) -> Any:
         """Refit this model family on ``data`` with the same lifetime
         distribution; used by the Cramer-von Mises bootstrap."""
         return self.fit_from_recurrent_data(data, dist=model.model.dist)
 
-    def create_negll_func(self, x, i, c, n, dist):
-        def negll_func(params):
+    def create_negll_func(
+        self,
+        x: np.ndarray,
+        i: np.ndarray,
+        c: np.ndarray,
+        n: np.ndarray,
+        dist: Any,
+    ) -> Callable:
+        def negll_func(params: np.ndarray) -> float:
             ll = 0
             q = params[0]
             dist_params = params[1:]
@@ -154,7 +164,7 @@ class GeneralizedOneRenewal(RenewalFitMixin):
         return negll_func
 
     @staticmethod
-    def _check_dist_eligible(dist):
+    def _check_dist_eligible(dist: Any) -> None:
         """
         The G1 renewal process scales interarrival times by ``(1 + q) ** j``.
         For the scaled times to remain valid the base distribution must be a
@@ -169,7 +179,12 @@ class GeneralizedOneRenewal(RenewalFitMixin):
                 "LogNormal).".format(dist.name, dist.support)
             )
 
-    def fit_from_recurrent_data(self, data, dist=Weibull, init=None):
+    def fit_from_recurrent_data(
+        self,
+        data: Any,
+        dist: Any = Weibull,
+        init: "ArrayLike | None" = None,
+    ) -> "RenewalModel":
         """
         Fit the generalized renewal model from recurrent data.
 
@@ -225,7 +240,7 @@ class GeneralizedOneRenewal(RenewalFitMixin):
         # The G1 likelihood only needs ``q > -1``, so it is optimised directly
         # under simple box bounds rather than an unconstrained transform.
         # result is sensitive to the initial value of q.
-        def fit_once(x0):
+        def fit_once(x0: np.ndarray) -> Any:
             return minimize(
                 neg_ll,
                 np.asarray(x0, dtype=float),
@@ -248,7 +263,15 @@ class GeneralizedOneRenewal(RenewalFitMixin):
         self._attach_inference(out, neg_ll, res.x, len(data.x), res, data)
         return out
 
-    def fit(self, x, i=None, c=None, n=None, dist=Weibull, init=None):
+    def fit(
+        self,
+        x: ArrayLike,
+        i: "ArrayLike | None" = None,
+        c: "ArrayLike | None" = None,
+        n: "ArrayLike | None" = None,
+        dist: Any = Weibull,
+        init: "ArrayLike | None" = None,
+    ) -> "RenewalModel":
         """
         Fit the generalized renewal model.
 
@@ -298,7 +321,9 @@ class GeneralizedOneRenewal(RenewalFitMixin):
         data = handle_xicn(x, i, c, n)
         return self.fit_from_recurrent_data(data, dist=dist, init=init)
 
-    def fit_from_parameters(self, params, q, dist=Weibull):
+    def fit_from_parameters(
+        self, params: ArrayLike, q: float, dist: Any = Weibull
+    ) -> "RenewalModel":
         """
         Fit the generalized renewal model from given parameters.
 

--- a/surpyval/recurrent/renewal/generalized_renewal.py
+++ b/surpyval/recurrent/renewal/generalized_renewal.py
@@ -1,4 +1,7 @@
+from typing import Any, Callable
+
 import numpy as np
+from numpy.typing import ArrayLike
 
 from surpyval import Weibull
 from surpyval.recurrent.renewal.fit_mixin import RenewalFitMixin
@@ -12,7 +15,9 @@ from surpyval.utils.recurrent_utils import (
 )
 
 
-def kijima_ii_from_prev_interarrival(previous_interarrival_times, q):
+def kijima_ii_from_prev_interarrival(
+    previous_interarrival_times: np.ndarray, q: float
+) -> np.ndarray:
     """
     Takes the interarrival times from the previous event for a given item
     and returns the virtual age for each interarrival time.
@@ -70,13 +75,13 @@ class GeneralizedRenewal(RenewalFitMixin):
     array([0.1214   , 1.1772   , 2.406    , 3.919    , 5.804    , 8.6088822])
     """
 
-    def kijima_i(self, v, x, q):
+    def kijima_i(self, v: float, x: float, q: float) -> float:
         return v + q * x
 
-    def kijima_ii(self, v, x, q):
+    def kijima_ii(self, v: float, x: float, q: float) -> float:
         return q * (v + x)
 
-    def _resolve_virtual_age_function(self, kijima_type):
+    def _resolve_virtual_age_function(self, kijima_type: str) -> Callable:
         if kijima_type == "i":
             return self.kijima_i
         if kijima_type == "ii":
@@ -86,12 +91,12 @@ class GeneralizedRenewal(RenewalFitMixin):
         )
 
     @staticmethod
-    def _build_sampler(model):
+    def _build_sampler(model: Any) -> Callable:
         q = model.q
         virtual_age_function = model._virtual_age_function
         virtual_age = 0.0
 
-        def sample(ui):
+        def sample(ui: float) -> float:
             nonlocal virtual_age
             u_adj = ui * model.model.sf(virtual_age)
             xi = model.model.qf(1 - u_adj) - virtual_age
@@ -100,7 +105,9 @@ class GeneralizedRenewal(RenewalFitMixin):
 
         return sample
 
-    def _make_model(self, underlying_model, q, kijima_type):
+    def _make_model(
+        self, underlying_model: Any, q: float, kijima_type: str
+    ) -> "RenewalModel":
         out = RenewalModel(
             underlying_model,
             q,
@@ -116,7 +123,7 @@ class GeneralizedRenewal(RenewalFitMixin):
         )
         return out
 
-    def _rescaled_increments(self, model, data):
+    def _rescaled_increments(self, model: Any, data: Any) -> np.ndarray:
         """
         Per-interval cumulative-hazard increments ``H(v_k + x_k) - H(v_k)``
         (the time-rescaling residuals) for a fitted Kijima renewal model, where
@@ -151,7 +158,7 @@ class GeneralizedRenewal(RenewalFitMixin):
             model.model.Hf(x_new) - model.model.Hf(virtual_ages), dtype=float
         )
 
-    def _refit(self, model, data):
+    def _refit(self, model: Any, data: Any) -> Any:
         """Refit this model family on ``data`` with the same lifetime
         distribution and Kijima type; used by the Cramer-von Mises bootstrap.
         """
@@ -159,17 +166,18 @@ class GeneralizedRenewal(RenewalFitMixin):
             data, dist=model.model.dist, kijima=model.kijima_type
         )
 
-    def create_negll_func(self, data, dist, kijima="i"):
+    def create_negll_func(
+        self, data: Any, dist: Any, kijima: str = "i"
+    ) -> Callable:
         _, idx = np.unique(data.i, return_index=True)
         c = data.c
         x_interarrival = data.get_interarrival_times()
 
         if kijima == "i":
             arrival_times = np.split(data.x, idx)[1:]
-            cumulative_previous = [
-                np.concatenate([[0], arr[:-1]]) for arr in arrival_times
-            ]
-            cumulative_previous = np.concatenate(cumulative_previous)
+            cumulative_previous = np.concatenate(
+                [np.concatenate([[0], arr[:-1]]) for arr in arrival_times]
+            )
 
         elif kijima == "ii":
             prev_x_interarrival = np.concatenate(
@@ -179,7 +187,7 @@ class GeneralizedRenewal(RenewalFitMixin):
                 ]
             )
 
-        def negll_func(params):
+        def negll_func(params: np.ndarray) -> float:
             q = params[0]
             params = params[1:]
 
@@ -215,8 +223,12 @@ class GeneralizedRenewal(RenewalFitMixin):
         return negll_func
 
     def fit_from_recurrent_data(
-        self, data, dist=Weibull, kijima="i", init=None
-    ):
+        self,
+        data: Any,
+        dist: Any = Weibull,
+        kijima: str = "i",
+        init: "ArrayLike | None" = None,
+    ) -> "RenewalModel":
         """
         Fit the generalized renewal model from recurrent data.
 
@@ -291,8 +303,15 @@ class GeneralizedRenewal(RenewalFitMixin):
         return out
 
     def fit(
-        self, x, i=None, c=None, n=None, dist=Weibull, kijima="i", init=None
-    ):
+        self,
+        x: ArrayLike,
+        i: "ArrayLike | None" = None,
+        c: "ArrayLike | None" = None,
+        n: "ArrayLike | None" = None,
+        dist: Any = Weibull,
+        kijima: str = "i",
+        init: "ArrayLike | None" = None,
+    ) -> "RenewalModel":
         """
         Fit the generalized renewal model.
 
@@ -346,7 +365,13 @@ class GeneralizedRenewal(RenewalFitMixin):
         data = handle_xicn(x, i, c, n)
         return self.fit_from_recurrent_data(data, dist, kijima, init=init)
 
-    def fit_from_parameters(self, params, q, kijima="i", dist=Weibull):
+    def fit_from_parameters(
+        self,
+        params: ArrayLike,
+        q: float,
+        kijima: str = "i",
+        dist: Any = Weibull,
+    ) -> "RenewalModel":
         """
         Fit the generalized renewal model from given parameters.
 

--- a/surpyval/recurrent/renewal/renewal_model.py
+++ b/surpyval/recurrent/renewal/renewal_model.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Callable
 
 import numpy as np
 
@@ -50,6 +50,9 @@ class RenewalModel(
         a transform that keeps its confidence bounds inside the support.
     """
 
+    # Set by the GeneralizedRenewal fitter for its Kijima sampler.
+    _virtual_age_function: Any
+
     #: Set by the fitter for the generalized-renewal family (``"i"``/``"ii"``);
     #: absent otherwise.
     kijima_type: Any
@@ -58,15 +61,15 @@ class RenewalModel(
 
     def __init__(
         self,
-        model,
-        restoration,
-        restoration_name,
-        restoration_label,
-        kind,
-        sampler_factory,
-        dist_label="Distribution",
-        restoration_bounds=(None, None),
-    ):
+        model: Any,
+        restoration: float,
+        restoration_name: str,
+        restoration_label: str,
+        kind: str,
+        sampler_factory: Callable,
+        dist_label: str = "Distribution",
+        restoration_bounds: tuple = (None, None),
+    ) -> None:
         self.model = model
         self.restoration = restoration
         self._restoration_param_name = restoration_name
@@ -189,25 +192,25 @@ class RenewalModel(
         # GeneralizedOneRenewal
         return fitter.fit_from_parameters(params, restoration, dist=dist)
 
-    def _new_sequence_sampler(self):
+    def _new_sequence_sampler(self) -> Callable:
         return self._sampler_factory(self)
 
-    def _parameter_names(self):
+    def _parameter_names(self) -> list:
         # The restoration parameter (``q``/``rho``) leads ``_mle``, followed by
         # the underlying lifetime/intensity model's parameters.
         return [self._restoration_param_name, *self.model.dist.param_names]
 
-    def _parameter_bounds(self):
+    def _parameter_bounds(self) -> list:
         return [self._restoration_bounds, *self.model.dist.bounds]
 
-    def _check_has_data(self, what):
+    def _check_has_data(self, what: str) -> None:
         if not hasattr(self, "data"):
             raise ValueError(
                 "{} requires a model fitted from data; fit_from_parameters "
                 "models carry no data.".format(what)
             )
 
-    def residuals(self, kind="cumulative_hazard"):
+    def residuals(self, kind: str = "cumulative_hazard") -> np.ndarray:
         """
         Residual diagnostics for the fitted imperfect-repair model, from the
         time-rescaling theorem applied to the process's *conditional*
@@ -260,7 +263,9 @@ class RenewalModel(
             "got {!r}".format(kind)
         )
 
-    def trend_test(self, test="laplace", alternative="two-sided"):
+    def trend_test(
+        self, test: str = "laplace", alternative: str = "two-sided"
+    ) -> Any:
         """
         Run a trend test on the data this model was fitted to. The null
         hypothesis is a *homogeneous* Poisson process (no trend); the statistic
@@ -289,7 +294,9 @@ class RenewalModel(
             self.data, test=test, alternative=alternative
         )
 
-    def cramer_von_mises(self, n_boot=200, seed=None):
+    def cramer_von_mises(
+        self, n_boot: int = 200, seed: "int | None" = None
+    ) -> Any:
         """
         Cramer-von Mises goodness-of-fit test of the fitted imperfect-repair
         model.
@@ -328,7 +335,7 @@ class RenewalModel(
             self, n_boot=n_boot, seed=seed
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         title = f"{self.kind} SurPyval Model"
         lines = [
             title,

--- a/surpyval/recurrent/serialisation.py
+++ b/surpyval/recurrent/serialisation.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 """Shared helpers for serialising fitted recurrent-event models.
 
 The recurrence intensity models (``HPP``, ``CrowAMSAA``, ``Duane``,
@@ -9,7 +11,7 @@ an explicit name map here.
 """
 
 
-def intensity_dist_by_name(name):
+def intensity_dist_by_name(name: str) -> Any:
     """
     Resolve a recurrence intensity model from its display ``name``.
 

--- a/surpyval/recurrent/simulation.py
+++ b/surpyval/recurrent/simulation.py
@@ -1,7 +1,9 @@
 import warnings
+from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np
 from matplotlib import pyplot as plt
+from numpy.typing import ArrayLike
 from scipy.stats import uniform
 
 from surpyval.recurrent.nonparametric import NonParametricCounting
@@ -29,7 +31,17 @@ class RecurrenceSimulationMixin:
     declare those via ``_cif_args`` rather than reimplementing the sampler.
     """
 
-    def _set_simulation_seed(self, seed):
+    if TYPE_CHECKING:
+        # The host model supplies these; declared rather than defined so a
+        # model that forgets one still gets the AttributeError naming it.
+        data: Any
+        dist: Any
+        params: Any
+
+        def cif(self, x: Any, *args: Any) -> Any: ...
+        def inv_cif(self, x: Any, *args: Any) -> Any: ...
+
+    def _set_simulation_seed(self, seed: "int | None") -> None:
         # ``None`` defers to numpy's global RNG (so ``np.random.seed`` still
         # controls the stream); an int/Generator gives a reproducible stream
         # that is independent of global state.
@@ -37,23 +49,23 @@ class RecurrenceSimulationMixin:
             None if seed is None else np.random.default_rng(seed)
         )
 
-    def initialize_simulation(self):
+    def initialize_simulation(self) -> None:
         self.us = uniform.rvs(
             size=100_000,
             random_state=getattr(self, "_sim_random_state", None),
         ).tolist()
 
-    def clear_simulation(self):
+    def clear_simulation(self) -> None:
         del self.us
 
-    def get_uniform_random_number(self):
+    def get_uniform_random_number(self) -> float:
         try:
             return self.us.pop()
         except IndexError:
             self.initialize_simulation()
             return self.us.pop()
 
-    def _cif_args(self):
+    def _cif_args(self) -> tuple:
         """
         Extra positional arguments threaded into ``cif``/``inv_cif`` for each
         simulated sequence. Empty for unconditional models; the covariate
@@ -61,7 +73,7 @@ class RecurrenceSimulationMixin:
         """
         return ()
 
-    def _new_sequence_sampler(self):
+    def _new_sequence_sampler(self) -> Callable:
         """
         Return a callable ``sample(ui) -> xi`` that draws the next interarrival
         time from a uniform random number, maintaining per-sequence state
@@ -76,7 +88,7 @@ class RecurrenceSimulationMixin:
         cif_args = self._cif_args()
         x_prev = 0.0
 
-        def sample(ui):
+        def sample(ui: float) -> float:
             nonlocal x_prev
             u_adj = ui * np.exp(-self.cif(x_prev, *cif_args))
             xi = self.inv_cif(-np.log(u_adj), *cif_args) - x_prev
@@ -85,7 +97,7 @@ class RecurrenceSimulationMixin:
 
         return sample
 
-    def _postprocess_simulated_model(self, model):
+    def _postprocess_simulated_model(self, model: Any) -> Any:
         """
         Adjust the fitted ``NonParametricCounting`` model in place before it is
         returned. A CoxLewis (log-linear) intensity has a non-zero baseline
@@ -100,7 +112,9 @@ class RecurrenceSimulationMixin:
         # exact, so the simulated MCF needs no baseline offset (#288).
         return model
 
-    def _simulate_count_xicn(self, events, items, seed):
+    def _simulate_count_xicn(
+        self, events: int, items: int, seed: "int | None"
+    ) -> dict:
         """
         Simulate ``items`` count-terminated sequences and return the raw event
         data as an ``xicn`` dict (``events + 1`` exact events per sequence).
@@ -108,7 +122,7 @@ class RecurrenceSimulationMixin:
         self._set_simulation_seed(seed)
         self.initialize_simulation()
 
-        xicn = {"x": [], "i": [], "c": [], "n": []}
+        xicn: dict = {"x": [], "i": [], "c": [], "n": []}
 
         for i in range(0, items):
             running = 0
@@ -124,7 +138,14 @@ class RecurrenceSimulationMixin:
         self.clear_simulation()
         return xicn
 
-    def _simulate_time_xicn(self, T, items, tol, max_events, seed):
+    def _simulate_time_xicn(
+        self,
+        T: float,
+        items: int,
+        tol: float,
+        max_events: int,
+        seed: "int | None",
+    ) -> dict:
         """
         Simulate ``items`` time-terminated sequences and return the raw event
         data as an ``xicn`` dict. Each sequence ends in a right-censored (c=1)
@@ -136,7 +157,7 @@ class RecurrenceSimulationMixin:
         stalled = False
         hit_max_events = False
 
-        xicn = {"x": [], "i": [], "c": [], "n": []}
+        xicn: dict = {"x": [], "i": [], "c": [], "n": []}
 
         for i in range(0, items):
             running = 0
@@ -176,7 +197,9 @@ class RecurrenceSimulationMixin:
 
         return xicn
 
-    def count_terminated_simulation_data(self, events, items=1, seed=None):
+    def count_terminated_simulation_data(
+        self, events: int, items: int = 1, seed: "int | None" = None
+    ) -> Any:
         """
         Simulate count-terminated recurrence data and return the raw events.
 
@@ -223,8 +246,13 @@ class RecurrenceSimulationMixin:
         return handle_xicn(**xicn)
 
     def time_terminated_simulation_data(
-        self, T, items=1, tol=1e-8, max_events=10_000, seed=None
-    ):
+        self,
+        T: float,
+        items: int = 1,
+        tol: float = 1e-8,
+        max_events: int = 10_000,
+        seed: "int | None" = None,
+    ) -> Any:
         """
         Simulate time-terminated recurrence data and return the raw events.
 
@@ -260,7 +288,9 @@ class RecurrenceSimulationMixin:
         xicn = self._simulate_time_xicn(T, items, tol, max_events, seed)
         return handle_xicn(**xicn)
 
-    def count_terminated_simulation(self, events, items=1, seed=None):
+    def count_terminated_simulation(
+        self, events: int, items: int = 1, seed: "int | None" = None
+    ) -> Any:
         """
         Simulate count-terminated recurrence data based on the fitted model.
 
@@ -292,8 +322,13 @@ class RecurrenceSimulationMixin:
         return model
 
     def time_terminated_simulation(
-        self, T, items=1, tol=1e-8, max_events=10_000, seed=None
-    ):
+        self,
+        T: float,
+        items: int = 1,
+        tol: float = 1e-8,
+        max_events: int = 10_000,
+        seed: "int | None" = None,
+    ) -> Any:
         """
         Simulate time-terminated recurrence data based on the fitted model.
 
@@ -336,7 +371,9 @@ class RecurrenceSimulationMixin:
         model.var = None
         return model
 
-    def mcf(self, x, items=1000, seed=None):
+    def mcf(
+        self, x: ArrayLike, items: int = 1000, seed: "int | None" = None
+    ) -> Any:
         """
         Estimate the mean cumulative function (MCF) at ``x``.
 
@@ -367,7 +404,9 @@ class RecurrenceSimulationMixin:
         )
         return np_model.mcf(x)
 
-    def plot(self, ax=None, items=1000, seed=None):
+    def plot(
+        self, ax: Any = None, items: int = 1000, seed: "int | None" = None
+    ) -> Any:
         """
         Overlay the simulated MCF on the empirical MCF of the fitted data.
 

--- a/surpyval/univariate/competing_risks/aalen_johansen.py
+++ b/surpyval/univariate/competing_risks/aalen_johansen.py
@@ -7,9 +7,12 @@ those copies went wrong (#278). It now lives here once.
 """
 
 import numpy as np
+import numpy.typing as npt
 
 
-def aalen_johansen_iif(S, hazard_increments):
+def aalen_johansen_iif(
+    S: npt.NDArray, hazard_increments: npt.NDArray
+) -> npt.NDArray:
     """Instantaneous incidence increments.
 
     The cause-specific hazard increment at ``t_i`` acts on the

--- a/surpyval/univariate/competing_risks/nonparametric/competing_risks.py
+++ b/surpyval/univariate/competing_risks/nonparametric/competing_risks.py
@@ -8,8 +8,10 @@ Copyright 2022 Cartiga LLC
 """
 
 import textwrap
+from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 
 import surpyval as surv
 from surpyval.serialisation import SerialisableMixin, stamp_schema, to_native
@@ -28,6 +30,9 @@ from surpyval.utils import (
 
 
 class CompetingRisks(SerialisableMixin):
+    #: The source DataFrame when fitted via ``fit_from_df`` (named so it
+    #: does not shadow the density method ``df``, #253).
+    source_df: Any
     # Attributes populated by ``fit`` / ``from_dict``; declared for the type
     # checker.
     event_idx_map: dict
@@ -95,14 +100,14 @@ class CompetingRisks(SerialisableMixin):
             setattr(out, name, np.array(model_dict[name], dtype=float))
         return out
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         out = """\
         Competing Risk model with events:
         {events}
         """.format(events=list(self.event_idx_map.keys()))
         return textwrap.dedent(out)
 
-    def _f(self, f, x, event):
+    def _f(self, f: str, x: npt.ArrayLike, event: Any) -> npt.NDArray:
         validate_event(self.event_idx_map, event)
         idx, rev = _get_idx(self.x, x)
 
@@ -126,16 +131,16 @@ class CompetingRisks(SerialisableMixin):
         # first event time.
         return np.where(idx[rev] < 0, 0.0, out)
 
-    def hf(self, x, event=None):
+    def hf(self, x: npt.ArrayLike, event: Any = None) -> npt.NDArray:
         return self._f("h", x, event)
 
-    def Hf(self, x, event=None):
+    def Hf(self, x: npt.ArrayLike, event: Any = None) -> npt.NDArray:
         return self._f("H", x, event)
 
-    def sf(self, x, event=None):
+    def sf(self, x: npt.ArrayLike, event: Any = None) -> npt.NDArray:
         return np.exp(-self.Hf(x, event=event))
 
-    def ff(self, x, event=None):
+    def ff(self, x: npt.ArrayLike, event: Any = None) -> npt.NDArray:
         """
         A lot of commentary about this being difficult to interpret.
         In engineering this is not the case, eliminating the failure
@@ -143,17 +148,17 @@ class CompetingRisks(SerialisableMixin):
         """
         return 1 - np.exp(-self.Hf(x, event=event))
 
-    def df(self, x, event=None):
+    def df(self, x: npt.ArrayLike, event: Any = None) -> npt.NDArray:
         return self.hf(x, event=event) * self.sf(x, event=event)
 
-    def iif(self, x, event):
+    def iif(self, x: npt.ArrayLike, event: Any) -> npt.NDArray:
         """
         Instantaneous Incidence Function
         """
         validate_cif_event(event)
         return self._f("IIF", x, event)
 
-    def cif(self, x, event):
+    def cif(self, x: npt.ArrayLike, event: Any) -> npt.NDArray:
         """
         Cumulative Incidence Function
         """
@@ -163,8 +168,14 @@ class CompetingRisks(SerialisableMixin):
 
     @classmethod
     def fit_from_df(
-        cls, df, x_col, e_col, c_col=None, n_col=None, method="Nelson-Aalen"
-    ):
+        cls,
+        df: Any,
+        x_col: str,
+        e_col: str,
+        c_col: "str | None" = None,
+        n_col: "str | None" = None,
+        method: str = "Nelson-Aalen",
+    ) -> "CompetingRisks":
         x, c, n, e = validate_cr_df_inputs(df, x_col, e_col, c_col, n_col)
         model = cls.fit(x, e, c, n, method)
         # Keep the source frame without shadowing the ``df`` (density)
@@ -173,7 +184,14 @@ class CompetingRisks(SerialisableMixin):
         return model
 
     @classmethod
-    def fit(cls, x, e, c=None, n=None, method="Nelson-Aalen"):
+    def fit(
+        cls,
+        x: npt.ArrayLike,
+        e: npt.ArrayLike,
+        c: "npt.ArrayLike | None" = None,
+        n: "npt.ArrayLike | None" = None,
+        method: str = "Nelson-Aalen",
+    ) -> "CompetingRisks":
         """
         Need to check that causes is the same length
         TODO: FlemingHarrington baseline.

--- a/surpyval/univariate/competing_risks/nonparametric/gray_test.py
+++ b/surpyval/univariate/competing_risks/nonparametric/gray_test.py
@@ -18,6 +18,7 @@ References
 from typing import Any, NamedTuple
 
 import numpy as np
+import numpy.typing as npt
 from scipy.stats import chi2
 
 from surpyval.univariate.competing_risks.aalen_johansen import (
@@ -36,12 +37,12 @@ class GrayTestResult(NamedTuple):
 
 
 def gray_test(
-    x,
-    e,
-    group,
-    cause,
-    c=None,
-    n=None,
+    x: npt.ArrayLike,
+    e: npt.ArrayLike,
+    group: npt.ArrayLike,
+    cause: Any,
+    c: "npt.ArrayLike | None" = None,
+    n: "npt.ArrayLike | None" = None,
     rho: float = 0.0,
 ) -> GrayTestResult:
     """
@@ -166,7 +167,13 @@ def gray_test(
     )
 
 
-def _pooled_cif(x, all_event, is_cause, n, cause_times) -> np.ndarray:
+def _pooled_cif(
+    x: npt.NDArray,
+    all_event: npt.NDArray,
+    is_cause: npt.NDArray,
+    n: npt.NDArray,
+    cause_times: npt.NDArray,
+) -> np.ndarray:
     """Aalen-Johansen cumulative incidence of the cause on the pooled sample,
     evaluated at ``cause_times``."""
     times = np.unique(x)

--- a/surpyval/univariate/competing_risks/parametric/parametric_competing_risks.py
+++ b/surpyval/univariate/competing_risks/parametric/parametric_competing_risks.py
@@ -24,7 +24,10 @@ H_j(u))`. The cause CIFs sum to the all-cause failure probability
 :math:`1 - S(t)`.
 """
 
+from typing import Any
+
 import numpy as np
+import numpy.typing as npt
 from scipy.integrate import cumulative_trapezoid
 
 from surpyval.serialisation import SerialisableMixin, stamp_schema, to_native
@@ -37,7 +40,12 @@ from surpyval.utils import (
 )
 
 
-def _validate(x, c, n, e):
+def _validate(
+    x: npt.ArrayLike,
+    c: "npt.ArrayLike | None",
+    n: "npt.ArrayLike | None",
+    e: npt.ArrayLike,
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     """Wrangle ``x``/``c``/``n`` and check the event labels: ``e`` is the
     per-observation cause. A missing event (``None`` / ``NaN``) marks a
     censored observation; if ``c`` is not given it is derived from the events.
@@ -109,7 +117,7 @@ class ParametricCompetingRisks(SerialisableMixin):
         }
         return out
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         dists = ", ".join(
             "{}: {}".format(k, self.models[k].dist.name) for k in self.causes
         )
@@ -124,7 +132,7 @@ class ParametricCompetingRisks(SerialisableMixin):
 
     # -- cause-specific and all-cause functions ---------------------------
 
-    def Hf(self, x, event=None):
+    def Hf(self, x: npt.ArrayLike, event: Any = None) -> npt.NDArray:
         """Cumulative hazard. ``event=None`` gives the all-cause cumulative
         hazard :math:`\\sum_k H_k`; ``event=k`` gives cause ``k``'s."""
         if event is not None:
@@ -132,7 +140,7 @@ class ParametricCompetingRisks(SerialisableMixin):
             return self.models[event].Hf(x)
         return sum(self.models[k].Hf(x) for k in self.causes)
 
-    def hf(self, x, event=None):
+    def hf(self, x: npt.ArrayLike, event: Any = None) -> npt.NDArray:
         """Hazard rate. ``event=None`` is the all-cause hazard
         :math:`\\sum_k h_k`; ``event=k`` is the cause-specific hazard."""
         if event is not None:
@@ -140,16 +148,16 @@ class ParametricCompetingRisks(SerialisableMixin):
             return self.models[event].hf(x)
         return sum(self.models[k].hf(x) for k in self.causes)
 
-    def sf(self, x):
+    def sf(self, x: npt.ArrayLike) -> npt.NDArray:
         """All-cause survival :math:`S(t) = \\prod_k S_k(t)`."""
         return np.exp(-self.Hf(x))
 
-    def ff(self, x):
+    def ff(self, x: npt.ArrayLike) -> npt.NDArray:
         """All-cause failure probability :math:`1 - S(t)` (the total
         cumulative incidence over all causes)."""
         return -np.expm1(-self.Hf(x))
 
-    def iif(self, x, event):
+    def iif(self, x: npt.ArrayLike, event: Any) -> npt.NDArray:
         """
         Instantaneous incidence function (the subdistribution density) of a
         cause: :math:`f_k^{\\mathrm{sub}}(t) = h_k(t) S(t) = f_k(t)
@@ -166,7 +174,9 @@ class ParametricCompetingRisks(SerialisableMixin):
         with np.errstate(divide="ignore", invalid="ignore"):
             return self.models[event].df(x) * others
 
-    def cif(self, x, event=None):
+    def cif(
+        self, x: npt.ArrayLike, event: Any = None
+    ) -> "npt.NDArray | float":
         """
         Cumulative incidence function. ``event=k`` returns
         :math:`\\int_0^t f_k^{\\mathrm{sub}}(u)\\,du`, the probability of
@@ -187,7 +197,7 @@ class ParametricCompetingRisks(SerialisableMixin):
         out = np.interp(x_arr, grid, cif_grid)
         return out if np.ndim(x) else float(out[0])
 
-    def probability_of_cause(self, event):
+    def probability_of_cause(self, event: Any) -> Any:
         """
         The eventual probability that a unit fails from ``event``,
         :math:`\\mathrm{CIF}_k(\\infty)`. These sum to one over all causes.
@@ -198,7 +208,9 @@ class ParametricCompetingRisks(SerialisableMixin):
         upper = max(self._model_horizon(k) for k in self.causes)
         return self.cif(upper, event)
 
-    def random(self, size, random_state=None):
+    def random(
+        self, size: int, random_state: "int | None" = None
+    ) -> npt.NDArray:
         """
         Draw ``size`` samples of ``(time, cause)`` from the model, using the
         latent-failure-time representation: draw a latent time from each cause
@@ -234,21 +246,21 @@ class ParametricCompetingRisks(SerialisableMixin):
 
     # -- goodness of fit (the joint likelihood factorises over causes) ----
 
-    def neg_ll(self):
+    def neg_ll(self) -> float:
         """Total negative log-likelihood: the sum over the per-cause fits."""
         return float(sum(self.models[k].neg_ll() for k in self.causes))
 
-    def aic(self):
+    def aic(self) -> float:
         """Akaike information criterion of the joint model."""
         return float(sum(self.models[k].aic() for k in self.causes))
 
-    def bic(self):
+    def bic(self) -> float:
         """Bayesian information criterion of the joint model."""
         return float(sum(self.models[k].bic() for k in self.causes))
 
     # -- helpers ----------------------------------------------------------
 
-    def _check_event(self, event):
+    def _check_event(self, event: Any) -> None:
         if event not in self.models:
             raise ValueError(
                 "Unknown cause {!r}; fitted causes are {}.".format(
@@ -256,7 +268,7 @@ class ParametricCompetingRisks(SerialisableMixin):
                 )
             )
 
-    def _model_horizon(self, k):
+    def _model_horizon(self, k: Any) -> float:
         # The time by which cause k has essentially played out, used as the
         # finite upper limit for the (numerically integrated) CIF(inf). Its
         # very high quantile when that is finite; for a cure fraction the
@@ -288,7 +300,7 @@ class ParametricCompetingRisks(SerialisableMixin):
     # -- construction -----------------------------------------------------
 
     @classmethod
-    def from_fitted(cls, models):
+    def from_fitted(cls, models: dict) -> "ParametricCompetingRisks":
         """
         Assemble a competing-risks model from already-fitted single-cause
         models -- one per cause -- instead of fitting them here.
@@ -356,7 +368,15 @@ class ParametricCompetingRisks(SerialisableMixin):
         return model
 
     @classmethod
-    def fit(cls, x, e, c=None, n=None, dist=Weibull, how="MLE"):
+    def fit(
+        cls,
+        x: npt.ArrayLike,
+        e: npt.ArrayLike,
+        c: "npt.ArrayLike | None" = None,
+        n: "npt.ArrayLike | None" = None,
+        dist: Any = Weibull,
+        how: str = "MLE",
+    ) -> "ParametricCompetingRisks":
         """
         Fit a parametric distribution to each cause's cause-specific hazard.
 
@@ -408,8 +428,15 @@ class ParametricCompetingRisks(SerialisableMixin):
 
     @classmethod
     def fit_from_df(
-        cls, df, x_col, e_col, c_col=None, n_col=None, dist=Weibull, how="MLE"
-    ):
+        cls,
+        df: Any,
+        x_col: str,
+        e_col: str,
+        c_col: "str | None" = None,
+        n_col: "str | None" = None,
+        dist: Any = Weibull,
+        how: str = "MLE",
+    ) -> "ParametricCompetingRisks":
         """Fit from a DataFrame; see :meth:`fit`. ``x_col`` / ``e_col`` name
         the time and cause columns, with optional ``c_col`` / ``n_col``."""
         x = df[x_col].to_numpy()

--- a/surpyval/univariate/competing_risks/regression/competing_risks_proportional_hazard.py
+++ b/surpyval/univariate/competing_risks/regression/competing_risks_proportional_hazard.py
@@ -7,7 +7,10 @@ code constitutes acceptance of these terms.
 Copyright 2022 Cartiga LLC
 """
 
+from typing import Any
+
 import numpy as np
+import numpy.typing as npt
 
 from surpyval.univariate.competing_risks.aalen_johansen import (
     aalen_johansen_iif,
@@ -24,6 +27,23 @@ from .fine_gray import FineGray
 
 
 class CompetingRisksProportionalHazards:
+    # Populated by ``fit``; declared for the type checker.
+    how: str
+    x: "npt.NDArray"
+    results: list
+    betas: "npt.NDArray"
+    beta: "npt.NDArray"
+    event_idx_map: dict
+    n_event_types: int
+    h0_e: "npt.NDArray"
+    H0_e: "npt.NDArray"
+    phi: Any
+    phi_e: Any
+    _fg_models: dict
+    feature_names: "list | None"
+    formula: Any
+    _model_spec: Any
+
     """
     Competing-risks proportional-hazards regression.
 
@@ -36,7 +56,7 @@ class CompetingRisksProportionalHazards:
     TODO: Time-Varying Implementation
     """
 
-    def _fg_model(self, event):
+    def _fg_model(self, event: Any) -> Any:
         # Resolve the per-cause Fine-Gray subdistribution model, requiring an
         # explicit cause (the Fine-Gray CIF is defined one cause at a time).
         if event is None:
@@ -47,7 +67,14 @@ class CompetingRisksProportionalHazards:
             raise ValueError("Unrecognised event type for this model")
         return self._fg_models[event]
 
-    def _f(self, arr, x, Z, event=None, interp="step"):
+    def _f(
+        self,
+        arr: npt.NDArray,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        event: Any = None,
+        interp: str = "step",
+    ) -> npt.NDArray:
         idx, rev = _get_idx(self.x, x)
 
         if event is not None:
@@ -70,7 +97,13 @@ class CompetingRisksProportionalHazards:
         # zero there (#253).
         return np.where(idx[rev] < 0, 0.0, out)
 
-    def hf(self, x, Z, event=None, interp="step"):
+    def hf(
+        self,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        event: Any = None,
+        interp: str = "step",
+    ) -> npt.NDArray:
         if self.how == "Fine-Gray":
             raise ValueError(
                 "The Fine-Gray subdistribution hazard has no pointwise "
@@ -78,23 +111,47 @@ class CompetingRisksProportionalHazards:
             )
         return self._f(self.h0_e, x, Z, event=event, interp=interp)
 
-    def Hf(self, x, Z, event=None, interp="step"):
+    def Hf(
+        self,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        event: Any = None,
+        interp: str = "step",
+    ) -> npt.NDArray:
         if self.how == "Fine-Gray":
             # Cumulative subdistribution hazard H0_k(x) * exp(beta'Z) = -log S.
             return -np.log(self.sf(x, Z, event=event))
         return self._f(self.H0_e, x, Z, event=event, interp=interp)
 
-    def sf(self, x, Z, event=None, interp="step"):
+    def sf(
+        self,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        event: Any = None,
+        interp: str = "step",
+    ) -> npt.NDArray:
         if self.how == "Fine-Gray":
             return self._fg_model(event).sf(x, Z)
         return np.exp(-self.Hf(x, Z, event=event, interp=interp))
 
-    def ff(self, x, Z, event=None, interp="step"):
+    def ff(
+        self,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        event: Any = None,
+        interp: str = "step",
+    ) -> npt.NDArray:
         if self.how == "Fine-Gray":
             return self.cif(x, Z, event)
         return 1 - self.sf(x, Z, event=event, interp=interp)
 
-    def df(self, x, Z, event=None, interp="step"):
+    def df(
+        self,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        event: Any = None,
+        interp: str = "step",
+    ) -> npt.NDArray:
         if self.how == "Fine-Gray":
             raise ValueError(
                 "The Fine-Gray subdistribution density has no pointwise form "
@@ -104,7 +161,9 @@ class CompetingRisksProportionalHazards:
             x, Z, event=event, interp=interp
         )
 
-    def cif(self, x, Z, event):
+    def cif(
+        self, x: npt.ArrayLike, Z: npt.ArrayLike, event: Any
+    ) -> npt.NDArray:
         if self.how == "Fine-Gray":
             # Direct subdistribution CIF: 1 - exp(-H0_k(x) exp(beta'Z)).
             return self._fg_model(event).cif(x, Z)
@@ -123,16 +182,16 @@ class CompetingRisksProportionalHazards:
     @classmethod
     def fit_from_df(
         cls,
-        df,
-        x_col,
-        e_col,
-        Z_cols=None,
-        c_col=None,
-        n_col=None,
-        formula=None,
-        how="Cox",
-        tie_method="efron",
-    ):
+        df: Any,
+        x_col: str,
+        e_col: str,
+        Z_cols: "str | list[str] | None" = None,
+        c_col: "str | None" = None,
+        n_col: "str | None" = None,
+        formula: "str | None" = None,
+        how: str = "Cox",
+        tie_method: str = "efron",
+    ) -> "CompetingRisksProportionalHazards":
         """
         Fit a competing-risks proportional-hazards model from a pandas
         DataFrame.
@@ -188,7 +247,16 @@ class CompetingRisksProportionalHazards:
         return model
 
     @classmethod
-    def fit(cls, x, Z, e, c=None, n=None, how="Cox", tie_method="efron"):
+    def fit(
+        cls,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        e: npt.ArrayLike,
+        c: "npt.ArrayLike | None" = None,
+        n: "npt.ArrayLike | None" = None,
+        how: str = "Cox",
+        tie_method: str = "efron",
+    ) -> "CompetingRisksProportionalHazards":
         r"""
         This function aimed to have an API to mimic the simplicity
         of the scipy API. That is, to use a simple :code:`fit()` call,

--- a/surpyval/univariate/competing_risks/regression/fine_gray.py
+++ b/surpyval/univariate/competing_risks/regression/fine_gray.py
@@ -30,7 +30,10 @@ already had the event of interest, leave the risk set. The partial likelihood
 is the Breslow form of this weighted risk set.
 """
 
+from typing import Any
+
 import numpy as np
+import numpy.typing as npt
 from autograd import grad, hessian
 from autograd import numpy as anp
 from scipy.optimize import minimize
@@ -42,7 +45,14 @@ from surpyval.utils.ipcw import censoring_survival, step_at
 from surpyval.utils.linalg import safe_inv
 
 
-def _fit_cause(x, Z, e, c, n, cause):
+def _fit_cause(
+    x: npt.NDArray,
+    Z: npt.NDArray,
+    e: npt.NDArray,
+    c: npt.NDArray,
+    n: npt.NDArray,
+    cause: Any,
+) -> dict:
     """
     Fit the Fine-Gray subdistribution-hazard model for a single ``cause``.
 
@@ -80,7 +90,7 @@ def _fit_cause(x, Z, e, c, n, cause):
     n_event = n[is_event]
     Z_event = Z[is_event]
 
-    def neg_ll(beta):
+    def neg_ll(beta: Any) -> Any:
         eta = anp.dot(Z, beta)
         weighted_exp = n * anp.exp(eta)
         denom = anp.dot(W, weighted_exp)
@@ -134,7 +144,7 @@ class FineGrayModel(SerialisableMixin):
     hazard ratios.
     """
 
-    def __init__(self, fit):
+    def __init__(self, fit: dict) -> None:
         self.cause = fit["cause"]
         self.coefficients = fit["beta"]
         self.beta = fit["beta"]
@@ -148,7 +158,7 @@ class FineGrayModel(SerialisableMixin):
 
     # -- serialisation -----------------------------------------------------
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         """
         Serialise this fitted Fine-Gray model to a plain, JSON-serialisable
         dict.
@@ -177,7 +187,7 @@ class FineGrayModel(SerialisableMixin):
         )
 
     @classmethod
-    def from_dict(cls, model_dict):
+    def from_dict(cls, model_dict: dict) -> "FineGrayModel":
         """Rebuild a Fine-Gray model from a :meth:`to_dict` dictionary."""
         if model_dict.get("model") != "FineGrayModel":
             raise ValueError(
@@ -201,10 +211,10 @@ class FineGrayModel(SerialisableMixin):
             }
         )
 
-    def phi(self, Z):
+    def phi(self, Z: npt.ArrayLike) -> npt.NDArray:
         return np.exp(np.asarray(Z, dtype=float) @ self.beta)
 
-    def cif(self, x, Z):
+    def cif(self, x: npt.ArrayLike, Z: npt.ArrayLike) -> npt.NDArray:
         """
         Cumulative incidence of the cause of interest at times ``x`` for a
         single covariate vector ``Z``: ``1 - exp(-Lambda0(x) * exp(beta'Z))``.
@@ -216,12 +226,12 @@ class FineGrayModel(SerialisableMixin):
         H0 = step_at(self._times, self._cumhaz, x, before=0.0)
         return 1.0 - np.exp(-H0 * np.exp(Z @ self.beta))
 
-    def sf(self, x, Z):
+    def sf(self, x: npt.ArrayLike, Z: npt.ArrayLike) -> npt.NDArray:
         """One minus the cumulative incidence (the cause-of-interest-free
         probability under the subdistribution)."""
         return 1.0 - self.cif(x, Z)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         lines = [
             "Fine-Gray Subdistribution Hazard Model",
             "======================================",
@@ -234,7 +244,15 @@ class FineGrayModel(SerialisableMixin):
 
 
 class FineGray_:
-    def fit(self, x, Z, e, c=None, n=None, cause=None):
+    def fit(
+        self,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        e: npt.ArrayLike,
+        c: "npt.ArrayLike | None" = None,
+        n: "npt.ArrayLike | None" = None,
+        cause: Any = None,
+    ) -> FineGrayModel:
         """
         Fit the Fine-Gray model for a cause of interest.
 

--- a/surpyval/univariate/parametric/fitters/__init__.py
+++ b/surpyval/univariate/parametric/fitters/__init__.py
@@ -206,7 +206,7 @@ def add_to_funcs(
 
 
 def bounds_convert(
-    x: npt.ArrayLike,
+    x: "npt.ArrayLike | None",
     bounds: Sequence[tuple[float | None, float | None]],
     fixed: dict[str, float] | None,
     param_map: dict[str, int],

--- a/surpyval/univariate/parametric/parametric.py
+++ b/surpyval/univariate/parametric/parametric.py
@@ -839,7 +839,7 @@ class Parametric(
         size: int | tuple[int, ...],
         a: float | None = None,
         b: float | None = None,
-    ) -> npt.NDArray:
+    ) -> "npt.NDArray | tuple":
         r"""
 
         A method to draw random samples from the distributions using the
@@ -858,9 +858,13 @@ class Parametric(
 
         Returns
         -------
-        random : numpy array
-            Returns a numpy array of size ``size`` with random values
-            drawn from the distribution.
+        random : numpy array, or tuple of numpy arrays
+            For a plain model, a numpy array of size ``size`` with random
+            values drawn from the distribution. A limited-failure-population
+            or zero-inflated model instead returns the draw as xcnt-format
+            ``(x, c, n, t)`` arrays, because some of its draws are
+            never-failing (right-censored) units that a bare array of
+            failure times cannot represent.
 
         Examples
         --------

--- a/surpyval/univariate/regression/_bounds.py
+++ b/surpyval/univariate/regression/_bounds.py
@@ -20,10 +20,16 @@ survival bound, which is its own.
 """
 
 import numpy as np
+import numpy.typing as npt
 from scipy.stats import norm
 
 
-def logit_sf_bound(sf_hat, se, sign, alpha_tail):
+def logit_sf_bound(
+    sf_hat: npt.ArrayLike,
+    se: npt.ArrayLike,
+    sign: float,
+    alpha_tail: float,
+) -> npt.NDArray:
     """
     A single survival-function confidence bound on the logit scale, which keeps
     it inside ``(0, 1)``: ``expit(logit(sf) + sign z se/(sf(1-sf)))``. ``sign``

--- a/surpyval/univariate/regression/_fit_skeleton.py
+++ b/surpyval/univariate/regression/_fit_skeleton.py
@@ -53,6 +53,19 @@ class LogLinearPhi:
         return {"beta_" + str(i): i for i in range(Z.shape[1])}
 
 
+class MirroredDistributionAttrs:
+    """Class-level declarations for the attributes
+    :func:`mirror_distribution` sets, so a fitter that inherits this
+    alongside its other mixins has them visible to the type checker."""
+
+    dist: Any
+    k_dist: int
+    bounds: tuple
+    support: tuple
+    param_names: list
+    param_map: dict
+
+
 def mirror_distribution(fitter: Any, distribution: Any) -> None:
     """Copy a distribution's metadata onto a regression fitter.
 

--- a/surpyval/univariate/regression/_fit_skeleton.py
+++ b/surpyval/univariate/regression/_fit_skeleton.py
@@ -10,9 +10,10 @@ family supplies only its optimiser strategy and covariate-link object
 separate: its life-model parameter juggling does not fit this shape.
 """
 
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import autograd.numpy as np
+import numpy.typing as npt
 from autograd import jacobian
 from scipy.optimize import minimize
 
@@ -20,6 +21,7 @@ from surpyval.univariate.parametric.fitters import (
     bounds_convert,
     preconditioned_bfgs,
 )
+from surpyval.univariate.parametric.parametric_fitter import Boxable, Numeric
 from surpyval.utils.surpyval_data import SurpyvalData
 
 from .parametric_regression_model import ParametricRegressionModel
@@ -34,20 +36,20 @@ class LogLinearPhi:
     constructor argument.
     """
 
-    def __init__(self, name: str, phi_param_map: dict):
+    def __init__(self, name: str, phi_param_map: dict) -> None:
         self.name = name
         self.phi_param_map = phi_param_map
 
     @staticmethod
-    def phi(Z, *params):
+    def phi(Z: Numeric, *params: Boxable) -> Boxable:
         return np.exp(np.dot(Z, np.array(params)))
 
     @staticmethod
-    def phi_bounds(Z):
+    def phi_bounds(Z: npt.NDArray) -> tuple:
         return ((None, None),) * Z.shape[1]
 
     @staticmethod
-    def make_param_map(Z):
+    def make_param_map(Z: npt.NDArray) -> dict[str, int]:
         return {"beta_" + str(i): i for i in range(Z.shape[1])}
 
 
@@ -82,38 +84,45 @@ class HazardIdentitiesMixin:
     point — the fit fails rather than returning an invalid model.
     """
 
-    def sf(self, x, Z, *params):
+    if TYPE_CHECKING:
+        # The host class supplies these; declared rather than defined so
+        # a fitter that forgets one gets the AttributeError that names
+        # it (the same pattern as ParametricFitter's contract block).
+        def Hf(self, x: Any, Z: Any, *params: Any) -> Any: ...
+        def hf(self, x: Any, Z: Any, *params: Any) -> Any: ...
+
+    def sf(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         return np.exp(-self.Hf(x, Z, *params))
 
-    def ff(self, x, Z, *params):
+    def ff(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         return -np.expm1(-self.Hf(x, Z, *params))
 
-    def df(self, x, Z, *params):
+    def df(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         return self.hf(x, Z, *params) * np.exp(-self.Hf(x, Z, *params))
 
-    def log_sf(self, x, Z, *params):
+    def log_sf(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         return -self.Hf(x, Z, *params)
 
-    def log_ff(self, x, Z, *params):
+    def log_ff(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         return np.log(self.ff(x, Z, *params))
 
-    def log_df(self, x, Z, *params):
+    def log_df(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         return np.log(self.hf(x, Z, *params)) - self.Hf(x, Z, *params)
 
 
 def prepare_regression_fit(
     fitter: Any,
-    x,
-    Z,
-    c,
-    n,
-    t,
-    init,
-    fixed,
-    phi_bounds,
-    phi_param_map,
-    phi_init=None,
-):
+    x: npt.ArrayLike,
+    Z: npt.ArrayLike,
+    c: "npt.ArrayLike | None",
+    n: "npt.ArrayLike | None",
+    t: "npt.ArrayLike | None",
+    init: "npt.ArrayLike | None",
+    fixed: "dict[str, float] | None",
+    phi_bounds: "Callable[[npt.NDArray], tuple] | tuple",
+    phi_param_map: "Callable[[npt.NDArray], dict] | dict",
+    phi_init: "Callable[[npt.NDArray], npt.NDArray] | None" = None,
+) -> tuple[SurpyvalData, tuple]:
     """Common head of every parametric-regression ``fit``.
 
     Returns ``(data, fun_builder_inputs)`` where the second element is the
@@ -166,8 +175,8 @@ def assemble_regression_model(
     reg_model: Any,
     data: SurpyvalData,
     res: Any,
-    params,
-    bounds,
+    params: npt.ArrayLike,
+    bounds: tuple,
     pmap: dict,
     fixed: dict,
     neg_ll: "float | None" = None,
@@ -180,9 +189,10 @@ def assemble_regression_model(
     model.reg_model = reg_model
     model.kind = kind
     model.distribution = fitter.dist
-    model.params = np.array(params)
-    model.dist_params = np.array(params[: fitter.k_dist])
-    model.phi_params = np.array(params[fitter.k_dist :])
+    params_arr = np.array(params)
+    model.params = params_arr
+    model.dist_params = np.array(params_arr[: fitter.k_dist])
+    model.phi_params = np.array(params_arr[fitter.k_dist :])
     model.res = res
     model._neg_ll = float(res.fun) if neg_ll is None else neg_ll
     model.fixed = fixed
@@ -192,7 +202,7 @@ def assemble_regression_model(
     return model
 
 
-def optimise_ph(fun: Callable, init_t):
+def optimise_ph(fun: Callable, init_t: npt.NDArray) -> Any:
     """Preconditioned BFGS on the analytic gradient, TNC as the fallback.
 
     The historical ladder was ``minimize(fun, init_t)`` followed by TNC
@@ -252,7 +262,7 @@ def optimise_ph(fun: Callable, init_t):
     return best
 
 
-def optimise_nm_tnc(fun: Callable, init_t):
+def optimise_nm_tnc(fun: Callable, init_t: npt.NDArray) -> Any:
     """AFT/PO's historical ladder: Nelder-Mead, then TNC kept only on
     success."""
     res = minimize(

--- a/surpyval/univariate/regression/_likelihood.py
+++ b/surpyval/univariate/regression/_likelihood.py
@@ -15,14 +15,21 @@ single, well-tested place rather than duplicated — and subtly inconsistent —
 across each fitter.
 """
 
+from typing import Any
+
 import autograd.numpy as np
+
+from surpyval.univariate.parametric.parametric_fitter import Boxable
+from surpyval.utils.surpyval_data import SurpyvalData
 
 # Smallest positive float; used to floor probability masses so that
 # ``log`` stays finite for impossible (zero-width) intervals.
 _TINY = np.finfo(float).tiny
 
 
-def truncation_correction(model, data, *params):
+def truncation_correction(
+    model: Any, data: SurpyvalData, *params: Boxable
+) -> Boxable:
     """Log of the probability mass within each observation's truncation
     interval, summed over the truncated rows.
 
@@ -86,7 +93,9 @@ def truncation_correction(model, data, *params):
     return (data.n_t * log_mass).sum()
 
 
-def regression_neg_ll(model, data, *params):
+def regression_neg_ll(
+    model: Any, data: SurpyvalData, *params: Boxable
+) -> Boxable:
     """Negative log-likelihood for a covariate-aware survival model.
 
     Parameters
@@ -100,7 +109,7 @@ def regression_neg_ll(model, data, *params):
     *params : float
         The distribution parameters followed by the regression parameters.
     """
-    ll = 0.0
+    ll: Boxable = 0.0
 
     if data.x_o.size > 0:
         ll = ll + (data.n_o * model.log_df(data.x_o, data.Z_o, *params)).sum()

--- a/surpyval/univariate/regression/accelerated_failure_time/aft_fitter.py
+++ b/surpyval/univariate/regression/accelerated_failure_time/aft_fitter.py
@@ -1,5 +1,13 @@
+from typing import Any
+
 import autograd.numpy as np
 import numpy.typing as npt
+
+from surpyval.univariate.parametric.parametric_fitter import (
+    Boxable,
+    Numeric,
+)
+from surpyval.utils.surpyval_data import SurpyvalData
 
 from .._fit_skeleton import (
     HazardIdentitiesMixin,
@@ -20,18 +28,20 @@ class _LogLinearPhiModel:
 
     name = "Log Linear [exp(beta'Z)]"
 
-    def phi(self, Z, *params):
+    def phi(self, Z: Numeric, *params: Boxable) -> Boxable:
         return np.exp(np.dot(Z, np.array(params)))
 
-    def phi_bounds(self, Z):
+    def phi_bounds(self, Z: npt.NDArray) -> tuple:
         return ((None, None),) * Z.shape[1]
 
-    def phi_param_map(self, Z):
+    def phi_param_map(self, Z: npt.NDArray) -> dict[str, int]:
         return {"beta_" + str(i): i for i in range(Z.shape[1])}
 
 
 class AFTFitter(
-    HazardIdentitiesMixin, AFTTVCFitMixin, DataFrameRegressionMixin
+    HazardIdentitiesMixin,
+    AFTTVCFitMixin,
+    DataFrameRegressionMixin,
 ):
     """
     Accelerated Failure Time fitter using exp(beta'Z) as the acceleration
@@ -44,7 +54,7 @@ class AFTFitter(
     failure (shorter life), consistent with the PH sign convention.
     """
 
-    def __init__(self, distribution):
+    def __init__(self, distribution: Any) -> None:
         mirror_distribution(self, distribution)
         self._phi_model = _LogLinearPhiModel()
         self.Hf_dist = distribution.Hf
@@ -52,17 +62,17 @@ class AFTFitter(
         self.sf_dist = distribution.sf
         self.ff_dist = distribution.ff
 
-    def _phi(self, Z, *phi_params):
+    def _phi(self, Z: Numeric, *phi_params: Boxable) -> Boxable:
         return self._phi_model.phi(Z, *phi_params)
 
-    def Hf(self, x, Z, *params):
+    def Hf(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         x = np.atleast_1d(np.asarray(x, dtype=float))
         Z = np.atleast_2d(np.asarray(Z, dtype=float))
         dist_params = params[: self.k_dist]
         phi_params = params[self.k_dist :]
         return self.Hf_dist(self._phi(Z, *phi_params) * x, *dist_params)
 
-    def hf(self, x, Z, *params):
+    def hf(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         x = np.atleast_1d(np.asarray(x, dtype=float))
         Z = np.atleast_2d(np.asarray(Z, dtype=float))
         dist_params = params[: self.k_dist]
@@ -70,7 +80,7 @@ class AFTFitter(
         phi_val = self._phi(Z, *phi_params)
         return phi_val * self.hf_dist(phi_val * x, *dist_params)
 
-    def neg_ll(self, data, *params):
+    def neg_ll(self, data: SurpyvalData, *params: Boxable) -> Boxable:
         return regression_neg_ll(self, data, *params)
 
     def fit(
@@ -99,7 +109,7 @@ class AFTFitter(
 
         with np.errstate(all="ignore"):
 
-            def fun(params):
+            def fun(params: npt.NDArray) -> Boxable:
                 return self.neg_ll(data, *inv_trans(const(params)))
 
             res = optimise_nm_tnc(fun, init_t)
@@ -120,7 +130,7 @@ class AFTFitter(
         )
 
 
-def AFT(distribution):
+def AFT(distribution: Any) -> "AFTFitter":
     """
     Create an Accelerated Failure Time fitter for the given distribution.
 

--- a/surpyval/univariate/regression/accelerated_failure_time/aft_tvc_fit.py
+++ b/surpyval/univariate/regression/accelerated_failure_time/aft_tvc_fit.py
@@ -32,8 +32,10 @@ code.
 """
 
 import types
+from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 from scipy.optimize import minimize
 
 from surpyval.univariate.parametric.fitters import bounds_convert
@@ -42,7 +44,9 @@ from surpyval.utils.surpyval_data import SurpyvalData
 from ..parametric_regression_model import ParametricRegressionModel
 
 
-def _validate_full_coverage(x, tl, ident):
+def _validate_full_coverage(
+    x: npt.NDArray, tl: npt.NDArray, ident: npt.NDArray
+) -> None:
     """
     Require each subject's episodes to tile ``(0, T]`` completely: first
     entry at 0 and no gaps between consecutive episodes.
@@ -83,7 +87,13 @@ def _validate_full_coverage(x, tl, ident):
             )
 
 
-def _grouped_episodes(x, c, n, tl, ident):
+def _grouped_episodes(
+    x: npt.NDArray,
+    c: npt.NDArray,
+    n: npt.NDArray,
+    tl: npt.NDArray,
+    ident: npt.NDArray,
+) -> dict:
     """
     From the (subject-contiguous, entry-sorted) episode arrays returned by
     ``handle_tvc``, derive the per-subject grouping the accumulated-age
@@ -111,7 +121,7 @@ def _grouped_episodes(x, c, n, tl, ident):
     }
 
 
-def _aft_tvc_neg_ll(self, data, *params):
+def _aft_tvc_neg_ll(self: Any, data: Any, *params: float) -> float:
     """
     Negative log-likelihood of the accelerated-failure-time model along each
     subject's time-varying covariate path.
@@ -148,7 +158,10 @@ def _aft_tvc_neg_ll(self, data, *params):
     return -ll
 
 
-class AFTTVCFitMixin:
+from .._fit_skeleton import MirroredDistributionAttrs  # noqa: E402
+
+
+class AFTTVCFitMixin(MirroredDistributionAttrs):
     """
     Adds time-varying-covariate fitting (``fit_tvc`` and friends) to the
     accelerated failure time fitter. Mixed into ``AFTFitter``; kept separate
@@ -156,7 +169,16 @@ class AFTTVCFitMixin:
     accumulated-age likelihood rather than a reshape-and-refit.
     """
 
-    def fit_tvc(self, i, xl, xr, c, Z, n=None, fixed=None):
+    def fit_tvc(
+        self,
+        i: npt.ArrayLike,
+        xl: npt.ArrayLike,
+        xr: npt.ArrayLike,
+        c: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        n: "npt.ArrayLike | None" = None,
+        fixed: "dict[str, float] | None" = None,
+    ) -> ParametricRegressionModel:
         """
         Fit the accelerated failure time model to start-stop (counting-process)
         time-varying-covariate data.
@@ -191,7 +213,15 @@ class AFTTVCFitMixin:
             x, c_a, n_a, tl, Z_a, ident, AFTFitter, fixed
         )
 
-    def fit_tvc_timeline(self, i, x, Z, c, n=None, fixed=None):
+    def fit_tvc_timeline(
+        self,
+        i: npt.ArrayLike,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        c: npt.ArrayLike,
+        n: "npt.ArrayLike | None" = None,
+        fixed: "dict[str, float] | None" = None,
+    ) -> ParametricRegressionModel:
         """
         Fit from a per-subject covariate *timeline* (one row per covariate
         change, terminal status on the last row) instead of explicit
@@ -203,8 +233,16 @@ class AFTTVCFitMixin:
         return self.fit_tvc(i2, xl, xr, c2, Z2, n=n2, fixed=fixed)
 
     def fit_tvc_from_df(
-        self, df, id_col, xl_col, xr_col, c_col, Z_cols, n_col=None, fixed=None
-    ):
+        self,
+        df: Any,
+        id_col: str,
+        xl_col: str,
+        xr_col: str,
+        c_col: str,
+        Z_cols: "str | list[str]",
+        n_col: "str | None" = None,
+        fixed: "dict[str, float] | None" = None,
+    ) -> ParametricRegressionModel:
         """
         ``fit_tvc`` from a start-stop ``DataFrame``. ``Z_cols`` may be a single
         column name or a list; ``feature_names`` is recorded on the model.
@@ -223,7 +261,17 @@ class AFTTVCFitMixin:
         model.feature_names = cols
         return model
 
-    def _fit_tvc_arrays(self, x, c, n, tl, Z, ident, AFTFitter, fixed):
+    def _fit_tvc_arrays(
+        self,
+        x: npt.NDArray,
+        c: npt.NDArray,
+        n: npt.NDArray,
+        tl: npt.NDArray,
+        Z: npt.NDArray,
+        ident: npt.NDArray,
+        AFTFitter: Any,
+        fixed: "dict[str, float] | None",
+    ) -> ParametricRegressionModel:
         if fixed is None:
             fixed = {}
         Z = np.atleast_2d(np.asarray(Z, dtype=float))
@@ -262,7 +310,7 @@ class AFTTVCFitMixin:
 
         with np.errstate(all="ignore"):
 
-            def fun(pars):
+            def fun(pars: npt.NDArray) -> float:
                 return like.neg_ll(None, *inv_trans(const(pars)))
 
             res = minimize(
@@ -279,7 +327,7 @@ class AFTTVCFitMixin:
             name = "Log Linear [exp(beta'Z)]"
             phi_param_map = _pm
 
-            def phi(self, Z, *pp):
+            def phi(self, Z: npt.NDArray, *pp: float) -> npt.NDArray:
                 return np.exp(np.dot(Z, np.array(pp)))
 
         # Episode-level data container so generic consumers (repr, plotting)

--- a/surpyval/univariate/regression/additive_hazards/__init__.py
+++ b/surpyval/univariate/regression/additive_hazards/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from surpyval.univariate.parametric import (
     Exponential,
     Gamma,
@@ -12,7 +14,7 @@ from .additive_hazards import AdditiveHazards, AdditiveHazardsModel
 from .additive_hazards_fitter import AdditiveHazardsFitter
 
 
-def AH(distribution):
+def AH(distribution: Any) -> AdditiveHazardsFitter:
     """
     Create a parametric Additive Hazards fitter for the given distribution.
 

--- a/surpyval/univariate/regression/additive_hazards/additive_hazards.py
+++ b/surpyval/univariate/regression/additive_hazards/additive_hazards.py
@@ -104,7 +104,7 @@ class AdditiveHazardsModel(SerialisableMixin):
     _A: npt.NDArray
     _b: npt.NDArray
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.kind = "Additive Hazards"
         self.parameterization = "Semi-Parametric"
 

--- a/surpyval/univariate/regression/additive_hazards/additive_hazards_fitter.py
+++ b/surpyval/univariate/regression/additive_hazards/additive_hazards_fitter.py
@@ -36,9 +36,16 @@ import autograd.numpy as np
 import numpy.typing as npt
 from scipy.optimize import minimize
 
+from surpyval.univariate.parametric.parametric_fitter import (
+    Boxable,
+    Numeric,
+)
+from surpyval.utils.surpyval_data import SurpyvalData
+
 from .._fit_skeleton import (
     HazardIdentitiesMixin,
     LogLinearPhi,
+    MirroredDistributionAttrs,
     assemble_regression_model,
     mirror_distribution,
     prepare_regression_fit,
@@ -57,18 +64,12 @@ class _AdditiveReg:
 
 
 class AdditiveHazardsFitter(
-    HazardIdentitiesMixin, TVCFitMixin, DataFrameRegressionMixin
+    MirroredDistributionAttrs,
+    HazardIdentitiesMixin,
+    TVCFitMixin,
+    DataFrameRegressionMixin,
 ):
-    # Set by ``mirror_distribution`` in ``__init__``; declared so the
-    # attributes are visible to the type checker.
-    dist: Any
-    k_dist: int
-    bounds: tuple
-    support: tuple
-    param_names: list
-    param_map: dict
-
-    def __init__(self, name, dist):
+    def __init__(self, name: str, dist: Any) -> None:
         self.name = name
         mirror_distribution(self, dist)
         self.Hf_dist = dist.Hf
@@ -76,15 +77,15 @@ class AdditiveHazardsFitter(
 
     # -- covariate-aware distribution functions (x, Z, *params) -----------
 
-    def _beta_Z(self, Z, beta):
+    def _beta_Z(self, Z: Numeric, beta: "tuple[Boxable, ...]") -> Boxable:
         return np.dot(Z, np.array(beta))
 
-    def hf(self, x, Z, *params):
+    def hf(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         dist_params = np.array(params[: self.k_dist])
         beta = params[self.k_dist :]
         return self.hf_dist(x, *dist_params) + self._beta_Z(Z, beta)
 
-    def Hf(self, x, Z, *params):
+    def Hf(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         # H(x | Z) = H_0(x) + integral_0^x beta'Z ds = H_0(x) + x * beta'Z.
         dist_params = np.array(params[: self.k_dist])
         beta = params[self.k_dist :]
@@ -97,19 +98,21 @@ class AdditiveHazardsFitter(
     # mpp transforms are the identity (probability plotting is not used for
     # these models, but the interface is kept consistent with the other
     # regression fitters).
-    def mpp_x_transform(self, x, gamma=0):
+    def mpp_x_transform(self, x: Numeric, gamma: Boxable = 0) -> Boxable:
         return x - gamma
 
-    def mpp_y_transform(self, y, *params):
+    def mpp_y_transform(self, y: Numeric, *params: Boxable) -> Numeric:
         return y
 
-    def mpp_inv_y_transform(self, y, *params):
+    def mpp_inv_y_transform(self, y: Numeric, *params: Boxable) -> Numeric:
         return y
 
-    def neg_ll(self, data, *params):
+    def neg_ll(self, data: SurpyvalData, *params: Boxable) -> Boxable:
         return regression_neg_ll(self, data, *params)
 
-    def random(self, size, Z, *params):
+    def random(
+        self, size: int, Z: npt.ArrayLike, *params: float
+    ) -> tuple[npt.NDArray, npt.NDArray]:
         """
         Draw ``size`` samples for a single covariate vector ``Z`` by
         numerically inverting the (monotone) cumulative hazard. Requires the
@@ -121,7 +124,7 @@ class AdditiveHazardsFitter(
         bz = float(np.dot(Z, beta))
         target = -np.log(np.random.uniform(0, 1, size))
 
-        def cum_haz(xv):
+        def cum_haz(xv: npt.NDArray) -> npt.NDArray:
             return self.Hf_dist(xv, *dist_params) + xv * bz
 
         lo = np.zeros(size)
@@ -143,7 +146,7 @@ class AdditiveHazardsFitter(
     # -- factory ----------------------------------------------------------
 
     @staticmethod
-    def create(distribution):
+    def create(distribution: Any) -> "AdditiveHazardsFitter":
         """
         Create a parametric additive hazards fitter for the given
         distribution.
@@ -232,10 +235,10 @@ class AdditiveHazardsFitter(
 
         with np.errstate(all="ignore"):
 
-            def true_neg_ll(params):
+            def true_neg_ll(params: npt.NDArray) -> Boxable:
                 return self.neg_ll(data, *inv_trans(const(params)))
 
-            def fun(params):
+            def fun(params: npt.NDArray) -> Boxable:
                 # Where the additive hazard goes non-positive the log-
                 # likelihood is genuinely -inf; return a large finite penalty
                 # (not a solver constraint) so the derivative-free optimiser

--- a/surpyval/univariate/regression/buckley_james/buckley_james.py
+++ b/surpyval/univariate/regression/buckley_james/buckley_james.py
@@ -34,8 +34,10 @@ two-point cycle rather than a fixed point -- a known feature of the estimator
 """
 
 import warnings
+from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 
 from surpyval.serialisation import SerialisableMixin, stamp_schema
 from surpyval.utils import (
@@ -45,7 +47,9 @@ from surpyval.utils import (
 )
 
 
-def _residual_km(e, delta, w):
+def _residual_km(
+    e: npt.NDArray, delta: npt.NDArray, w: npt.NDArray
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
     """
     Weighted Kaplan-Meier of the residuals with an Efron tail-correction.
 
@@ -81,7 +85,9 @@ def _residual_km(e, delta, w):
     return uniq, surv, jumps
 
 
-def _impute(Y, delta, Zbeta, w):
+def _impute(
+    Y: npt.NDArray, delta: npt.NDArray, Zbeta: npt.NDArray, w: npt.NDArray
+) -> npt.NDArray:
     """
     Buckley-James imputed responses. Observed (``delta == 1``) rows keep their
     value; each censored row is replaced by ``Zbeta_i + E[e | e > e_i]``, the
@@ -108,7 +114,7 @@ def _impute(Y, delta, Zbeta, w):
     return np.where(keep, Y, imputed)
 
 
-def _wls_slope(Z, Y, w):
+def _wls_slope(Z: npt.NDArray, Y: npt.NDArray, w: npt.NDArray) -> npt.NDArray:
     """Weighted least-squares slope of ``Y`` on ``Z`` with the intercept
     profiled out by centring (the location stays in the residuals)."""
     wsum = w.sum()
@@ -120,7 +126,14 @@ def _wls_slope(Z, Y, w):
     return np.linalg.solve(A, b.ravel())
 
 
-def _fit_beta(Y, delta, Z, w, tol, max_iter):
+def _fit_beta(
+    Y: npt.NDArray,
+    delta: npt.NDArray,
+    Z: npt.NDArray,
+    w: npt.NDArray,
+    tol: float,
+    max_iter: int,
+) -> tuple[npt.NDArray, int, bool]:
     """Run the Buckley-James iteration and return
     ``(beta, n_iter, converged)``. A two-point cycle is resolved by averaging
     the cycle."""
@@ -158,7 +171,15 @@ class BuckleyJamesModel(SerialisableMixin):
     formula = None
     _model_spec = None
 
-    def __init__(self, beta, resid, resid_surv, n_iter, converged, data):
+    def __init__(
+        self,
+        beta: npt.ArrayLike,
+        resid: npt.NDArray,
+        resid_surv: npt.NDArray,
+        n_iter: int,
+        converged: bool,
+        data: "tuple | None",
+    ) -> None:
         self.beta = np.asarray(beta, dtype=float)
         self.params = self.beta
         self.coef = self.beta
@@ -168,12 +189,12 @@ class BuckleyJamesModel(SerialisableMixin):
         self.converged = converged
         self._data = data  # (Y, delta, Z, w) for the bootstrap
 
-    def _prepare_Z(self, Z):
+    def _prepare_Z(self, Z: Any) -> npt.NDArray:
         from ..regression_data import prepare_Z
 
         return prepare_Z(Z, self.feature_names, self._model_spec)
 
-    def _resid_sf(self, r):
+    def _resid_sf(self, r: npt.NDArray) -> npt.NDArray:
         # Right-continuous residual survival at query points ``r``.
         idx = np.searchsorted(self._resid, r, side="right") - 1
         out = np.where(
@@ -185,7 +206,7 @@ class BuckleyJamesModel(SerialisableMixin):
 
     # -- serialisation -----------------------------------------------------
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         """
         Serialise this fitted Buckley-James model to a plain, JSON-serialisable
         dict.
@@ -231,7 +252,7 @@ class BuckleyJamesModel(SerialisableMixin):
         return stamp_schema(out)
 
     @classmethod
-    def from_dict(cls, model_dict):
+    def from_dict(cls, model_dict: dict) -> "BuckleyJamesModel":
         """
         Rebuild a Buckley-James model from a :meth:`to_dict` dictionary.
 
@@ -270,7 +291,7 @@ class BuckleyJamesModel(SerialisableMixin):
             out._model_spec = rebuild_model_spec(out.formula, formula_meta)
         return out
 
-    def sf(self, x, Z):
+    def sf(self, x: npt.ArrayLike, Z: npt.ArrayLike) -> npt.NDArray:
         """Survival ``P(T > x | Z) = S_eps(log x - beta'Z)`` for a single
         covariate vector ``Z``."""
         x = np.atleast_1d(np.asarray(x, dtype=float))
@@ -281,14 +302,19 @@ class BuckleyJamesModel(SerialisableMixin):
         r = np.log(x) + Z @ self.beta
         return self._resid_sf(r)
 
-    def ff(self, x, Z):
+    def ff(self, x: npt.ArrayLike, Z: npt.ArrayLike) -> npt.NDArray:
         return 1.0 - self.sf(x, Z)
 
-    def Hf(self, x, Z):
+    def Hf(self, x: npt.ArrayLike, Z: npt.ArrayLike) -> npt.NDArray:
         with np.errstate(divide="ignore"):
             return -np.log(self.sf(x, Z))
 
-    def bootstrap_ci(self, alpha_ci=0.05, n_boot=200, seed=None):
+    def bootstrap_ci(
+        self,
+        alpha_ci: float = 0.05,
+        n_boot: int = 200,
+        seed: "int | None" = None,
+    ) -> npt.NDArray:
         """
         Percentile bootstrap confidence intervals for the coefficients.
 
@@ -297,6 +323,11 @@ class BuckleyJamesModel(SerialisableMixin):
         taking percentiles of the coefficient distribution. Returns an
         ``(n_coef, 2)`` array of ``[lower, upper]`` bounds.
         """
+        if self._data is None:
+            raise ValueError(
+                "bootstrap_ci needs the fit data, which this model does not "
+                "carry"
+            )
         Y, delta, Z, w = self._data
         rng = np.random.default_rng(seed)
         n = Y.shape[0]
@@ -310,12 +341,12 @@ class BuckleyJamesModel(SerialisableMixin):
                 boot.append(-g)  # report in the accelerated-failure sign
             except np.linalg.LinAlgError:
                 continue
-        boot = np.asarray(boot)
-        lo = np.quantile(boot, alpha_ci / 2.0, axis=0)
-        hi = np.quantile(boot, 1.0 - alpha_ci / 2.0, axis=0)
+        boot_arr = np.asarray(boot)
+        lo = np.quantile(boot_arr, alpha_ci / 2.0, axis=0)
+        hi = np.quantile(boot_arr, 1.0 - alpha_ci / 2.0, axis=0)
         return np.stack([lo, hi], axis=-1)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         lines = [
             "Buckley-James AFT SurPyval Model",
             "================================",
@@ -334,13 +365,13 @@ class BuckleyJamesModel(SerialisableMixin):
 class BuckleyJames_:
     def fit(
         self,
-        x,
-        Z,
-        c=None,
-        n=None,
-        tol=1e-5,
-        max_iter=100,
-    ):
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        c: "npt.ArrayLike | None" = None,
+        n: "npt.ArrayLike | None" = None,
+        tol: float = 1e-5,
+        max_iter: int = 100,
+    ) -> BuckleyJamesModel:
         """
         Fit the Buckley-James AFT model.
 
@@ -365,26 +396,28 @@ class BuckleyJames_:
         BuckleyJamesModel
             The fitted model.
         """
-        x, c, n, _ = xcnt_handler(x, c, n, group_and_sort=False)
-        Z, mask = wrangle_Z(Z)
-        x, c, n = x[mask], c[mask], n[mask]
-        x, c, n, Z = (a.astype(float) for a in (x, c, n, Z))
+        x_h, c_h, n_h, _ = xcnt_handler(x, c, n, group_and_sort=False)
+        Z_arr, mask = wrangle_Z(Z)
+        x_a = np.asarray(x_h, dtype=float)[mask]
+        c_a = np.asarray(c_h, dtype=float)[mask]
+        n_a = np.asarray(n_h, dtype=float)[mask]
+        Z_a = np.asarray(Z_arr, dtype=float)
 
-        if np.any((c != 0) & (c != 1)):
+        if np.any((c_a != 0) & (c_a != 1)):
             raise ValueError(
                 "Buckley-James supports only observed (c=0) and "
                 "right-censored (c=1) data."
             )
-        if np.any(x <= 0):
+        if np.any(x_a <= 0):
             raise ValueError(
                 "Buckley-James models log(time); all times must be positive."
             )
 
-        Y = np.log(x)
-        delta = (c == 0).astype(float)
+        Y = np.log(x_a)
+        delta = (c_a == 0).astype(float)
         # gamma is the textbook ``log T = gamma'Z + eps`` slope; report its
         # negative so a positive coefficient accelerates failure.
-        gamma, n_iter, converged = _fit_beta(Y, delta, Z, n, tol, max_iter)
+        gamma, n_iter, converged = _fit_beta(Y, delta, Z_a, n_a, tol, max_iter)
         if not converged:
             warnings.warn(
                 "Buckley-James did not converge in {} iterations; returning "
@@ -392,23 +425,23 @@ class BuckleyJames_:
             )
 
         # Final residual distribution used for prediction.
-        resid, resid_surv, _ = _residual_km(Y - Z @ gamma, delta, n)
+        resid, resid_surv, _ = _residual_km(Y - Z_a @ gamma, delta, n_a)
 
         return BuckleyJamesModel(
-            -gamma, resid, resid_surv, n_iter, converged, (Y, delta, Z, n)
+            -gamma, resid, resid_surv, n_iter, converged, (Y, delta, Z_a, n_a)
         )
 
     def fit_from_df(
         self,
-        df,
-        x_col,
-        Z_cols=None,
-        c_col=None,
-        n_col=None,
-        formula=None,
-        tol=1e-5,
-        max_iter=100,
-    ):
+        df: Any,
+        x_col: str,
+        Z_cols: "str | list[str] | None" = None,
+        c_col: "str | None" = None,
+        n_col: "str | None" = None,
+        formula: "str | None" = None,
+        tol: float = 1e-5,
+        max_iter: int = 100,
+    ) -> BuckleyJamesModel:
         """
         Fit a Buckley-James model from a pandas DataFrame. See :meth:`fit` for
         the estimator; ``Z_cols`` or ``formula`` selects the covariates.

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -94,6 +94,9 @@ class ParametricRegressionModel(InformationCriteriaMixin, SerialisableMixin):
     fun: Any
     _neg_ll: float
     _bic: float
+    #: Set by the AFT time-varying-covariate fit; absent otherwise.
+    is_tvc: bool
+    n_subjects: int
     _aic: float
     _aic_c: float
 

--- a/surpyval/univariate/regression/parametric_regression_model.py
+++ b/surpyval/univariate/regression/parametric_regression_model.py
@@ -482,7 +482,9 @@ class ParametricRegressionModel(InformationCriteriaMixin, SerialisableMixin):
         "Accelerated Failure Time",
     )
 
-    def _tvc_segments(self, schedule, t_max):
+    def _tvc_segments(
+        self, schedule: Any, t_max: float
+    ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
         """
         Materialise ``schedule`` to ``t_max`` with the first segment held back
         to the time origin (survival measured from ``0``).
@@ -491,7 +493,7 @@ class ParametricRegressionModel(InformationCriteriaMixin, SerialisableMixin):
 
         return segments_from_origin(schedule, t_max)
 
-    def _to_schedule(self, Z, xl):
+    def _to_schedule(self, Z: Any, xl: "npt.ArrayLike | None") -> Any:
         """
         Coerce the ``sf_tvc`` covariate argument into a
         :class:`~...tvc_schedule.StepSchedule` and check its covariate count
@@ -567,7 +569,13 @@ class ParametricRegressionModel(InformationCriteriaMixin, SerialisableMixin):
             return self._tvc_hf_additive(xq, starts, ends, Zseg)
         return self._tvc_hf_aft(xq, starts, ends, Zseg)
 
-    def _tvc_hf_additive(self, xq, starts, ends, Zseg):
+    def _tvc_hf_additive(
+        self,
+        xq: npt.NDArray,
+        starts: npt.NDArray,
+        ends: npt.NDArray,
+        Zseg: npt.NDArray,
+    ) -> npt.NDArray:
         """
         Cumulative hazard along a step path for the additive-cumulative-hazard
         families (PH, AH): telescoping sum of the model's ``Hf`` increment on
@@ -586,7 +594,13 @@ class ParametricRegressionModel(InformationCriteriaMixin, SerialisableMixin):
             H = H + (hi - lo)
         return H
 
-    def _tvc_hf_aft(self, xq, starts, ends, Zseg):
+    def _tvc_hf_aft(
+        self,
+        xq: npt.NDArray,
+        starts: npt.NDArray,
+        ends: npt.NDArray,
+        Zseg: npt.NDArray,
+    ) -> npt.NDArray:
         r"""
         Cumulative hazard along a step path for accelerated failure time.
 
@@ -878,11 +892,11 @@ class ParametricRegressionModel(InformationCriteriaMixin, SerialisableMixin):
         )
 
     # neg_ll/aic/bic/aic_c come from InformationCriteriaMixin.
-    def _ic_counts(self):
+    def _ic_counts(self) -> tuple[int, int]:
         n, c = self.data.n, self.data.c
         return n[c == 0].sum(), n.sum()
 
-    def _ic_k_aic_c(self):
+    def _ic_k_aic_c(self) -> int:
         # Regression models have historically used the full parameter-
         # vector length here (which can differ from ``self.k`` when
         # parameters are fixed); preserved as-is (#298).

--- a/surpyval/univariate/regression/proportional_hazards/__init__.py
+++ b/surpyval/univariate/regression/proportional_hazards/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from surpyval.univariate.parametric import (
     Exponential,
     Gamma,
@@ -12,7 +14,7 @@ from .cox_ph import CoxPH
 from .proportional_hazards_fitter import ProportionalHazardsFitter
 
 
-def PH(distribution):
+def PH(distribution: Any) -> ProportionalHazardsFitter:
     """
     Create a Proportional Hazards fitter for the given distribution.
 

--- a/surpyval/univariate/regression/proportional_hazards/cox_ph.py
+++ b/surpyval/univariate/regression/proportional_hazards/cox_ph.py
@@ -69,7 +69,7 @@ class _GroupBy:
     and only ever rebinds the result, never mutates it in place.
     """
 
-    def __init__(self, keys):
+    def __init__(self, keys: npt.NDArray) -> None:
         self.unique, self._inv = np.unique(keys, return_inverse=True)
         self._inv = np.asarray(self._inv).ravel()
         self._n = len(self.unique)
@@ -83,7 +83,7 @@ class _GroupBy:
             None if already_grouped else np.argsort(self._inv, kind="stable")
         )
 
-    def sum(self, values):
+    def sum(self, values: npt.NDArray) -> tuple[npt.NDArray, npt.NDArray]:
         # ``asarray`` rather than ``astype``: no copy when the caller
         # already handed over float64, which it almost always does.
         values = np.asarray(values, dtype=float)
@@ -98,14 +98,14 @@ class _GroupBy:
             )
         return self.unique, result
 
-    def max(self, values):
+    def max(self, values: npt.NDArray) -> tuple[npt.NDArray, npt.NDArray]:
         values = np.asarray(values)
         result = np.full(self._n, -np.inf)
         np.maximum.at(result, self._inv, values)
         return self.unique, result
 
 
-def _efron_tie_weights(n_d):
+def _efron_tie_weights(n_d: npt.NDArray) -> tuple[npt.NDArray, npt.NDArray]:
     """``c = j / d`` for every tied death, with a mask marking the entries
     that only exist to square off the ragged ``j < d`` ranges.
 
@@ -125,7 +125,9 @@ def _efron_tie_weights(n_d):
     return weights, valid
 
 
-def efron_log_denominator(n_d, Ri, Di):
+def efron_log_denominator(
+    n_d: npt.NDArray, Ri: npt.NDArray, Di: npt.NDArray
+) -> npt.NDArray:
     """Per event time, ``sum_j log(R - (j/d) D)`` over the ``d`` tied deaths.
 
     Where at most one death occurs, ``j`` only ever takes the value 0, so
@@ -149,7 +151,14 @@ def efron_log_denominator(n_d, Ri, Di):
 
 
 # @njit
-def efron_jac(n_d, Ri, ZRi, Di, ZDi, masked_array):
+def efron_jac(
+    n_d: npt.NDArray,
+    Ri: npt.NDArray,
+    ZRi: npt.NDArray,
+    Di: npt.NDArray,
+    ZDi: npt.NDArray,
+    masked_array: npt.NDArray,
+) -> npt.NDArray:
     # Vectorised implementation of term two of the efron ll
     # jacobian.
 
@@ -170,7 +179,15 @@ def efron_jac(n_d, Ri, ZRi, Di, ZDi, masked_array):
     return out
 
 
-def efron_hess(n_d, Ri, ZRi, Z2Ri, Di, ZDi, Z2Di):
+def efron_hess(
+    n_d: npt.NDArray,
+    Ri: npt.NDArray,
+    ZRi: npt.NDArray,
+    Z2Ri: npt.NDArray,
+    Di: npt.NDArray,
+    ZDi: npt.NDArray,
+    Z2Di: npt.NDArray,
+) -> npt.NDArray:
     # Per-event-time contribution to the observed information (the Hessian of
     # the negative Efron partial log-likelihood). For each of the ``n_d[i]``
     # tied deaths the Efron correction shrinks the risk set by ``c * D``:
@@ -239,7 +256,13 @@ def efron_hess(n_d, Ri, ZRi, Z2Ri, Di, ZDi, Z2Di):
     return out
 
 
-def _sort_by_event_time(x, Z, c, n, tl):
+def _sort_by_event_time(
+    x: npt.NDArray,
+    Z: npt.NDArray,
+    c: npt.NDArray,
+    n: npt.NDArray,
+    tl: npt.NDArray,
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     """Put the rows in event-time order before building the closures.
 
     Nothing in the partial likelihood depends on the order of the rows --
@@ -257,13 +280,15 @@ def _sort_by_event_time(x, Z, c, n, tl):
     return x[order], Z[order], c[order], n[order], tl[order]
 
 
-def at_risk_beta_Z(arr, n, gb_x):
+def at_risk_beta_Z(
+    arr: npt.NDArray, n: npt.NDArray, gb_x: "_GroupBy"
+) -> npt.NDArray:
     R = gb_x.sum(n * arr)[1]
     # Get the reverse cumulative sum
     return R[::-1].cumsum(axis=0)[::-1]
 
 
-def not_yet_entered(pos, mass_by_tl):
+def not_yet_entered(pos: npt.NDArray, mass_by_tl: npt.NDArray) -> npt.NDArray:
     """Per unique event time, the total ``mass_by_tl`` of observations whose
     entry (left-truncation) time is at or after that event time — the amount
     to subtract from the reverse-cumulative at-risk sums so that a subject
@@ -282,7 +307,7 @@ def not_yet_entered(pos, mass_by_tl):
     return np.concatenate([suffix, pad], axis=0)[pos]
 
 
-def _sub(a, mask):
+def _sub(a: "npt.ArrayLike | None", mask: npt.NDArray) -> "npt.NDArray | None":
     """Index ``a`` by ``mask``, passing ``None`` through unchanged."""
     if a is None:
         return None
@@ -296,7 +321,7 @@ def _sub(a, mask):
 _EXACT_MAX_TIES = 12
 
 
-def _elementary_symmetric(v, d):
+def _elementary_symmetric(v: Any, d: int) -> Any:
     """The ``d``-th elementary symmetric polynomial ``e_d`` of the entries of
     ``v`` -- i.e. the sum, over every ``d``-subset of ``v``, of the product of
     that subset's entries.
@@ -317,7 +342,7 @@ def _elementary_symmetric(v, d):
     return e[d]
 
 
-def _exact_ordering_logterm(a, risk_sum):
+def _exact_ordering_logterm(a: Any, risk_sum: Any) -> Any:
     """``log`` of the average-over-orderings exact tie term.
 
     For ``d`` tied deaths with risk scores ``a`` (``a_j = exp(Z_j'b)``) drawn
@@ -358,7 +383,12 @@ def _exact_ordering_logterm(a, risk_sum):
     return anp.log(h[full])
 
 
-def _solve_beta_and_p_values(neg_ll, jac, beta_init, tol):
+def _solve_beta_and_p_values(
+    neg_ll: Callable,
+    jac: Callable,
+    beta_init: npt.NDArray,
+    tol: float,
+) -> tuple[Any, npt.NDArray]:
     """Root-find the score (with BFGS fallback) and compute Wald p-values
     from the observed information; shared by ``fit`` and
     ``_fit_stratified`` so the most-patched block in this file exists
@@ -402,7 +432,7 @@ def _solve_beta_and_p_values(neg_ll, jac, beta_init, tol):
     return res, p_values
 
 
-def _combine_generators(gens):
+def _combine_generators(gens: list) -> tuple[Callable, Callable]:
     """Sum per-stratum ``(log_like, jac_hess)`` generators into one.
 
     The Cox partial likelihood factorises across strata: with a separate
@@ -413,10 +443,10 @@ def _combine_generators(gens):
     own observations.
     """
 
-    def neg_ll(beta):
+    def neg_ll(beta: npt.NDArray) -> float:
         return sum(g[0](beta) for g in gens)
 
-    def jac_hess(beta):
+    def jac_hess(beta: npt.NDArray) -> tuple:
         jac_total = None
         hess_total = None
         for g in gens:
@@ -428,7 +458,9 @@ def _combine_generators(gens):
     return neg_ll, jac_hess
 
 
-def cox_at_risk_mask(x, tl, tau):
+def cox_at_risk_mask(
+    x: npt.NDArray, tl: npt.NDArray, tau: float
+) -> npt.NDArray:
     """The Cox risk-set convention, in one place (#299): a row is at risk
     at event time ``tau`` once it has entered (``tl < tau`` — strict, so a
     start-stop row is not at risk at its own entry time) and until it
@@ -443,7 +475,13 @@ class CoxPH_:
     # http://www-personal.umich.edu/~yili/lect4notes.pdf
 
     def baseline(
-        self, beta, x, c, n, Z, tl=None
+        self,
+        beta: npt.NDArray,
+        x: npt.NDArray,
+        c: npt.NDArray,
+        n: npt.NDArray,
+        Z: npt.NDArray,
+        tl: "npt.NDArray | None" = None,
     ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
         # Breslow baseline hazard. The risk set at each event time ``tau_i``
         # follows ``cox_at_risk_mask`` (entered ``tl < tau_i``, not yet
@@ -480,7 +518,14 @@ class CoxPH_:
 
         return unique_x, r_exit - r_pre, d
 
-    def create_efron_ll_jac_hess(self, x, Z, c, n, tl):
+    def create_efron_ll_jac_hess(
+        self,
+        x: npt.NDArray,
+        Z: npt.NDArray,
+        c: npt.NDArray,
+        n: npt.NDArray,
+        tl: npt.NDArray,
+    ) -> tuple[Callable, Callable]:
         # The reference used to compute the jacobian and hessian
         # was https://mathweb.ucsd.edu/~rxu/math284/slect5.pdf
         # Left-truncation is handled by subtracting the pre-entry risk set
@@ -504,7 +549,7 @@ class CoxPH_:
         # feeds the not-yet-entered suffix-sum gather below.
         pos = np.searchsorted(x_tl, x_, side="left")
 
-        def log_like(beta):
+        def log_like(beta: npt.NDArray) -> float:
             beta_z = Z @ beta
 
             S_d = gb_x.sum(n_d_x * beta_z.reshape(-1, 1))[1].reshape(-1, 1)
@@ -536,7 +581,7 @@ class CoxPH_:
         # on every root-finding iteration, 1.1s of a 16.9s fit (#329).
         Z2 = np.einsum("ij, ik -> ijk", Z, Z)
 
-        def jac_hess(beta):
+        def jac_hess(beta: npt.NDArray) -> tuple:
             # This line troubled me for longer than I care
             # to admit. I was using n, but it is only the
             # number of deaths at each point, n_d_x
@@ -586,7 +631,14 @@ class CoxPH_:
 
         return log_like, jac_hess
 
-    def create_breslow_ll_jac_hess(self, x, Z, c, n, tl):
+    def create_breslow_ll_jac_hess(
+        self,
+        x: npt.NDArray,
+        Z: npt.NDArray,
+        c: npt.NDArray,
+        n: npt.NDArray,
+        tl: npt.NDArray,
+    ) -> tuple[Callable, Callable]:
         # The reference used to compute the jacobian and hessian
         # was https://mathweb.ucsd.edu/~rxu/math284/slect5.pdf
         # Left-truncation is handled by subtracting the pre-entry risk set
@@ -608,7 +660,7 @@ class CoxPH_:
         pos = np.searchsorted(x_tl, x_, side="left")
 
         # Create the log_like function for the data
-        def log_like(beta):
+        def log_like(beta: npt.NDArray) -> float:
             beta_z = Z @ beta
             di_beta_z = gb_x.sum(n_d_x * beta_z.reshape(-1, 1))[1].reshape(
                 -1, 1
@@ -631,7 +683,7 @@ class CoxPH_:
         # Constant for the life of the fit; see the Efron branch (#329).
         Z2 = np.einsum("ij, ik -> ijk", Z, Z)
 
-        def jac_hess(beta):
+        def jac_hess(beta: npt.NDArray) -> tuple:
             # Only call this once.. Yay.
             beta_z = Z @ beta
 
@@ -672,7 +724,14 @@ class CoxPH_:
 
         return log_like, jac_hess
 
-    def _prepare_exact_tie_data(self, x, Z, c, n, tl):
+    def _prepare_exact_tie_data(
+        self,
+        x: npt.NDArray,
+        Z: npt.NDArray,
+        c: npt.NDArray,
+        n: npt.NDArray,
+        tl: npt.NDArray,
+    ) -> tuple:
         """Expand count-weighted rows and pre-compute, per event time, the
         death rows, the (delayed-entry-aware) risk-set rows, and the death
         covariate sum. Shared by the ``exact`` and ``kalbfleisch-prentice``
@@ -711,7 +770,7 @@ class CoxPH_:
         return Ze, event_times, death_idx, risk_idx, np.array(death_Z_sum)
 
     @staticmethod
-    def _autograd_ll_jac_hess(neg_ll):
+    def _autograd_ll_jac_hess(neg_ll: Callable) -> tuple[Callable, Callable]:
         """Wrap a scalar ``autograd.numpy`` negative-log-likelihood into the
         ``(neg_ll, jac_hess)`` contract used by :meth:`fit`.
 
@@ -728,7 +787,7 @@ class CoxPH_:
         score = grad(neg_ll)
         eps = 1e-6
 
-        def jac_hess(beta):
+        def jac_hess(beta: npt.NDArray) -> tuple:
             beta = np.asarray(beta, dtype=float)
             s0 = np.asarray(score(beta))
             p = beta.shape[0]
@@ -742,7 +801,14 @@ class CoxPH_:
 
         return neg_ll, jac_hess
 
-    def create_kalbfleisch_prentice_ll_jac_hess(self, x, Z, c, n, tl):
+    def create_kalbfleisch_prentice_ll_jac_hess(
+        self,
+        x: npt.NDArray,
+        Z: npt.NDArray,
+        c: npt.NDArray,
+        n: npt.NDArray,
+        tl: npt.NDArray,
+    ) -> tuple[Callable, Callable]:
         """Kalbfleisch-Prentice discrete (conditional-logistic) tie handling.
 
         Treats tied event times as genuinely discrete: the contribution of a
@@ -761,7 +827,7 @@ class CoxPH_:
         )
         ds = [len(d) for d in death_idx]
 
-        def neg_ll(beta):
+        def neg_ll(beta: npt.NDArray) -> float:
             r = anp.exp(anp.dot(Ze, beta))
             total = anp.zeros(())
             for i in range(len(event_times)):
@@ -772,7 +838,14 @@ class CoxPH_:
 
         return self._autograd_ll_jac_hess(neg_ll)
 
-    def create_exact_ll_jac_hess(self, x, Z, c, n, tl):
+    def create_exact_ll_jac_hess(
+        self,
+        x: npt.NDArray,
+        Z: npt.NDArray,
+        c: npt.NDArray,
+        n: npt.NDArray,
+        tl: npt.NDArray,
+    ) -> tuple[Callable, Callable]:
         """Exact (average-over-orderings) partial-likelihood tie handling.
 
         Appropriate when ties arise from coarse rounding of an underlying
@@ -799,7 +872,7 @@ class CoxPH_:
                 )
             )
 
-        def neg_ll(beta):
+        def neg_ll(beta: npt.NDArray) -> float:
             r = anp.exp(anp.dot(Ze, beta))
             total = anp.zeros(())
             for i in range(len(event_times)):
@@ -938,7 +1011,16 @@ class CoxPH_:
         return model
 
     def _fit_stratified(
-        self, x, Z, c, n, tl, method, tol, strata, func_generator
+        self,
+        x: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        c: "npt.ArrayLike | None",
+        n: "npt.ArrayLike | None",
+        tl: "npt.ArrayLike | None",
+        method: str,
+        tol: float,
+        strata: npt.ArrayLike,
+        func_generator: Callable,
     ) -> SemiParametricRegressionModel:
         """Fit a stratified Cox model (shared ``beta``, per-stratum baseline).
 

--- a/surpyval/univariate/regression/proportional_hazards/diagnostics.py
+++ b/surpyval/univariate/regression/proportional_hazards/diagnostics.py
@@ -16,6 +16,7 @@ References
 from typing import TYPE_CHECKING
 
 import numpy as np
+import numpy.typing as npt
 from scipy.stats import chi2
 
 from surpyval.utils.linalg import safe_inv
@@ -57,7 +58,9 @@ def _require_cox(model: "SemiParametricRegressionModel") -> dict:
     return model._fit_data
 
 
-def _risk_set_means(data: dict, beta: np.ndarray, tie_method: str = "breslow"):
+def _risk_set_means(
+    data: dict, beta: np.ndarray, tie_method: str = "breslow"
+) -> tuple:
     """Per distinct event time: risk-set covariate means and baseline-hazard
     step aggregates, weighted by ``n * exp(beta'Z)`` and respecting delayed
     entry.
@@ -204,7 +207,7 @@ def compute_residuals(
         delta = (c == 0).astype(float)
         Lam = np.concatenate([[0.0], np.cumsum(A)])
 
-        def _Lam_at(t):
+        def _Lam_at(t: np.ndarray) -> np.ndarray:
             return Lam[np.searchsorted(event_times, t, side="right")]
 
         cum_haz = _Lam_at(x) - _Lam_at(tl)
@@ -272,7 +275,8 @@ def compute_residuals(
 
 
 def robust_covariance(
-    model: "SemiParametricRegressionModel", cluster=None
+    model: "SemiParametricRegressionModel",
+    cluster: "npt.ArrayLike | None" = None,
 ) -> np.ndarray:
     """
     Cluster-robust ("sandwich") covariance of the Cox coefficients.
@@ -336,7 +340,8 @@ def robust_covariance(
 
 
 def robust_summary(
-    model: "SemiParametricRegressionModel", cluster=None
+    model: "SemiParametricRegressionModel",
+    cluster: "npt.ArrayLike | None" = None,
 ) -> dict:
     """
     Cluster-robust standard errors, z-scores and p-values for the

--- a/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
+++ b/surpyval/univariate/regression/proportional_hazards/proportional_hazards_fitter.py
@@ -1,11 +1,18 @@
 import inspect
-from typing import Any
+from typing import Any, Callable
 
 import autograd.numpy as np
 import numpy.typing as npt
 
+from surpyval.univariate.parametric.parametric_fitter import (
+    Boxable,
+    Numeric,
+)
+from surpyval.utils.surpyval_data import SurpyvalData
+
 from .._fit_skeleton import (
     HazardIdentitiesMixin,
+    MirroredDistributionAttrs,
     assemble_regression_model,
     mirror_distribution,
     optimise_ph,
@@ -25,18 +32,21 @@ class Phi:
 
 
 class ProportionalHazardsFitter(
-    HazardIdentitiesMixin, TVCFitMixin, DataFrameRegressionMixin
+    MirroredDistributionAttrs,
+    HazardIdentitiesMixin,
+    TVCFitMixin,
+    DataFrameRegressionMixin,
 ):
     def __init__(
         self,
-        name,
-        dist,
-        phi,
-        phi_name,
-        phi_bounds,
-        phi_param_map,
-        phi_init=None,
-    ):
+        name: str,
+        dist: Any,
+        phi: Callable,
+        phi_name: str,
+        phi_bounds: "Callable[[npt.NDArray], tuple] | tuple",
+        phi_param_map: "Callable[[npt.NDArray], dict] | dict",
+        phi_init: "Callable[[npt.NDArray], npt.NDArray] | None" = None,
+    ) -> None:
         if str(inspect.signature(phi)) != "(Z, *params)":
             raise ValueError(
                 "PH function must have the signature '(Z, *params)'"
@@ -55,28 +65,30 @@ class ProportionalHazardsFitter(
         self.phi_bounds = phi_bounds
         self.phi_param_map = phi_param_map
 
-    def Hf(self, x, Z, *params):
+    def Hf(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         dist_params = np.array(params[0 : self.k_dist])
         phi_params = np.array(params[self.k_dist :])
         Hf_raw = self.Hf_dist(x, *dist_params)
         return self.phi(Z, *phi_params) * Hf_raw
 
-    def hf(self, x, Z, *params):
+    def hf(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         dist_params = np.array(params[0 : self.k_dist])
         phi_params = np.array(params[self.k_dist :])
         hf_raw = self.hf_dist(x, *dist_params)
         return self.phi(Z, *phi_params) * hf_raw
 
-    def mpp_inv_y_transform(self, y, *params):
+    def mpp_inv_y_transform(self, y: Numeric, *params: Boxable) -> Numeric:
         return y
 
-    def mpp_y_transform(self, y, *params):
+    def mpp_y_transform(self, y: Numeric, *params: Boxable) -> Numeric:
         return y
 
-    def mpp_x_transform(self, x, gamma=0):
+    def mpp_x_transform(self, x: Numeric, gamma: Boxable = 0) -> Boxable:
         return x - gamma
 
-    def random(self, size, Z, *params):
+    def random(
+        self, size: int, Z: npt.ArrayLike, *params: float
+    ) -> tuple[npt.NDArray, npt.NDArray]:
         dist_params = np.array(params[0 : self.k_dist])
         phi_params = np.array(params[self.k_dist :])
         Z_arr = np.atleast_2d(np.asarray(Z, dtype=float))
@@ -91,11 +103,11 @@ class ProportionalHazardsFitter(
             Z_out.append(np.tile(row, (size, 1)))
         return np.concatenate(x), np.vstack(Z_out)
 
-    def neg_ll(self, data, *params):
+    def neg_ll(self, data: SurpyvalData, *params: Boxable) -> Boxable:
         return regression_neg_ll(self, data, *params)
 
     @staticmethod
-    def create(distribution):
+    def create(distribution: Any) -> "ProportionalHazardsFitter":
         """
         Create a Proportional Hazards fitter for the given distribution using
         exp(beta'Z) as the hazard multiplier.
@@ -116,7 +128,9 @@ class ProportionalHazardsFitter(
         )
 
     @classmethod
-    def create_general_log_linear_fitter(cls, name, distribution):
+    def create_general_log_linear_fitter(
+        cls, name: str, distribution: Any
+    ) -> "ProportionalHazardsFitter":
         return cls(
             name,
             distribution,
@@ -228,7 +242,7 @@ class ProportionalHazardsFitter(
 
         with np.errstate(all="ignore"):
 
-            def fun(params):
+            def fun(params: npt.NDArray) -> Boxable:
                 return self.neg_ll(data, *inv_trans(const(params)))
 
             res = optimise_ph(fun, init_t)

--- a/surpyval/univariate/regression/proportional_hazards/tvc.py
+++ b/surpyval/univariate/regression/proportional_hazards/tvc.py
@@ -16,9 +16,24 @@ intervals with the same covariates gives the same fit as the unsplit subject.
 """
 
 import numpy as np
+import numpy.typing as npt
 
 
-def handle_tvc(i, xl, xr, c, Z, n=None):
+def handle_tvc(
+    i: npt.ArrayLike,
+    xl: npt.ArrayLike,
+    xr: npt.ArrayLike,
+    c: npt.ArrayLike,
+    Z: npt.ArrayLike,
+    n: "npt.ArrayLike | None" = None,
+) -> tuple[
+    npt.NDArray,
+    npt.NDArray,
+    npt.NDArray,
+    npt.NDArray,
+    npt.NDArray,
+    npt.NDArray,
+]:
     """
     Validate start-stop time-varying-covariate data and map it to the arrays
     the Cox partial likelihood fits.
@@ -138,7 +153,20 @@ def handle_tvc(i, xl, xr, c, Z, n=None):
     return x, c, n, tl, Z, ident
 
 
-def handle_tvc_timeline(i, x, Z, c, n=None):
+def handle_tvc_timeline(
+    i: npt.ArrayLike,
+    x: npt.ArrayLike,
+    Z: npt.ArrayLike,
+    c: npt.ArrayLike,
+    n: "npt.ArrayLike | None" = None,
+) -> tuple[
+    npt.NDArray,
+    npt.NDArray,
+    npt.NDArray,
+    npt.NDArray,
+    npt.NDArray,
+    npt.NDArray,
+]:
     """
     Convert a per-subject covariate *timeline* into the start-stop intervals
     that :func:`handle_tvc` (and ``CoxPH.fit_tvc``) consume.

--- a/surpyval/univariate/regression/proportional_odds/proportional_odds_fitter.py
+++ b/surpyval/univariate/regression/proportional_odds/proportional_odds_fitter.py
@@ -1,8 +1,17 @@
+from typing import Any
+
 import autograd.numpy as np
 import numpy.typing as npt
 
+from surpyval.univariate.parametric.parametric_fitter import (
+    Boxable,
+    Numeric,
+)
+from surpyval.utils.surpyval_data import SurpyvalData
+
 from .._fit_skeleton import (
     LogLinearPhi,
+    MirroredDistributionAttrs,
     assemble_regression_model,
     mirror_distribution,
     optimise_nm_tnc,
@@ -13,7 +22,9 @@ from ..parametric_regression_model import ParametricRegressionModel
 from ..regression_data import DataFrameRegressionMixin
 
 
-class ProportionalOddsFitter(DataFrameRegressionMixin):
+class ProportionalOddsFitter(
+    MirroredDistributionAttrs, DataFrameRegressionMixin
+):
     """
     Proportional Odds model fitter using exp(beta'Z) as the odds multiplier.
 
@@ -30,7 +41,7 @@ class ProportionalOddsFitter(DataFrameRegressionMixin):
     convention (positive beta = shorter life), negate your covariates or betas.
     """
 
-    def __init__(self, distribution):
+    def __init__(self, distribution: Any) -> None:
         mirror_distribution(self, distribution)
         self.Hf_dist = distribution.Hf
         self.hf_dist = distribution.hf
@@ -38,16 +49,16 @@ class ProportionalOddsFitter(DataFrameRegressionMixin):
         self.ff_dist = distribution.ff
         self.df_dist = distribution.df
 
-    def _phi_bounds(self, Z):
+    def _phi_bounds(self, Z: npt.NDArray) -> tuple:
         return ((None, None),) * Z.shape[1]
 
-    def _phi_param_map(self, Z):
+    def _phi_param_map(self, Z: npt.NDArray) -> dict[str, int]:
         return {"beta_" + str(i): i for i in range(Z.shape[1])}
 
-    def _phi(self, Z, *phi_params):
+    def _phi(self, Z: Numeric, *phi_params: Boxable) -> Boxable:
         return np.exp(np.dot(Z, np.array(phi_params)))
 
-    def sf(self, x, Z, *params):
+    def sf(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         x = np.atleast_1d(np.asarray(x, dtype=float))
         Z = np.atleast_2d(np.asarray(Z, dtype=float))
         dist_params = params[: self.k_dist]
@@ -57,7 +68,7 @@ class ProportionalOddsFitter(DataFrameRegressionMixin):
         F0 = self.ff_dist(x, *dist_params)
         return phi * S0 / (F0 + phi * S0)
 
-    def ff(self, x, Z, *params):
+    def ff(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         x = np.atleast_1d(np.asarray(x, dtype=float))
         Z = np.atleast_2d(np.asarray(Z, dtype=float))
         dist_params = params[: self.k_dist]
@@ -67,7 +78,7 @@ class ProportionalOddsFitter(DataFrameRegressionMixin):
         F0 = self.ff_dist(x, *dist_params)
         return F0 / (F0 + phi * S0)
 
-    def hf(self, x, Z, *params):
+    def hf(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         x = np.atleast_1d(np.asarray(x, dtype=float))
         Z = np.atleast_2d(np.asarray(Z, dtype=float))
         dist_params = params[: self.k_dist]
@@ -78,10 +89,10 @@ class ProportionalOddsFitter(DataFrameRegressionMixin):
         F0 = self.ff_dist(x, *dist_params)
         return h0 / (F0 + phi * S0)
 
-    def Hf(self, x, Z, *params):
+    def Hf(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         return -np.log(self.sf(x, Z, *params))
 
-    def df(self, x, Z, *params):
+    def df(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         x = np.atleast_1d(np.asarray(x, dtype=float))
         Z = np.atleast_2d(np.asarray(Z, dtype=float))
         dist_params = params[: self.k_dist]
@@ -93,7 +104,7 @@ class ProportionalOddsFitter(DataFrameRegressionMixin):
         denom = F0 + phi * S0
         return phi * f0 / (denom * denom)
 
-    def log_sf(self, x, Z, *params):
+    def log_sf(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         x = np.atleast_1d(np.asarray(x, dtype=float))
         Z = np.atleast_2d(np.asarray(Z, dtype=float))
         dist_params = params[: self.k_dist]
@@ -103,7 +114,7 @@ class ProportionalOddsFitter(DataFrameRegressionMixin):
         F0 = self.ff_dist(x, *dist_params)
         return np.log(phi) + np.log(S0) - np.log(F0 + phi * S0)
 
-    def log_ff(self, x, Z, *params):
+    def log_ff(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         x = np.atleast_1d(np.asarray(x, dtype=float))
         Z = np.atleast_2d(np.asarray(Z, dtype=float))
         dist_params = params[: self.k_dist]
@@ -113,7 +124,7 @@ class ProportionalOddsFitter(DataFrameRegressionMixin):
         F0 = self.ff_dist(x, *dist_params)
         return np.log(F0) - np.log(F0 + phi * S0)
 
-    def log_df(self, x, Z, *params):
+    def log_df(self, x: Numeric, Z: Numeric, *params: Boxable) -> Boxable:
         x = np.atleast_1d(np.asarray(x, dtype=float))
         Z = np.atleast_2d(np.asarray(Z, dtype=float))
         dist_params = params[: self.k_dist]
@@ -125,7 +136,7 @@ class ProportionalOddsFitter(DataFrameRegressionMixin):
         denom = F0 + phi * S0
         return np.log(phi) + np.log(f0) - 2.0 * np.log(denom)
 
-    def neg_ll(self, data, *params):
+    def neg_ll(self, data: SurpyvalData, *params: Boxable) -> Boxable:
         return regression_neg_ll(self, data, *params)
 
     def fit(
@@ -154,7 +165,7 @@ class ProportionalOddsFitter(DataFrameRegressionMixin):
 
         with np.errstate(all="ignore"):
 
-            def fun(params):
+            def fun(params: npt.NDArray) -> Boxable:
                 return self.neg_ll(data, *inv_trans(const(params)))
 
             res = optimise_nm_tnc(fun, init_t)
@@ -175,7 +186,7 @@ class ProportionalOddsFitter(DataFrameRegressionMixin):
         )
 
 
-def PO(distribution):
+def PO(distribution: Any) -> "ProportionalOddsFitter":
     """
     Create a Proportional Odds fitter for the given distribution.
 

--- a/surpyval/univariate/regression/semi_parametric_regression_model.py
+++ b/surpyval/univariate/regression/semi_parametric_regression_model.py
@@ -285,7 +285,9 @@ class SemiParametricRegressionModel(SerialisableMixin):
 
         return check_ph(self, transform)
 
-    def robust_covariance(self, cluster=None) -> npt.NDArray:
+    def robust_covariance(
+        self, cluster: "npt.ArrayLike | None" = None
+    ) -> npt.NDArray:
         """
         Cluster-robust ("sandwich") covariance of the coefficients.
 
@@ -298,7 +300,7 @@ class SemiParametricRegressionModel(SerialisableMixin):
 
         return robust_covariance(self, cluster)
 
-    def robust_summary(self, cluster=None) -> dict:
+    def robust_summary(self, cluster: "npt.ArrayLike | None" = None) -> dict:
         """
         Cluster-robust standard errors, z-scores and p-values for the
         coefficients. See :func:`~surpyval.univariate.regression.
@@ -377,7 +379,12 @@ class SemiParametricRegressionModel(SerialisableMixin):
         Hf = self._tvc_cumhaz(query, xl_a, Z_a)
         return query, np.exp(-Hf), Hf
 
-    def _tvc_cumhaz(self, query, starts, Zseg):
+    def _tvc_cumhaz(
+        self,
+        query: npt.NDArray,
+        starts: npt.NDArray,
+        Zseg: npt.NDArray,
+    ) -> npt.NDArray:
         r"""
         Cumulative hazard of the fitted baseline at each ``query`` time for a
         covariate that takes value ``Zseg[i]`` on the segment starting at

--- a/surpyval/univariate/regression/semi_parametric_regression_model.py
+++ b/surpyval/univariate/regression/semi_parametric_regression_model.py
@@ -44,10 +44,12 @@ class SemiParametricRegressionModel(SerialisableMixin):
     H0: npt.NDArray
     phi: Callable[..., npt.NDArray]
     p_values: npt.NDArray
-    jac: npt.NDArray
-    hess: npt.NDArray
+    #: The fit's score/Hessian and negative-partial-log-likelihood
+    #: closures (the scalar value is ``_neg_log_like``).
+    jac: Callable
+    hess: Callable
     res: Any
-    neg_ll: float
+    neg_ll: Callable
     _neg_log_like: float
     tie_method: str
     baseline_method: str

--- a/surpyval/univariate/regression/tvc_schedule.py
+++ b/surpyval/univariate/regression/tvc_schedule.py
@@ -376,24 +376,27 @@ class StepSchedule:
         the covariate beyond the final ``xr`` is held constant. Rows may be
         given in any order and are sorted by ``xl``.
         """
-        xl = np.atleast_1d(np.asarray(xl, dtype=float))
-        xr = np.atleast_1d(np.asarray(xr, dtype=float))
-        Z = np.asarray(Z, dtype=float)
-        if Z.ndim == 1:
-            Z = Z.reshape(-1, 1)
-        if not (xl.shape[0] == xr.shape[0] == Z.shape[0]):
+        # Fresh names after coercion: assigning back to the ArrayLike
+        # parameters keeps their declared union under some mypy releases,
+        # which then rejects the arithmetic below.
+        xl_a = np.atleast_1d(np.asarray(xl, dtype=float))
+        xr_a = np.atleast_1d(np.asarray(xr, dtype=float))
+        Z_a = np.asarray(Z, dtype=float)
+        if Z_a.ndim == 1:
+            Z_a = Z_a.reshape(-1, 1)
+        if not (xl_a.shape[0] == xr_a.shape[0] == Z_a.shape[0]):
             raise ValueError("xl, xr and Z must have the same number of rows")
-        order = np.argsort(xl)
-        xl, xr, Z = xl[order], xr[order], Z[order]
-        if np.any(xl >= xr):
+        order = np.argsort(xl_a)
+        xl_a, xr_a, Z_a = xl_a[order], xr_a[order], Z_a[order]
+        if np.any(xl_a >= xr_a):
             raise ValueError("every interval must have xl < xr")
-        if np.any(np.abs(xl[1:] - xr[:-1]) > 1e-9):
+        if np.any(np.abs(xl_a[1:] - xr_a[:-1]) > 1e-9):
             raise ValueError(
                 "intervals must be contiguous (each xr must equal the next "
                 "xl); a step schedule cannot have gaps or overlaps"
             )
-        edges = np.concatenate([xl, [xr[-1]]])
-        return cls(edges, Z)
+        edges = np.concatenate([xl_a, [xr_a[-1]]])
+        return cls(edges, Z_a)
 
     @classmethod
     def cyclic(

--- a/surpyval/univariate/regression/tvc_schedule.py
+++ b/surpyval/univariate/regression/tvc_schedule.py
@@ -32,8 +32,10 @@ into concrete ``(start, end, Z)`` triples.
 
 import ast
 import math
+from typing import Callable
 
 import numpy as np
+import numpy.typing as npt
 
 __all__ = ["StepSchedule", "StepValuedError"]
 
@@ -41,14 +43,19 @@ __all__ = ["StepSchedule", "StepValuedError"]
 # Functions that turn a continuous input into a piecewise-constant output. Once
 # ``t`` passes through one of these, later arithmetic keeps the result stepped
 # (any pure function of a step function is still a step function).
-_QUANTIZERS = {"floor", "ceil", "round", "trunc"}
+_QUANTIZERS: "set[str]" = {"floor", "ceil", "round", "trunc"}
 
 # Names an expression may reference besides the free variable ``t``.
-_CONSTANTS = {"pi": math.pi, "e": math.e, "tau": math.tau, "inf": math.inf}
+_CONSTANTS: "dict[str, float]" = {
+    "pi": math.pi,
+    "e": math.e,
+    "tau": math.tau,
+    "inf": math.inf,
+}
 
 # Callables an expression may use. Kept to quantizers plus a few pure helpers
 # that cannot smuggle in continuous variation on their own.
-_FUNCTIONS = {
+_FUNCTIONS: "dict[str, Callable]" = {
     "floor": math.floor,
     "ceil": math.ceil,
     "round": round,
@@ -69,7 +76,7 @@ class StepValuedError(ValueError):
     """
 
 
-def _varies_continuously(node):
+def _varies_continuously(node: ast.AST) -> bool:
     """
     Return ``True`` if the AST ``node`` lets the free variable ``t`` influence
     its value *continuously* (rather than only through a quantizer/comparison).
@@ -116,7 +123,7 @@ def _varies_continuously(node):
     return True
 
 
-def _safe_eval(node, t):
+def _safe_eval(node: ast.AST, t: float) -> "float | bool":
     """
     Evaluate a validated expression AST at a single time ``t``.
 
@@ -179,19 +186,19 @@ def _safe_eval(node, t):
     if isinstance(node, ast.Compare):
         left = _safe_eval(node.left, t)
         result = True
-        for op, comparator in zip(node.ops, node.comparators):
+        for cmp_op, comparator in zip(node.ops, node.comparators):
             right = _safe_eval(comparator, t)
-            if isinstance(op, ast.Lt):
+            if isinstance(cmp_op, ast.Lt):
                 ok = left < right
-            elif isinstance(op, ast.LtE):
+            elif isinstance(cmp_op, ast.LtE):
                 ok = left <= right
-            elif isinstance(op, ast.Gt):
+            elif isinstance(cmp_op, ast.Gt):
                 ok = left > right
-            elif isinstance(op, ast.GtE):
+            elif isinstance(cmp_op, ast.GtE):
                 ok = left >= right
-            elif isinstance(op, ast.Eq):
+            elif isinstance(cmp_op, ast.Eq):
                 ok = left == right
-            elif isinstance(op, ast.NotEq):
+            elif isinstance(cmp_op, ast.NotEq):
                 ok = left != right
             else:
                 raise StepValuedError("unsupported comparison in expression")
@@ -220,7 +227,9 @@ def _safe_eval(node, t):
     )
 
 
-def _coalesce(times, values):
+def _coalesce(
+    times: npt.NDArray, values: npt.NDArray
+) -> tuple[npt.NDArray, npt.NDArray]:
     """
     Collapse a fine grid of ``(time, value-row)`` samples into the minimal set
     of step segments, merging consecutive samples that share a covariate row.
@@ -265,7 +274,12 @@ class StepSchedule:
     All the family math needs is :meth:`segments`.
     """
 
-    def __init__(self, edges, Z, period=None):
+    def __init__(
+        self,
+        edges: npt.ArrayLike,
+        Z: npt.ArrayLike,
+        period: "float | None" = None,
+    ) -> None:
         edges = np.asarray(edges, dtype=float)
         Z = np.asarray(Z, dtype=float)
         if Z.ndim == 1:
@@ -303,14 +317,14 @@ class StepSchedule:
         self.period = period
 
     @property
-    def p(self):
+    def p(self) -> int:
         """Number of covariates (columns of ``Z``)."""
         return self.Z.shape[1]
 
     # -- structural constructors ------------------------------------------
 
     @classmethod
-    def constant(cls, Z):
+    def constant(cls, Z: npt.ArrayLike) -> "StepSchedule":
         """
         A constant covariate ``Z`` over all time. Evaluating a model on it is
         identical to ``model.sf(x, Z)``.
@@ -319,7 +333,9 @@ class StepSchedule:
         return cls(np.array([0.0, np.inf]), Z)
 
     @classmethod
-    def from_changepoints(cls, times, values):
+    def from_changepoints(
+        cls, times: npt.ArrayLike, values: npt.ArrayLike
+    ) -> "StepSchedule":
         """
         Build a schedule from ``(time, value)`` change-points.
 
@@ -349,7 +365,9 @@ class StepSchedule:
         return cls(edges, values)
 
     @classmethod
-    def from_intervals(cls, xl, xr, Z):
+    def from_intervals(
+        cls, xl: npt.ArrayLike, xr: npt.ArrayLike, Z: npt.ArrayLike
+    ) -> "StepSchedule":
         """
         Build a schedule from explicit ``(xl, xr]`` interval rows -- the same
         layout ``fit_tvc`` consumes.
@@ -378,7 +396,12 @@ class StepSchedule:
         return cls(edges, Z)
 
     @classmethod
-    def cyclic(cls, pattern_times, pattern_values, period):
+    def cyclic(
+        cls,
+        pattern_times: npt.ArrayLike,
+        pattern_values: npt.ArrayLike,
+        period: float,
+    ) -> "StepSchedule":
         """
         A within-period covariate pattern repeated indefinitely.
 
@@ -416,7 +439,13 @@ class StepSchedule:
     # -- expression constructor -------------------------------------------
 
     @classmethod
-    def from_expression(cls, expr, horizon, resolution=1.0, t0=0.0):
+    def from_expression(
+        cls,
+        expr: "str | list[str]",
+        horizon: float,
+        resolution: float = 1.0,
+        t0: float = 0.0,
+    ) -> "StepSchedule":
         r"""
         Build a schedule from a step-valued expression string (or list of
         strings) in the free variable ``t``.
@@ -498,7 +527,9 @@ class StepSchedule:
 
     # -- consumption ------------------------------------------------------
 
-    def segments(self, t_max):
+    def segments(
+        self, t_max: float
+    ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
         """
         Materialise the schedule up to ``t_max`` into concrete step segments.
 
@@ -530,14 +561,14 @@ class StepSchedule:
             pattern_starts = self.edges[:-1]
             base = self.edges[0]
             reps = int(math.ceil((t_max - base) / self.period))
-            starts = []
+            start_list = []
             Zrows = []
             for k in range(reps):
                 offset = k * self.period
                 for s, z in zip(pattern_starts, self.Z):
-                    starts.append(s + offset)
+                    start_list.append(s + offset)
                     Zrows.append(z)
-            starts = np.asarray(starts, dtype=float)
+            starts = np.asarray(start_list, dtype=float)
             edges = np.concatenate([starts, [starts[0] + reps * self.period]])
             Z = np.asarray(Zrows, dtype=float)
 
@@ -550,7 +581,7 @@ class StepSchedule:
         ends = np.minimum(ends, t_max)
         return starts, ends, Z
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         kind = "cyclic" if self.period is not None else "step"
         return "StepSchedule({}, {} segment(s), p={})".format(
             kind, self.Z.shape[0], self.p
@@ -565,7 +596,9 @@ class StepSchedule:
 # covariate row per segment).
 
 
-def as_step_schedule(Z, xl=None):
+def as_step_schedule(
+    Z: "StepSchedule | npt.ArrayLike", xl: "npt.ArrayLike | None" = None
+) -> StepSchedule:
     """
     Coerce a model ``sf_tvc`` covariate argument into a :class:`StepSchedule`.
 
@@ -586,7 +619,9 @@ def as_step_schedule(Z, xl=None):
     return StepSchedule.from_changepoints(xl, Z)
 
 
-def segments_from_origin(schedule, t_max):
+def segments_from_origin(
+    schedule: StepSchedule, t_max: float
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
     """
     Materialise ``schedule`` to ``t_max``, holding the first segment back to
     the time origin so cumulative hazard is measured from ``0`` (unconditional

--- a/surpyval/utils/__init__.py
+++ b/surpyval/utils/__init__.py
@@ -1,4 +1,6 @@
 import warnings
+from numbers import Number
+from typing import Any, Callable
 from collections import defaultdict
 
 import numpy as np
@@ -10,7 +12,7 @@ COX_PH_METHODS = ["breslow", "efron", "exact", "kalbfleisch-prentice", "kp"]
 FG_BASELINE_OPTIONS = ["Nelson-Aalen", "Kaplan-Meier"]
 
 
-def _round_vals(x):
+def _round_vals(x: npt.NDArray) -> npt.NDArray:
     not_different = True
     i = 1
     while not_different:
@@ -20,7 +22,7 @@ def _round_vals(x):
     return x_ticks
 
 
-def round_sig(points, sig=2):
+def round_sig(points: npt.NDArray, sig: int = 2) -> list:
     # Used to round to sig significant figures.
     places = sig - np.floor(np.log10(np.abs(points))) - 1
     output = []
@@ -29,9 +31,9 @@ def round_sig(points, sig=2):
     return output
 
 
-def _check_x_not_empty(func):
+def _check_x_not_empty(func: Callable) -> Callable:
     # Decorator to check that x is not empty
-    def wrap(obj, x, *args, **kwargs):
+    def wrap(obj: Any, x: Any, *args: Any, **kwargs: Any) -> Any:
         x = np.array(x)
         if x.size == 0:
             return 0
@@ -43,15 +45,17 @@ def _check_x_not_empty(func):
     return wrap
 
 
-def check_no_censoring(c):
+def check_no_censoring(c: npt.NDArray) -> bool:
     return any(c != 0)
 
 
-def no_left_or_int(c):
+def no_left_or_int(c: npt.NDArray) -> bool:
     return any((c == -1) | (c == 2))
 
 
-def validate_float_array(arr, name):
+def validate_float_array(
+    arr: "npt.ArrayLike | None", name: str
+) -> npt.NDArray:
     """Convert input to float array with better error handling."""
     if arr is None:
         return np.array([], dtype=np.float64)
@@ -63,7 +67,7 @@ def validate_float_array(arr, name):
         )
 
 
-def validate_1d(arr, name: str) -> npt.NDArray:
+def validate_1d(arr: npt.ArrayLike, name: str) -> npt.NDArray:
     """
     Coerce ``arr`` to a one-dimensional float array, naming it in the
     error when it is not. A scalar becomes a length-one array; anything
@@ -75,7 +79,7 @@ def validate_1d(arr, name: str) -> npt.NDArray:
     return out
 
 
-def _group_ids(key):
+def _group_ids(key: npt.NDArray) -> tuple[npt.NDArray, npt.NDArray]:
     """Group id per row, plus the row at which each group first appears.
 
     ``np.lexsort`` rather than ``np.unique(axis=0)``: the latter takes a
@@ -98,7 +102,9 @@ def _group_ids(key):
     return group, order[starts]
 
 
-def group_xcnt(x, c, n, t):
+def group_xcnt(
+    x: npt.NDArray, c: npt.NDArray, n: npt.NDArray, t: npt.NDArray
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     """Collapse identical ``(x, c, t)`` rows, summing their counts.
 
     This used to walk every observation in Python, accumulating into a
@@ -162,7 +168,9 @@ def group_xcnt(x, c, n, t):
     return x[representative], c[representative], totals, t[representative]
 
 
-def xcnt_sort(x, c, n, t):
+def xcnt_sort(
+    x: npt.NDArray, c: npt.NDArray, n: npt.NDArray, t: npt.NDArray
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     idx_c = np.argsort(c, kind="stable")
     x = x[idx_c]
     c = c[idx_c]
@@ -191,7 +199,12 @@ def xcnt_sort(x, c, n, t):
     return x, c, n, t
 
 
-def fsli_handler(f=None, s=None, l=None, i=None):
+def fsli_handler(
+    f: "npt.ArrayLike | None" = None,
+    s: "npt.ArrayLike | None" = None,
+    l: "npt.ArrayLike | None" = None,
+    i: "npt.ArrayLike | None" = None,
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     """
     Takes in the fsli format and ensures that the data is correctly defined.
     Takes an assorted combination of f, s, l, and i and returns them in the
@@ -273,7 +286,9 @@ def fsli_handler(f=None, s=None, l=None, i=None):
     return f, s, l, i
 
 
-def xrd_handler(x, r, d):
+def xrd_handler(
+    x: npt.ArrayLike, r: npt.ArrayLike, d: npt.ArrayLike
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
     """
     Takes a combination of 'x', 'r', and 'd' arrays and ensures that the data
     is feasible.
@@ -358,7 +373,7 @@ def xrd_handler(x, r, d):
     return x, r, d
 
 
-def coerce_xcnt_x(x) -> npt.NDArray:
+def coerce_xcnt_x(x: npt.ArrayLike) -> npt.NDArray:
     """
     Coerce the ``x`` variable of xcnt-format data into a numpy array.
 
@@ -404,7 +419,12 @@ def coerce_xcnt_x(x) -> npt.NDArray:
     return x
 
 
-def format_truncation(t, tl, tr, n_rows) -> npt.NDArray:
+def format_truncation(
+    t: "npt.ArrayLike | None",
+    tl: "npt.ArrayLike | Number | None",
+    tr: "npt.ArrayLike | Number | None",
+    n_rows: int,
+) -> npt.NDArray:
     """
     Build the ``(n_rows, 2)`` truncation array from either a ``t`` matrix or
     separate ``tl``/``tr`` bounds (scalars broadcast to all rows). The default
@@ -464,15 +484,15 @@ def format_truncation(t, tl, tr, n_rows) -> npt.NDArray:
 
 
 def xcnt_handler(
-    x=None,
-    c=None,
-    n=None,
-    t=None,
-    xl=None,
-    xr=None,
-    tl=None,
-    tr=None,
-    group_and_sort=True,
+    x: "npt.ArrayLike | None" = None,
+    c: "npt.ArrayLike | None" = None,
+    n: "npt.ArrayLike | None" = None,
+    t: "npt.ArrayLike | None" = None,
+    xl: "npt.ArrayLike | None" = None,
+    xr: "npt.ArrayLike | None" = None,
+    tl: "npt.ArrayLike | Number | None" = None,
+    tr: "npt.ArrayLike | Number | None" = None,
+    group_and_sort: bool = True,
 ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     """
     Main handler that ensures any input to a surpyval fitter meets the
@@ -746,7 +766,11 @@ def xcnt_handler(
     return x, c, n, t
 
 
-def xcn_to_fs(x, c=None, n=None):
+def xcn_to_fs(
+    x: npt.ArrayLike,
+    c: "npt.ArrayLike | None" = None,
+    n: "npt.ArrayLike | None" = None,
+) -> tuple[npt.NDArray, npt.NDArray]:
     x = np.array(x)
     if c is None:
         c = np.zeros_like(x)
@@ -761,7 +785,9 @@ def xcn_to_fs(x, c=None, n=None):
     return f, s
 
 
-def _entered_before(tl, x, n):
+def _entered_before(
+    tl: npt.NDArray, x: npt.NDArray, n: npt.NDArray
+) -> npt.NDArray:
     """Weighted count of observations that entered strictly before each ``x``.
 
     ``e[j] = sum_i n_i * 1[tl_i < x_j]`` -- the ``(entry, exit]``
@@ -802,7 +828,13 @@ def _entered_before(tl, x, n):
     return cumulative[np.searchsorted(tl_sorted, x, side="left")]
 
 
-def xcnt_to_xrd(x, c=None, n=None, t=None, **kwargs):
+def xcnt_to_xrd(
+    x: npt.ArrayLike,
+    c: "npt.ArrayLike | None" = None,
+    n: "npt.ArrayLike | None" = None,
+    t: "npt.ArrayLike | None" = None,
+    **kwargs: Any,
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
     """
     Converts the xcn format to the xrd format.
 
@@ -892,7 +924,9 @@ def xcnt_to_xrd(x, c=None, n=None, t=None, **kwargs):
     return x, r, d
 
 
-def xrd_to_xcnt(x, r, d):
+def xrd_to_xcnt(
+    x: npt.ArrayLike, r: npt.ArrayLike, d: npt.ArrayLike
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     """
     Converts the xrd format to the xcn format. Assumes that there is no
     right truncation or left censoring.
@@ -961,19 +995,25 @@ def xrd_to_xcnt(x, r, d):
             " output, so this data cannot be converted with xrd_to_xcnt."
         )
 
+    x = np.asarray(x)
     delta = np.abs(np.diff(np.hstack([r, [0]])))
 
     sus = delta - d
     x_s = x[sus > 0]
     n_s = sus[sus > 0]
 
-    x_f = np.repeat(x_f, n_f)
-    x_s = np.repeat(x_s, n_s)
+    x_f = np.repeat(np.asarray(x_f), np.asarray(n_f, dtype=int))
+    x_s = np.repeat(x_s, np.asarray(n_s, dtype=int))
 
     return fs_to_xcnt(x_f, x_s)
 
 
-def fsli_to_xcnt(f=None, s=None, l=None, i=None):
+def fsli_to_xcnt(
+    f: "npt.ArrayLike | None" = None,
+    s: "npt.ArrayLike | None" = None,
+    l: "npt.ArrayLike | None" = None,
+    i: "npt.ArrayLike | None" = None,
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     """
     Converts the fsli format to the xcn format. This ensures is so that the
     data can be passed to one of the parametric or nonparametric fitters.
@@ -1046,7 +1086,11 @@ def fsli_to_xcnt(f=None, s=None, l=None, i=None):
         return x, c, n, t
 
 
-def fsl_to_xcnt(f=None, s=None, l=None):
+def fsl_to_xcnt(
+    f: "npt.ArrayLike | None" = None,
+    s: "npt.ArrayLike | None" = None,
+    l: "npt.ArrayLike | None" = None,
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     if f is None:
         f = []
     if s is None:
@@ -1073,11 +1117,15 @@ def fsl_to_xcnt(f=None, s=None, l=None):
     return x, c, n, t
 
 
-def fs_to_xcnt(f=None, s=None):
+def fs_to_xcnt(
+    f: "npt.ArrayLike | None" = None, s: "npt.ArrayLike | None" = None
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     return fsl_to_xcnt(f, s, None)
 
 
-def _get_idx(x_target, x):
+def _get_idx(
+    x_target: npt.NDArray, x: npt.ArrayLike
+) -> tuple[npt.NDArray, npt.NDArray]:
     """
     Function to get the indices for a given vector of x values
     """
@@ -1089,26 +1137,26 @@ def _get_idx(x_target, x):
     return idx, rev
 
 
-def check_left_or_int_cens(c):
+def check_left_or_int_cens(c: npt.NDArray) -> None:
     if (-1 in c) or (2 in c):
         raise ValueError(
             "Left or interval censoring not implemented with Competing Risks"
         )
 
 
-def check_Z_and_x(Z, x):
+def check_Z_and_x(Z: npt.NDArray, x: npt.NDArray) -> None:
     if x.shape[0] != Z.shape[0]:
         raise ValueError("Z must have len(x) number of rows")
 
 
-def check_e_and_x(e, x):
+def check_e_and_x(e: npt.NDArray, x: npt.NDArray) -> None:
     if e.shape != x.shape:
         raise ValueError(
             "Event vector, e, and duration vector, x, must have same shape"
         )
 
 
-def check_c_and_e(c, e):
+def check_c_and_e(c: npt.NDArray, e: npt.NDArray) -> None:
     if any(e_i is not None for e_i in e[c == 1]) or any(
         e_i is None for e_i in e[c != 1]
     ):
@@ -1119,7 +1167,7 @@ def check_c_and_e(c, e):
         )
 
 
-def is_missing_event(value):
+def is_missing_event(value: Any) -> bool:
     """Whether a competing-risks event value marks *no* attributed cause -- a
     censored observation. That is Python ``None`` or any missing value
     (``NaN``, pandas ``NA``)."""
@@ -1131,7 +1179,9 @@ def is_missing_event(value):
         return False
 
 
-def resolve_cr_censoring(e, c):
+def resolve_cr_censoring(
+    e: npt.ArrayLike, c: "npt.ArrayLike | None"
+) -> tuple[npt.NDArray, npt.NDArray]:
     """Canonicalise a competing-risks event vector and its censoring flag.
 
     A *missing* event value (``None``, ``NaN`` or pandas ``NA``) marks a
@@ -1149,10 +1199,14 @@ def resolve_cr_censoring(e, c):
     e = np.array([None if m else v for v, m in zip(e, missing)], dtype=object)
     if c is None:
         c = np.where(missing, 1, 0)
-    return e, c
+    return e, np.asarray(c)
 
 
-def wrangle_and_check_form_and_Z_cols(Z_cols, formula, df):
+def wrangle_and_check_form_and_Z_cols(
+    Z_cols: "str | list[str] | None",
+    formula: "str | None",
+    df: Any,
+) -> tuple:
     if (Z_cols is None) and (formula is None):
         raise ValueError("'Z_cols' or 'formula' cannot both be None")
 
@@ -1190,7 +1244,7 @@ def wrangle_and_check_form_and_Z_cols(Z_cols, formula, df):
     return Z, mask, form, feature_names, model_spec
 
 
-def wrangle_Z(Z):
+def wrangle_Z(Z: npt.ArrayLike) -> tuple[npt.NDArray, npt.NDArray]:
     Z = np.array(Z)
 
     if Z.ndim == 1:
@@ -1205,7 +1259,13 @@ def wrangle_Z(Z):
     return Z[mask], mask
 
 
-def validate_cr_df_inputs(df, x_col, e_col, c_col=None, n_col=None):
+def validate_cr_df_inputs(
+    df: Any,
+    x_col: str,
+    e_col: str,
+    c_col: "str | None" = None,
+    n_col: "str | None" = None,
+) -> tuple:
     x = df[x_col].values
     e = df[e_col].values
 
@@ -1221,7 +1281,13 @@ def validate_cr_df_inputs(df, x_col, e_col, c_col=None, n_col=None):
     return x, c, n, e
 
 
-def validate_cr_inputs(x, c, n, e, method):
+def validate_cr_inputs(
+    x: npt.ArrayLike,
+    c: "npt.ArrayLike | None",
+    n: "npt.ArrayLike | None",
+    e: npt.ArrayLike,
+    method: str,
+) -> tuple:
     # Validates the inputs prior to be used by the CoxPH model.
     # Use existing surpyval validator. But don't group and sort
     # so as to put it out of order of the event array, e.
@@ -1251,17 +1317,19 @@ def validate_cr_inputs(x, c, n, e, method):
     return x, c, n, e
 
 
-def validate_event(mapping, event):
+def validate_event(mapping: dict, event: Any) -> None:
     if event is not None and event not in mapping:
         raise ValueError("Event type not in model")
 
 
-def validate_cif_event(event):
+def validate_cif_event(event: Any) -> None:
     if event is None:
         raise ValueError("CIF needs event type, not None")
 
 
-def _check_an_ids_tl_and_x(id, tl, x):
+def _check_an_ids_tl_and_x(
+    id: npt.NDArray, tl: npt.NDArray, x: npt.NDArray
+) -> None:
     # This function checks that, for a given item, id, the history
     # of the item is complete. That is, the timeline provided in the
     # steps from tl[0] > x[0] == tl[1] > x[1] == ... tl[-1] > x[-1]
@@ -1285,47 +1353,63 @@ def _check_an_ids_tl_and_x(id, tl, x):
 
     # check that there is one start time and one finish time and
     # no other double ups or gaps
-    x, n = np.unique([tl, x], return_counts=True)
+    _, counts = np.unique([tl, x], return_counts=True)
 
-    if n[0] != 1:
+    if counts[0] != 1:
         raise ValueError("Multiple start times for item {id}".format(id=id))
-    if n[-1] != 1:
+    if counts[-1] != 1:
         raise ValueError("Multiple end times for item {id}".format(id=id))
 
-    if np.any(n[1:-1] != 2):
+    if np.any(counts[1:-1] != 2):
         raise ValueError(
             "Missing or doubled-up time windows for item {id}".format(id=id)
         )
 
 
-def validate_tv_coxph(id, tl, x, Z, c, n):
-    x, c, n, t = xcnt_handler(x, c, n, tl=tl, group_and_sort=False)
+def validate_tv_coxph(
+    id: npt.ArrayLike,
+    tl: npt.ArrayLike,
+    x: npt.ArrayLike,
+    Z: npt.ArrayLike,
+    c: "npt.ArrayLike | None",
+    n: "npt.ArrayLike | None",
+) -> tuple:
+    x_a, c_a, n_a, t_a = xcnt_handler(x, c, n, tl=tl, group_and_sort=False)
 
     if id is None:
         warnings.warn("No id provided, model fitted by coherence not checked")
     else:
-        id = np.array(id)
-        for i in id:
-            tl_i = tl[id == i]
-            x_i = x[id == i]
+        id_arr = np.array(id)
+        tl_arr = np.asarray(tl)
+        for i in id_arr:
+            tl_i = tl_arr[id_arr == i]
+            x_i = x_a[id_arr == i]
             _check_an_ids_tl_and_x(i, tl_i, x_i)
 
     # One validation pass is enough: mask the already-validated arrays
     # (including the truncation bounds — the old second xcnt_handler call
     # used the unmasked tl and would raise a confusing length error
     # whenever wrangle_Z actually dropped NaN rows).
-    Z, mask = wrangle_Z(Z)
-    x, c, n, t = (arr[mask] for arr in (x, c, n, t))
-    x, c, n, Z = (arr.astype(float) for arr in [x, c, n, Z])
+    Z_arr, mask = wrangle_Z(Z)
+    x_a, c_a, n_a, t_a = (arr[mask] for arr in (x_a, c_a, n_a, t_a))
+    x_a, c_a, n_a = (arr.astype(float) for arr in [x_a, c_a, n_a])
+    Z_arr = Z_arr.astype(float)
 
-    check_Z_and_x(Z, x)
+    check_Z_and_x(Z_arr, x_a)
 
-    return t[:, 0], x, Z, c, n
+    return t_a[:, 0], x_a, Z_arr, c_a, n_a
 
 
 def validate_tv_coxph_df_inputs(
-    df, id_col, tl_col, x_col, Z_cols, c_col, n_col, formula
-):
+    df: Any,
+    id_col: str,
+    tl_col: str,
+    x_col: str,
+    Z_cols: "str | list[str] | None",
+    c_col: "str | None",
+    n_col: "str | None",
+    formula: "str | None",
+) -> tuple:
     # TODO: Create count of dropped rows
 
     if x_col is None:
@@ -1378,7 +1462,14 @@ def validate_tv_coxph_df_inputs(
     return t[:, 0], x, Z, id, c, n, form
 
 
-def validate_coxph_df_inputs(df, x_col, c_col, n_col, Z_cols, formula):
+def validate_coxph_df_inputs(
+    df: Any,
+    x_col: str,
+    c_col: "str | None",
+    n_col: "str | None",
+    Z_cols: "str | list[str] | None",
+    formula: "str | None",
+) -> tuple:
     # TODO: Return the count of dropped rows?
 
     Z, mask, form, feature_names, model_spec = (
@@ -1403,7 +1494,12 @@ def validate_coxph_df_inputs(df, x_col, c_col, n_col, Z_cols, formula):
 
 
 def validate_coxph(
-    x, c, n, Z, tl, method
+    x: "npt.ArrayLike | None",
+    c: "npt.ArrayLike | None",
+    n: "npt.ArrayLike | None",
+    Z: "npt.ArrayLike | None",
+    tl: "npt.ArrayLike | None",
+    method: str,
 ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     if method not in COX_PH_METHODS:
         raise ValueError("Method must be in {}".format(COX_PH_METHODS))
@@ -1423,43 +1519,54 @@ def validate_coxph(
             "for right/interval-truncated data."
         )
 
-    x, c, n, t = xcnt_handler(x, c, n, tl=tl, group_and_sort=False)
+    x_a, c_a, n_a, t_a = xcnt_handler(x, c, n, tl=tl, group_and_sort=False)
 
-    tl = t[:, 0]
+    tl_a = t_a[:, 0]
 
-    x, c, n, Z, tl = (np.array(a).astype(float) for a in [x, c, n, Z, tl])
+    x_a, c_a, n_a, tl_a = (
+        np.array(a).astype(float) for a in [x_a, c_a, n_a, tl_a]
+    )
 
-    Z, mask = wrangle_Z(Z)
-    x, c, n, tl = (arr[mask] for arr in (x, c, n, tl))
-    x, c, n, tl, Z = (arr.astype(float) for arr in [x, c, n, tl, Z])
+    Z_arr, mask = wrangle_Z(np.array(Z).astype(float))
+    x_a, c_a, n_a, tl_a = (arr[mask] for arr in (x_a, c_a, n_a, tl_a))
+    Z_arr = Z_arr.astype(float)
 
-    check_Z_and_x(Z, x)
+    check_Z_and_x(Z_arr, x_a)
 
-    return x, c, n, tl, Z
+    return x_a, c_a, n_a, tl_a, Z_arr
 
 
-def validate_fine_gray_inputs(x, Z, e, c, n):
+def validate_fine_gray_inputs(
+    x: npt.ArrayLike,
+    Z: npt.ArrayLike,
+    e: npt.ArrayLike,
+    c: "npt.ArrayLike | None",
+    n: "npt.ArrayLike | None",
+) -> tuple:
     # A missing event (None / NaN) marks a censored observation; if c is not
     # given it is derived from the events.
     e, c = resolve_cr_censoring(e, c)
-    x, c, n, _ = xcnt_handler(x, c, n, group_and_sort=False)
+    x_a, c_a, n_a, _ = xcnt_handler(x, c, n, group_and_sort=False)
 
-    e = np.array(e)
-    Z, mask = wrangle_Z(Z)
-    x, c, n, e = (arr[mask] for arr in (x, c, n, e))
+    e_arr = np.array(e)
+    Z_arr, mask = wrangle_Z(Z)
+    x_a, c_a, n_a, e_arr = (arr[mask] for arr in (x_a, c_a, n_a, e_arr))
 
     # Set all dtypes to float. Very poor results otherwise.
-    x, c, n, Z = (arr.astype(float) for arr in [x, c, n, Z])
+    x_a, c_a, n_a = (arr.astype(float) for arr in [x_a, c_a, n_a])
+    Z_arr = Z_arr.astype(float)
 
-    check_e_and_x(e, x)
-    check_Z_and_x(Z, x)
-    check_c_and_e(c, e)
-    check_left_or_int_cens(c)
+    check_e_and_x(e_arr, x_a)
+    check_Z_and_x(Z_arr, x_a)
+    check_c_and_e(c_a, e_arr)
+    check_left_or_int_cens(c_a)
 
-    return x, Z, e, c, n
+    return x_a, Z_arr, e_arr, c_a, n_a
 
 
-def fs_to_xrd(f, s):
+def fs_to_xrd(
+    f: npt.ArrayLike, s: npt.ArrayLike
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
     """
     Converts the fs format to the xrd format.
 

--- a/surpyval/utils/__init__.py
+++ b/surpyval/utils/__init__.py
@@ -1265,7 +1265,7 @@ def validate_cr_df_inputs(
     e_col: str,
     c_col: "str | None" = None,
     n_col: "str | None" = None,
-) -> tuple:
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     x = df[x_col].values
     e = df[e_col].values
 
@@ -1287,7 +1287,7 @@ def validate_cr_inputs(
     n: "npt.ArrayLike | None",
     e: npt.ArrayLike,
     method: str,
-) -> tuple:
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     # Validates the inputs prior to be used by the CoxPH model.
     # Use existing surpyval validator. But don't group and sort
     # so as to put it out of order of the event array, e.
@@ -1542,7 +1542,7 @@ def validate_fine_gray_inputs(
     e: npt.ArrayLike,
     c: "npt.ArrayLike | None",
     n: "npt.ArrayLike | None",
-) -> tuple:
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     # A missing event (None / NaN) marks a censored observation; if c is not
     # given it is derived from the events.
     e, c = resolve_cr_censoring(e, c)

--- a/surpyval/utils/autograd_gamma_compat.py
+++ b/surpyval/utils/autograd_gamma_compat.py
@@ -22,9 +22,13 @@ Replaces the abandoned autograd-gamma package. VJP approach:
     inner VJPs are plain numpy), which nothing in surpyval needs.
 """
 
+from typing import Callable
+
 import autograd.numpy as anp
 import numpy as np
+import numpy.typing as npt
 from autograd.extend import defvjp, primitive
+from autograd.numpy.numpy_boxes import ArrayBox
 from autograd.scipy.special import betaln as _ag_betaln
 from autograd.scipy.special import gammaln as _ag_gammaln
 from autograd.tracer import getval
@@ -32,17 +36,21 @@ from scipy.special import betainc as _sc_betainc
 from scipy.special import gammainc as _sc_gammainc
 from scipy.special import gammaincc as _sc_gammaincc
 
+# The value-or-box union the distributions use (see parametric_fitter):
+# every boundary here may see a plain numpy value or an ArrayBox.
+Boxable = npt.NDArray | float | ArrayBox
+
 _LOG_EPS = 1e-35
 _EPS_H = np.finfo(float).eps ** (1.0 / 3.0)
 
 
-def _step(v):
+def _step(v: Boxable) -> Boxable:
     """Exact floating-point step size for central differences."""
     h = np.maximum(np.abs(v) * _EPS_H, 1e-7)
     return (v + h) - v
 
 
-def _cdiff(f, v):
+def _cdiff(f: Callable, v: Boxable) -> Boxable:
     """5th-order central difference of a one-argument callable at v."""
     h = _step(v)
     return (-f(v + 2 * h) + 8 * f(v + h) - 8 * f(v - h) + f(v - 2 * h)) / (
@@ -50,7 +58,7 @@ def _cdiff(f, v):
     )
 
 
-def _cdiff_second(f, v):
+def _cdiff_second(f: Callable, v: Boxable) -> Boxable:
     """5-point second-derivative stencil of a one-argument callable at v."""
     h = _step(v)
     return (
@@ -62,7 +70,7 @@ def _cdiff_second(f, v):
     ) / (12 * h * h)
 
 
-def _cdiff1(f, a, x):
+def _cdiff1(f: Callable, a: Boxable, x: Boxable) -> Boxable:
     """5th-order central diff of f(a, x) w.r.t. a.
 
     Both a and x must be plain numpy values — call with getval().
@@ -70,17 +78,17 @@ def _cdiff1(f, a, x):
     return _cdiff(lambda aa: f(aa, x), a)
 
 
-def _cdiff2_a(f, a, b, x):
+def _cdiff2_a(f: Callable, a: Boxable, b: Boxable, x: Boxable) -> Boxable:
     """5th-order central diff of f(a, b, x) w.r.t. a — all args plain numpy."""
     return _cdiff(lambda aa: f(aa, b, x), a)
 
 
-def _cdiff2_b(f, a, b, x):
+def _cdiff2_b(f: Callable, a: Boxable, b: Boxable, x: Boxable) -> Boxable:
     """5th-order central diff of f(a, b, x) w.r.t. b — all args plain numpy."""
     return _cdiff(lambda bb: f(a, bb, x), b)
 
 
-def _make_da_primitive(f):
+def _make_da_primitive(f: Callable) -> Callable:
     """Traced first derivative w.r.t. the shape parameter of f(a, x).
 
     Returns a primitive ``f_da(a, x) = df/da`` whose own VJPs are the
@@ -89,15 +97,15 @@ def _make_da_primitive(f):
     """
 
     @primitive
-    def f_da(a, x):
+    def f_da(a: Boxable, x: Boxable) -> Boxable:
         return _cdiff1(f, a, x)
 
-    def vjp_a(ans, a, x):
+    def vjp_a(ans: Boxable, a: Boxable, x: Boxable) -> Callable:
         av, xv = getval(a), getval(x)
         d2 = _cdiff_second(lambda aa: f(aa, xv), av)
         return lambda g: (getval(g) * d2).sum()
 
-    def vjp_x(ans, a, x):
+    def vjp_x(ans: Boxable, a: Boxable, x: Boxable) -> Callable:
         av, xv = getval(a), getval(x)
         mixed = _cdiff(lambda xx: _cdiff1(f, av, xx), xv)
         return lambda g: getval(g) * mixed
@@ -106,7 +114,7 @@ def _make_da_primitive(f):
     return f_da
 
 
-def _make_dab_primitives(f):
+def _make_dab_primitives(f: Callable) -> tuple[Callable, Callable]:
     """Traced first derivatives w.r.t. both shape parameters of f(a, b, x).
 
     Returns primitives ``(f_da, f_db)`` whose VJPs are the numerical pure,
@@ -114,42 +122,44 @@ def _make_dab_primitives(f):
     """
 
     @primitive
-    def f_da(a, b, x):
+    def f_da(a: Boxable, b: Boxable, x: Boxable) -> Boxable:
         return _cdiff2_a(f, a, b, x)
 
     @primitive
-    def f_db(a, b, x):
+    def f_db(a: Boxable, b: Boxable, x: Boxable) -> Boxable:
         return _cdiff2_b(f, a, b, x)
 
-    def _vals(a, b, x):
+    def _vals(
+        a: Boxable, b: Boxable, x: Boxable
+    ) -> tuple[Boxable, Boxable, Boxable]:
         return getval(a), getval(b), getval(x)
 
-    def da_vjp_a(ans, a, b, x):
+    def da_vjp_a(ans: Boxable, a: Boxable, b: Boxable, x: Boxable) -> Callable:
         av, bv, xv = _vals(a, b, x)
         d2 = _cdiff_second(lambda aa: f(aa, bv, xv), av)
         return lambda g: (getval(g) * d2).sum()
 
-    def da_vjp_b(ans, a, b, x):
+    def da_vjp_b(ans: Boxable, a: Boxable, b: Boxable, x: Boxable) -> Callable:
         av, bv, xv = _vals(a, b, x)
         d2 = _cdiff(lambda bb: _cdiff2_a(f, av, bb, xv), bv)
         return lambda g: (getval(g) * d2).sum()
 
-    def da_vjp_x(ans, a, b, x):
+    def da_vjp_x(ans: Boxable, a: Boxable, b: Boxable, x: Boxable) -> Callable:
         av, bv, xv = _vals(a, b, x)
         mixed = _cdiff(lambda xx: _cdiff2_a(f, av, bv, xx), xv)
         return lambda g: getval(g) * mixed
 
-    def db_vjp_a(ans, a, b, x):
+    def db_vjp_a(ans: Boxable, a: Boxable, b: Boxable, x: Boxable) -> Callable:
         av, bv, xv = _vals(a, b, x)
         d2 = _cdiff(lambda aa: _cdiff2_b(f, aa, bv, xv), av)
         return lambda g: (getval(g) * d2).sum()
 
-    def db_vjp_b(ans, a, b, x):
+    def db_vjp_b(ans: Boxable, a: Boxable, b: Boxable, x: Boxable) -> Callable:
         av, bv, xv = _vals(a, b, x)
         d2 = _cdiff_second(lambda bb: f(av, bb, xv), bv)
         return lambda g: (getval(g) * d2).sum()
 
-    def db_vjp_x(ans, a, b, x):
+    def db_vjp_x(ans: Boxable, a: Boxable, b: Boxable, x: Boxable) -> Callable:
         av, bv, xv = _vals(a, b, x)
         mixed = _cdiff(lambda xx: _cdiff2_b(f, av, bv, xx), xv)
         return lambda g: getval(g) * mixed
@@ -165,7 +175,7 @@ def _make_dab_primitives(f):
 
 
 @primitive
-def gammainc(a, x):
+def gammainc(a: Boxable, x: Boxable) -> Boxable:
     return _sc_gammainc(a, x)
 
 
@@ -186,12 +196,12 @@ defvjp(
 # ---------------------------------------------------------------------------
 
 
-def _gammaincln_raw(a, x):
+def _gammaincln_raw(a: Boxable, x: Boxable) -> Boxable:
     return np.log(np.clip(_sc_gammainc(a, x), _LOG_EPS, np.inf))
 
 
 @primitive
-def gammaincln(a, x):
+def gammaincln(a: Boxable, x: Boxable) -> Boxable:
     return _gammaincln_raw(a, x)
 
 
@@ -210,12 +220,12 @@ defvjp(
 # ---------------------------------------------------------------------------
 
 
-def _gammainccln_raw(a, x):
+def _gammainccln_raw(a: Boxable, x: Boxable) -> Boxable:
     return np.log(np.clip(_sc_gammaincc(a, x), _LOG_EPS, np.inf))
 
 
 @primitive
-def gammainccln(a, x):
+def gammainccln(a: Boxable, x: Boxable) -> Boxable:
     return _gammainccln_raw(a, x)
 
 
@@ -235,7 +245,7 @@ defvjp(
 
 
 @primitive
-def betainc(a, b, x):
+def betainc(a: Boxable, b: Boxable, x: Boxable) -> Boxable:
     return _sc_betainc(a, b, x)
 
 
@@ -257,12 +267,12 @@ defvjp(
 # ---------------------------------------------------------------------------
 
 
-def _betaincln_raw(a, b, x):
+def _betaincln_raw(a: Boxable, b: Boxable, x: Boxable) -> Boxable:
     return np.log(np.clip(_sc_betainc(a, b, x), _LOG_EPS, np.inf))
 
 
 @primitive
-def betaincln(a, b, x):
+def betaincln(a: Boxable, b: Boxable, x: Boxable) -> Boxable:
     return _betaincln_raw(a, b, x)
 
 

--- a/surpyval/utils/fitter.py
+++ b/surpyval/utils/fitter.py
@@ -11,9 +11,10 @@ a fitter class rather than a class that is only ever instantiated once.
 """
 
 import sys
+from typing import Any
 
 
-def singleton_fitter(cls):
+def singleton_fitter(cls: type) -> Any:
     """Bind the decorated class' name to a single configured instance.
 
     Use on a fitter whose ``__init__`` takes no required arguments. The name is

--- a/surpyval/utils/fitter.py
+++ b/surpyval/utils/fitter.py
@@ -11,10 +11,12 @@ a fitter class rather than a class that is only ever instantiated once.
 """
 
 import sys
-from typing import Any
+from typing import TypeVar
+
+T = TypeVar("T")
 
 
-def singleton_fitter(cls: type) -> Any:
+def singleton_fitter(cls: type[T]) -> T:
     """Bind the decorated class' name to a single configured instance.
 
     Use on a fitter whose ``__init__`` takes no required arguments. The name is

--- a/surpyval/utils/recurrent_event_data.py
+++ b/surpyval/utils/recurrent_event_data.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 import numpy.typing as npt
 
@@ -48,7 +50,16 @@ class RecurrentEventData:
     array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
     """
 
-    def __init__(self, x, i, c, n, e=None, tl=None, tr=None):
+    def __init__(
+        self,
+        x: npt.ArrayLike,
+        i: npt.ArrayLike,
+        c: npt.ArrayLike,
+        n: npt.ArrayLike,
+        e: "npt.ArrayLike | None" = None,
+        tl: "npt.ArrayLike | None" = None,
+        tr: "npt.ArrayLike | None" = None,
+    ) -> None:
         self.x = np.atleast_1d(x)
         self.i = np.atleast_1d(i)
         self.c = np.atleast_1d(c)
@@ -82,7 +93,9 @@ class RecurrentEventData:
             x_midpoints[self.c == -1, 0] = x_midpoints.min()
             self.midpoints = x_midpoints.mean(axis=1)
 
-    def to_xrd(self, estimator="Nelson-Aalen"):
+    def to_xrd(
+        self, estimator: str = "Nelson-Aalen"
+    ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
         """
         Convert the recurrent event data to xrd format.
 
@@ -145,7 +158,7 @@ class RecurrentEventData:
         return self.xrd
 
     @property
-    def event_types(self):
+    def event_types(self) -> list:
         """
         The distinct event types (marks) present in the data, excluding the
         ``None`` mark used for censored / end-of-observation rows. Returns an
@@ -155,7 +168,9 @@ class RecurrentEventData:
             return []
         return sorted({e for e in self.e if e is not None})
 
-    def to_cause_specific_xrd(self, cause):
+    def to_cause_specific_xrd(
+        self, cause: Any
+    ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
         """
         Convert the recurrent event data to xrd format for a single event
         type (cause). The at-risk set ``r`` is shared across all causes (an
@@ -204,7 +219,7 @@ class RecurrentEventData:
         )
         return x_unique, r, d_cause
 
-    def get_interarrival_times(self):
+    def get_interarrival_times(self) -> npt.NDArray:
         """
         Finds the interarrival times between events for each item. The class
         assumes that the time of the event is cumulative, sometimes it is
@@ -222,7 +237,7 @@ class RecurrentEventData:
         interarrival_times = [np.diff(arr, prepend=0) for arr in arrival_times]
         return np.concatenate(interarrival_times)
 
-    def get_previous_x(self, min_x=0):
+    def get_previous_x(self, min_x: float = 0) -> npt.NDArray:
         """
         Finds the previous event time for each event. This is useful for
         calculating the time since the last event. This method returns the
@@ -259,7 +274,7 @@ class RecurrentEventData:
 
         return np.concatenate(x_previous)
 
-    def split_for_nhpp_likelihood(self):
+    def split_for_nhpp_likelihood(self) -> dict:
         """Split the data into the pieces every NHPP-style likelihood
         needs: per-censoring-type event and previous-event times, the
         right-truncation window close, and the row masks (so regression
@@ -278,7 +293,13 @@ class RecurrentEventData:
             x_prev if x_prev.ndim == 1 else x_prev[:, 0]
         )  # not x[:, 0] (#288)
         x_prev_r = x_prev[:, 1] if x_prev.ndim == 2 else None
-        prev = x_prev_r if has_interval else x_prev_l
+        # ``has_interval`` implies 2-D data, so the right columns exist;
+        # assert the link for the type checker.
+        if has_interval:
+            assert x_r is not None and x_prev_r is not None
+            prev = x_prev_r
+        else:
+            prev = x_prev_l
 
         mask_o = c == 0
         mask_right = c == 1
@@ -294,7 +315,9 @@ class RecurrentEventData:
             "x_left": x_l[mask_left] if mask_left.any() else empty,
             "n_left": n[mask_left] if mask_left.any() else empty,
             "x_i_l": x_l[mask_i] if mask_i.any() else empty,
-            "x_i_r": x_r[mask_i] if mask_i.any() else empty,
+            "x_i_r": (
+                x_r[mask_i] if (mask_i.any() and x_r is not None) else empty
+            ),
             "n_i": n[mask_i] if mask_i.any() else empty,
             "mask_o": mask_o,
             "mask_right": mask_right,
@@ -312,7 +335,9 @@ class RecurrentEventData:
         ) = self.get_right_truncation_close()
         return out
 
-    def get_right_truncation_close(self):
+    def get_right_truncation_close(
+        self,
+    ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
         """
         Per-item integration bounds for the NHPP likelihood's right
         window-close.
@@ -357,7 +382,9 @@ class RecurrentEventData:
             np.array(rep_idx, dtype=int),
         )
 
-    def get_events_for_item(self, item):
+    def get_events_for_item(
+        self, item: Any
+    ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
         """
         Get all events for a specific item or subject.
 
@@ -375,7 +402,7 @@ class RecurrentEventData:
         mask = self.i == item
         return self.x[mask], self.c[mask], self.n[mask]
 
-    def get_times_to_first_events(self):
+    def get_times_to_first_events(self) -> "SurpyvalData":
         """
         Get the times to the first events for each item or subject. In the
         estimation of recurrent or renewal events it can be helpful to know
@@ -394,7 +421,7 @@ class RecurrentEventData:
         n_ttff = np.array([self.n[self.i == item][0] for item in self.items])
         return SurpyvalData(x_ttff, c_ttff, n_ttff)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: Any) -> "RecurrentEventData":
         return RecurrentEventData(
             self.x[index],
             self.i[index],
@@ -405,12 +432,12 @@ class RecurrentEventData:
             tr=self.tr[index],
         )
 
-    def __iter__(self):
+    def __iter__(self) -> Any:
         # A stateless iterator: the old hand-rolled _index version broke
         # nested iteration over the same object.
         return zip(self.x, self.i, self.c, self.n)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"""
             RecurrentEventData(
     x={self.x},

--- a/surpyval/utils/surpyval_data.py
+++ b/surpyval/utils/surpyval_data.py
@@ -1,6 +1,7 @@
 import json
 from numbers import Number
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -246,7 +247,7 @@ class SurpyvalData:
             self.tr_unique = np.array([])
             self.n_t_unique = np.array([])
 
-    def to_xrd(self, estimator="Nelson-Aalen") -> tuple:
+    def to_xrd(self, estimator: str = "Nelson-Aalen") -> tuple:
         """
         Converts the data into the xrd format. If the data has right truncated
         observations or left or interval censored observations, the data is
@@ -296,7 +297,7 @@ class SurpyvalData:
         x = self.x[mask] if self.x.ndim == 1 else self.x[mask, 0]
         return x, self.n[mask]
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: Any) -> "SurpyvalData":
         # A scalar index on interval-censored (2-D) data used to flatten
         # one [xl, xr] row into two 1-D observations and crash the type
         # split; keep the row structure instead (#282).
@@ -326,7 +327,7 @@ class SurpyvalData:
     def __len__(self) -> int:
         return len(self.x)
 
-    def __iter__(self):
+    def __iter__(self) -> Any:
         return zip(self.x, self.c, self.n, self.t)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Completes #143. **Every function in the package is annotated — 1750 of 1750 defs — and the per-module ratchet list is gone**: `disallow_untyped_defs` now holds package-wide, with only the test suite and the alpha tree exempt (exercised, not typed, but still checked against the package's annotations).

## The commits, in dependency order

1. **`8f98581`** — regression layers 0+1: `_fit_skeleton`, `_likelihood`, `_bounds`, `tvc_schedule`, the two model classes, the `PH`/`AH` factories.
2. **`07a38be`** — the rest of `univariate.regression`: the four fitters, `cox_ph`, `buckley_james`, `aft_tvc_fit`, the TVC wranglers, diagnostics. A `MirroredDistributionAttrs` declarations base makes the fitters' mirrored attributes checker-visible.
3. **`e58169b`** — `utils`: the xcnt/fsli/xrd wrangling surface, the `autograd_gamma_compat` shim typed end-to-end on the `Boxable` union, `recurrent_event_data`, `surpyval_data`, `fitter`.
4. **`d6d010b`** — `univariate.competing_risks`, with the utils validators gaining precise tuple returns so call sites narrow without local renames.
5. **`2ab3f51`** — the whole `recurrent` package; the intensity contract moves off the documented `ArrayLike` trap onto `Boxable` (those functions are autograd-differentiated in the NHPP likelihoods).
6. **`e6310c6`** — `degradation`; **`aabaaf5`** — the copulas; **`c4de850`** — the `beta.ml` forest stragglers and the config flip.

## What typing the bodies found (the reason to do this at all)

- `SemiParametricRegressionModel.neg_ll`/`jac` were declared as a float and an array; they hold the fit's closures.
- `Parametric.random` is documented to return an array but returns xcnt-format `(x, c, n, t)` arrays for LFP/zero-inflated models — annotated and documented honestly rather than changed.
- `singleton_fitter` is now `(cls: type[T]) -> T`, so the checker knows every fitter singleton is an instance.
- `NonParametricCounting.var` is honestly Optional (simulated MCFs carry no variance), and three crash paths became named `ValueError`s: `BuckleyJamesModel.bootstrap_ci` and destructive-degradation bootstrap bounds on models carrying no fit data, and `mcf_cb` on a simulated MCF.
- Genuine signature divergences (the covariate-extended simulation methods, the named-single-parameter intensity/copula families against variadic base contracts) are documented at the definition with targeted ignores, not silently widened — the same family of API warts as the `fit`-signature divergence already on the books (#238-adjacent).

## Verification

- **Full matrix green**: `check_all_pythons` — test suite plus both doctest passes on 3.11, 3.12 and 3.13, all nine checks ok, run after the final config flip.
- mypy clean on all 310 source files under global `disallow_untyped_defs`; flake8, black and isort clean.
- Per-area suites run standalone along the way: regression 315, competing risks 75, recurrent 349, degradation 171, multivariate 29.
- No behavioural changes except the three named-error paths above, each replacing a crash on the same failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)