### PR TITLE
Model degradation path parameters against stress (#155, Stage 2 part A)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,32 @@ Changelog
 v0.19.1 (unreleased)
 --------------------
 
+- **Accelerated degradation, Stage 2: stress-dependent path
+  parameters** (<#155>, first half). ``DegradationAnalysis.fit`` takes
+  ``links`` alongside ``Z`` to model the degradation *mechanism*
+  against stress rather than only the pseudo failure times: the path
+  parameters named in ``links`` depend on the unit's stress on an
+  ``"identity"`` or ``"log"`` link (a log-linked rate with ``Z = 1/T``
+  is the Arrhenius relationship), the others are common, and a
+  per-unit random effect sits on top -- ``eta_i = D(z_i) gamma + u_i``
+  with ``u_i ~ MVN(0, Sigma)``. ``gamma`` and ``Sigma`` are estimated
+  by the same two-stage (Lu-Meeker) or REML route as the plain
+  population and stored as ``path_param_fixed`` (labelled by
+  ``path_param_fixed_names``) and ``path_param_link_cov``; the fitted
+  model round-trips through ``to_dict``/``from_dict`` and shows the
+  fixed effects in its ``repr``. The life model is still the Stage-1
+  regression on the pseudo failure times, so every existing prediction
+  method is unchanged; the stress-conditional prior for ``predict_rul``
+  and ``induced_life`` is the second half.
+
+  Under the hood a :class:`LinkedPathModel` presents any path model on
+  its link scale, so the per-unit fits and the FOCE linearisation apply
+  unchanged, and the REML routines take an optional fixed-effects
+  design (``a_mat_list`` / ``d_mat_list``). Without ``links`` the
+  pipeline is bit-identical to before (verified by fingerprinting 55
+  numeric outputs across the moments, REML, nonlinear-REML,
+  best-path, Stage-1 ADT and bootstrap surfaces).
+
 - **API reference completed for the remaining public surfaces**
   (<#141>). New autodoc pages for every distribution that had none:
   the discrete lifetimes (Geometric, Poisson, Binomial, Negative

--- a/docs/surpyval.degradation.rst
+++ b/docs/surpyval.degradation.rst
@@ -54,6 +54,19 @@ Path Models
 
 .. autofunction:: surpyval.degradation.path_models.get_path_model
 
+Stress-Dependent Path Parameters
+--------------------------------
+
+For accelerated degradation tests whose *mechanism* depends on stress
+(``links`` in :meth:`DegradationAnalysis.fit`): the path parameters are
+modelled on a link scale, ``eta_i = D(z_i) gamma + u_i``, so a
+log-linked rate with ``Z = 1/T`` follows the Arrhenius relationship.
+
+.. autoclass:: surpyval.degradation.stress.LinkedPathModel
+   :members:
+
+.. autofunction:: surpyval.degradation.stress.stress_design
+
 Stochastic Process Models
 -------------------------
 

--- a/surpyval/degradation/__init__.py
+++ b/surpyval/degradation/__init__.py
@@ -27,6 +27,8 @@ from .path_models import (
     get_path_model,
 )
 
+from .stress import LinkedPathModel  # isort: skip
+
 from .degradation_analysis import (  # isort: skip
     DegradationAnalysis,
     DegradationModel,

--- a/surpyval/degradation/degradation_analysis.py
+++ b/surpyval/degradation/degradation_analysis.py
@@ -46,6 +46,22 @@ from ._bounds import (
 )
 from .path_models import PATH_MODELS, PathModel, get_path_model
 from .population import reml_estimate, reml_estimate_nonlinear
+from .stress import (
+    LinkedPathModel,
+    fixed_effect_names,
+    stress_design,
+    validate_links,
+)
+
+
+def _optional_list(arr: "npt.NDArray | None") -> "list | None":
+    """``to_dict`` helper: an optional array as a nested list."""
+    return None if arr is None else np.asarray(arr, dtype=float).tolist()
+
+
+def _optional_array(value: "list | None") -> "npt.NDArray | None":
+    """``from_dict`` helper: the inverse of :func:`_optional_list`."""
+    return None if value is None else np.array(value, dtype=float)
 
 
 def _is_regression_fitter(fitter: Any) -> bool:
@@ -305,6 +321,27 @@ class DegradationModel(SerialisableMixin):
         candidate path model (``nan`` for candidates that could not be
         fitted to every unit); ``None`` otherwise. The fitted
         ``path_model`` is the candidate with the smallest score.
+    links : dict or None
+        When the path parameters were modelled against stress
+        (``links`` given to :meth:`DegradationAnalysis.fit`), the
+        stress-dependent parameters and their links; ``None``
+        otherwise. With ``links`` the population of path parameters is
+        stress-conditional, on the link scale: ``eta_i = D(z_i) gamma
+        + u_i`` with ``u_i ~ MVN(0, Sigma)`` and ``theta_i = h(eta_i)``.
+    path_param_fixed : ndarray or None
+        The fixed effects ``gamma`` of the stress-conditional population
+        model, labelled by ``path_param_fixed_names``: for every path
+        parameter its link-scale intercept, followed (for the
+        stress-dependent ones) by its coefficient on each covariate.
+    path_param_fixed_names : list of str or None
+        Labels for ``path_param_fixed``: the link-scale parameter name
+        (``"log(b)"`` for a log link) and ``"<name>:Z<j>"`` for the
+        coefficient on covariate ``j``.
+    path_param_link_cov : ndarray or None
+        The between-unit covariance ``Sigma`` of the link-scale path
+        parameters *given* the stress -- the scatter left after the
+        stress effect is removed, unlike the pooled ``path_param_cov``
+        which mixes the stress levels.
     """
 
     x: npt.NDArray
@@ -328,6 +365,10 @@ class DegradationModel(SerialisableMixin):
     #: Per-unit covariates when fitted as an accelerated-degradation model
     #: (``Z`` given to :meth:`DegradationAnalysis.fit`); ``None`` otherwise.
     Z: "npt.NDArray | None"
+    links: "dict[str, str] | None"
+    path_param_fixed: "npt.NDArray | None"
+    path_param_fixed_names: "list[str] | None"
+    path_param_link_cov: "npt.NDArray | None"
     # Recorded after construction so the bootstrap bounds can rerun the fit.
     _distribution: Any
     _how: str
@@ -351,6 +392,10 @@ class DegradationModel(SerialisableMixin):
         population_method: str,
         path_selection: "dict | None" = None,
         Z: "npt.NDArray | None" = None,
+        links: "dict[str, str] | None" = None,
+        path_param_fixed: "npt.NDArray | None" = None,
+        path_param_fixed_names: "list[str] | None" = None,
+        path_param_link_cov: "npt.NDArray | None" = None,
     ) -> None:
         self.x = x
         self.y = y
@@ -369,6 +414,10 @@ class DegradationModel(SerialisableMixin):
         self.population_method = population_method
         self.path_selection = path_selection
         self.Z = Z
+        self.links = links
+        self.path_param_fixed = path_param_fixed
+        self.path_param_fixed_names = path_param_fixed_names
+        self.path_param_link_cov = path_param_link_cov
         self._unit_index = {unit: idx for idx, unit in enumerate(units)}
 
     # -- serialisation -----------------------------------------------------
@@ -438,6 +487,16 @@ class DegradationModel(SerialisableMixin):
                 "path_selection": self.path_selection,
                 "Z": None if self.Z is None else np.asarray(self.Z).tolist(),
                 "how": self._how,
+                "links": None if self.links is None else dict(self.links),
+                "path_param_fixed": _optional_list(self.path_param_fixed),
+                "path_param_fixed_names": (
+                    None
+                    if self.path_param_fixed_names is None
+                    else list(self.path_param_fixed_names)
+                ),
+                "path_param_link_cov": _optional_list(
+                    self.path_param_link_cov
+                ),
             }
         )
 
@@ -481,6 +540,14 @@ class DegradationModel(SerialisableMixin):
             population_method=model_dict["population_method"],
             path_selection=model_dict.get("path_selection"),
             Z=None if Z is None else np.array(Z, dtype=float),
+            links=model_dict.get("links"),
+            path_param_fixed=_optional_array(
+                model_dict.get("path_param_fixed")
+            ),
+            path_param_fixed_names=model_dict.get("path_param_fixed_names"),
+            path_param_link_cov=_optional_array(
+                model_dict.get("path_param_link_cov")
+            ),
         )
         # Recorded so bootstrap bounds can rerun the pipeline; the original
         # distribution object is not serialised, so bounds default to the
@@ -1117,6 +1184,25 @@ class DegradationModel(SerialisableMixin):
         ax.legend()
         return ax
 
+    def _stress_repr(self) -> str:
+        """The stress-conditional path population, for ``__repr__``."""
+        if self.links is None or self.path_param_fixed is None:
+            return ""
+        assert self.path_param_fixed_names is not None
+        link_string = ", ".join(
+            "{}: {}".format(name, link) for name, link in self.links.items()
+        )
+        effects = "\n".join(
+            f"{name:>14}: {value}"
+            for name, value in zip(
+                self.path_param_fixed_names, self.path_param_fixed
+            )
+        )
+        return (
+            f"\nPath Stress Links   : {link_string}"
+            "\nPath Fixed Effects  :\n" + effects
+        )
+
     def __repr__(self) -> str:
         if self.is_accelerated:
             names = self.life_model.parameter_names()
@@ -1134,7 +1220,9 @@ class DegradationModel(SerialisableMixin):
                 f"\nNumber of Units     : {len(self.units)}"
                 f"\nCensored Units      : {int((self.c == 1).sum())}"
                 f"\nLife Distribution   : {dist_name} ({reg_name} covariates)"
-                "\nParameters          :\n" + param_string
+                "\nParameters          :\n"
+                + param_string
+                + self._stress_repr()
             )
         param_string = "\n".join(
             [
@@ -1205,6 +1293,7 @@ class DegradationAnalysis_:
         how: str = "MLE",
         population_method: str = "moments",
         Z: npt.ArrayLike | None = None,
+        links: "dict[str, str] | None" = None,
     ) -> DegradationModel:
         """
         Fit a degradation analysis model.
@@ -1265,6 +1354,25 @@ class DegradationAnalysis_:
             failure time model, ``AFT(distribution)``. The returned model's
             prediction methods (``sf``, ``ff``, ``qf``, ``random`` ...) then
             take the stress vector ``Z`` at which to evaluate life.
+        links : dict, optional
+            Model the degradation *mechanism* against stress as well
+            (requires ``Z``): the path parameters named here depend on
+            the unit's stress, the rest do not. Each value is the link
+            the parameter is modelled on -- ``"identity"`` (the
+            parameter is linear in ``Z``) or ``"log"`` (its log is
+            linear in ``Z``, so a rate with ``Z = 1/T`` follows an
+            Arrhenius relationship and the parameter stays positive).
+            Per unit, ``eta_i = D(z_i) gamma + u_i`` on the link scale
+            with a between-unit random effect ``u_i ~ MVN(0, Sigma)``;
+            ``gamma`` and ``Sigma`` are estimated by the same two-stage
+            or REML route as the plain population, and stored as
+            ``path_param_fixed`` (labelled by ``path_param_fixed_names``)
+            and ``path_param_link_cov``. The life model is still the
+            covariate regression on the pseudo failure times, so every
+            prediction method works as without ``links``. For example
+            ``links={"b": "log"}`` with the linear path lets the
+            degradation rate ``b`` accelerate log-linearly with stress
+            while the intercept ``a`` (the initial state) is common.
 
         Returns
         -------
@@ -1299,6 +1407,19 @@ class DegradationAnalysis_:
         else:
             path_model = get_path_model(path)
 
+        # Stage-2 accelerated degradation: the path parameters depend on
+        # stress, modelled on a link scale by a wrapped path model.
+        Z_units = None if Z is None else self._handle_Z(Z, i_arr, units)
+        linked: "LinkedPathModel | None" = None
+        if links is not None:
+            if Z_units is None:
+                raise ValueError(
+                    "links models the path parameters against stress, so "
+                    "the stress covariates Z must be given too"
+                )
+            links = validate_links(path_model, links)
+            linked = LinkedPathModel(path_model, links)
+
         n_params = len(path_model.param_names)
         path_params = np.empty((len(units), n_params))
         pseudo = np.empty(len(units))
@@ -1309,6 +1430,9 @@ class DegradationAnalysis_:
         y_by_unit = []
         x_by_unit = []
         design_by_unit = []
+        link_params = np.empty((len(units), n_params))
+        link_design_by_unit = []
+        link_estimation_covs = []
 
         for idx, unit in enumerate(units):
             mask = i_arr == unit
@@ -1334,6 +1458,17 @@ class DegradationAnalysis_:
             y_by_unit.append(y_unit)
             x_by_unit.append(x_unit)
             design_by_unit.append(jacobian)
+
+            if linked is not None:
+                # the same fit on the link scale, with the Jacobian
+                # (and hence the estimation covariance) mapped there
+                eta = linked.to_link(params)
+                link_params[idx] = eta
+                link_jacobian = linked.jacobian(x_unit, *eta)
+                link_design_by_unit.append(link_jacobian)
+                link_estimation_covs.append(
+                    safe_inv(link_jacobian.T @ link_jacobian)
+                )
 
         # Two-stage (Lu-Meeker) noise correction: the scatter of the
         # per-unit estimates is Sigma + V_i, so subtracting the average
@@ -1399,6 +1534,37 @@ class DegradationAnalysis_:
             path_param_cov = reml_cov
             measurement_var = reml_var
 
+        path_param_fixed = None
+        path_param_fixed_names = None
+        path_param_link_cov = None
+        if linked is not None:
+            assert Z_units is not None and links is not None
+            path_param_fixed, path_param_link_cov, link_var = (
+                self._fit_stress_population(
+                    linked,
+                    links,
+                    Z_units,
+                    y_by_unit,
+                    x_by_unit,
+                    link_params,
+                    link_design_by_unit,
+                    link_estimation_covs,
+                    measurement_var,
+                    population_method,
+                )
+            )
+            path_param_fixed_names = fixed_effect_names(
+                linked.param_names,
+                path_model.param_names,
+                links,
+                Z_units.shape[1],
+            )
+            if population_method == "reml":
+                # the stress-conditional model is the population model
+                # of a linked fit; its noise estimate supersedes the
+                # pooled one
+                measurement_var = link_var
+
         events = np.isfinite(pseudo) & (pseudo > 0)
         if not events.any():
             raise ValueError(
@@ -1418,11 +1584,9 @@ class DegradationAnalysis_:
         pseudo_failure_times = np.where(events, pseudo, last_time)
         c = np.where(events, 0, 1)
 
-        Z_units = None
-        if Z is None:
+        if Z_units is None:
             life_model = distribution.fit(x=pseudo_failure_times, c=c, how=how)
         else:
-            Z_units = self._handle_Z(Z, i_arr, units)
             reg = (
                 distribution
                 if _is_regression_fitter(distribution)
@@ -1448,12 +1612,93 @@ class DegradationAnalysis_:
             population_method=population_method,
             path_selection=path_selection,
             Z=Z_units,
+            links=links,
+            path_param_fixed=path_param_fixed,
+            path_param_fixed_names=path_param_fixed_names,
+            path_param_link_cov=path_param_link_cov,
         )
         # Recorded so the bootstrap confidence bounds can rerun the pipeline
         # (with the selected path model held fixed) on resampled units.
         model._distribution = distribution
         model._how = how
         return model
+
+    @staticmethod
+    def _fit_stress_population(
+        linked: LinkedPathModel,
+        links: dict[str, str],
+        Z_units: npt.NDArray,
+        y_by_unit: list,
+        x_by_unit: list,
+        link_params: npt.NDArray,
+        link_design_by_unit: list,
+        link_estimation_covs: list,
+        measurement_var: float,
+        population_method: str,
+    ) -> tuple[npt.NDArray, npt.NDArray, float]:
+        """
+        Estimate the stress-conditional population of link-scale path
+        parameters, ``eta_i = D(z_i) gamma + u_i``.
+
+        The two-stage estimate regresses the per-unit link-scale fits on
+        their stress designs by least squares for ``gamma``, and takes
+        the covariance of the residuals less the average link-scale
+        estimation covariance (the Lu-Meeker correction) for ``Sigma``.
+        With ``population_method="reml"`` that is the starting point of
+        the mixed-model REML fit, exact for a linear-in-parameters
+        linked path and by FOCE linearisation otherwise.
+
+        Returns ``(gamma, Sigma, sigma2)``.
+        """
+        n_units, n_params = link_params.shape
+        designs = [
+            stress_design(z, links, linked.base.param_names) for z in Z_units
+        ]
+        stacked = np.vstack(designs)
+        gamma, *_ = np.linalg.lstsq(stacked, link_params.ravel(), rcond=None)
+        residuals = link_params - np.array([d @ gamma for d in designs])
+        ddof = 1 if n_units > 1 else 0
+        residual_cov = np.atleast_2d(
+            np.cov(residuals, rowvar=False, ddof=ddof)
+        )
+        mean_estimation_cov = measurement_var * np.mean(
+            link_estimation_covs, axis=0
+        )
+        link_cov, _ = psd_project(residual_cov - mean_estimation_cov)
+        sigma2 = measurement_var
+
+        if population_method == "reml":
+            if linked.linear_in_parameters:
+                a_by_unit = [
+                    jac @ d for jac, d in zip(link_design_by_unit, designs)
+                ]
+                gamma, link_cov, sigma2, converged = reml_estimate(
+                    y_by_unit,
+                    link_design_by_unit,
+                    link_cov,
+                    measurement_var,
+                    a_mat_list=a_by_unit,
+                )
+            else:
+                gamma, link_cov, sigma2, converged = reml_estimate_nonlinear(
+                    y_by_unit,
+                    x_by_unit,
+                    linked,
+                    gamma,
+                    link_cov,
+                    measurement_var,
+                    link_params,
+                    d_mat_list=designs,
+                )
+            if not converged:
+                warnings.warn(
+                    "The REML optimisation of the stress-conditional path "
+                    "population did not report convergence; "
+                    "path_param_fixed and path_param_link_cov may be "
+                    "inaccurate",
+                    stacklevel=3,
+                )
+        return gamma, link_cov, sigma2
 
     @staticmethod
     def _select_path_model(

--- a/surpyval/degradation/population.py
+++ b/surpyval/degradation/population.py
@@ -40,6 +40,22 @@ alternating algorithm (the FOCE linearisation used by ``nlme``):
 iterating 1-3 to convergence. For a linear-in-parameters path this
 reduces exactly to the linear REML in one pass (``w_i = y_i`` and the
 modes drop out), so the two routines agree.
+
+Stress-dependent path parameters
+--------------------------------
+For an accelerated degradation test whose path parameters depend on
+the unit's stress (``links`` in ``DegradationAnalysis.fit``) the fixed
+effect is no longer a single mean but ``D_i gamma``, a per-unit
+fixed-effects design times a coefficient vector, and the marginal model
+is
+
+    y_i ~ N(A_i gamma, V_i),  A_i = X_i D_i,  V_i = X_i Sigma X_i' + sigma^2 I.
+
+Both routines take that fixed-effects design optionally
+(``a_mat_list`` / ``d_mat_list``); without it ``D_i = I`` and ``gamma``
+is the population mean ``mu`` as above. The random-effects design
+``X_i`` is unchanged, so ``Sigma`` keeps its meaning as the
+between-unit covariance of the path parameters *given* the stress.
 """
 
 from typing import Any
@@ -87,40 +103,45 @@ def _reml_pieces(
     y_list: list,
     x_mat_list: list,
     p: int,
+    a_mat_list: list,
 ) -> tuple:
     """
     Evaluate the model at ``z``.
 
-    Returns ``(neg_reml, mu, Sigma, sigma2)`` where ``neg_reml`` is the
-    negative REML log-likelihood (up to a constant) with the fixed
-    effect ``mu`` profiled out by GLS.
+    Returns ``(neg_reml, gamma, Sigma, sigma2)`` where ``neg_reml`` is
+    the negative REML log-likelihood (up to a constant) with the fixed
+    effects ``gamma`` profiled out by GLS. ``x_mat_list`` is the
+    random-effects design (it forms ``V_i``) and ``a_mat_list`` the
+    fixed-effects design; the two are the same list for the plain
+    population model.
     """
     chol = _chol_from_z(z, p)
     covariance = chol @ chol.T
     sigma2 = np.exp(2.0 * z[-1])
 
-    gls_information = np.zeros((p, p))  # sum X' V^-1 X
-    gls_rhs = np.zeros(p)  # sum X' V^-1 y
+    m = a_mat_list[0].shape[1]
+    gls_information = np.zeros((m, m))  # sum A' V^-1 A
+    gls_rhs = np.zeros(m)  # sum A' V^-1 y
     y_v_y = 0.0  # sum y' V^-1 y
     logdet_v = 0.0
 
-    for y_i, x_mat in zip(y_list, x_mat_list):
+    for y_i, x_mat, a_mat in zip(y_list, x_mat_list, a_mat_list):
         v_i = x_mat @ covariance @ x_mat.T + sigma2 * np.eye(len(y_i))
         cho = cho_factor(v_i, lower=True)
         logdet_v += 2.0 * np.log(np.diag(cho[0])).sum()
         v_inv_y = cho_solve(cho, y_i)
-        v_inv_x = cho_solve(cho, x_mat)
-        gls_information += x_mat.T @ v_inv_x
-        gls_rhs += x_mat.T @ v_inv_y
+        v_inv_a = cho_solve(cho, a_mat)
+        gls_information += a_mat.T @ v_inv_a
+        gls_rhs += a_mat.T @ v_inv_y
         y_v_y += y_i @ v_inv_y
 
-    mu = np.linalg.solve(gls_information, gls_rhs)
-    quad = y_v_y - 2.0 * mu @ gls_rhs + mu @ gls_information @ mu
+    gamma = np.linalg.solve(gls_information, gls_rhs)
+    quad = y_v_y - 2.0 * gamma @ gls_rhs + gamma @ gls_information @ gamma
     sign, logdet_info = np.linalg.slogdet(gls_information)
     if sign <= 0:
         raise np.linalg.LinAlgError("GLS information not positive definite")
     neg_reml = 0.5 * (logdet_v + quad + logdet_info)
-    return neg_reml, mu, covariance, sigma2
+    return neg_reml, gamma, covariance, sigma2
 
 
 def reml_estimate(
@@ -128,31 +149,41 @@ def reml_estimate(
     x_mat_list: "list[npt.NDArray]",
     cov_init: npt.NDArray,
     sigma2_init: float,
+    a_mat_list: "list[npt.NDArray] | None" = None,
 ) -> tuple[npt.NDArray, npt.NDArray, float, bool]:
     """
-    REML fit of ``y_i ~ N(X_i mu, X_i Sigma X_i' + sigma^2 I)``.
+    REML fit of ``y_i ~ N(A_i gamma, X_i Sigma X_i' + sigma^2 I)``.
 
     Parameters
     ----------
     y_list : list of ndarray
         Each unit's measurement vector.
     x_mat_list : list of ndarray
-        Each unit's design matrix (the path Jacobian, constant in the
-        parameters for linear-in-parameter path models).
+        Each unit's random-effects design matrix (the path Jacobian,
+        constant in the parameters for linear-in-parameter path
+        models).
     cov_init, sigma2_init : ndarray, float
         Starting values for ``Sigma`` and ``sigma^2`` (typically the
         two-stage moment estimates); ``cov_init`` may be
         rank-deficient, its eigenvalues are floored.
+    a_mat_list : list of ndarray, optional
+        Each unit's fixed-effects design ``A_i = X_i D_i`` when the
+        path parameters depend on the unit's stress. Default ``None``:
+        ``A_i = X_i``, so the fixed effect is the population mean.
 
     Returns
     -------
-    (mu, Sigma, sigma2, converged)
+    (gamma, Sigma, sigma2, converged)
+        ``gamma`` is the population mean ``mu`` when ``a_mat_list`` is
+        not given.
     """
     p = x_mat_list[0].shape[1]
+    if a_mat_list is None:
+        a_mat_list = x_mat_list
 
     def objective(z: npt.NDArray) -> float:
         try:
-            return _reml_pieces(z, y_list, x_mat_list, p)[0]
+            return _reml_pieces(z, y_list, x_mat_list, p, a_mat_list)[0]
         except np.linalg.LinAlgError:
             return _LARGE
 
@@ -168,8 +199,10 @@ def reml_estimate(
             "fatol": 1e-10,
         },
     )
-    _, mu, covariance, sigma2 = _reml_pieces(result.x, y_list, x_mat_list, p)
-    return mu, covariance, sigma2, bool(result.success)
+    _, gamma, covariance, sigma2 = _reml_pieces(
+        result.x, y_list, x_mat_list, p, a_mat_list
+    )
+    return gamma, covariance, sigma2, bool(result.success)
 
 
 def _prior_precision(cov: npt.NDArray, sigma2: float) -> npt.NDArray:
@@ -247,6 +280,7 @@ def reml_estimate_nonlinear(
     theta_init: npt.NDArray,
     max_outer: int = 50,
     tol: float = 1e-5,
+    d_mat_list: "list[npt.NDArray] | None" = None,
 ) -> tuple[npt.NDArray, npt.NDArray, float, bool]:
     """
     REML fit of a nonlinear random-effects degradation path by the
@@ -262,8 +296,9 @@ def reml_estimate_nonlinear(
     path_model : PathModel
         The (nonlinear) degradation path model.
     mean_init, cov_init, sigma2_init : ndarray, ndarray, float
-        Starting values for ``mu``, ``Sigma`` and ``sigma^2`` (typically
-        the two-stage moment estimates).
+        Starting values for ``mu`` (or ``gamma``, see ``d_mat_list``),
+        ``Sigma`` and ``sigma^2`` (typically the two-stage moment
+        estimates).
     theta_init : ndarray
         Per-unit unpenalised least-squares path fits, one row per unit;
         the starting points for the conditional-mode search.
@@ -271,12 +306,19 @@ def reml_estimate_nonlinear(
         Maximum outer (linearise / LME) iterations. Default 50.
     tol : float, optional
         Relative convergence tolerance on ``(mu, Sigma, sigma^2)``.
+    d_mat_list : list of ndarray, optional
+        Each unit's ``(p, m)`` fixed-effects design ``D_i`` when the
+        path parameters depend on the unit's stress: the unit's prior
+        mean is ``D_i gamma`` and the linearised fixed-effects design is
+        ``A_i = J_i D_i``. Default ``None``: ``D_i = I``.
 
     Returns
     -------
-    (mu, Sigma, sigma2, converged)
+    (gamma, Sigma, sigma2, converged)
+        ``gamma`` is the population mean ``mu`` when ``d_mat_list`` is
+        not given.
     """
-    mu = np.array(mean_init, dtype=float)
+    gamma = np.array(mean_init, dtype=float)
     covariance = np.array(cov_init, dtype=float)
     sigma2 = float(sigma2_init)
     theta_hat = np.array(theta_init, dtype=float)
@@ -285,13 +327,14 @@ def reml_estimate_nonlinear(
     for _ in range(max_outer):
         prior_precision = _prior_precision(covariance, sigma2)
         # Step 1: conditional modes given the current population.
-        w_list, jac_list = [], []
+        w_list, jac_list, a_list = [], [], []
         for k, (y_i, x_i) in enumerate(zip(y_list, x_list)):
+            prior_mean = gamma if d_mat_list is None else d_mat_list[k] @ gamma
             theta_i = _conditional_mode(
                 path_model,
                 x_i,
                 y_i,
-                mu,
+                prior_mean,
                 prior_precision,
                 sigma2,
                 theta_hat[k],
@@ -302,21 +345,27 @@ def reml_estimate_nonlinear(
             fitted = np.asarray(path_model.path(x_i, *theta_i), dtype=float)
             w_list.append(y_i - fitted + jac @ theta_i)
             jac_list.append(jac)
+            if d_mat_list is not None:
+                a_list.append(jac @ d_mat_list[k])
 
         # Step 3: linear REML step on the pseudo-data, warm-started from
         # the current variance components.
-        mu_new, cov_new, sigma2_new, inner_ok = reml_estimate(
-            w_list, jac_list, covariance, sigma2
+        gamma_new, cov_new, sigma2_new, inner_ok = reml_estimate(
+            w_list,
+            jac_list,
+            covariance,
+            sigma2,
+            a_mat_list=None if d_mat_list is None else a_list,
         )
 
-        prev = np.concatenate([mu, covariance.ravel(), [sigma2]])
-        curr = np.concatenate([mu_new, cov_new.ravel(), [sigma2_new]])
+        prev = np.concatenate([gamma, covariance.ravel(), [sigma2]])
+        curr = np.concatenate([gamma_new, cov_new.ravel(), [sigma2_new]])
         scale = np.maximum(np.abs(prev), np.abs(curr)) + 1e-12
         rel_change = float(np.max(np.abs(curr - prev) / scale))
 
-        mu, covariance, sigma2 = mu_new, cov_new, sigma2_new
+        gamma, covariance, sigma2 = gamma_new, cov_new, sigma2_new
         if rel_change < tol:
             converged = bool(inner_ok)
             break
 
-    return mu, covariance, sigma2, converged
+    return gamma, covariance, sigma2, converged

--- a/surpyval/degradation/stress.py
+++ b/surpyval/degradation/stress.py
@@ -1,0 +1,211 @@
+"""Stress-dependent path parameters for accelerated degradation tests.
+
+Stage 1 of accelerated degradation testing (``Z`` alone in
+:meth:`DegradationAnalysis.fit`) lets stress act only on the pseudo
+failure times, through the life regression. Stage 2 (``links``) models
+the degradation *mechanism*: the path parameters themselves depend on
+the stress a unit was tested at, with a random effect per unit on top.
+Per unit ``i`` with stress row ``z_i``,
+
+    eta_i = D(z_i) gamma + u_i,    u_i ~ MVN(0, Sigma),
+    theta_i = h(eta_i),
+
+where ``theta_i`` are the path parameters on their natural scale,
+``eta_i`` the same parameters on a *link* scale (identity, or log for a
+parameter that must stay positive and whose stress effect is
+multiplicative -- a ``log`` link on a rate with ``Z = 1/T`` is the
+Arrhenius relationship), ``D(z)`` the fixed-effects design that gives
+every stress-dependent parameter the row ``[1, z']`` and every other
+parameter an intercept only, and ``gamma`` the fixed effects.
+
+Everything downstream works on the link scale: :class:`LinkedPathModel`
+presents any path model as a path model in ``eta`` (so the existing
+per-unit fits, the two-stage moments and the REML machinery apply
+unchanged), and :func:`stress_design` builds ``D(z)``. Because the
+population model is on the link scale, the random effect of a
+``log``-linked parameter is log-normal on the natural scale.
+"""
+
+from typing import Any, Callable
+
+import numpy as np
+import numpy.typing as npt
+
+from .path_models import PathModel
+
+#: ``link name -> (h, h^-1, h')``: the natural-scale parameter as a
+#: function of the link-scale one, its inverse, and its derivative.
+_LINKS: dict[str, tuple[Callable, Callable, Callable]] = {
+    "identity": (lambda e: e, lambda t: t, lambda e: np.ones_like(e)),
+    "log": (np.exp, np.log, np.exp),
+}
+
+LINK_NAMES = tuple(_LINKS)
+
+
+def validate_links(path_model: PathModel, links: Any) -> dict[str, str]:
+    """
+    Check a user ``links`` mapping against a path model.
+
+    ``links`` names the *stress-dependent* path parameters and the link
+    each is modelled on (``"identity"`` or ``"log"``). Returns the
+    mapping in path-parameter order.
+    """
+    if not isinstance(links, dict) or len(links) == 0:
+        raise ValueError(
+            "links must be a non-empty dict mapping path parameter names "
+            "to a link ('identity' or 'log'), e.g. {'b': 'log'}"
+        )
+    unknown = [name for name in links if name not in path_model.param_names]
+    if unknown:
+        raise ValueError(
+            "links names parameter(s) {} that the {} path model does not "
+            "have; its parameters are {}".format(
+                unknown, path_model.name, path_model.param_names
+            )
+        )
+    bad = {name: link for name, link in links.items() if link not in _LINKS}
+    if bad:
+        raise ValueError(
+            "Unknown link(s) {}; each link must be one of {}".format(
+                bad, list(LINK_NAMES)
+            )
+        )
+    return {
+        name: str(links[name])
+        for name in path_model.param_names
+        if name in links
+    }
+
+
+class LinkedPathModel(PathModel):
+    """
+    A path model reparameterised onto a link scale.
+
+    Wraps ``base`` so that its parameters ``theta`` are replaced by
+    ``eta`` with ``theta = h(eta)`` elementwise: ``h`` is the identity
+    for most parameters and ``exp`` for those given a ``"log"`` link.
+    ``path``, ``inv_path``, ``jacobian`` and ``fit`` all take and return
+    link-scale parameters, so the wrapped model is a drop-in path model
+    for the per-unit fits and the population (REML) machinery, which
+    then estimate the population of ``eta``.
+
+    Parameters
+    ----------
+    base : PathModel
+        The path model on its natural scale.
+    links : dict
+        ``{parameter name: "identity" | "log"}`` for the parameters
+        whose link is not the identity (a parameter left out gets the
+        identity link).
+    """
+
+    def __init__(self, base: PathModel, links: dict[str, str]) -> None:
+        self.base = base
+        self.links = {
+            name: links.get(name, "identity") for name in base.param_names
+        }
+        self.name = base.name
+        self.param_names = [
+            "log({})".format(name) if link == "log" else name
+            for name, link in self.links.items()
+        ]
+        self.linear_in_parameters = base.linear_in_parameters and all(
+            link == "identity" for link in self.links.values()
+        )
+        fns = [_LINKS[link] for link in self.links.values()]
+        self._forward = [f[0] for f in fns]
+        self._inverse = [f[1] for f in fns]
+        self._deriv = [f[2] for f in fns]
+
+    def to_natural(self, eta: npt.ArrayLike) -> npt.NDArray:
+        """Natural-scale parameters ``theta = h(eta)``."""
+        eta_arr = np.asarray(eta, dtype=float)
+        return np.array([h(e) for h, e in zip(self._forward, eta_arr)])
+
+    def to_link(self, theta: npt.ArrayLike) -> npt.NDArray:
+        """Link-scale parameters ``eta = h^-1(theta)``."""
+        theta_arr = np.asarray(theta, dtype=float)
+        for name, link, t in zip(
+            self.base.param_names, self.links.values(), theta_arr
+        ):
+            if link == "log" and not t > 0:
+                raise ValueError(
+                    "Path parameter {} = {:.6g} is not positive, so it "
+                    "cannot be modelled on a log link".format(name, t)
+                )
+        return np.array([g(t) for g, t in zip(self._inverse, theta_arr)])
+
+    def _link_derivative(self, eta: npt.NDArray) -> npt.NDArray:
+        return np.array([d(e) for d, e in zip(self._deriv, eta)])
+
+    def path(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
+        return self.base.path(x, *self.to_natural(params))
+
+    def inv_path(self, y: npt.ArrayLike, *params: float) -> npt.NDArray:
+        return self.base.inv_path(y, *self.to_natural(params))
+
+    def jacobian(self, x: npt.ArrayLike, *params: float) -> npt.NDArray:
+        # chain rule: d path / d eta = (d path / d theta) * h'(eta)
+        eta = np.asarray(params, dtype=float)
+        natural = np.asarray(
+            self.base.jacobian(x, *self.to_natural(eta)), dtype=float
+        )
+        return natural * self._link_derivative(eta)[None, :]
+
+    def check_data(self, x: npt.NDArray, y: npt.NDArray) -> None:
+        self.base.check_data(x, y)
+
+    def fit(self, x: npt.ArrayLike, y: npt.ArrayLike) -> npt.NDArray:
+        """The base model's per-unit fit, returned on the link scale."""
+        return self.to_link(self.base.fit(x, y))
+
+    def __repr__(self) -> str:
+        return "{} Degradation Path Model on links {}".format(
+            self.base.name, self.links
+        )
+
+
+def stress_design(
+    z: npt.ArrayLike, links: dict[str, str], param_names: list[str]
+) -> npt.NDArray:
+    """
+    The fixed-effects design ``D(z)`` of one unit: a ``(p, m)`` matrix
+    mapping the fixed effects ``gamma`` to the unit's link-scale path
+    parameter means, ``eta_mean = D(z) gamma``.
+
+    The columns are laid out parameter by parameter, in path order: an
+    intercept column for every parameter, followed -- for the
+    stress-dependent parameters named in ``links`` -- by one column per
+    covariate carrying that unit's stress values. So
+    ``m = p + q * len(links)`` with ``q`` covariates.
+    """
+    z_arr = np.atleast_1d(np.asarray(z, dtype=float))
+    q = z_arr.shape[0]
+    m = len(param_names) + q * len(links)
+    design = np.zeros((len(param_names), m))
+    col = 0
+    for row, name in enumerate(param_names):
+        design[row, col] = 1.0
+        col += 1
+        if name in links:
+            design[row, col : col + q] = z_arr
+            col += q
+    return design
+
+
+def fixed_effect_names(
+    linked_param_names: list[str],
+    param_names: list[str],
+    links: dict[str, str],
+    n_cov: int,
+) -> list[str]:
+    """Labels for ``gamma`` matching :func:`stress_design`'s columns:
+    the link-scale parameter name for each intercept and
+    ``"<name>:Z<j>"`` for each stress coefficient."""
+    names = []
+    for linked_name, name in zip(linked_param_names, param_names):
+        names.append(linked_name)
+        if name in links:
+            names.extend("{}:Z{}".format(linked_name, j) for j in range(n_cov))
+    return names

--- a/surpyval/tests/degradation/test_stress.py
+++ b/surpyval/tests/degradation/test_stress.py
@@ -1,0 +1,408 @@
+"""Stage-2 accelerated degradation: stress-dependent path parameters."""
+
+import warnings
+
+import numpy as np
+import pytest
+
+from surpyval.degradation import (
+    DegradationAnalysis,
+    DegradationModel,
+    ExponentialPath,
+    LinearPath,
+    LinkedPathModel,
+    PathModel,
+    PowerPath,
+)
+from surpyval.degradation.population import reml_estimate
+from surpyval.degradation.stress import (
+    fixed_effect_names,
+    stress_design,
+    validate_links,
+)
+
+
+def _rt(d):
+    """JSON round trip, so tuples/arrays become plain lists."""
+    import json
+
+    return json.loads(json.dumps(d))
+
+
+# -- LinkedPathModel -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "base,links,theta",
+    [
+        (LinearPath, {"b": "log"}, (2.0, 0.5)),
+        (LinearPath, {"a": "log", "b": "log"}, (2.0, 0.5)),
+        (LinearPath, {"b": "identity"}, (2.0, -0.5)),
+        (ExponentialPath, {"b": "log"}, (2.0, 0.05)),
+        (PowerPath, {"a": "log", "b": "log"}, (2.0, 0.8)),
+    ],
+)
+def test_linked_model_matches_base(base, links, theta):
+    linked = LinkedPathModel(base, links)
+    x = np.linspace(1, 10, 20)
+    eta = linked.to_link(theta)
+    assert np.allclose(linked.to_natural(eta), theta)
+    assert np.allclose(linked.path(x, *eta), base.path(x, *theta))
+    level = 0.5 * (base.path(x, *theta).min() + base.path(x, *theta).max())
+    assert np.allclose(
+        linked.inv_path(level, *eta), base.inv_path(level, *theta)
+    )
+    # chain-rule Jacobian against the base class' finite differences
+    analytic = linked.jacobian(x, *eta)
+    numeric = PathModel.jacobian(linked, x, *eta)
+    assert analytic.shape == (len(x), len(base.param_names))
+    assert np.allclose(analytic, numeric, rtol=1e-4, atol=1e-6)
+    # a fit on the link scale is the base fit mapped there
+    y = base.path(x, *theta)
+    assert np.allclose(linked.fit(x, y), linked.to_link(base.fit(x, y)))
+
+
+def test_linked_model_names_and_linearity():
+    linked = LinkedPathModel(LinearPath, {"b": "log"})
+    assert linked.param_names == ["a", "log(b)"]
+    assert linked.links == {"a": "identity", "b": "log"}
+    assert not linked.linear_in_parameters
+    assert LinkedPathModel(LinearPath, {"b": "identity"}).linear_in_parameters
+    assert not LinkedPathModel(
+        ExponentialPath, {"b": "identity"}
+    ).linear_in_parameters
+    assert "Linear" in repr(linked)
+
+
+def test_log_link_rejects_non_positive_parameter():
+    linked = LinkedPathModel(LinearPath, {"b": "log"})
+    with pytest.raises(ValueError, match="not positive"):
+        linked.to_link([2.0, -0.5])
+
+
+def test_validate_links_errors():
+    with pytest.raises(ValueError, match="non-empty dict"):
+        validate_links(LinearPath, {})
+    with pytest.raises(ValueError, match="non-empty dict"):
+        validate_links(LinearPath, "log")
+    with pytest.raises(ValueError, match="does not have"):
+        validate_links(LinearPath, {"c": "log"})
+    with pytest.raises(ValueError, match="Unknown link"):
+        validate_links(LinearPath, {"b": "logit"})
+    # returned in path-parameter order, only the named parameters
+    assert list(validate_links(LinearPath, {"b": "log", "a": "identity"})) == [
+        "a",
+        "b",
+    ]
+
+
+def test_stress_design_layout():
+    # linear path, b stress-dependent, two covariates
+    d = stress_design([0.5, 2.0], {"b": "log"}, ["a", "b"])
+    assert d.shape == (2, 4)
+    assert np.allclose(d, [[1, 0, 0, 0], [0, 1, 0.5, 2.0]])
+    names = fixed_effect_names(["a", "log(b)"], ["a", "b"], {"b": "log"}, 2)
+    assert names == ["a", "log(b)", "log(b):Z0", "log(b):Z1"]
+    # both parameters stress-dependent, one covariate
+    d = stress_design(3.0, {"a": "identity", "b": "log"}, ["a", "b"])
+    assert np.allclose(d, [[1, 3.0, 0, 0], [0, 0, 1, 3.0]])
+
+
+# -- the widened REML ------------------------------------------------------
+
+
+def test_reml_fixed_design_defaults_to_random_design():
+    # with A_i = X_i the widened routine is the old one
+    rng = np.random.default_rng(3)
+    y_list, d_list = [], []
+    for _ in range(30):
+        n_k = int(rng.integers(3, 9))
+        x_k = np.sort(rng.uniform(5, 60, n_k))
+        y_k = rng.normal(10, 1) + rng.normal(0.4, 0.05) * x_k
+        y_list.append(y_k + rng.normal(0, 1.0, n_k))
+        d_list.append(np.column_stack([np.ones_like(x_k), x_k]))
+    cov0 = np.diag([1.0, 0.0025])
+    plain = reml_estimate(y_list, d_list, cov0, 1.0)
+    explicit = reml_estimate(y_list, d_list, cov0, 1.0, a_mat_list=d_list)
+    assert np.array_equal(plain[0], explicit[0])
+    assert np.array_equal(plain[1], explicit[1])
+    assert plain[2] == explicit[2]
+
+
+def test_reml_recovers_linear_stress_effect():
+    # y = a + b(z) t with b(z) = 0.2 + 0.3 z plus unit scatter: an exact
+    # linear mixed model with a wider fixed-effects design
+    rng = np.random.default_rng(5)
+    y_list, x_list, a_list, z_rows = [], [], [], []
+    t = np.arange(5.0, 45.0, 5.0)
+    for z in np.repeat([0.0, 1.0, 2.0], 20):
+        a = rng.normal(10.0, 1.0)
+        b = 0.2 + 0.3 * z + rng.normal(0, 0.03)
+        y_list.append(a + b * t + rng.normal(0, 0.5, t.size))
+        design = np.column_stack([np.ones_like(t), t])
+        x_list.append(design)
+        d = stress_design(z, {"b": "identity"}, ["a", "b"])
+        a_list.append(design @ d)
+        z_rows.append(z)
+    gamma, cov, sigma2, ok = reml_estimate(
+        y_list, x_list, np.diag([1.0, 0.001]), 0.25, a_mat_list=a_list
+    )
+    assert np.allclose(gamma, [10.0, 0.2, 0.3], atol=[0.4, 0.03, 0.02])
+    assert np.isclose(sigma2, 0.25, rtol=0.3)
+    assert np.isclose(cov[1, 1], 0.03**2, rtol=0.6)
+
+
+# -- DegradationAnalysis.fit(links=) ----------------------------------------
+
+
+def adt_data(gamma=0.8, b0=0.5, intercept=10.0, seed=0, sd_log_b=0.15):
+    """Linear degradation whose rate is log-linear in stress:
+    ``y = a + b t``, ``log b = log b0 + gamma Z + N(0, sd_log_b^2)``,
+    ``a ~ N(intercept, 1)``, measurement noise sd 0.5."""
+    rng = np.random.default_rng(seed)
+    times = np.arange(1, 11) * 5.0
+    xs, ys, ii, ZZ = [], [], [], []
+    uid = 0
+    for Z in [0.0, 0.5, 1.0, 1.5]:
+        for _ in range(12):
+            b = b0 * np.exp(gamma * Z) * np.exp(rng.normal(0, sd_log_b))
+            a = intercept + rng.normal(0, 1.0)
+            y = a + b * times + rng.normal(0, 0.5, size=times.size)
+            xs.append(times)
+            ys.append(y)
+            ii.append(np.full(times.size, uid))
+            ZZ.append(np.full(times.size, Z))
+            uid += 1
+    return tuple(np.concatenate(v) for v in (xs, ys, ii, ZZ))
+
+
+@pytest.mark.parametrize("population_method", ["moments", "reml"])
+def test_log_link_recovers_arrhenius_style_rate(population_method):
+    x, y, i, Z = adt_data()
+    model = DegradationAnalysis.fit(
+        x,
+        y,
+        i,
+        threshold=100.0,
+        Z=Z,
+        links={"b": "log"},
+        population_method=population_method,
+    )
+    assert model.links == {"b": "log"}
+    assert model.path_param_fixed_names == ["a", "log(b)", "log(b):Z0"]
+    fixed = dict(zip(model.path_param_fixed_names, model.path_param_fixed))
+    assert fixed["a"] == pytest.approx(10.0, abs=0.5)
+    assert fixed["log(b)"] == pytest.approx(np.log(0.5), abs=0.1)
+    assert fixed["log(b):Z0"] == pytest.approx(0.8, abs=0.1)
+    # between-unit scatter given stress: var a = 1, var log b = 0.15^2
+    link_cov = model.path_param_link_cov
+    assert link_cov.shape == (2, 2)
+    assert np.isclose(link_cov[0, 0], 1.0, rtol=0.6)
+    assert np.isclose(link_cov[1, 1], 0.15**2, rtol=0.6)
+    assert model.measurement_var == pytest.approx(0.25, rel=0.3)
+    # the Stage-1 life regression is still there and unchanged in kind
+    assert model.is_accelerated
+    assert model.life_model.params[-1] == pytest.approx(0.8, abs=0.2)
+    # the pooled population summaries are still the natural-scale ones
+    assert model.path_params.shape == (48, 2)
+    assert (model.path_params[:, 1] > 0).all()
+    assert model.path_param_mean.shape == (2,)
+
+
+def test_identity_link_is_an_exact_linear_mixed_model():
+    # b(z) = 0.2 + 0.3 z, additive in stress, so the identity link and
+    # a linear path keep the model an exact LMM (no FOCE)
+    rng = np.random.default_rng(7)
+    t = np.arange(5.0, 45.0, 5.0)
+    xs, ys, ii, ZZ = [], [], [], []
+    for uid, z in enumerate(np.repeat([0.0, 1.0, 2.0], 16)):
+        a = rng.normal(10.0, 1.0)
+        b = 0.2 + 0.3 * z + rng.normal(0, 0.03)
+        xs.append(t)
+        ys.append(a + b * t + rng.normal(0, 0.5, t.size))
+        ii.append(np.full(t.size, uid))
+        ZZ.append(np.full(t.size, z))
+    x, y, i, Z = (np.concatenate(v) for v in (xs, ys, ii, ZZ))
+    reml = DegradationAnalysis.fit(
+        x,
+        y,
+        i,
+        threshold=60.0,
+        Z=Z,
+        links={"b": "identity"},
+        population_method="reml",
+    )
+    moments = DegradationAnalysis.fit(
+        x, y, i, threshold=60.0, Z=Z, links={"b": "identity"}
+    )
+    assert reml.path_param_fixed_names == ["a", "b", "b:Z0"]
+    assert np.allclose(
+        reml.path_param_fixed, [10.0, 0.2, 0.3], atol=[0.4, 0.03, 0.02]
+    )
+    # balanced design: REML and the two-stage moments agree closely
+    assert np.allclose(
+        reml.path_param_fixed, moments.path_param_fixed, rtol=1e-3, atol=1e-3
+    )
+    assert np.allclose(
+        reml.path_param_link_cov,
+        moments.path_param_link_cov,
+        rtol=0.05,
+        atol=1e-4,
+    )
+
+
+def test_links_on_a_nonlinear_path():
+    # exponential path a exp(b t) with a stress-dependent rate
+    rng = np.random.default_rng(9)
+    t = np.arange(1.0, 13.0)
+    xs, ys, ii, ZZ = [], [], [], []
+    for uid, z in enumerate(np.repeat([0.0, 0.5, 1.0], 20)):
+        a = rng.normal(2.0, 0.1)
+        b = 0.05 * np.exp(0.6 * z) * np.exp(rng.normal(0, 0.05))
+        xs.append(t)
+        ys.append(a * np.exp(b * t) + rng.normal(0, 0.03, t.size))
+        ii.append(np.full(t.size, uid))
+        ZZ.append(np.full(t.size, z))
+    x, y, i, Z = (np.concatenate(v) for v in (xs, ys, ii, ZZ))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        model = DegradationAnalysis.fit(
+            x,
+            y,
+            i,
+            threshold=6.0,
+            path="exponential",
+            Z=Z,
+            links={"b": "log"},
+            population_method="reml",
+        )
+    fixed = dict(zip(model.path_param_fixed_names, model.path_param_fixed))
+    assert fixed["a"] == pytest.approx(2.0, abs=0.1)
+    assert fixed["log(b)"] == pytest.approx(np.log(0.05), abs=0.1)
+    assert fixed["log(b):Z0"] == pytest.approx(0.6, abs=0.1)
+    assert (np.linalg.eigvalsh(model.path_param_link_cov) > 0).all()
+
+
+def test_links_with_two_covariates_and_two_linked_parameters():
+    rng = np.random.default_rng(2)
+    t = np.arange(5.0, 45.0, 5.0)
+    xs, ys, ii, ZZ = [], [], [], []
+    uid = 0
+    for z1 in [0.0, 1.0]:
+        for z2 in [0.0, 1.0, 2.0]:
+            for _ in range(8):
+                a = 10.0 + 2.0 * z1 + rng.normal(0, 0.5)
+                b = (
+                    0.5
+                    * np.exp(0.4 * z1 - 0.2 * z2)
+                    * np.exp(rng.normal(0, 0.05))
+                )
+                xs.append(t)
+                ys.append(a + b * t + rng.normal(0, 0.3, t.size))
+                ii.append(np.full(t.size, uid))
+                ZZ.append(np.tile([z1, z2], (t.size, 1)))
+                uid += 1
+    x, y, i = (np.concatenate(v) for v in (xs, ys, ii))
+    Z = np.vstack(ZZ)
+    model = DegradationAnalysis.fit(
+        x, y, i, threshold=60.0, Z=Z, links={"a": "identity", "b": "log"}
+    )
+    assert model.path_param_fixed_names == [
+        "a",
+        "a:Z0",
+        "a:Z1",
+        "log(b)",
+        "log(b):Z0",
+        "log(b):Z1",
+    ]
+    fixed = dict(zip(model.path_param_fixed_names, model.path_param_fixed))
+    assert fixed["a:Z0"] == pytest.approx(2.0, abs=0.4)
+    assert fixed["a:Z1"] == pytest.approx(0.0, abs=0.3)
+    assert fixed["log(b):Z0"] == pytest.approx(0.4, abs=0.08)
+    assert fixed["log(b):Z1"] == pytest.approx(-0.2, abs=0.05)
+
+
+def test_links_require_Z():
+    x, y, i, Z = adt_data()
+    with pytest.raises(ValueError, match="Z must be given"):
+        DegradationAnalysis.fit(x, y, i, threshold=100.0, links={"b": "log"})
+
+
+def test_links_validation_errors_surface_from_fit():
+    x, y, i, Z = adt_data()
+    with pytest.raises(ValueError, match="does not have"):
+        DegradationAnalysis.fit(
+            x, y, i, threshold=100.0, Z=Z, links={"rate": "log"}
+        )
+    with pytest.raises(ValueError, match="Unknown link"):
+        DegradationAnalysis.fit(
+            x, y, i, threshold=100.0, Z=Z, links={"b": "sqrt"}
+        )
+
+
+def test_log_link_needs_positive_fitted_parameters():
+    # a unit whose fitted rate is negative cannot sit on a log link
+    x, y, i, Z = adt_data()
+    y = y.copy()
+    mask = i == 0
+    y[mask] = 10.0 - 0.5 * x[mask]
+    with pytest.raises(ValueError, match="not positive"):
+        DegradationAnalysis.fit(
+            x, y, i, threshold=100.0, Z=Z, links={"b": "log"}
+        )
+
+
+def test_plain_fit_has_no_stress_attributes():
+    x, y, i, Z = adt_data()
+    model = DegradationAnalysis.fit(x, y, i, threshold=100.0, Z=Z)
+    assert model.links is None
+    assert model.path_param_fixed is None
+    assert model.path_param_fixed_names is None
+    assert model.path_param_link_cov is None
+    assert "Path Stress" not in repr(model)
+
+
+def test_repr_shows_stress_population():
+    x, y, i, Z = adt_data()
+    model = DegradationAnalysis.fit(
+        x, y, i, threshold=100.0, Z=Z, links={"b": "log"}
+    )
+    text = repr(model)
+    assert "Path Stress Links   : b: log" in text
+    assert "log(b):Z0" in text
+
+
+def test_linked_model_round_trips():
+    x, y, i, Z = adt_data()
+    model = DegradationAnalysis.fit(
+        x, y, i, threshold=100.0, Z=Z, links={"b": "log"}
+    )
+    restored = DegradationModel.from_dict(_rt(model.to_dict()))
+    assert restored.links == {"b": "log"}
+    assert restored.path_param_fixed_names == model.path_param_fixed_names
+    assert np.allclose(restored.path_param_fixed, model.path_param_fixed)
+    assert np.allclose(restored.path_param_link_cov, model.path_param_link_cov)
+    t = np.array([100.0, 200.0])
+    assert np.allclose(model.sf(t, Z=[1.0]), restored.sf(t, Z=[1.0]))
+    # a plain model's dict carries the (absent) stress fields as None
+    plain = DegradationAnalysis.fit(x, y, i, threshold=100.0, Z=Z)
+    d = plain.to_dict()
+    assert d["links"] is None and d["path_param_fixed"] is None
+    assert DegradationModel.from_dict(_rt(d)).links is None
+
+
+def test_fit_from_df_passes_links():
+    import pandas as pd
+
+    x, y, i, Z = adt_data()
+    df = pd.DataFrame({"t": x, "deg": y, "unit": i, "stress": Z})
+    model = DegradationAnalysis.fit_from_df(
+        df,
+        x="t",
+        y="deg",
+        i="unit",
+        Z_cols="stress",
+        threshold=100.0,
+        links={"b": "log"},
+    )
+    assert model.path_param_fixed_names == ["a", "log(b)", "log(b):Z0"]


### PR DESCRIPTION
First half of Stage 2 of #155, per the plan agreed on the issue. Part B (the stress-conditional prior for `predict_rul(Z)` and `induced_life(Z)`, the theory and how-to docs) follows.

## What it does

`DegradationAnalysis.fit` takes `links` alongside `Z` to model the degradation *mechanism* against stress, not only the pseudo failure times:

```python
model = DegradationAnalysis.fit(x, y, i, threshold=100, Z=Z, links={"b": "log"})
model.path_param_fixed_names   # ['a', 'log(b)', 'log(b):Z0']
model.path_param_fixed         # gamma
model.path_param_link_cov      # Sigma, between-unit scatter given stress
```

The path parameters named in `links` depend on the unit's stress on an `"identity"` or `"log"` link (a log-linked rate with `Z = 1/T` is the Arrhenius relationship); the rest are common; a per-unit random effect sits on top: `eta_i = D(z_i) gamma + u_i`, `u_i ~ MVN(0, Sigma)`, `theta_i = h(eta_i)`. `gamma`/`Sigma` come from the same two-stage (Lu–Meeker) or REML route as the plain population. The life model stays the Stage-1 regression on the pseudo failure times, so every existing prediction method is unchanged (the additive design decided on the issue).

## How

- **`stress.py`** (new): `LinkedPathModel` presents any path model on its link scale (`path`/`inv_path`/`jacobian`/`fit` in `eta`, chain-rule Jacobian, `linear_in_parameters` kept only for all-identity links), so the per-unit fits, the two-stage moments and the existing Lindstrom–Bates FOCE linearisation apply unchanged; `stress_design` builds `D(z)`; `fixed_effect_names` labels `gamma`.
- **`population.py`**: `reml_estimate` / `reml_estimate_nonlinear` take an optional fixed-effects design (`a_mat_list` / `d_mat_list`), decoupling the fixed design `A_i = X_i D_i` from the random design `X_i` that forms `V_i`. Without it the routines are the old ones.
- **`degradation_analysis.py`**: `fit(links=)`, `_fit_stress_population` (least-squares of the link-scale per-unit fits on `D(z_i)` for `gamma`, residual covariance less the link-scale estimation covariance for `Sigma`, then REML if asked), new model attributes, `repr`, `to_dict`/`from_dict`.

## Verification

- **Bit-identical without `links`**: 55 fingerprinted outputs across moments, REML, nonlinear REML, best-path selection, Stage-1 ADT (moments/REML/LogNormal), bootstrap bounds, the direct REML routines and serialisation match the previous commit exactly.
- **Recovers the mechanism**: on the existing ADT fixture (`log b = log 0.5 + 0.8 Z + N(0, 0.15²)`) the fit gives `(a, log b, gamma) = (10.18, −0.687, 0.84)`, `Sigma` diag `(0.68, 0.021)` vs truth `(1.0, 0.0225)`, `sigma² = 0.258` vs 0.25 — with both the two-stage and REML routes. Also tested: an identity link as an exact LMM (REML ≈ moments on a balanced design), a log link on the nonlinear exponential path, two covariates with two linked parameters, all error paths, `repr`, round-trip serialisation, `fit_from_df`.
- 23 new tests; full matrix green (suite + both doctest passes on 3.11/3.12/3.13); full-package mypy, flake8/black/isort clean; the degradation API page builds with the new entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRhKL2fJBiAAfNo9rihwts)_